### PR TITLE
Filter watchers by boolean function result

### DIFF
--- a/src/main/java/build/buildfarm/instance/AbstractServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/AbstractServerInstance.java
@@ -328,6 +328,7 @@ public abstract class AbstractServerInstance implements Instance {
           if (o.getDone()) {
             onOperation.accept(o);
           }
+          return true;
         });
       }
     }

--- a/src/main/java/build/buildfarm/instance/Instance.java
+++ b/src/main/java/build/buildfarm/instance/Instance.java
@@ -73,5 +73,5 @@ public interface Instance {
   boolean watchOperation(
       String operationName,
       boolean watchInitialState,
-      Consumer<Operation> watcher);
+      Function<Operation, Boolean> watcher);
 }

--- a/src/main/java/build/buildfarm/instance/memory/MemoryInstance.java
+++ b/src/main/java/build/buildfarm/instance/memory/MemoryInstance.java
@@ -48,7 +48,7 @@ import java.util.function.Function;
 
 public class MemoryInstance extends AbstractServerInstance {
   private final MemoryInstanceConfig config;
-  private final Map<String, List<Consumer<Operation>>> watchers;
+  private final Map<String, List<Function<Operation, Boolean>>> watchers;
   private final Map<String, ByteStringStreamSource> streams;
   private final List<Operation> queuedOperations;
   private final List<Worker> workers;
@@ -94,7 +94,7 @@ public class MemoryInstance extends AbstractServerInstance {
         actionCache,
         outstandingOperations);
     this.config = config;
-    watchers = new HashMap<String, List<Consumer<Operation>>>();
+    watchers = new HashMap<String, List<Function<Operation, Boolean>>>();
     streams = new HashMap<String, ByteStringStreamSource>();
     queuedOperations = new ArrayList<Operation>();
     workers = new ArrayList<Worker>();
@@ -151,15 +151,26 @@ public class MemoryInstance extends AbstractServerInstance {
 
   @Override
   protected void updateOperationWatchers(Operation operation) {
-    Iterable<Consumer<Operation>> operationWatchers =
+    List<Function<Operation, Boolean>> operationWatchers =
         watchers.get(operation.getName());
     if (operationWatchers != null) {
       if (operation.getDone()) {
         watchers.remove(operation.getName());
       }
+      long unfilteredWatcherCount = operationWatchers.size();
       super.updateOperationWatchers(operation);
-      for (Consumer<Operation> watcher : operationWatchers) {
-        watcher.accept(operation);
+      ImmutableList.Builder<Function<Operation, Boolean>> filteredWatchers = new ImmutableList.Builder<>();
+      long filteredWatcherCount = 0;
+      for (Function<Operation, Boolean> watcher : operationWatchers) {
+        if (watcher.apply(operation)) {
+          filteredWatchers.add(watcher);
+          filteredWatcherCount++;
+        }
+      }
+      if (!operation.getDone() && filteredWatcherCount != unfilteredWatcherCount) {
+        operationWatchers = new ArrayList<>();
+        Iterables.addAll(operationWatchers, filteredWatchers.build());
+        watchers.put(operation.getName(), operationWatchers);
       }
     } else {
       throw new IllegalStateException();
@@ -170,7 +181,7 @@ public class MemoryInstance extends AbstractServerInstance {
   protected Operation createOperation(Action action) {
     String name = createOperationName(UUID.randomUUID().toString());
 
-    watchers.put(name, new ArrayList<Consumer<Operation>>());
+    watchers.put(name, new ArrayList<Function<Operation, Boolean>>());
 
     Digest actionDigest = Digests.computeDigest(action.toByteString());
 
@@ -297,16 +308,14 @@ public class MemoryInstance extends AbstractServerInstance {
   public boolean watchOperation(
       String operationName,
       boolean watchInitialState,
-      Consumer<Operation> watcher) {
-    List<Consumer<Operation>> operationWatchers = watchers.get(operationName);
-    if (operationWatchers == null) {
-      if (watchInitialState) {
-        watcher.accept(null);
-      }
+      Function<Operation, Boolean> watcher) {
+    if (watchInitialState &&
+        !watcher.apply(getOperation(operationName))) {
       return false;
     }
-    if (watchInitialState) {
-      watcher.accept(getOperation(operationName));
+    List<Function<Operation, Boolean>> operationWatchers = watchers.get(operationName);
+    if (operationWatchers == null) {
+      return false;
     }
     operationWatchers.add(watcher);
     return true;

--- a/src/main/java/build/buildfarm/instance/stub/StubInstance.java
+++ b/src/main/java/build/buildfarm/instance/stub/StubInstance.java
@@ -401,7 +401,7 @@ public class StubInstance implements Instance {
   public boolean watchOperation(
       String operationName,
       boolean watchInitialState,
-      Consumer<Operation> watcher) {
+      Function<Operation, Boolean> watcher) {
     return false;
   }
 

--- a/src/main/java/build/buildfarm/server/WatcherService.java
+++ b/src/main/java/build/buildfarm/server/WatcherService.java
@@ -86,7 +86,13 @@ public class WatcherService extends WatcherGrpc.WatcherImplBase {
             if (ex.getStatus().getCode() != Status.Code.CANCELLED) {
               throw ex;
             }
+            return false;
+          } catch (IllegalStateException ex) {
+            ex.printStackTrace();
+            // check for 'call is closed'?
+            return false;
           }
+          return true;
         });
     if (!watching) {
       responseObserver.onCompleted();


### PR DESCRIPTION
Instance Operation Watchers can deregister for operation update
notifications by returning false from their callbacks. This is used to
prevent subsequent notifications from being sent to clients of the
Watcher API.