### PR TITLE
Use hard links in action working directories

### DIFF
--- a/src/main/java/build/buildfarm/worker/Worker.java
+++ b/src/main/java/build/buildfarm/worker/Worker.java
@@ -282,7 +282,7 @@ class Worker {
         }
         Files.setPosixFilePermissions(fileCachePath, perms.build());
       }
-      Files.createSymbolicLink(execDir.resolve(fileNode.getName()), fileCachePath);
+      Files.createLink(execDir.resolve(fileNode.getName()), fileCachePath);
     }
 
     for (DirectoryNode directoryNode : directory.getDirectoriesList()) {


### PR DESCRIPTION
Some actions (binaries with $ORIGIN) have demonstrated an unwillingness
to behave appropriately under the operations directories.