### PR TITLE
ContentAddressableStorage interface/reference

### DIFF
--- a/src/main/java/build/buildfarm/common/ContentAddressableStorage.java
+++ b/src/main/java/build/buildfarm/common/ContentAddressableStorage.java
@@ -1,0 +1,75 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.common;
+
+import build.buildfarm.common.ThreadSafety.ThreadSafe;
+import com.google.devtools.remoteexecution.v1test.Digest;
+import com.google.protobuf.ByteString;
+
+public interface ContentAddressableStorage {
+  /**
+   * Blob storage for the CAS. This class should be used at all times when interacting with
+   * complete blobs in order to cut down on independent digest computation.
+   */
+  public static final class Blob {
+    private final Digest digest;
+    private final ByteString data;
+
+    public Blob(ByteString data) {
+      digest = Digests.computeDigest(data);
+      this.data = data;
+    }
+
+    public Digest getDigest() {
+      return digest;
+    }
+
+    public ByteString getData() {
+      return data;
+    }
+
+    public long size() {
+      return digest.getSizeBytes();
+    }
+
+    public boolean isEmpty() {
+      return size() == 0;
+    }
+  }
+
+  /** Indicates presence in the CAS for a digest. */
+  @ThreadSafe
+  boolean contains(Digest digest);
+
+  /** Retrieve a value from the CAS. */
+  @ThreadSafe
+  Blob get(Digest digest);
+
+  /** Insert a blob into the CAS. */
+  @ThreadSafe
+  void put(Blob blob);
+
+  /**
+   * Insert a value into the CAS with expiration callback.
+   *
+   * <p>The callback provided will be run after the value is expired
+   * and removed from the storage. Successive calls to this method
+   * for a unique blob digest will register additional callbacks, does
+   * not deduplicate by callback, and the order of which is not
+   * guaranteed for invocation.
+   */
+  @ThreadSafe
+  void put(Blob blob, Runnable onExpiration);
+}

