### PR TITLE
Implement newStreamInput for stub, refactor

### DIFF
--- a/src/main/java/build/buildfarm/instance/AbstractServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/AbstractServerInstance.java
@@ -74,6 +74,14 @@ public abstract class AbstractServerInstance implements Instance {
   }
 
   @Override
+  public String getBlobName(Digest blobDigest) {
+    return String.format(
+        "%s/blobs/%s",
+        getName(),
+        Digests.toString(blobDigest));
+  }
+
+  @Override
   public ByteString getBlob(Digest blobDigest) {
     return getBlob(blobDigest, 0, 0);
   }

--- a/src/main/java/build/buildfarm/instance/Instance.java
+++ b/src/main/java/build/buildfarm/instance/Instance.java
@@ -42,6 +42,7 @@ public interface Instance {
   Iterable<Digest> putAllBlobs(Iterable<ByteString> blobs)
       throws IOException, IllegalArgumentException, InterruptedException;
 
+  String getBlobName(Digest blobDigest);
   ByteString getBlob(Digest blobDigest);
   ByteString getBlob(Digest blobDigest, long offset, long limit);
   Digest putBlob(ByteString blob)

--- a/src/main/java/build/buildfarm/instance/stub/ByteStringIteratorInputStream.java
+++ b/src/main/java/build/buildfarm/instance/stub/ByteStringIteratorInputStream.java
@@ -1,0 +1,97 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.instance.stub;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.protobuf.ByteString;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Iterator;
+
+public class ByteStringIteratorInputStream extends InputStream {
+  private final Iterator<ByteString> iterator;
+  private InputStream input;
+  private boolean closed;
+
+  @VisibleForTesting
+  public ByteStringIteratorInputStream(Iterator<ByteString> iterator) {
+    this.iterator = iterator;
+    input = ByteString.EMPTY.newInput();
+    closed = false;
+  }
+
+  @Override
+  public int available() throws IOException {
+    if (closed) {
+      throw new IOException("stream is closed");
+    }
+    if (input.available() == 0) {
+      advance();
+    }
+    return input.available();
+  }
+
+  @Override
+  public int read() throws IOException {
+    if (closed) {
+      throw new IOException("stream is closed");
+    }
+    byte[] b = new byte[1];
+    if (read(b) == -1) {
+      return -1;
+    }
+    return b[0];
+  }
+
+  @Override
+  public int read(byte[] b, int off, int len) throws IOException {
+    if (closed) {
+      throw new IOException("stream is closed");
+    }
+    boolean atInputEndOfFile = false;
+    int totalLen = 0;
+    while (len != 0) {
+      int readLen = input.read(b, off, len);
+      if (readLen == -1) {
+        if (atInputEndOfFile) {
+          return totalLen == 0 ? -1 : totalLen;
+        }
+        atInputEndOfFile = true;
+        advance();
+        continue; // restart read with EOF indicator
+      }
+      atInputEndOfFile = false;
+      len -= readLen;
+      off += readLen;
+      totalLen += readLen;
+    }
+    return totalLen;
+  }
+
+  // FIXME efficient skip
+
+  @Override
+  public void close() {
+    closed = true;
+  }
+
+  private void advance() {
+    ByteString data = ByteString.EMPTY;
+    while (iterator.hasNext() && data.isEmpty()) {
+      data = iterator.next();
+    }
+    input = data.newInput();
+  }
+}

--- a/src/test/java/build/buildfarm/BUILD
+++ b/src/test/java/build/buildfarm/BUILD
@@ -15,3 +15,14 @@ java_test(
       "@googleapis//:google_rpc_code_java_proto",
   ]
 )
+
+java_test(
+  name = "ByteStringIteratorInputStreamTest",
+  srcs = ["ByteStringIteratorInputStreamTest.java"],
+  deps = [
+      "//src/main/java/build/buildfarm:stub-instance",
+      "//third_party:guava",
+      "//third_party:truth",
+      "@com_google_protobuf//:protobuf_java",
+  ]
+)

