### PR TITLE
ByteStream read limit checks and stream tolerance

### DIFF
--- a/src/main/java/build/buildfarm/server/ByteStreamService.java
+++ b/src/main/java/build/buildfarm/server/ByteStreamService.java
@@ -115,19 +115,14 @@ public class ByteStreamService extends ByteStreamGrpc.ByteStreamImplBase {
   private void readOperationStream(
       ReadRequest request,
       StreamObserver<ReadResponse> responseObserver) throws IOException {
-    long readLimit = request.getReadLimit();
-    long readOffset = request.getReadOffset();
-    if (readLimit < 0 || readOffset < 0) {
-      responseObserver.onError(new StatusException(Status.OUT_OF_RANGE));
-      return;
-    }
-
     String resourceName = request.getResourceName();
 
     Instance instance = server.getInstanceFromBlob(resourceName);
     String operationStream = parseOperationStream(resourceName);
 
     InputStream input = instance.newStreamInput(operationStream);
+    long readLimit = request.getReadLimit();
+    long readOffset = request.getReadOffset();
     while (readOffset > 0) {
       long n = input.skip(readOffset);
       if (n == 0) {
@@ -137,9 +132,6 @@ public class ByteStreamService extends ByteStreamGrpc.ByteStreamImplBase {
       readOffset -= n;
     }
     boolean unlimitedReadLimit = readLimit == 0;
-    if (unlimitedReadLimit) {
-      readLimit = DEFAULT_CHUNK_SIZE;
-    }
     byte[] buffer = new byte[(int) Math.min(readLimit, DEFAULT_CHUNK_SIZE)];
     int len;
     while ((unlimitedReadLimit || readLimit > 0) &&
@@ -161,6 +153,13 @@ public class ByteStreamService extends ByteStreamGrpc.ByteStreamImplBase {
       ReadRequest request,
       StreamObserver<ReadResponse> responseObserver) {
     String resourceName = request.getResourceName();
+
+    long readLimit = request.getReadLimit();
+    long readOffset = request.getReadOffset();
+    if (readLimit < 0 || readOffset < 0) {
+      responseObserver.onError(new StatusException(Status.OUT_OF_RANGE));
+      return;
+    }
 
     try {
       if (isBlob(resourceName)) {


### PR DESCRIPTION
Move read limit validations to general read method. Prevent limitation
of an operation stream read response in the event of unlimited read to
the chunk size - chunk-sized reads are enforced through buffer size
limitation.