--- a/src/main/java/build/buildfarm/common/ThreadSafety.java
+++ b/src/main/java/build/buildfarm/common/ThreadSafety.java
@@ -1,0 +1,135 @@
+// Copyright 2014 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package build.buildfarm.common;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Define some standard attributes for documenting thread safety properties.
+ *<p>
+ * The names used here are adapted from those used in Joshua Bloch's book
+ * "Effective Java", which are also described at
+ * <http://www.ibm.com/developerworks/java/library/j-jtp09263/>.
+ *<p>
+ * These attributes are just documentation.  They don't have any run-time
+ * effect.  The main aim is mainly just to standardize the terminology.
+ * (However, if this catches on, I can also imagine in the future having
+ * a presubmit check that checks that all new classes have thread safety
+ * annotations :)
+ *<p>
+ * See ThreadSafetyTest for examples of how these attributes should be used.
+ */
+public class ThreadSafety {
+  /**
+   * The Immutable attribute indicates that instances of the class are
+   * immutable, or at least appear that way are far as their external API
+   * is concerned.  Immutable classes are usually also ThreadSafe,
+   * but can be ThreadHostile if they perform unsynchronized access to
+   * mutable static data.  (We deviate from Bloch's nomenclature by
+   * not assuming that Immutable implies ThreadSafe; developers should
+   * explicitly annotate classes as both Immutable and ThreadSafe when
+   * appropriate.)
+   */
+  @Documented
+  @Target(value = {ElementType.TYPE})
+  @Retention(RetentionPolicy.RUNTIME)
+  public @interface Immutable {}
+
+  /**
+   * The ThreadSafe attribute marks a class or method which can safely be used
+   * from multiple threads without any need for external synchronization.
+   *
+   * When applied to a class, this attribute indicates that instances
+   * of the class can safely be used concurrently from multiple threads
+   * without any need for external synchronization, i.e. that all non-static methods
+   * are thread-safe (except any private methods that are explicitly
+   * annotated with a different thread safety annotation).  In addition it
+   * also indicates that all non-static nested classes are thread-safe (except any private
+   * nested classes that are explicitly annotated with a different thread
+   * safety annotation). Note that no guarantees are made about static class methods or static
+   * nested classes - they should be annotated separately.
+   *
+   * When applied to a method, this attribute indicates that the
+   * method can safely be called concurrently from multiple threads.
+   * The implementation must synchronize any accesses to mutable data.
+   */
+  @Documented
+  @Target(value = {ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.TYPE})
+  @Retention(RetentionPolicy.SOURCE)
+  public @interface ThreadSafe {}
+
+  /**
+   * The ThreadCompatible attribute marks a class or method that
+   * is thread-safe provided that only one thread attempts to
+   * access each object at a time.
+   *
+   * The implementation of such a class must synchronize accesses
+   * to mutable static data, but can assume that each instance will
+   * only be accessed from one thread at a time.
+   *
+   * The client must obtain an appropriate lock before calling ThreadCompatible
+   * methods, or must otherwise ensure that only one thread calls such methods.
+   * Unless otherwise specified, an appropriate lock means synchronizing on the
+   * instance.
+   *
+   * A ThreadCompatible class may contain private methods or private nested
+   * classes that are not ThreadCompatible provided that they are explicitly
+   * annotated with a different thread safety annotation.
+   */
+  @Documented
+  @Target(value = {ElementType.METHOD, ElementType.TYPE})
+  @Retention(RetentionPolicy.SOURCE)
+  public @interface ThreadCompatible {}
+
+  /**
+   * The ThreadHostile attribute marks a class or method that
+   * can't safely be used by multiple threads, for example because
+   * it performs unsynchronized access to mutable static objects.
+   */
+  @Documented
+  @Target(value = {ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.TYPE})
+  @Retention(RetentionPolicy.SOURCE)
+  public @interface ThreadHostile {}
+
+  /**
+   * The ConditionallyThreadSafe attribute marks a class that contains
+   * some methods (or nested classes) which are ThreadSafe but others which are
+   * only ThreadCompatible or ThreadHostile.
+   *
+   * The methods (and nested classes) of a ConditionallyThreadSafe class should
+   * each have their thread safety marked.
+   */
+  @Documented
+  @Target(value = {ElementType.METHOD, ElementType.TYPE})
+  @Retention(RetentionPolicy.SOURCE)
+  public @interface ConditionallyThreadSafe {}
+
+  /**
+   * The ConditionallyThreadCompatible attribute marks a class that contains
+   * some methods (or nested classes) which are ThreadCompatible but others
+   * which are ThreadHostile.
+   *
+   * The methods (and nested classes) of a ConditionallyThreadCompatible class
+   * should each have their thread safety marked.
+   */
+  @Documented
+  @Target(value = {ElementType.METHOD, ElementType.TYPE})
+  @Retention(RetentionPolicy.SOURCE)
+  public @interface ConditionallyThreadCompatible {}
+
+}

