### PR TITLE
Handle missing values for root and casCacheDirectory fields.

### DIFF
--- a/src/main/java/build/buildfarm/BUILD
+++ b/src/main/java/build/buildfarm/BUILD
@@ -110,13 +110,12 @@ java_library(
         "@googleapis//:google_devtools_remoteexecution_v1test_remote_execution_java_proto",
         "@googleapis//:google_longrunning_operations_java_proto",
         "@googleapis//:google_rpc_code_java_proto",
-    ]
+    ],
 )
 
-java_binary(
-    name = "buildfarm-worker",
+java_library(
+    name = "buildfarm-worker-impl",
     srcs = glob(["worker/**/*.java"]),
-    main_class = "build.buildfarm.worker.Worker",
     deps = [
         "//src/main/protobuf:build_buildfarm_v1test_buildfarm_java_proto",
         "//third_party:guava",
@@ -127,3 +126,12 @@ java_binary(
         ":stub-instance",
     ],
 )
+
+java_binary(
+    name = "buildfarm-worker",
+    main_class = "build.buildfarm.worker.Worker",
+    runtime_deps = [
+      ":buildfarm-worker-impl",
+    ],
+)
+

--- a/src/main/java/build/buildfarm/worker/Worker.java
+++ b/src/main/java/build/buildfarm/worker/Worker.java
@@ -141,7 +141,7 @@ public class Worker {
     // Have to handle empty string here because all later APIs happily ignore
     // empty strings (WTF)
     if (Strings.isNullOrEmpty(casCacheValue)) {
-        throw new ConfigurationException("root value in config missing");
+        throw new ConfigurationException("Cas cache directory value in config missing");
     }
     return root.resolve(casCacheValue);
   }

--- a/src/main/java/build/buildfarm/worker/Worker.java
+++ b/src/main/java/build/buildfarm/worker/Worker.java
@@ -142,7 +142,7 @@ public class Worker {
     return root.resolve(casCacheValue);
   }
 
-  public Worker(WorkerConfig config) throws ConfigurationException{
+  public Worker(WorkerConfig config) throws ConfigurationException {
     this.config = config;
     root = getValidRoot(config);
     cacheDir = getValidCasCacheDirectory(config, root);

--- a/src/main/java/build/buildfarm/worker/Worker.java
+++ b/src/main/java/build/buildfarm/worker/Worker.java
@@ -128,8 +128,6 @@ public class Worker {
 
   private static Path getValidRoot(WorkerConfig config) throws ConfigurationException {
     String rootValue = config.getRoot();
-    // Have to handle empty string here because all later APIs happily ignore
-    // empty strings (WTF)
     if (Strings.isNullOrEmpty(rootValue)) {
         throw new ConfigurationException("root value in config missing");
     }
@@ -138,8 +136,6 @@ public class Worker {
 
   private static Path getValidCasCacheDirectory(WorkerConfig config, Path root) throws ConfigurationException {
     String casCacheValue = config.getCasCacheDirectory();
-    // Have to handle empty string here because all later APIs happily ignore
-    // empty strings (WTF)
     if (Strings.isNullOrEmpty(casCacheValue)) {
         throw new ConfigurationException("Cas cache directory value in config missing");
     }

--- a/src/test/java/build/buildfarm/BUILD
+++ b/src/test/java/build/buildfarm/BUILD
@@ -17,6 +17,16 @@ java_test(
 )
 
 java_test(
+  name = "BuildFarmWorkerTest",
+  srcs = ["BuildFarmWorkerTest.java"],
+  deps = [
+      "//src/main/java/build/buildfarm:common",
+      "//src/main/java/build/buildfarm:buildfarm-worker-impl",
+      "//src/main/protobuf:build_buildfarm_v1test_buildfarm_java_proto",
+  ],
+)
+
+java_test(
   name = "ByteStringIteratorInputStreamTest",
   srcs = ["ByteStringIteratorInputStreamTest.java"],
   deps = [

--- a/src/test/java/build/buildfarm/BuildFarmWorkerTest.java
+++ b/src/test/java/build/buildfarm/BuildFarmWorkerTest.java
@@ -1,0 +1,39 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm;
+
+import build.buildfarm.v1test.WorkerConfig;
+import build.buildfarm.worker.Worker;
+import javax.naming.ConfigurationException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class BuildFarmWorkerTest {
+  @Test(expected = ConfigurationException.class)
+  public void missingWorkerRoot() throws ConfigurationException {
+    WorkerConfig.Builder builder = WorkerConfig.newBuilder();
+    new Worker(builder.build());
+  }
+
+  @Test(expected = ConfigurationException.class)
+  public void missingCasCacheDirectory() throws ConfigurationException {
+    WorkerConfig.Builder builder = WorkerConfig.newBuilder();
+    builder.setRoot("/");
+    new Worker(builder.build());
+  }
+}
+


### PR DESCRIPTION
For both throw ConfigurationException. Previously there was no error but still did not work.
Also added belonging Tests for Worker.