### PR TITLE
Break circular dependency on BuildFarmService.

### DIFF
--- a/src/main/java/build/buildfarm/server/ActionCacheService.java
+++ b/src/main/java/build/buildfarm/server/ActionCacheService.java
@@ -24,10 +24,10 @@ import io.grpc.StatusException;
 import io.grpc.stub.StreamObserver;
 
 public class ActionCacheService extends ActionCacheGrpc.ActionCacheImplBase {
-  private final BuildFarmServer server;
+  private final BuildFarmInstances instances;
 
-  public ActionCacheService(BuildFarmServer server) {
-    this.server = server;
+  public ActionCacheService(BuildFarmInstances instances) {
+    this.instances = instances;
   }
 
   @Override
@@ -36,7 +36,7 @@ public class ActionCacheService extends ActionCacheGrpc.ActionCacheImplBase {
       StreamObserver<ActionResult> responseObserver) {
     Instance instance;
     try {
-      instance = server.getInstance(request.getInstanceName());
+      instance = instances.getInstance(request.getInstanceName());
     } catch (InstanceNotFoundException ex) {
       responseObserver.onError(new StatusException(Status.NOT_FOUND));
       return;
@@ -59,7 +59,7 @@ public class ActionCacheService extends ActionCacheGrpc.ActionCacheImplBase {
       StreamObserver<ActionResult> responseObserver) {
     Instance instance;
     try {
-      instance = server.getInstance(request.getInstanceName());
+      instance = instances.getInstance(request.getInstanceName());
     } catch (InstanceNotFoundException ex) {
       responseObserver.onError(new StatusException(Status.NOT_FOUND));
       return;

--- a/src/main/java/build/buildfarm/server/BuildFarmInstances.java
+++ b/src/main/java/build/buildfarm/server/BuildFarmInstances.java
@@ -1,0 +1,132 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.server;
+
+import build.buildfarm.instance.Instance;
+import build.buildfarm.instance.memory.MemoryInstance;
+import build.buildfarm.v1test.InstanceConfig;
+import com.google.common.collect.Iterables;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class BuildFarmInstances {
+  private final Map<String, Instance> instances;
+  private final Instance defaultInstance;
+
+  public BuildFarmInstances(List<InstanceConfig> instanceConfigs, String defaultInstanceName) {
+    instances = new HashMap<String, Instance>();
+    createInstances(instanceConfigs);
+    if (!defaultInstanceName.isEmpty()) {
+      if (!instances.containsKey(defaultInstanceName)) {
+        throw new IllegalArgumentException();
+      }
+      defaultInstance = instances.get(defaultInstanceName);
+    } else {
+      defaultInstance = null;
+    }
+  }
+
+  public Instance getDefaultInstance() {
+    return defaultInstance;
+  }
+
+  public Instance getInstance(String name) throws InstanceNotFoundException {
+    Instance instance;
+    if (name == null || name.isEmpty()) {
+      instance = getDefaultInstance();
+    } else {
+      instance = instances.get(name);
+    }
+    if (instance == null) {
+      throw new InstanceNotFoundException(name);
+    }
+    return instance;
+  }
+
+  public Instance getInstanceFromOperationsCollectionName(
+      String operationsCollectionName) throws InstanceNotFoundException {
+    // {instance_name=**}/operations
+    String[] components = operationsCollectionName.split("/");
+    String instanceName = String.join(
+        "/", Iterables.limit(
+            Arrays.asList(components),
+            components.length - 1));
+    return getInstance(instanceName);
+  }
+
+  public Instance getInstanceFromOperationName(String operationName)
+      throws InstanceNotFoundException {
+    // {instance_name=**}/operations/{uuid}
+    String[] components = operationName.split("/");
+    String instanceName = String.join(
+        "/", Iterables.limit(
+            Arrays.asList(components),
+            components.length - 2));
+    return getInstance(instanceName);
+  }
+
+  public Instance getInstanceFromOperationStream(String operationStream)
+      throws InstanceNotFoundException {
+    // {instance_name=**}/operations/{uuid}/streams/{stream}
+    String[] components = operationStream.split("/");
+    String instanceName = String.join(
+        "/", Iterables.limit(
+            Arrays.asList(components),
+            components.length - 4));
+    return getInstance(instanceName);
+  }
+
+  public Instance getInstanceFromBlob(String blobName)
+      throws InstanceNotFoundException {
+    // {instance_name=**}/blobs/{hash}/{size}
+    String[] components = blobName.split("/");
+    String instanceName = String.join(
+        "/", Iterables.limit(
+            Arrays.asList(components),
+            components.length - 3));
+    return getInstance(instanceName);
+  }
+
+  public Instance getInstanceFromUploadBlob(String uploadBlobName)
+      throws InstanceNotFoundException {
+    // {instance_name=**}/uploads/{uuid}/blobs/{hash}/{size}
+    String[] components = uploadBlobName.split("/");
+    String instanceName = String.join(
+        "/", Iterables.limit(
+            Arrays.asList(components),
+            components.length - 5));
+    return getInstance(instanceName);
+  }
+
+  private void createInstances(List<InstanceConfig> instanceConfigs) {
+    for (InstanceConfig instanceConfig : instanceConfigs) {
+      String name = instanceConfig.getName();
+      InstanceConfig.TypeCase typeCase = instanceConfig.getTypeCase();
+      switch (instanceConfig.getTypeCase()) {
+        default:
+        case TYPE_NOT_SET:
+          throw new IllegalArgumentException("Instance type not set in config");
+        case MEMORY_INSTANCE_CONFIG:
+          instances.put(name, new MemoryInstance(
+              name,
+              instanceConfig.getMemoryInstanceConfig()));
+          break;
+      }
+    }
+  }
+}
+

--- a/src/main/java/build/buildfarm/server/ByteStreamService.java
+++ b/src/main/java/build/buildfarm/server/ByteStreamService.java
@@ -40,11 +40,11 @@ public class ByteStreamService extends ByteStreamGrpc.ByteStreamImplBase {
   private static final long DEFAULT_CHUNK_SIZE = 1024 * 16;
 
   private final Map<String, ByteString> active_write_requests;
-  private final BuildFarmServer server;
+  private final BuildFarmInstances instances;
 
-  public ByteStreamService(BuildFarmServer server) {
+  public ByteStreamService(BuildFarmInstances instances) {
     active_write_requests = new HashMap<String, ByteString>();
-    this.server = server;
+    this.instances = instances;
   }
 
   private static boolean isBlob(String resourceName) {
@@ -98,7 +98,7 @@ public class ByteStreamService extends ByteStreamGrpc.ByteStreamImplBase {
 
     Instance instance;
     try {
-      instance = server.getInstanceFromBlob(resourceName);
+      instance = instances.getInstanceFromBlob(resourceName);
     } catch (InstanceNotFoundException ex) {
       responseObserver.onError(new StatusException(Status.NOT_FOUND));
       return;
@@ -137,7 +137,7 @@ public class ByteStreamService extends ByteStreamGrpc.ByteStreamImplBase {
 
     Instance instance;
     try {
-      instance = server.getInstanceFromBlob(resourceName);
+      instance = instances.getInstanceFromBlob(resourceName);
     } catch (InstanceNotFoundException ex) {
       responseObserver.onError(new StatusException(Status.NOT_FOUND));
       return;
@@ -265,7 +265,7 @@ public class ByteStreamService extends ByteStreamGrpc.ByteStreamImplBase {
             Instance instance;
 
             try {
-              instance = server.getInstanceFromUploadBlob(writeResourceName);
+              instance = instances.getInstanceFromUploadBlob(writeResourceName);
             } catch (InstanceNotFoundException ex) {
               responseObserver.onError(new StatusException(Status.NOT_FOUND));
               failed = true;
@@ -287,7 +287,7 @@ public class ByteStreamService extends ByteStreamGrpc.ByteStreamImplBase {
         Instance instance;
 
         try {
-          instance = server.getInstanceFromOperationStream(writeResourceName);
+          instance = instances.getInstanceFromOperationStream(writeResourceName);
         } catch (InstanceNotFoundException ex) {
           responseObserver.onError(new StatusException(Status.NOT_FOUND));
           return;

--- a/src/main/java/build/buildfarm/server/ContentAddressableStorageService.java
+++ b/src/main/java/build/buildfarm/server/ContentAddressableStorageService.java
@@ -36,10 +36,10 @@ import java.io.IOException;
 import java.util.function.Function;
 
 public class ContentAddressableStorageService extends ContentAddressableStorageGrpc.ContentAddressableStorageImplBase {
-  private final BuildFarmServer server;
+  private final BuildFarmInstances instances;
 
-  public ContentAddressableStorageService(BuildFarmServer server) {
-    this.server = server;
+  public ContentAddressableStorageService(BuildFarmInstances instances) {
+    this.instances = instances;
   }
 
   @Override
@@ -48,7 +48,7 @@ public class ContentAddressableStorageService extends ContentAddressableStorageG
       StreamObserver<FindMissingBlobsResponse> responseObserver) {
     Instance instance;
     try {
-      instance = server.getInstance(request.getInstanceName());
+      instance = instances.getInstance(request.getInstanceName());
     } catch (InstanceNotFoundException ex) {
       responseObserver.onError(new StatusException(Status.NOT_FOUND));
       return;
@@ -67,7 +67,7 @@ public class ContentAddressableStorageService extends ContentAddressableStorageG
       StreamObserver<BatchUpdateBlobsResponse> responseObserver) {
     Instance instance;
     try {
-      instance = server.getInstance(batchRequest.getInstanceName());
+      instance = instances.getInstance(batchRequest.getInstanceName());
     } catch (InstanceNotFoundException ex) {
       responseObserver.onError(new StatusException(Status.NOT_FOUND));
       return;
@@ -115,7 +115,7 @@ public class ContentAddressableStorageService extends ContentAddressableStorageG
       StreamObserver<GetTreeResponse> responseObserver) {
     Instance instance;
     try {
-      instance = server.getInstance(request.getInstanceName());
+      instance = instances.getInstance(request.getInstanceName());
     } catch (InstanceNotFoundException ex) {
       responseObserver.onError(new StatusException(Status.NOT_FOUND));
       return;

--- a/src/main/java/build/buildfarm/server/ExecutionService.java
+++ b/src/main/java/build/buildfarm/server/ExecutionService.java
@@ -24,10 +24,10 @@ import io.grpc.stub.StreamObserver;
 import java.util.UUID;
 
 public class ExecutionService extends ExecutionGrpc.ExecutionImplBase {
-  private final BuildFarmServer server;
+  private final BuildFarmInstances instances;
 
-  public ExecutionService(BuildFarmServer server) {
-    this.server = server;
+  public ExecutionService(BuildFarmInstances instances) {
+    this.instances = instances;
   }
 
   @Override
@@ -35,7 +35,7 @@ public class ExecutionService extends ExecutionGrpc.ExecutionImplBase {
       ExecuteRequest request, StreamObserver<Operation> responseObserver) {
     Instance instance;
     try {
-      instance = server.getInstance(request.getInstanceName());
+      instance = instances.getInstance(request.getInstanceName());
     } catch (InstanceNotFoundException ex) {
       responseObserver.onError(new StatusException(Status.NOT_FOUND));
       return;

--- a/src/main/java/build/buildfarm/server/OperationQueueService.java
+++ b/src/main/java/build/buildfarm/server/OperationQueueService.java
@@ -29,10 +29,10 @@ import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 
 public class OperationQueueService extends OperationQueueGrpc.OperationQueueImplBase {
-  private final BuildFarmServer server;
+  private final BuildFarmInstances instances;
 
-  public OperationQueueService(BuildFarmServer server) {
-    this.server = server;
+  public OperationQueueService(BuildFarmInstances instances) {
+    this.instances = instances;
   }
 
   @Override
@@ -41,7 +41,7 @@ public class OperationQueueService extends OperationQueueGrpc.OperationQueueImpl
       StreamObserver<Operation> responseObserver) {
     Instance instance;
     try {
-      instance = server.getInstance(request.getInstanceName());
+      instance = instances.getInstance(request.getInstanceName());
     } catch (InstanceNotFoundException ex) {
       responseObserver.onError(new StatusException(Status.NOT_FOUND));
       return;
@@ -82,7 +82,7 @@ public class OperationQueueService extends OperationQueueGrpc.OperationQueueImpl
       StreamObserver<com.google.rpc.Status> responseObserver) {
     Instance instance;
     try {
-      instance = server.getInstanceFromOperationName(operation.getName());
+      instance = instances.getInstanceFromOperationName(operation.getName());
     } catch (InstanceNotFoundException ex) {
       responseObserver.onError(new StatusException(Status.NOT_FOUND));
       return;
@@ -102,7 +102,7 @@ public class OperationQueueService extends OperationQueueGrpc.OperationQueueImpl
       StreamObserver<com.google.rpc.Status> responseObserver) {
     Instance instance;
     try {
-      instance = server.getInstanceFromOperationName(
+      instance = instances.getInstanceFromOperationName(
           request.getOperationName());
     } catch (InstanceNotFoundException ex) {
       responseObserver.onError(new StatusException(Status.NOT_FOUND));

--- a/src/main/java/build/buildfarm/server/OperationsService.java
+++ b/src/main/java/build/buildfarm/server/OperationsService.java
@@ -29,10 +29,10 @@ import io.grpc.StatusException;
 import io.grpc.stub.StreamObserver;
 
 public class OperationsService extends OperationsGrpc.OperationsImplBase {
-  private final BuildFarmServer server;
+  private final BuildFarmInstances instances;
 
-  public OperationsService(BuildFarmServer server) {
-    this.server = server;
+  public OperationsService(BuildFarmInstances instances) {
+    this.instances = instances;
   }
 
   @Override
@@ -41,7 +41,7 @@ public class OperationsService extends OperationsGrpc.OperationsImplBase {
       StreamObserver<ListOperationsResponse> responseObserver) {
     Instance instance;
     try {
-      instance = server.getInstanceFromOperationsCollectionName(
+      instance = instances.getInstanceFromOperationsCollectionName(
           request.getName());
     } catch (InstanceNotFoundException ex) {
       responseObserver.onError(new StatusException(Status.NOT_FOUND));
@@ -76,7 +76,7 @@ public class OperationsService extends OperationsGrpc.OperationsImplBase {
       StreamObserver<Operation> responseObserver) {
     Instance instance;
     try {
-      instance = server.getInstanceFromOperationName(request.getName());
+      instance = instances.getInstanceFromOperationName(request.getName());
     } catch (InstanceNotFoundException ex) {
       responseObserver.onError(new StatusException(Status.NOT_FOUND));
       return;
@@ -92,7 +92,7 @@ public class OperationsService extends OperationsGrpc.OperationsImplBase {
       StreamObserver<Empty> responseObserver) {
     Instance instance;
     try {
-      instance = server.getInstanceFromOperationName(request.getName());
+      instance = instances.getInstanceFromOperationName(request.getName());
     } catch (InstanceNotFoundException ex) {
       responseObserver.onError(new StatusException(Status.NOT_FOUND));
       return;
@@ -113,7 +113,7 @@ public class OperationsService extends OperationsGrpc.OperationsImplBase {
       StreamObserver<Empty> responseObserver) {
     Instance instance;
     try {
-      instance = server.getInstanceFromOperationName(request.getName());
+      instance = instances.getInstanceFromOperationName(request.getName());
     } catch (InstanceNotFoundException ex) {
       responseObserver.onError(new StatusException(Status.NOT_FOUND));
       return;

--- a/src/main/java/build/buildfarm/server/WatcherService.java
+++ b/src/main/java/build/buildfarm/server/WatcherService.java
@@ -28,10 +28,10 @@ import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 
 public class WatcherService extends WatcherGrpc.WatcherImplBase {
-  private final BuildFarmServer server;
+  private final BuildFarmInstances instances;
 
-  public WatcherService(BuildFarmServer server) {
-    this.server = server;
+  public WatcherService(BuildFarmInstances instances) {
+    this.instances = instances;
   }
 
   @Override
@@ -41,7 +41,7 @@ public class WatcherService extends WatcherGrpc.WatcherImplBase {
     String operationName = request.getTarget();
     Instance instance;
     try {
-      instance = server.getInstanceFromOperationName(operationName);
+      instance = instances.getInstanceFromOperationName(operationName);
     } catch (InstanceNotFoundException ex) {
       responseObserver.onError(new StatusException(Status.NOT_FOUND));
       return;


### PR DESCRIPTION
Due to SOC, if Services are only interested in Instances, there is no need to make BuildFarmService accessible.
Rather seperate out BuildFarmInstances. This also enables a simpler API later on.