### PR TITLE
Refactor worker cache, impose size-expiration

### DIFF
--- a/src/main/java/build/buildfarm/worker/CASFileCache.java
+++ b/src/main/java/build/buildfarm/worker/CASFileCache.java
@@ -1,0 +1,330 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.worker;
+
+import static java.nio.file.LinkOption.NOFOLLOW_LINKS;
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+
+import build.buildfarm.common.Digests;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.devtools.remoteexecution.v1test.Digest;
+import io.grpc.StatusRuntimeException;
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.io.InputStream;
+import java.util.concurrent.ConcurrentHashMap;
+
+class CASFileCache {
+  private final InputStreamFactory inputStreamFactory;
+  private final Path root;
+  private final long maxSizeInBytes;
+  private final Map<String, Entry> storage;
+
+  private transient long sizeInBytes;
+  private transient Entry header;
+
+  CASFileCache(InputStreamFactory inputStreamFactory, Path root, long maxSizeInBytes) {
+    this.inputStreamFactory = inputStreamFactory;
+    this.root = root;
+    this.maxSizeInBytes = maxSizeInBytes;
+
+    sizeInBytes = 0;
+    header = new SentinelEntry();
+    header.before = header.after = header;
+    storage = new ConcurrentHashMap<>();
+  }
+
+  /**
+   * initialize the cache for persistent storage and inject any
+   * consistent entries which already exist under the root into
+   * the storage map. This call will create the root if it does
+   * not exist, and will scale in cost with the number of files
+   * already present.
+   */
+  public void start() throws IOException {
+    Files.createDirectories(root);
+
+    Files.walkFileTree(root, new SimpleFileVisitor<Path>() {
+      private String parseFileEntryKey(String fileName, long size) {
+        String[] components = fileName.toString().split("_");
+        Digest digest;
+        if (components.length < 2 || components.length > 3) {
+          return null;
+        }
+
+        String hashComponent = components[0];
+        String sizeComponent = components[1];
+        // FIXME hash size check, and it should probably match hash func...
+        int parsedSizeComponent;
+        try {
+          parsedSizeComponent = Integer.parseInt(sizeComponent);
+        } catch (NumberFormatException ex) {
+          return null;
+        }
+
+        if (parsedSizeComponent != size) {
+          return null;
+        }
+
+        digest = Digests.buildDigest(hashComponent, parsedSizeComponent);
+        boolean isExecutable = false;
+        if (components.length == 3) {
+          if (components[2].equals("exec")) {
+            isExecutable = true;
+          } else {
+            return null;
+          }
+        }
+
+        return toFileEntryKey(
+            Digests.buildDigest(hashComponent, parsedSizeComponent),
+            isExecutable);
+      }
+
+      @Override
+      public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+        long size = attrs.size();
+        if (sizeInBytes + size > maxSizeInBytes) {
+          Files.delete(file);
+        } else {
+          String key = null;
+          if (file.getParent().equals(root)) {
+            key = parseFileEntryKey(file.getFileName().toString(), size);
+          }
+          if (key != null) {
+            Entry e = new Entry(key, size);
+            storage.put(e.key, e);
+            e.decrementReference(header);
+            sizeInBytes += size;
+          } else {
+            Files.delete(file);
+          }
+        }
+        return FileVisitResult.CONTINUE;
+      }
+    });
+  }
+
+  private static String digestFilename(Digest digest) {
+    return String.format("%s_%d", digest.getHash(), digest.getSizeBytes());
+  }
+
+  public static String toFileEntryKey(Digest digest, boolean isExecutable) {
+    return String.format(
+        "%s%s",
+        digestFilename(digest),
+        (isExecutable ? "_exec" : ""));
+  }
+
+  public synchronized void update(Iterable<String> inputs) {
+    // decrement references and notify if any dropped to 0
+    boolean entriesMadeAvailable = false;
+
+    for (String input : inputs) {
+      Entry e = storage.get(input);
+      if (e == null) {
+        throw new IllegalStateException(input + " has been removed with references");
+      }
+      if (!e.key.equals(input)) {
+        throw new RuntimeException("ERROR: entry retrieved: " + e.key + " != " + input);
+      }
+      e.decrementReference(header);
+      if (e.referenceCount == 0) {
+        entriesMadeAvailable = true;
+      }
+    }
+    if (entriesMadeAvailable) {
+      notify();
+    }
+  }
+
+  public Path getPath(String key) {
+    return root.resolve(key);
+  }
+
+  /** must be called in synchronized context */
+  private String expireEntry() throws IOException, InterruptedException {
+    while (header.before == header.after) {
+      wait();
+    }
+    Entry e = header.after;
+    if (e.referenceCount != 0) {
+      throw new RuntimeException("ERROR: Reference counts lru ordering has not been maintained correctly, attempting to expire referenced (or negatively counted) content");
+    }
+    storage.remove(e.key);
+    e.remove();
+    sizeInBytes -= e.size;
+    return e.key;
+  }
+
+  public String put(Digest digest, boolean isExecutable) throws InterruptedException {
+    String key = toFileEntryKey(digest, isExecutable);
+    ImmutableList.Builder<String> expiredKeys = null;
+
+    synchronized(this) {
+      Entry e = storage.get(key);
+      if (e != null) {
+        e.incrementReference(header);
+        return key;
+      }
+
+      sizeInBytes += digest.getSizeBytes();
+
+      while (sizeInBytes > maxSizeInBytes) {
+        if (expiredKeys == null) {
+          expiredKeys = new ImmutableList.Builder<String>();
+        }
+        try {
+          expiredKeys.add(expireEntry());
+        } catch (IOException ex) {
+        }
+      }
+    }
+
+    if (expiredKeys != null) {
+      for (String expiredKey : expiredKeys.build()) {
+        try {
+          Files.delete(getPath(expiredKey));
+        } catch (IOException ex) {
+        }
+      }
+    }
+
+    try (InputStream in = inputStreamFactory.apply(digest)) {
+      Path path = getPath(key);
+      // FIXME make a validating file copy object and verify digest
+      Path tmpPath = path.resolveSibling(path.getFileName() + ".tmp");
+      long copySize = Files.copy(in, tmpPath);
+      in.close();
+      if (copySize != digest.getSizeBytes()) {
+        Files.delete(tmpPath);
+        return null;
+      }
+      setPermissions(tmpPath, isExecutable);
+      Files.move(tmpPath, path, REPLACE_EXISTING);
+    } catch (IOException ex) {
+      ex.printStackTrace();
+      return null;
+    } catch (StatusRuntimeException ex) {
+      ex.printStackTrace();
+      return null;
+    }
+
+    Entry e = new Entry(key, digest.getSizeBytes());
+
+    storage.put(key, e);
+
+    return key;
+  }
+
+  private static void setPermissions(Path path, boolean isExecutable) throws IOException {
+    ImmutableSet.Builder<PosixFilePermission> perms = new ImmutableSet.Builder<PosixFilePermission>()
+      .add(PosixFilePermission.OWNER_READ);
+    if (isExecutable) {
+      perms.add(PosixFilePermission.OWNER_EXECUTE);
+    }
+    Files.setPosixFilePermissions(path, perms.build());
+  }
+
+  private static class Entry {
+    Entry before, after;
+    final String key;
+    final long size;
+    int referenceCount;
+
+    private Entry() {
+      key = null;
+      size = -1;
+      referenceCount = -1;
+    }
+
+    public Entry(String key, long size) {
+      this.key = key;
+      this.size = size;
+      referenceCount = 1;
+    }
+
+    public void remove() {
+      before.after = after;
+      after.before = before;
+    }
+
+    public void addBefore(Entry existingEntry) {
+      after = existingEntry;
+      before = existingEntry.before;
+      before.after = this;
+      after.before = this;
+    }
+
+    public void addAfter(Entry existingEntry) {
+      before = existingEntry;
+      after = existingEntry.after;
+      after.before = this;
+      before.after = this;
+    }
+
+    public void incrementReference(Entry header) {
+      if (referenceCount == 0) {
+        remove();
+      }
+      referenceCount++;
+    }
+
+    public void decrementReference(Entry header) {
+      referenceCount--;
+      if (referenceCount == 0) {
+        addBefore(header);
+      }
+    }
+  }
+
+  private static class SentinelEntry extends Entry {
+    @Override
+    public void remove() {
+      throw new UnsupportedOperationException("sentinal cannot be removed");
+    }
+
+    @Override
+    public void addBefore(Entry existingEntry) {
+      throw new UnsupportedOperationException("sentinal cannot be added");
+    }
+
+    @Override
+    public void addAfter(Entry existingEntry) {
+      throw new UnsupportedOperationException("sentinal cannot be added");
+    }
+
+    @Override
+    public void incrementReference(Entry header) {
+      throw new UnsupportedOperationException("sentinal cannot be referenced");
+    }
+
+    @Override
+    public void decrementReference(Entry header) {
+      throw new UnsupportedOperationException("sentinal cannot be referenced");
+    }
+  }
+}

