### PR TITLE
Retain Done operations for getOperation/watchers

### DIFF
--- a/src/main/java/build/buildfarm/instance/Instance.java
+++ b/src/main/java/build/buildfarm/instance/Instance.java
@@ -72,6 +72,7 @@ public interface Instance {
       ImmutableList.Builder<Operation> operations);
   Operation getOperation(String name);
   void cancelOperation(String name);
+  void deleteOperation(String name);
 
   boolean watchOperation(
       String operationName,

--- a/src/main/java/build/buildfarm/instance/memory/MemoryInstance.java
+++ b/src/main/java/build/buildfarm/instance/memory/MemoryInstance.java
@@ -56,6 +56,7 @@ public class MemoryInstance extends AbstractServerInstance {
   private final Map<String, Watchdog> requeuers;
   private final Map<String, Watchdog> operationTimeoutDelays;
   private final Map<String, Operation> outstandingOperations;
+  private final Map<String, Operation> completedOperations;
 
   private static final class Worker {
     private final Platform platform;
@@ -81,7 +82,8 @@ public class MemoryInstance extends AbstractServerInstance {
         config,
         /*contentAddressableStorage=*/ new ConcurrentHashMap<Digest, ByteString>(),
         /*actionCache=*/ new ConcurrentHashMap<Digest, ActionResult>(),
-        /*outstandingOperations=*/ new TreeMap<String, Operation>());
+        /*outstandingOperations=*/ new TreeMap<String, Operation>(),
+        /*completedOperations=*/ new ConcurrentHashMap<String, Operation>());
   }
 
   private MemoryInstance(
@@ -89,12 +91,14 @@ public class MemoryInstance extends AbstractServerInstance {
       MemoryInstanceConfig config,
       Map<Digest, ByteString> contentAddressableStorage,
       Map<Digest, ActionResult> actionCache,
-      Map<String, Operation> outstandingOperations) {
+      Map<String, Operation> outstandingOperations,
+      Map<String, Operation> completedOperations) {
     super(
         name,
         contentAddressableStorage,
         actionCache,
-        outstandingOperations);
+        outstandingOperations,
+        completedOperations);
     this.config = config;
     watchers = new ConcurrentHashMap<String, List<Function<Operation, Boolean>>>();
     streams = new HashMap<String, ByteStringStreamSource>();
@@ -103,6 +107,7 @@ public class MemoryInstance extends AbstractServerInstance {
     requeuers = new HashMap<String, Watchdog>();
     operationTimeoutDelays = new HashMap<String, Watchdog>();
     this.outstandingOperations = outstandingOperations;
+    this.completedOperations = completedOperations;
   }
 
   private ByteStringStreamSource getSource(String name) {
@@ -336,9 +341,14 @@ public class MemoryInstance extends AbstractServerInstance {
       String operationName,
       boolean watchInitialState,
       Function<Operation, Boolean> watcher) {
-    if (watchInitialState &&
-        !watcher.apply(getOperation(operationName))) {
-      return false;
+    if (watchInitialState) {
+      Operation operation = getOperation(operationName);
+      if (!watcher.apply(operation)) {
+        return false;
+      }
+      if (operation.getDone()) {
+        return true;
+      }
     }
     synchronized(watchers) {
       List<Function<Operation, Boolean>> operationWatchers = watchers.get(operationName);
@@ -424,5 +434,13 @@ public class MemoryInstance extends AbstractServerInstance {
         return "";
       }
     };
+  }
+
+  @Override
+  protected Object operationLock(String name) {
+    /**
+     * simple instance-wide locking on the completed operations
+     */
+    return completedOperations;
   }
 }

--- a/src/main/java/build/buildfarm/instance/stub/StubInstance.java
+++ b/src/main/java/build/buildfarm/instance/stub/StubInstance.java
@@ -374,6 +374,11 @@ public class StubInstance implements Instance {
   }
 
   @Override
+  public void deleteOperation(String operationName) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public void cancelOperation(String operationName) {
     throw new UnsupportedOperationException();
   }

--- a/src/main/java/build/buildfarm/server/OperationsService.java
+++ b/src/main/java/build/buildfarm/server/OperationsService.java
@@ -78,7 +78,15 @@ public class OperationsService extends OperationsGrpc.OperationsImplBase {
   public void deleteOperation(
       DeleteOperationRequest request,
       StreamObserver<Empty> responseObserver) {
-    responseObserver.onError(new StatusException(Status.UNIMPLEMENTED));
+    Instance instance = server.getInstanceFromOperationName(request.getName());
+
+    try {
+      instance.deleteOperation(request.getName());
+      responseObserver.onNext(Empty.newBuilder().build());
+      responseObserver.onCompleted();
+    } catch (IllegalStateException ex) {
+      responseObserver.onError(new StatusException(Status.fromThrowable(ex)));
+    }
   }
 
   @Override


### PR DESCRIPTION
Provide initial watcher data and a getOperation response for operations
which have completed. Expiration of this data will be left up to the
concrete instance implementation, with the deleteOperation request now
supported for completed operations.