### PR TITLE
Chunk ReadResponses from ByteStream service

### DIFF
--- a/src/main/java/build/buildfarm/server/ByteStreamService.java
+++ b/src/main/java/build/buildfarm/server/ByteStreamService.java
@@ -106,9 +106,20 @@ public class ByteStreamService extends ByteStreamGrpc.ByteStreamImplBase {
       return;
     }
 
-    responseObserver.onNext(ReadResponse.newBuilder()
-        .setData(blob)
-        .build());
+    while (!blob.isEmpty()) {
+      ByteString chunk;
+      if (blob.size() < DEFAULT_CHUNK_SIZE) {
+        chunk = blob;
+        blob = ByteString.EMPTY;
+      } else {
+        chunk = blob.substring(0, (int) DEFAULT_CHUNK_SIZE);
+        blob = blob.substring((int) DEFAULT_CHUNK_SIZE);
+      }
+      responseObserver.onNext(ReadResponse.newBuilder()
+          .setData(chunk)
+          .build());
+    }
+
     responseObserver.onCompleted();
   }
 


### PR DESCRIPTION
Requests for sufficiently large files will trigger frame errors in grpc
response delivery. Chunking the data in ByteStream responses allows for
requests up to the arbitrary request limit.