--- a/src/main/java/build/buildfarm/worker/InputStreamFactory.java
+++ b/src/main/java/build/buildfarm/worker/InputStreamFactory.java
@@ -1,0 +1,22 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.worker;
+
+import com.google.devtools.remoteexecution.v1test.Digest;
+import java.io.InputStream;
+import java.util.function.Function;
+
+interface InputStreamFactory extends Function<Digest, InputStream> {
+}

--- a/src/main/java/build/buildfarm/worker/Worker.java
+++ b/src/main/java/build/buildfarm/worker/Worker.java
@@ -54,9 +54,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Collections;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -72,7 +72,7 @@ public class Worker {
   private final Instance instance;
   private final WorkerConfig config;
   private final Path root;
-  private final Path cacheDir;
+  private final CASFileCache fileCache;
 
   private static final OutputStream nullOutputStream = ByteStreams.nullOutputStream();
 
@@ -120,7 +120,7 @@ public class Worker {
   private static Path getValidRoot(WorkerConfig config) throws ConfigurationException {
     String rootValue = config.getRoot();
     if (Strings.isNullOrEmpty(rootValue)) {
-        throw new ConfigurationException("root value in config missing");
+      throw new ConfigurationException("root value in config missing");
     }
     return Paths.get(rootValue);
   }
@@ -128,7 +128,7 @@ public class Worker {
   private static Path getValidCasCacheDirectory(WorkerConfig config, Path root) throws ConfigurationException {
     String casCacheValue = config.getCasCacheDirectory();
     if (Strings.isNullOrEmpty(casCacheValue)) {
-        throw new ConfigurationException("Cas cache directory value in config missing");
+      throw new ConfigurationException("Cas cache directory value in config missing");
     }
     return root.resolve(casCacheValue);
   }
@@ -136,16 +136,25 @@ public class Worker {
   public Worker(WorkerConfig config) throws ConfigurationException {
     this.config = config;
     root = getValidRoot(config);
-    cacheDir = getValidCasCacheDirectory(config, root);
     instance = new StubInstance(
         config.getInstanceName(),
         createChannel(config.getOperationQueue()));
+    InputStreamFactory inputStreamFactory = new InputStreamFactory() {
+      @Override
+      public InputStream apply(Digest digest) {
+        return instance.newStreamInput(instance.getBlobName(digest));
+      }
+    };
+    fileCache = new CASFileCache(
+        inputStreamFactory,
+        root.resolve(getValidCasCacheDirectory(config, root)),
+        config.getCasCacheMaxSizeBytes());
   }
 
   public void start() {
     try {
       Files.createDirectories(root);
-      Files.createDirectories(cacheDir);
+      fileCache.start();
     } catch(IOException ex) {
       ex.printStackTrace();
       return;
@@ -179,10 +188,12 @@ public class Worker {
     Path execDir = root.resolve(operation.getName());
     Files.createDirectories(execDir);
 
+    List<String> inputs = new ArrayList<>();
+
     try {
       /* set up inputs */
       /* we should update the operation status at this point to indicate input fetches have begun */
-      if (!fetchInputs(execDir, action.getInputRootDigest()) ||
+      if (!fetchInputs(execDir, action.getInputRootDigest(), inputs) ||
           !verifyOutputLocations(execDir, action.getOutputFilesList(), action.getOutputDirectoriesList())) {
         poller.stop();
         return;
@@ -227,6 +238,8 @@ public class Worker {
           if (!Files.exists(outputPath)) {
             continue;
           }
+
+          // FIXME put the output into the fileCache
 
           InputStream inputStream = Files.newInputStream(outputPath);
           ByteString content = ByteString.readFrom(inputStream);
@@ -278,47 +291,41 @@ public class Worker {
 
       /* cleanup */
       removeDirectory(execDir);
+
+      fileCache.update(inputs);
     }
   }
 
-  private boolean linkInputs(Path execDir, Digest inputRoot, Map<Digest, Directory> directoriesIndex) throws IOException {
+  private boolean linkInputs(
+      Path execDir,
+      Digest inputRoot,
+      Map<Digest, Directory> directoriesIndex,
+      List<String> inputs)
+      throws IOException, InterruptedException {
     Directory directory = directoriesIndex.get(inputRoot);
 
     for (FileNode fileNode : directory.getFilesList()) {
-      Digest digest = fileNode.getDigest();
-      Path fileCachePath = cacheDir.resolve(String.format(
-          "%s_%d%s",
-          digest.getHash(),
-          digest.getSizeBytes(),
-          fileNode.getIsExecutable() ? "_exec" : ""));
-      boolean createFile = !Files.exists(fileCachePath);
-      if (createFile) {
-        OutputStream outputStream = Files.newOutputStream(fileCachePath);
-        instance.getBlob(digest).writeTo(outputStream);
-        outputStream.close();
+      Path execPath = execDir.resolve(fileNode.getName());
+      String fileCacheKey = fileCache.put(fileNode.getDigest(), fileNode.getIsExecutable());
+      if (fileCacheKey == null) {
+        return false;
       }
-      if (createFile || Files.isExecutable(fileCachePath) != fileNode.getIsExecutable()) {
-        ImmutableSet.Builder<PosixFilePermission> perms = new ImmutableSet.Builder<PosixFilePermission>()
-          .add(PosixFilePermission.OWNER_READ);
-        if (fileNode.getIsExecutable()) {
-          perms.add(PosixFilePermission.OWNER_EXECUTE);
-        }
-        Files.setPosixFilePermissions(fileCachePath, perms.build());
-      }
-      Files.createLink(execDir.resolve(fileNode.getName()), fileCachePath);
+      inputs.add(fileCacheKey);
+      Files.createLink(execPath, fileCache.getPath(fileCacheKey));
     }
 
     for (DirectoryNode directoryNode : directory.getDirectoriesList()) {
       Digest digest = directoryNode.getDigest();
       Path dirPath = execDir.resolve(directoryNode.getName());
       Files.createDirectory(dirPath);
-      linkInputs(dirPath, directoryNode.getDigest(), directoriesIndex);
+      linkInputs(dirPath, directoryNode.getDigest(), directoriesIndex, inputs);
     }
 
     return true;
   }
 
-  private boolean fetchInputs(Path execDir, Digest inputRoot) throws IOException {
+  private boolean fetchInputs(Path execDir, Digest inputRoot, List<String> inputs)
+      throws IOException, InterruptedException {
     ImmutableList.Builder<Directory> directories = new ImmutableList.Builder<>();
     String pageToken = "";
 
@@ -336,7 +343,7 @@ public class Worker {
       directoriesIndex.put(directoryDigest, directory);
     }
 
-    return linkInputs(execDir, inputRoot, directoriesIndex.build());
+    return linkInputs(execDir, inputRoot, directoriesIndex.build(), inputs);
   }
 
   private boolean verifyOutputLocations(

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -121,34 +121,38 @@ message WorkerConfig {
   // if relative, is made relative to root
   string cas_cache_directory = 4;
 
+  // limit for contents of files retained
+  // from CAS in the cache
+  int64 cas_cache_max_size_bytes = 5;
+
   // whether to stream stdout from processes
-  bool stream_stdout = 5;
+  bool stream_stdout = 6;
 
   // control for process stdout
-  CASInsertionControl stdout_cas_control = 6;
+  CASInsertionControl stdout_cas_control = 7;
 
   // whether to stream stderr from processes
-  bool stream_stderr = 7;
+  bool stream_stderr = 8;
 
   // control for process stdout
-  CASInsertionControl stderr_cas_control = 8;
+  CASInsertionControl stderr_cas_control = 9;
 
   // control for process output files
-  CASInsertionControl file_cas_control = 9;
+  CASInsertionControl file_cas_control = 10;
 
   // whether the worker should attempt to requeue
   // an operation when an unexpected failure
   // occurs during an execution
-  bool requeue_on_failure = 10;
+  bool requeue_on_failure = 11;
 
   // page size for getTree request
-  uint32 tree_page_size = 11;
+  uint32 tree_page_size = 12;
 
   // period of poll requests during execution
-  google.protobuf.Duration operation_poll_period = 12;
+  google.protobuf.Duration operation_poll_period = 13;
 
   // initial platform used to match operations
-  google.devtools.remoteexecution.v1test.Platform platform = 13;
+  google.devtools.remoteexecution.v1test.Platform platform = 14;
 }
 
 message TreeIteratorToken {


### PR DESCRIPTION
Use a CAS-fetching file cache supplier of Paths in the worker, which
manages expiration based on a configurable maximum number of bytes. The
file cache refreshes its access time based on each action execution, and
as such is capable of reporting actual input edge traversals, as well as
retaining those file legitimately used most recently - benefit may be
negligible in this case, since inputs must be fetched even if unused,
but may aggregate over distinct actions to be effective. The file cache
will allow temporary oversubscription in this case, when all of the
inputs combined for a single action resolve to be larger than the max,
but it will prevent a single input that is larger than the max from
being inserted.