--- a/src/main/java/build/buildfarm/instance/memory/DelegateCASMap.java
+++ b/src/main/java/build/buildfarm/instance/memory/DelegateCASMap.java
@@ -1,0 +1,134 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.instance.memory;
+
+import build.buildfarm.common.ContentAddressableStorage;
+import build.buildfarm.common.ContentAddressableStorage.Blob;
+import build.buildfarm.common.Digests;
+import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
+import com.google.devtools.remoteexecution.v1test.Digest;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Message;
+import com.google.protobuf.Parser;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+class DelegateCASMap<K,V extends Message> implements Map<K,V> {
+  private final ContentAddressableStorage contentAddressableStorage;
+  private final Map<K, Digest> digestMap;
+  private final Parser<V> parser;
+
+  public DelegateCASMap(
+      ContentAddressableStorage contentAddressableStorage,
+      Parser<V> parser) {
+    this.contentAddressableStorage = contentAddressableStorage;
+    this.parser = parser;
+    this.digestMap = new ConcurrentHashMap<>();
+  }
+
+  @Override
+  public V put(K key, V value) {
+    Blob blob = new Blob(value.toByteString());
+    digestMap.put(key, blob.getDigest());
+    contentAddressableStorage.put(blob, () -> digestMap.remove(key));
+    return value;
+  }
+
+  @Override
+  public V get(Object key) {
+    Digest valueDigest = digestMap.get(key);
+    if (valueDigest == null) {
+      return null;
+    }
+
+    return expectValueType(valueDigest);
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return digestMap.isEmpty();
+  }
+
+  @Override
+  public int size() {
+    return digestMap.size();
+  }
+
+  @Override
+  public boolean containsKey(Object key) {
+    return digestMap.get(key) != null;
+  }
+
+  @Override
+  public boolean containsValue(Object value) {
+    Preconditions.checkState(value instanceof Message);
+    return contentAddressableStorage.contains(Digests.computeDigest((Message) value));
+  }
+
+  @Override
+  public Set<Map.Entry<K, V>> entrySet() {
+    return delegate().entrySet();
+  }
+
+  @Override
+  public Collection<V> values() {
+    return delegate().values();
+  }
+
+  @Override
+  public Set<K> keySet() {
+    return digestMap.keySet();
+  }
+
+  @Override
+  public void clear() {
+    digestMap.clear();
+  }
+
+  @Override
+  public void putAll(Map<? extends K,? extends V> m) {
+    Map<? extends K, Blob> blobs = Maps.transformValues(
+        m,
+        (value) -> new Blob(value.toByteString()));
+    for (Blob blob : blobs.values()) {
+      contentAddressableStorage.put(blob);
+    }
+    digestMap.putAll(Maps.transformValues(blobs, (blob) -> blob.getDigest()));
+  }
+
+  @Override
+  public V remove(Object key) {
+    Digest valueDigest = digestMap.remove(key);
+    return expectValueType(valueDigest);
+  }
+
+  private V expectValueType(Digest valueDigest) {
+    try {
+      return parser.parseFrom(contentAddressableStorage.get(valueDigest).getData());
+    } catch (InvalidProtocolBufferException ex) {
+      return null;
+    }
+  }
+
+  private Map<K, V> delegate() {
+    return Maps.transformValues(
+        digestMap,
+        (valueDigest) -> expectValueType(valueDigest));
+  }
+}

