### PR TITLE
Remove instance mention from getters in BuildFarmInstances.

### DIFF
--- a/src/main/java/build/buildfarm/server/ActionCacheService.java
+++ b/src/main/java/build/buildfarm/server/ActionCacheService.java
@@ -36,7 +36,7 @@ public class ActionCacheService extends ActionCacheGrpc.ActionCacheImplBase {
       StreamObserver<ActionResult> responseObserver) {
     Instance instance;
     try {
-      instance = instances.getInstance(request.getInstanceName());
+      instance = instances.get(request.getInstanceName());
     } catch (InstanceNotFoundException ex) {
       responseObserver.onError(new StatusException(Status.NOT_FOUND));
       return;
@@ -59,7 +59,7 @@ public class ActionCacheService extends ActionCacheGrpc.ActionCacheImplBase {
       StreamObserver<ActionResult> responseObserver) {
     Instance instance;
     try {
-      instance = instances.getInstance(request.getInstanceName());
+      instance = instances.get(request.getInstanceName());
     } catch (InstanceNotFoundException ex) {
       responseObserver.onError(new StatusException(Status.NOT_FOUND));
       return;

--- a/src/main/java/build/buildfarm/server/BuildFarmInstances.java
+++ b/src/main/java/build/buildfarm/server/BuildFarmInstances.java
@@ -40,14 +40,14 @@ public class BuildFarmInstances {
     }
   }
 
-  public Instance getDefaultInstance() {
+  public Instance getDefault() {
     return defaultInstance;
   }
 
-  public Instance getInstance(String name) throws InstanceNotFoundException {
+  public Instance get(String name) throws InstanceNotFoundException {
     Instance instance;
     if (name == null || name.isEmpty()) {
-      instance = getDefaultInstance();
+      instance = getDefault();
     } else {
       instance = instances.get(name);
     }
@@ -57,7 +57,7 @@ public class BuildFarmInstances {
     return instance;
   }
 
-  public Instance getInstanceFromOperationsCollectionName(
+  public Instance getFromOperationsCollectionName(
       String operationsCollectionName) throws InstanceNotFoundException {
     // {instance_name=**}/operations
     String[] components = operationsCollectionName.split("/");
@@ -65,10 +65,10 @@ public class BuildFarmInstances {
         "/", Iterables.limit(
             Arrays.asList(components),
             components.length - 1));
-    return getInstance(instanceName);
+    return get(instanceName);
   }
 
-  public Instance getInstanceFromOperationName(String operationName)
+  public Instance getFromOperationName(String operationName)
       throws InstanceNotFoundException {
     // {instance_name=**}/operations/{uuid}
     String[] components = operationName.split("/");
@@ -76,10 +76,10 @@ public class BuildFarmInstances {
         "/", Iterables.limit(
             Arrays.asList(components),
             components.length - 2));
-    return getInstance(instanceName);
+    return get(instanceName);
   }
 
-  public Instance getInstanceFromOperationStream(String operationStream)
+  public Instance getFromOperationStream(String operationStream)
       throws InstanceNotFoundException {
     // {instance_name=**}/operations/{uuid}/streams/{stream}
     String[] components = operationStream.split("/");
@@ -87,10 +87,10 @@ public class BuildFarmInstances {
         "/", Iterables.limit(
             Arrays.asList(components),
             components.length - 4));
-    return getInstance(instanceName);
+    return get(instanceName);
   }
 
-  public Instance getInstanceFromBlob(String blobName)
+  public Instance getFromBlob(String blobName)
       throws InstanceNotFoundException {
     // {instance_name=**}/blobs/{hash}/{size}
     String[] components = blobName.split("/");
@@ -98,10 +98,10 @@ public class BuildFarmInstances {
         "/", Iterables.limit(
             Arrays.asList(components),
             components.length - 3));
-    return getInstance(instanceName);
+    return get(instanceName);
   }
 
-  public Instance getInstanceFromUploadBlob(String uploadBlobName)
+  public Instance getFromUploadBlob(String uploadBlobName)
       throws InstanceNotFoundException {
     // {instance_name=**}/uploads/{uuid}/blobs/{hash}/{size}
     String[] components = uploadBlobName.split("/");
@@ -109,7 +109,7 @@ public class BuildFarmInstances {
         "/", Iterables.limit(
             Arrays.asList(components),
             components.length - 5));
-    return getInstance(instanceName);
+    return get(instanceName);
   }
 
   private void createInstances(List<InstanceConfig> instanceConfigs) {

--- a/src/main/java/build/buildfarm/server/ByteStreamService.java
+++ b/src/main/java/build/buildfarm/server/ByteStreamService.java
@@ -98,7 +98,7 @@ public class ByteStreamService extends ByteStreamGrpc.ByteStreamImplBase {
 
     Instance instance;
     try {
-      instance = instances.getInstanceFromBlob(resourceName);
+      instance = instances.getFromBlob(resourceName);
     } catch (InstanceNotFoundException ex) {
       responseObserver.onError(new StatusException(Status.NOT_FOUND));
       return;
@@ -137,7 +137,7 @@ public class ByteStreamService extends ByteStreamGrpc.ByteStreamImplBase {
 
     Instance instance;
     try {
-      instance = instances.getInstanceFromBlob(resourceName);
+      instance = instances.getFromBlob(resourceName);
     } catch (InstanceNotFoundException ex) {
       responseObserver.onError(new StatusException(Status.NOT_FOUND));
       return;
@@ -265,7 +265,7 @@ public class ByteStreamService extends ByteStreamGrpc.ByteStreamImplBase {
             Instance instance;
 
             try {
-              instance = instances.getInstanceFromUploadBlob(writeResourceName);
+              instance = instances.getFromUploadBlob(writeResourceName);
             } catch (InstanceNotFoundException ex) {
               responseObserver.onError(new StatusException(Status.NOT_FOUND));
               failed = true;
@@ -287,7 +287,7 @@ public class ByteStreamService extends ByteStreamGrpc.ByteStreamImplBase {
         Instance instance;
 
         try {
-          instance = instances.getInstanceFromOperationStream(writeResourceName);
+          instance = instances.getFromOperationStream(writeResourceName);
         } catch (InstanceNotFoundException ex) {
           responseObserver.onError(new StatusException(Status.NOT_FOUND));
           return;

--- a/src/main/java/build/buildfarm/server/ContentAddressableStorageService.java
+++ b/src/main/java/build/buildfarm/server/ContentAddressableStorageService.java
@@ -48,7 +48,7 @@ public class ContentAddressableStorageService extends ContentAddressableStorageG
       StreamObserver<FindMissingBlobsResponse> responseObserver) {
     Instance instance;
     try {
-      instance = instances.getInstance(request.getInstanceName());
+      instance = instances.get(request.getInstanceName());
     } catch (InstanceNotFoundException ex) {
       responseObserver.onError(new StatusException(Status.NOT_FOUND));
       return;
@@ -67,7 +67,7 @@ public class ContentAddressableStorageService extends ContentAddressableStorageG
       StreamObserver<BatchUpdateBlobsResponse> responseObserver) {
     Instance instance;
     try {
-      instance = instances.getInstance(batchRequest.getInstanceName());
+      instance = instances.get(batchRequest.getInstanceName());
     } catch (InstanceNotFoundException ex) {
       responseObserver.onError(new StatusException(Status.NOT_FOUND));
       return;
@@ -115,7 +115,7 @@ public class ContentAddressableStorageService extends ContentAddressableStorageG
       StreamObserver<GetTreeResponse> responseObserver) {
     Instance instance;
     try {
-      instance = instances.getInstance(request.getInstanceName());
+      instance = instances.get(request.getInstanceName());
     } catch (InstanceNotFoundException ex) {
       responseObserver.onError(new StatusException(Status.NOT_FOUND));
       return;

--- a/src/main/java/build/buildfarm/server/ExecutionService.java
+++ b/src/main/java/build/buildfarm/server/ExecutionService.java
@@ -35,7 +35,7 @@ public class ExecutionService extends ExecutionGrpc.ExecutionImplBase {
       ExecuteRequest request, StreamObserver<Operation> responseObserver) {
     Instance instance;
     try {
-      instance = instances.getInstance(request.getInstanceName());
+      instance = instances.get(request.getInstanceName());
     } catch (InstanceNotFoundException ex) {
       responseObserver.onError(new StatusException(Status.NOT_FOUND));
       return;

--- a/src/main/java/build/buildfarm/server/OperationQueueService.java
+++ b/src/main/java/build/buildfarm/server/OperationQueueService.java
@@ -41,7 +41,7 @@ public class OperationQueueService extends OperationQueueGrpc.OperationQueueImpl
       StreamObserver<Operation> responseObserver) {
     Instance instance;
     try {
-      instance = instances.getInstance(request.getInstanceName());
+      instance = instances.get(request.getInstanceName());
     } catch (InstanceNotFoundException ex) {
       responseObserver.onError(new StatusException(Status.NOT_FOUND));
       return;
@@ -82,7 +82,7 @@ public class OperationQueueService extends OperationQueueGrpc.OperationQueueImpl
       StreamObserver<com.google.rpc.Status> responseObserver) {
     Instance instance;
     try {
-      instance = instances.getInstanceFromOperationName(operation.getName());
+      instance = instances.getFromOperationName(operation.getName());
     } catch (InstanceNotFoundException ex) {
       responseObserver.onError(new StatusException(Status.NOT_FOUND));
       return;
@@ -102,7 +102,7 @@ public class OperationQueueService extends OperationQueueGrpc.OperationQueueImpl
       StreamObserver<com.google.rpc.Status> responseObserver) {
     Instance instance;
     try {
-      instance = instances.getInstanceFromOperationName(
+      instance = instances.getFromOperationName(
           request.getOperationName());
     } catch (InstanceNotFoundException ex) {
       responseObserver.onError(new StatusException(Status.NOT_FOUND));

--- a/src/main/java/build/buildfarm/server/OperationsService.java
+++ b/src/main/java/build/buildfarm/server/OperationsService.java
@@ -41,7 +41,7 @@ public class OperationsService extends OperationsGrpc.OperationsImplBase {
       StreamObserver<ListOperationsResponse> responseObserver) {
     Instance instance;
     try {
-      instance = instances.getInstanceFromOperationsCollectionName(
+      instance = instances.getFromOperationsCollectionName(
           request.getName());
     } catch (InstanceNotFoundException ex) {
       responseObserver.onError(new StatusException(Status.NOT_FOUND));
@@ -76,7 +76,7 @@ public class OperationsService extends OperationsGrpc.OperationsImplBase {
       StreamObserver<Operation> responseObserver) {
     Instance instance;
     try {
-      instance = instances.getInstanceFromOperationName(request.getName());
+      instance = instances.getFromOperationName(request.getName());
     } catch (InstanceNotFoundException ex) {
       responseObserver.onError(new StatusException(Status.NOT_FOUND));
       return;
@@ -92,7 +92,7 @@ public class OperationsService extends OperationsGrpc.OperationsImplBase {
       StreamObserver<Empty> responseObserver) {
     Instance instance;
     try {
-      instance = instances.getInstanceFromOperationName(request.getName());
+      instance = instances.getFromOperationName(request.getName());
     } catch (InstanceNotFoundException ex) {
       responseObserver.onError(new StatusException(Status.NOT_FOUND));
       return;
@@ -113,7 +113,7 @@ public class OperationsService extends OperationsGrpc.OperationsImplBase {
       StreamObserver<Empty> responseObserver) {
     Instance instance;
     try {
-      instance = instances.getInstanceFromOperationName(request.getName());
+      instance = instances.getFromOperationName(request.getName());
     } catch (InstanceNotFoundException ex) {
       responseObserver.onError(new StatusException(Status.NOT_FOUND));
       return;

--- a/src/main/java/build/buildfarm/server/WatcherService.java
+++ b/src/main/java/build/buildfarm/server/WatcherService.java
@@ -41,7 +41,7 @@ public class WatcherService extends WatcherGrpc.WatcherImplBase {
     String operationName = request.getTarget();
     Instance instance;
     try {
-      instance = instances.getInstanceFromOperationName(operationName);
+      instance = instances.getFromOperationName(operationName);
     } catch (InstanceNotFoundException ex) {
       responseObserver.onError(new StatusException(Status.NOT_FOUND));
       return;


### PR DESCRIPTION
No sense in having instance explicitly mentioned when operating on a "Collection" of instances.