--- a/src/test/java/build/buildfarm/ByteStringIteratorInputStreamTest.java
+++ b/src/test/java/build/buildfarm/ByteStringIteratorInputStreamTest.java
@@ -1,0 +1,119 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import build.buildfarm.instance.stub.ByteStringIteratorInputStream;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterators;
+import com.google.protobuf.ByteString;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import java.io.IOException;
+import java.io.InputStream;
+
+@RunWith(JUnit4.class)
+public class ByteStringIteratorInputStreamTest {
+  @Test
+  public void readSingleChunk() throws IOException {
+    ByteString hello = ByteString.copyFromUtf8("Hello, World");
+    InputStream in = new ByteStringIteratorInputStream(
+        Iterators.<ByteString>singletonIterator(hello));
+    byte[] data = new byte[hello.size()];
+
+    assertThat(in.read(data)).isEqualTo(hello.size());
+    assertThat(ByteString.copyFrom(data)).isEqualTo(hello);
+    assertThat(in.read()).isEqualTo(-1);
+  }
+
+  @Test
+  public void readEmpty() throws IOException {
+    InputStream in = new ByteStringIteratorInputStream(
+        ImmutableList.<ByteString>of().iterator());
+    assertThat(in.read()).isEqualTo(-1);
+  }
+
+  @Test
+  public void readSingleByte() throws IOException {
+    byte[] single = new byte[1];
+    single[0] = 42;
+    InputStream in = new ByteStringIteratorInputStream(
+        ImmutableList.<ByteString>of(ByteString.copyFrom(single)).iterator());
+    assertThat(in.read()).isEqualTo(42);
+    assertThat(in.read()).isEqualTo(-1);
+  }
+
+  @Test
+  public void readSpanningChunks() throws IOException {
+    ByteString hello = ByteString.copyFromUtf8("Hello, ");
+    ByteString world = ByteString.copyFromUtf8("World");
+    InputStream in = new ByteStringIteratorInputStream(
+        ImmutableList.<ByteString>of(hello, world).iterator());
+    ByteString helloWorld = hello.concat(world);
+    byte[] data = new byte[helloWorld.size()];
+
+    assertThat(in.read(data)).isEqualTo(helloWorld.size());
+    assertThat(ByteString.copyFrom(data)).isEqualTo(helloWorld);
+    assertThat(in.read()).isEqualTo(-1);
+  }
+
+  @Test
+  public void readSpanningChunksWithEmptyChunk() throws IOException {
+    ByteString hello = ByteString.copyFromUtf8("Hello, ");
+    ByteString world = ByteString.copyFromUtf8("World");
+    InputStream in = new ByteStringIteratorInputStream(
+        ImmutableList.<ByteString>of(hello, ByteString.EMPTY, world).iterator());
+    ByteString helloWorld = hello.concat(world);
+    byte[] data = new byte[helloWorld.size()];
+
+    assertThat(in.read(data)).isEqualTo(helloWorld.size());
+    assertThat(ByteString.copyFrom(data)).isEqualTo(helloWorld);
+    assertThat(in.read()).isEqualTo(-1);
+  }
+
+  @Test
+  public void readWithOffsetAndLengthSpanningChunks() throws IOException {
+    byte[] data1 = new byte[1];
+
+    data1[0] = 1;
+
+    byte[] data2 = new byte[2];
+    data2[0] = 2;
+    data2[1] = 3;
+
+    byte[] buffer = new byte[6];
+    for (int i = 0; i < buffer.length; i++) {
+      buffer[i] = 42;
+    }
+
+    byte[] expected = new byte[6];
+    expected[0] = 42;
+    expected[1] = 42;
+    expected[2] = 1;
+    expected[3] = 2;
+    expected[4] = 42;
+    expected[5] = 42;
+
+    InputStream in = new ByteStringIteratorInputStream(ImmutableList.<ByteString>of(
+        ByteString.copyFrom(data1),
+        ByteString.copyFrom(data2)).iterator());
+    assertThat(in.read(buffer, 2, 2)).isEqualTo(2);
+    assertThat(ByteString.copyFrom(buffer)).isEqualTo(ByteString.copyFrom(expected));
+    assertThat(in.read()).isEqualTo(3);
+    assertThat(in.read()).isEqualTo(-1);
+  }
+}


### PR DESCRIPTION
Provide a streaming download mechanism for blobs to minimize memory
pressure when fetching inputs. Refactored the stub getBlob method
to use this, factored out digest -> resourceName into an instance
interface mechanism (tightly couples server instance implementation to
worker implementation).