--- a/src/main/java/build/buildfarm/instance/memory/MemoryLRUContentAddressableStorage.java
+++ b/src/main/java/build/buildfarm/instance/memory/MemoryLRUContentAddressableStorage.java
@@ -1,0 +1,196 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.instance.memory;
+
+import build.buildfarm.common.ContentAddressableStorage;
+import build.buildfarm.common.ContentAddressableStorage.Blob;
+import build.buildfarm.common.Digests;
+import com.google.devtools.remoteexecution.v1test.Digest;
+import com.google.protobuf.ByteString;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+class MemoryLRUContentAddressableStorage implements ContentAddressableStorage {
+  private final long maxSizeInBytes;
+  private final Map<Digest, Entry> storage;
+  private transient long sizeInBytes;
+  private transient Entry header;
+
+  public MemoryLRUContentAddressableStorage(long maxSizeInBytes) {
+    this.maxSizeInBytes = maxSizeInBytes;
+    sizeInBytes = 0;
+    header = new SentinelEntry();
+    header.before = header.after = header;
+    storage = new HashMap<>();
+  }
+
+  @Override
+  public synchronized boolean contains(Digest digest) {
+    // incur access use of the digest
+    return get(digest) != null;
+  }
+
+  @Override
+  public synchronized Blob get(Digest digest) {
+    Entry e = storage.get(digest);
+    if (e == null) {
+      return null;
+    }
+    e.recordAccess(header);
+    return e.value;
+  }
+
+  private long size() {
+    Entry e = header.before;
+    long count = 0;
+    while (e != header) {
+      count++;
+      e = e.before;
+    }
+    return count;
+  }
+
+  @Override
+  public void put(Blob blob) {
+    put(blob, null);
+  }
+
+  @Override
+  public synchronized void put(Blob blob, Runnable onExpiration) {
+    Entry e = storage.get(blob.getDigest());
+    if (e != null) {
+      if (onExpiration != null) {
+        e.addOnExpiration(onExpiration);
+      }
+      e.recordAccess(header);
+      return;
+    }
+
+    sizeInBytes += blob.size();
+
+    while (sizeInBytes > maxSizeInBytes && header.after != header) {
+      expireEntry(header.after);
+    }
+
+    if (sizeInBytes > maxSizeInBytes) {
+      System.out.println(String.format(
+          "Out of nodes to remove, sizeInBytes = %d, maxSizeInBytes = %d, storage = %d, list = %d",
+          sizeInBytes,
+          maxSizeInBytes,
+          storage.size(),
+          size()));
+    }
+
+    createEntry(blob, onExpiration);
+
+    storage.put(blob.getDigest(), header.before);
+  }
+
+  private void createEntry(Blob blob, Runnable onExpiration) {
+    Entry e = new Entry(blob);
+    if (onExpiration != null) {
+      e.addOnExpiration(onExpiration);
+    }
+    e.addBefore(header);
+  }
+
+  private void expireEntry(Entry e) {
+    storage.remove(e.key);
+    e.expire();
+    sizeInBytes -= e.value.size();
+  }
+
+  private static class Entry {
+    Entry before, after;
+    final Digest key;
+    final Blob value;
+    private List<Runnable> onExpirations;
+
+    /** implemented only for sentinel */
+    private Entry() {
+      key = null;
+      value = null;
+      onExpirations = null;
+    }
+
+    public Entry(Blob blob) {
+      key = blob.getDigest();
+      value = blob;
+      onExpirations = null;
+    }
+
+    public void addOnExpiration(Runnable onExpiration) {
+      if (onExpirations == null) {
+        onExpirations = new ArrayList<>(1);
+      }
+      onExpirations.add(onExpiration);
+    }
+
+    public void remove() {
+      before.after = after;
+      after.before = before;
+    }
+
+    public void expire() {
+      remove();
+      if (onExpirations != null) {
+        for (Runnable r : onExpirations) {
+          r.run();
+        }
+      }
+    }
+
+    public void addBefore(Entry existingEntry) {
+      after = existingEntry;
+      before = existingEntry.before;
+      before.after = this;
+      after.before = this;
+    }
+
+    public void recordAccess(Entry header) {
+      remove();
+      addBefore(header);
+    }
+  }
+
+  class SentinelEntry extends Entry {
+    @Override
+    public void addOnExpiration(Runnable onExpiration) {
+      throw new UnsupportedOperationException("cannot add expiration to sentinal");
+    }
+
+    @Override
+    public void remove() {
+      throw new UnsupportedOperationException("cannot remove sentinel");
+    }
+
+    @Override
+    public void expire() {
+      throw new UnsupportedOperationException("cannot expire sentinel");
+    }
+
+    @Override
+    public void addBefore(Entry existingEntry) {
+      throw new UnsupportedOperationException("cannot add sentinel");
+    }
+
+    @Override
+    public void recordAccess(Entry header) {
+      throw new UnsupportedOperationException("cannot record sentinel access");
+    }
+  }
+}

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -75,6 +75,9 @@ message MemoryInstanceConfig {
   // completed must be received, or the operation is
   // considered lost on a worker and is requeued
   google.protobuf.Duration operation_completed_delay = 6;
+
+  // limit for CAS total content size
+  int64 cas_max_size_bytes = 7;
 }
 
 message InstanceConfig {


### PR DESCRIPTION
Define a ContentAddressableStorage interface that simplifies Map-style
operations to capitalize on addressable Set-like behavior. The reference
implementation maintains a maximum size of content through an
access-based expiration, with all member operations (contains, get, put)
representing an entry access.