### PR TITLE
Initial support for option parsing.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,11 @@
 workspace(name = "build_buildfarm")
 
+maven_jar(
+    name = "com_github_pcj_google_options",
+    artifact = "com.github.pcj:google-options:jar:1.0.0",
+    sha1 = "85d54fe6771e5ff0d54827b0a3315c3e12fdd0c7",
+)
+
 new_local_repository(
     name = "com_google_protobuf",
     build_file = "./third_party/protobuf/3.2.0/BUILD",

--- a/src/main/java/build/buildfarm/BUILD
+++ b/src/main/java/build/buildfarm/BUILD
@@ -73,6 +73,7 @@ java_library(
         ":common",
         ":instance",
         ":memory-instance",
+        "@com_github_pcj_google_options//jar",
         "@googleapis//:google_bytestream_bytestream_java_grpc",
         "@googleapis//:google_bytestream_bytestream_java_proto",
         "@googleapis//:google_devtools_remoteexecution_v1test_remote_execution_java_grpc",

--- a/src/main/java/build/buildfarm/server/BuildFarmServer.java
+++ b/src/main/java/build/buildfarm/server/BuildFarmServer.java
@@ -20,6 +20,7 @@ import build.buildfarm.v1test.BuildFarmServerConfig;
 import build.buildfarm.v1test.InstanceConfig;
 import com.google.common.collect.Iterables;
 import com.google.common.io.ByteStreams;
+import com.google.devtools.common.options.OptionsParser;
 import com.google.protobuf.TextFormat;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
@@ -29,6 +30,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Logger;
@@ -185,8 +187,21 @@ public class BuildFarmServer {
     }
   }
 
+  private static void printUsage(OptionsParser parser) {
+    System.out.println("Usage: CONFIG_PATH");
+    System.out.println(parser.describeOptions(Collections.<String, String>emptyMap(),
+                                              OptionsParser.HelpVerbosity.LONG));
+  }
+
   public static void main(String[] args) throws Exception {
-    Path configPath = Paths.get(args[0]);
+    OptionsParser parser = OptionsParser.newOptionsParser(BuildFarmServerOptions.class);
+    parser.parseAndExitUponError(args);
+    java.util.List<java.lang.String> residue = parser.getResidue();
+    if (residue.isEmpty()) {
+      printUsage(parser);
+      return;
+    }
+    Path configPath = Paths.get(residue.get(0));
     try (InputStream configInputStream = Files.newInputStream(configPath)) {
       BuildFarmServer server = new BuildFarmServer(toBuildFarmServerConfig(configInputStream));
       configInputStream.close();

--- a/src/main/java/build/buildfarm/server/BuildFarmServer.java
+++ b/src/main/java/build/buildfarm/server/BuildFarmServer.java
@@ -32,6 +32,7 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
 
@@ -196,7 +197,7 @@ public class BuildFarmServer {
   public static void main(String[] args) throws Exception {
     OptionsParser parser = OptionsParser.newOptionsParser(BuildFarmServerOptions.class);
     parser.parseAndExitUponError(args);
-    java.util.List<java.lang.String> residue = parser.getResidue();
+    List<java.lang.String> residue = parser.getResidue();
     if (residue.isEmpty()) {
       printUsage(parser);
       return;

--- a/src/main/java/build/buildfarm/server/BuildFarmServerOptions.java
+++ b/src/main/java/build/buildfarm/server/BuildFarmServerOptions.java
@@ -1,0 +1,32 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.server;
+
+import com.google.devtools.common.options.Option;
+import com.google.devtools.common.options.OptionsBase;
+
+/**
+ * Command-line options definition for example server.
+ */
+public class BuildFarmServerOptions extends OptionsBase {
+
+  @Option(
+      name = "help",
+      abbrev = 'h',
+      help = "Prints usage info.",
+      defaultValue = "true"
+    )
+  public boolean help;
+}


### PR DESCRIPTION
Uses pcj/google_options for option parsing (similar to Bazel).
Seems to have not direct positional support - so using residue for that.