### PR TITLE
Preceed operation response with initial put

### DIFF
--- a/src/main/java/build/buildfarm/instance/AbstractServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/AbstractServerInstance.java
@@ -281,11 +281,11 @@ public abstract class AbstractServerInstance implements Instance {
     ExecuteOperationMetadata metadata =
       expectExecuteOperationMetadata(operation);
 
+    putOperation(operation);
+
     if (!waitForCompletion) {
       onOperation.accept(operation);
     }
-
-    putOperation(operation);
 
     Operation.Builder operationBuilder = operation.toBuilder();
     ActionResult actionResult = null;


### PR DESCRIPTION
When executing an action, the created operation could be returned with a
client response for an operation that has not been registered through
putOperation (and watchers/outstanding map). Since there must be an
entity response for watchers who request initial state, this must be
done prior to providing an endpoint to watch.