### PR TITLE
Use ByteString#writeTo for operation stream output

### DIFF
--- a/src/main/java/build/buildfarm/server/ByteStreamService.java
+++ b/src/main/java/build/buildfarm/server/ByteStreamService.java
@@ -262,7 +262,7 @@ public class ByteStreamService extends ByteStreamGrpc.ByteStreamImplBase {
         String operationStream = parseOperationStream(resourceName);
 
         OutputStream outputStream = instance.getStreamOutput(operationStream);
-        outputStream.write(request.getData().toByteArray());
+        request.getData().writeTo(outputStream);
         if (request.getFinishWrite()) {
           outputStream.close();
         }


### PR DESCRIPTION
Prevent the awkward toByteArray and use the supported stream output
mechanism for ByteString for operation stream writes.
