### PR TITLE
Extend support for option parsing

### DIFF
--- a/src/main/java/build/buildfarm/BUILD
+++ b/src/main/java/build/buildfarm/BUILD
@@ -125,5 +125,6 @@ java_binary(
         ":common",
         ":instance",
         ":stub-instance",
+        "@com_github_pcj_google_options//jar",
     ],
 )

--- a/src/main/java/build/buildfarm/server/BuildFarmServer.java
+++ b/src/main/java/build/buildfarm/server/BuildFarmServer.java
@@ -197,7 +197,7 @@ public class BuildFarmServer {
   public static void main(String[] args) throws Exception {
     OptionsParser parser = OptionsParser.newOptionsParser(BuildFarmServerOptions.class);
     parser.parseAndExitUponError(args);
-    List<java.lang.String> residue = parser.getResidue();
+    List<String> residue = parser.getResidue();
     if (residue.isEmpty()) {
       printUsage(parser);
       throw new IllegalArgumentException("Missing CONFIG_PATH");

--- a/src/main/java/build/buildfarm/server/BuildFarmServer.java
+++ b/src/main/java/build/buildfarm/server/BuildFarmServer.java
@@ -200,7 +200,7 @@ public class BuildFarmServer {
     List<java.lang.String> residue = parser.getResidue();
     if (residue.isEmpty()) {
       printUsage(parser);
-      return;
+      throw new IllegalArgumentException("Missing CONFIG_PATH");
     }
     Path configPath = Paths.get(residue.get(0));
     try (InputStream configInputStream = Files.newInputStream(configPath)) {

--- a/src/main/java/build/buildfarm/worker/Worker.java
+++ b/src/main/java/build/buildfarm/worker/Worker.java
@@ -508,7 +508,7 @@ class Worker {
     List<String> residue = parser.getResidue();
     if (residue.isEmpty()) {
       printUsage(parser);
-      return;
+      throw new IllegalArgumentException("Missing CONFIG_PATH");
     }
     Path configPath = Paths.get(residue.get(0));
     try (InputStream configInputStream = Files.newInputStream(configPath)) {

--- a/src/main/java/build/buildfarm/worker/Worker.java
+++ b/src/main/java/build/buildfarm/worker/Worker.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.io.ByteStreams;
+import com.google.devtools.common.options.OptionsParser;
 import com.google.devtools.remoteexecution.v1test.Action;
 import com.google.devtools.remoteexecution.v1test.ActionResult;
 import com.google.devtools.remoteexecution.v1test.Command;
@@ -54,8 +55,10 @@ import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -486,17 +489,30 @@ class Worker {
     return latin1;
   }
 
-  private static WorkerConfig toWorkerConfig(InputStream inputStream) throws IOException {
+  private static WorkerConfig toWorkerConfig(InputStream inputStream, WorkerOptions options) throws IOException {
     WorkerConfig.Builder builder = WorkerConfig.newBuilder();
     String data = new String(convertFromLatin1(ByteStreams.toByteArray(inputStream)));
     TextFormat.merge(data, builder);
     return builder.build();
   }
 
+  private static void printUsage(OptionsParser parser) {
+    System.out.println("Usage: CONFIG_PATH");
+    System.out.println(parser.describeOptions(Collections.<String, String>emptyMap(),
+                                              OptionsParser.HelpVerbosity.LONG));
+  }
+
   public static void main(String[] args) throws Exception {
-    Path configPath = Paths.get(args[0]);
+    OptionsParser parser = OptionsParser.newOptionsParser(WorkerOptions.class);
+    parser.parseAndExitUponError(args);
+    List<String> residue = parser.getResidue();
+    if (residue.isEmpty()) {
+      printUsage(parser);
+      return;
+    }
+    Path configPath = Paths.get(residue.get(0));
     try (InputStream configInputStream = Files.newInputStream(configPath)) {
-      Worker worker = new Worker(toWorkerConfig(configInputStream));
+      Worker worker = new Worker(toWorkerConfig(configInputStream, parser.getOptions(WorkerOptions.class)));
       configInputStream.close();
       worker.start();
     }

--- a/src/main/java/build/buildfarm/worker/WorkerOptions.java
+++ b/src/main/java/build/buildfarm/worker/WorkerOptions.java
@@ -1,0 +1,32 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.worker;
+
+import com.google.devtools.common.options.Option;
+import com.google.devtools.common.options.OptionsBase;
+
+/**
+ * Command-line options definition for Worker.
+ */
+public class WorkerOptions extends OptionsBase {
+
+  @Option(
+      name = "help",
+      abbrev = 'h',
+      help = "Prints usage info.",
+      defaultValue = "true"
+    )
+  public boolean help;
+}


### PR DESCRIPTION
Uses pcj/google_options for option parsing (similar to Bazel).
Seems to have not direct positional support - so using residue for that.