### PR TITLE
Refactor worker into staged pipeline

### DIFF
--- a/src/main/java/build/buildfarm/worker/ExecuteActionStage.java
+++ b/src/main/java/build/buildfarm/worker/ExecuteActionStage.java
@@ -1,0 +1,78 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.worker;
+
+import com.google.common.collect.Iterables;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+
+class ExecuteActionStage extends PipelineStage {
+  private final Set<Thread> executors;
+  private BlockingQueue<OperationContext> queue;
+
+  ExecuteActionStage(Worker worker, PipelineStage output, PipelineStage error) {
+    super(worker, output, error);
+    queue = new ArrayBlockingQueue<>(1);
+    executors = new HashSet<>();
+  }
+
+  @Override
+  public void offer(OperationContext operationContext) {
+    queue.offer(operationContext);
+  }
+
+  @Override
+  public OperationContext take() throws InterruptedException {
+    return queue.take();
+  }
+
+  @Override
+  public synchronized boolean claim() throws InterruptedException {
+    if (isClosed()) {
+      return false;
+    }
+
+    while (executors.size() >= worker.config.getExecuteStageWidth()) {
+      wait();
+    }
+    return true;
+  }
+
+  @Override
+  public synchronized void release() {
+    if (!executors.remove(Thread.currentThread())) {
+      throw new IllegalStateException();
+    }
+    this.notify();
+  }
+
+  @Override
+  protected boolean isClaimed() {
+    return Iterables.any(executors, (executor) -> executor.isAlive());
+  }
+
+  @Override
+  protected void iterate() throws InterruptedException {
+    Thread executor = new Thread(new Executor(worker, take(), this));
+
+    synchronized(this) {
+      executors.add(executor);
+    }
+
+    executor.start();
+  }
+}

--- a/src/main/java/build/buildfarm/worker/Executor.java
+++ b/src/main/java/build/buildfarm/worker/Executor.java
@@ -1,0 +1,223 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.worker;
+
+import build.buildfarm.v1test.CASInsertionControl;
+import com.google.common.io.ByteStreams;
+import com.google.devtools.remoteexecution.v1test.ActionResult;
+import com.google.devtools.remoteexecution.v1test.Command;
+import com.google.devtools.remoteexecution.v1test.ExecuteOperationMetadata;
+import com.google.devtools.remoteexecution.v1test.ExecuteResponse;
+import com.google.longrunning.Operation;
+import com.google.protobuf.Any;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Duration;
+import com.google.protobuf.InvalidProtocolBufferException;
+import java.nio.file.Path;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+class Executor implements Runnable {
+  private final Worker worker;
+  private final OperationContext operationContext;
+  private final ExecuteActionStage owner;
+
+  private static final OutputStream nullOutputStream = ByteStreams.nullOutputStream();
+
+  Executor(Worker worker, OperationContext operationContext, ExecuteActionStage owner) {
+    this.worker = worker;
+    this.operationContext = operationContext;
+    this.owner = owner;
+  }
+
+  @Override
+  public void run() {
+    Command command;
+    try {
+      command = Command.parseFrom(worker.instance.getBlob(operationContext.action.getCommandDigest()));
+    } catch (InvalidProtocolBufferException ex) {
+      owner.error().offer(operationContext);
+      owner.release();
+      return;
+    }
+
+    ExecuteOperationMetadata executingMetadata = operationContext.metadata.toBuilder()
+        .setStage(ExecuteOperationMetadata.Stage.EXECUTING)
+        .build();
+
+    Operation operation = operationContext.operation.toBuilder()
+        .setMetadata(Any.pack(executingMetadata))
+        .build();
+
+    if (!worker.instance.putOperation(operation)) {
+      owner.error().offer(operationContext);
+      owner.release();
+      return;
+    }
+
+    final String operationName = operation.getName();
+    Poller poller = new Poller(
+        worker.config.getOperationPollPeriod(),
+        () -> {
+          boolean success = worker.instance.pollOperation(
+              operationName,
+              ExecuteOperationMetadata.Stage.EXECUTING);
+          return success;
+        });
+    new Thread(poller).start();
+
+    Duration timeout;
+    if (operationContext.action.hasTimeout()) {
+      timeout = operationContext.action.getTimeout();
+    } else {
+      timeout = null;
+    }
+
+    /* execute command */
+    ActionResult.Builder resultBuilder;
+    try {
+      resultBuilder = executeCommand(
+          operationContext.execDir,
+          command,
+          timeout,
+          operationContext.metadata.getStdoutStreamName(),
+          operationContext.metadata.getStderrStreamName());
+    } catch (IOException|InterruptedException ex) {
+      poller.stop();
+      owner.error().offer(operationContext);
+      owner.release();
+      return;
+    }
+
+    poller.stop();
+
+    try {
+      if (owner.output().claim()) {
+        operation = operation.toBuilder()
+            .setResponse(Any.pack(ExecuteResponse.newBuilder()
+                .setResult(resultBuilder.build())
+                .build()))
+            .build();
+        owner.output().offer(new OperationContext(
+            operation,
+            operationContext.execDir,
+            operationContext.metadata,
+            operationContext.action,
+            operationContext.inputFiles));
+      } else {
+        owner.error().offer(operationContext);
+      }
+    } catch (InterruptedException ex) {
+      owner.error().offer(operationContext);
+    }
+
+    owner.release();
+
+    worker.fileCache.update(operationContext.inputFiles);
+  }
+
+  private ActionResult.Builder executeCommand(
+      Path execDir,
+      Command command,
+      Duration timeout,
+      String stdoutStreamName,
+      String stderrStreamName)
+      throws IOException, InterruptedException {
+    ProcessBuilder processBuilder =
+        new ProcessBuilder(command.getArgumentsList())
+            .directory(execDir.toAbsolutePath().toFile());
+
+    Map<String, String> environment = processBuilder.environment();
+    environment.clear();
+    for (Command.EnvironmentVariable environmentVariable : command.getEnvironmentVariablesList()) {
+      environment.put(environmentVariable.getName(), environmentVariable.getValue());
+    }
+
+    OutputStream stdoutSink = null, stderrSink = null;
+
+    if (stdoutStreamName != null && !stdoutStreamName.isEmpty() && worker.config.getStreamStdout()) {
+      stdoutSink = worker.instance.getStreamOutput(stdoutStreamName);
+    } else {
+      stdoutSink = nullOutputStream;
+    }
+    if (stderrStreamName != null && !stderrStreamName.isEmpty() && worker.config.getStreamStderr()) {
+      stderrSink = worker.instance.getStreamOutput(stderrStreamName);
+    } else {
+      stderrSink = nullOutputStream;
+    }
+
+    long startNanoTime = System.nanoTime();
+    int exitValue = -1;
+    Process process;
+    try {
+      process = processBuilder.start();
+      process.getOutputStream().close();
+    } catch(IOException ex) {
+      ex.printStackTrace();
+      // again, should we do something else here??
+      ActionResult.Builder resultBuilder = ActionResult.newBuilder()
+          .setExitCode(exitValue);
+      return resultBuilder;
+    }
+
+    InputStream stdoutStream = process.getInputStream();
+    InputStream stderrStream = process.getErrorStream();
+
+    ByteStringSinkReader stdoutReader = new ByteStringSinkReader(
+        process.getInputStream(), stdoutSink);
+    ByteStringSinkReader stderrReader = new ByteStringSinkReader(
+        process.getErrorStream(), stderrSink);
+
+    Thread stdoutReaderThread = new Thread(stdoutReader);
+    Thread stderrReaderThread = new Thread(stderrReader);
+    stdoutReaderThread.start();
+    stderrReaderThread.start();
+
+    boolean doneWaiting = false;
+    if (timeout == null) {
+      exitValue = process.waitFor();
+    } else {
+      while (!doneWaiting) {
+        long timeoutNanos = timeout.getSeconds() * 1000000000L + timeout.getNanos();
+        long remainingNanoTime = timeoutNanos - (System.nanoTime() - startNanoTime);
+        if (remainingNanoTime > 0) {
+          if (process.waitFor(remainingNanoTime, TimeUnit.NANOSECONDS)) {
+            exitValue = process.exitValue();
+            doneWaiting = true;
+          }
+        } else {
+          process.destroyForcibly();
+          process.waitFor(100, TimeUnit.MILLISECONDS); // fair trade, i think
+          doneWaiting = true;
+        }
+      }
+    }
+    if (!stdoutReader.isComplete()) {
+      stdoutReaderThread.interrupt();
+    }
+    stdoutReaderThread.join();
+    if (!stderrReader.isComplete()) {
+      stderrReaderThread.interrupt();
+    }
+    stderrReaderThread.join();
+    return ActionResult.newBuilder()
+        .setExitCode(exitValue)
+        .setStdoutRaw(stdoutReader.getData())
+        .setStderrRaw(stderrReader.getData());
+  }
+}

--- a/src/main/java/build/buildfarm/worker/InputFetchStage.java
+++ b/src/main/java/build/buildfarm/worker/InputFetchStage.java
@@ -1,0 +1,167 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.worker;
+
+import build.buildfarm.common.Digests;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import com.google.devtools.remoteexecution.v1test.Digest;
+import com.google.devtools.remoteexecution.v1test.Directory;
+import com.google.devtools.remoteexecution.v1test.DirectoryNode;
+import com.google.devtools.remoteexecution.v1test.ExecuteOperationMetadata;
+import com.google.devtools.remoteexecution.v1test.FileNode;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ArrayBlockingQueue;
+
+class InputFetchStage extends PipelineStage {
+  private final BlockingQueue<OperationContext> queue;
+
+  InputFetchStage(Worker worker, PipelineStage output, PipelineStage error) {
+    super(worker, output, error);
+    queue = new ArrayBlockingQueue<>(1);
+  }
+
+  @Override
+  public OperationContext take() throws InterruptedException {
+    return queue.take();
+  }
+
+  @Override
+  public void offer(OperationContext operationContext) {
+    queue.offer(operationContext);
+  }
+
+  @Override
+  protected OperationContext tick(OperationContext operationContext) {
+    final String operationName = operationContext.operation.getName();
+    Poller poller = new Poller(worker.config.getOperationPollPeriod(), () -> {
+          boolean success = worker.instance.pollOperation(
+              operationName,
+              ExecuteOperationMetadata.Stage.QUEUED);
+          return success;
+        });
+    new Thread(poller).start();
+
+    Path execDir = operationContext.execDir;
+
+    boolean success = true;
+    try {
+      if (Files.exists(execDir)) {
+        Worker.removeDirectory(execDir);
+      }
+      Files.createDirectories(execDir);
+
+      fetchInputs(
+          execDir,
+          operationContext.action.getInputRootDigest(),
+          operationContext.inputFiles);
+
+      verifyOutputLocations(
+          execDir,
+          operationContext.action.getOutputFilesList(),
+          operationContext.action.getOutputDirectoriesList());
+    } catch (IOException|InterruptedException ex) {
+      ex.printStackTrace();
+      success = false;
+    }
+
+    poller.stop();
+
+    if (!success) {
+      worker.fileCache.update(operationContext.inputFiles);
+    }
+
+    return success ? operationContext : null;
+  }
+
+  private void fetchInputs(
+      Path execDir,
+      Digest inputRoot,
+      List<String> inputFiles) throws IOException, InterruptedException {
+    ImmutableList.Builder<Directory> directories = new ImmutableList.Builder<>();
+    String pageToken = "";
+
+    do {
+      pageToken = worker.instance.getTree(inputRoot, worker.config.getTreePageSize(), pageToken, directories);
+    } while (!pageToken.isEmpty());
+
+    Set<Digest> directoryDigests = new HashSet<>();
+    ImmutableMap.Builder<Digest, Directory> directoriesIndex = new ImmutableMap.Builder<>();
+    long entries = 0;
+    for (Directory directory : directories.build()) {
+      entries++;
+      Digest directoryDigest = Digests.computeDigest(directory);
+      if (!directoryDigests.add(directoryDigest)) {
+        continue;
+      }
+      directoriesIndex.put(directoryDigest, directory);
+    }
+
+    linkInputs(execDir, inputRoot, directoriesIndex.build(), inputFiles);
+  }
+
+  private void linkInputs(
+      Path execDir,
+      Digest inputRoot,
+      Map<Digest, Directory> directoriesIndex,
+      List<String> inputFiles)
+      throws IOException, InterruptedException {
+    Directory directory = directoriesIndex.get(inputRoot);
+
+    for (FileNode fileNode : directory.getFilesList()) {
+      Path execPath = execDir.resolve(fileNode.getName());
+      String fileCacheKey = worker.fileCache.put(fileNode.getDigest(), fileNode.getIsExecutable());
+      if (fileCacheKey == null) {
+        throw new IOException("InputFetchStage: Failed to create cache entry for " + execPath);
+      }
+      inputFiles.add(fileCacheKey);
+      Files.createLink(execPath, worker.fileCache.getPath(fileCacheKey));
+    }
+
+    for (DirectoryNode directoryNode : directory.getDirectoriesList()) {
+      Digest digest = directoryNode.getDigest();
+      String name = directoryNode.getName();
+      Path dirPath = execDir.resolve(name);
+      Files.createDirectories(dirPath);
+      linkInputs(dirPath, digest, directoriesIndex, inputFiles);
+    }
+  }
+
+  private void verifyOutputLocations(
+      Path execDir,
+      Iterable<String> outputFiles,
+      Iterable<String> outputDirs) throws IOException {
+    for (String outputFile : outputFiles) {
+      Path outputDir = execDir.resolve(outputFile).getParent();
+      if (!Files.exists(outputDir)) {
+        Files.createDirectories(outputDir);
+      }
+    }
+
+    for (String outputDir : outputDirs) {
+      throw new IllegalArgumentException("InputFetchStage: outputDir specified: " + outputDir);
+    }
+  }
+}

--- a/src/main/java/build/buildfarm/worker/MatchStage.java
+++ b/src/main/java/build/buildfarm/worker/MatchStage.java
@@ -1,0 +1,84 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.worker;
+
+import com.google.devtools.remoteexecution.v1test.Action;
+import com.google.devtools.remoteexecution.v1test.ExecuteOperationMetadata;
+import com.google.longrunning.Operation;
+import com.google.protobuf.InvalidProtocolBufferException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+
+class MatchStage extends PipelineStage {
+  MatchStage(Worker worker, PipelineStage output, PipelineStage error) {
+    super(worker, output, error);
+  }
+
+  @Override
+  protected void iterate() throws InterruptedException {
+    if (!output.claim()) {
+      return;
+    }
+    worker.instance.match(worker.config.getPlatform(), worker.config.getRequeueOnFailure(), (operation) -> {
+      return fetch(operation);
+    });
+  }
+
+  private boolean fetch(Operation operation) {
+    ExecuteOperationMetadata metadata;
+    Action action;
+    try {
+      metadata = operation.getMetadata().unpack(ExecuteOperationMetadata.class);
+      action = Action.parseFrom(worker.instance.getBlob(metadata.getActionDigest()));
+    } catch (InvalidProtocolBufferException ex) {
+      return false;
+    }
+    Path execDir = worker.root.resolve(operation.getName());
+    output.offer(new OperationContext(
+        operation,
+        execDir,
+        metadata,
+        action,
+        new ArrayList<>()));
+    return true;
+  }
+
+  @Override
+  public OperationContext take() throws InterruptedException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean claim() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void release() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void offer(OperationContext operation) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void setInput(PipelineStage input) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/src/main/java/build/buildfarm/worker/OperationContext.java
+++ b/src/main/java/build/buildfarm/worker/OperationContext.java
@@ -1,0 +1,43 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.worker;
+
+import com.google.devtools.remoteexecution.v1test.Digest;
+import com.google.devtools.remoteexecution.v1test.Action;
+import com.google.devtools.remoteexecution.v1test.ExecuteOperationMetadata;
+import com.google.longrunning.Operation;
+import java.nio.file.Path;
+import java.util.List;
+
+final class OperationContext {
+  final Operation operation;
+  final Path execDir;
+  final ExecuteOperationMetadata metadata;
+  final Action action;
+  final List<String> inputFiles;
+
+  public OperationContext(
+      Operation operation,
+      Path execDir,
+      ExecuteOperationMetadata metadata,
+      Action action,
+      List<String> inputFiles) {
+    this.operation = operation;
+    this.execDir = execDir;
+    this.metadata = metadata;
+    this.action = action;
+    this.inputFiles = inputFiles;
+  }
+}

--- a/src/main/java/build/buildfarm/worker/Pipeline.java
+++ b/src/main/java/build/buildfarm/worker/Pipeline.java
@@ -1,0 +1,100 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.worker;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+class Pipeline {
+  private final Map<PipelineStage, Thread> stageThreads;
+  private final Map<PipelineStage, Integer> stageClosePriorities;
+  // FIXME ThreadGroup?
+
+  Pipeline() {
+    stageThreads = new HashMap<>();
+    stageClosePriorities = new HashMap<>();
+  }
+
+  public void add(PipelineStage stage, int closePriority) {
+    stageThreads.put(stage, new Thread(stage));
+    if (closePriority < 0) {
+      throw new IllegalArgumentException("closePriority cannot be negative");
+    }
+    stageClosePriorities.put(stage, closePriority);
+  }
+
+  void start() {
+    for (Thread stageThread : stageThreads.values()) {
+      stageThread.start();
+    }
+  }
+
+  void join() {
+    List<PipelineStage> inactiveStages = new ArrayList<>();
+    boolean closeStage = false;
+    boolean wasInterrupted = false;
+    try {
+      while (!stageThreads.isEmpty()) {
+        if (closeStage) {
+          PipelineStage stageToClose = null;
+          int maxPriority = -1;
+          for (PipelineStage stage : stageThreads.keySet()) {
+            if (stage.isClosed()) {
+              stageToClose = null;
+              break;
+            }
+            if (stageClosePriorities.get(stage) > maxPriority) {
+              maxPriority = stageClosePriorities.get(stage);
+              stageToClose = stage;
+            }
+          }
+          if (stageToClose != null && !stageToClose.isClosed()) {
+            System.out.println("Closing stage at priority " + maxPriority);
+            stageToClose.close();
+          }
+        }
+        for (Map.Entry<PipelineStage, Thread> stageThread : stageThreads.entrySet()) {
+          PipelineStage stage = stageThread.getKey();
+          Thread thread = stageThread.getValue();
+          try {
+            thread.join(closeStage ? 1 : 1000);
+          } catch (InterruptedException ex) {
+            wasInterrupted = true;
+          }
+
+          if (!thread.isAlive()) {
+            System.out.println("Stage has exited at priority " + stageClosePriorities.get(stage));
+            inactiveStages.add(stage);
+          } else if (stage.isClosed()) {
+            System.out.println("Interrupting unterminated closed thread at priority " + stageClosePriorities.get(stage));
+            thread.interrupt();
+          }
+        }
+        closeStage = false;
+        for (PipelineStage stage : inactiveStages) {
+          stageThreads.remove(stage);
+          closeStage = true;
+        }
+        inactiveStages.clear();
+      }
+    } finally {
+      if (wasInterrupted) {
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+}

--- a/src/main/java/build/buildfarm/worker/PipelineStage.java
+++ b/src/main/java/build/buildfarm/worker/PipelineStage.java
@@ -1,0 +1,113 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.worker;
+
+abstract class PipelineStage implements Runnable {
+  protected final Worker worker;
+  protected final PipelineStage output;
+  private final PipelineStage error;
+
+  private PipelineStage input;
+  protected boolean claimed;
+  private boolean closed;
+
+  PipelineStage(Worker worker, PipelineStage output, PipelineStage error) {
+    this.worker = worker;
+    this.output = output;
+    this.error = error;
+
+    input = null;
+    claimed = false;
+    closed = false;
+  }
+
+  public void setInput(PipelineStage input) {
+    this.input = input;
+  }
+
+  @Override
+  public void run() {
+    try {
+      while (!output.isClosed() || isClaimed()) {
+        iterate();
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    } finally {
+      close();
+    }
+  }
+
+  protected void iterate() throws InterruptedException {
+    OperationContext operationContext;
+    try {
+      operationContext = take();
+      OperationContext nextOperationContext = tick(operationContext);
+      if (nextOperationContext != null && output.claim()) {
+        output.offer(nextOperationContext);
+      } else {
+        error.offer(operationContext);
+      }
+    } finally {
+      release();
+    }
+    after(operationContext);
+  }
+
+  protected OperationContext tick(OperationContext operationContext) {
+    return operationContext;
+  }
+
+  protected void after(OperationContext operationContext) { }
+
+  public synchronized boolean claim() throws InterruptedException {
+    while (!closed && claimed) {
+      wait();
+    }
+    if (closed) {
+      return false;
+    }
+    claimed = true;
+    return true;
+  }
+
+  public synchronized void release() {
+    claimed = false;
+    notify();
+  }
+
+  public void close() {
+    closed = true;
+  }
+
+  public boolean isClosed() {
+    return closed;
+  }
+
+  protected boolean isClaimed() {
+    return claimed;
+  }
+
+  public PipelineStage output() {
+    return this.output;
+  }
+
+  public PipelineStage error() {
+    return this.error;
+  }
+
+  abstract OperationContext take() throws InterruptedException;
+  abstract void offer(OperationContext operationContext);
+}

--- a/src/main/java/build/buildfarm/worker/Poller.java
+++ b/src/main/java/build/buildfarm/worker/Poller.java
@@ -1,0 +1,52 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.worker;
+
+import com.google.protobuf.Duration;
+import java.util.function.BooleanSupplier;
+
+class Poller implements Runnable {
+  private final Duration period;
+  private final BooleanSupplier poll;
+  private boolean running;
+
+  public Poller(Duration period, BooleanSupplier poll) {
+    this.period = period;
+    this.poll = poll;
+    running = true;
+  }
+
+  @Override
+  public synchronized void run() {
+    while (running) {
+      try {
+        this.wait(
+            period.getSeconds() * 1000 + period.getNanos() / 1000000,
+            period.getNanos() % 1000000);
+        if (running) {
+          // FP interface with distinct returns, do not memoize!
+          running = poll.getAsBoolean();
+        }
+      } catch (InterruptedException ex) {
+        running = false;
+      }
+    }
+  }
+
+  public synchronized void stop() {
+    running = false;
+    this.notify();
+  }
+}

--- a/src/main/java/build/buildfarm/worker/ReportResultStage.java
+++ b/src/main/java/build/buildfarm/worker/ReportResultStage.java
@@ -1,0 +1,222 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.worker;
+
+import build.buildfarm.common.Digests;
+import build.buildfarm.instance.Instance;
+import build.buildfarm.v1test.CASInsertionControl;
+import com.google.common.collect.ImmutableList;
+import com.google.devtools.remoteexecution.v1test.Action;
+import com.google.devtools.remoteexecution.v1test.ActionResult;
+import com.google.devtools.remoteexecution.v1test.Digest;
+import com.google.devtools.remoteexecution.v1test.ExecuteOperationMetadata;
+import com.google.devtools.remoteexecution.v1test.ExecuteResponse;
+import com.google.devtools.remoteexecution.v1test.OutputFile;
+import com.google.longrunning.Operation;
+import com.google.protobuf.Any;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ArrayBlockingQueue;
+
+class ReportResultStage extends PipelineStage {
+  private final BlockingQueue<OperationContext> queue;
+
+  public static class NullStage extends PipelineStage {
+    public NullStage() {
+      super(null, null, null);
+    }
+
+    @Override
+    public boolean claim() { return true; }
+    @Override
+    public void release() { }
+    @Override
+    public OperationContext take() { throw new UnsupportedOperationException(); }
+    @Override
+    public void offer(OperationContext operation) { }
+    @Override
+    public void setInput(PipelineStage input) { }
+    @Override
+    public void run() { }
+    @Override
+    public void close() { }
+    @Override
+    public boolean isClosed() { return false; }
+  }
+
+  ReportResultStage(Worker worker, PipelineStage error) {
+    super(worker, new NullStage(), error);
+    queue = new ArrayBlockingQueue<>(1);
+  }
+
+  @Override
+  public OperationContext take() throws InterruptedException {
+    return queue.take();
+  }
+
+  @Override
+  public void offer(OperationContext operationContext) {
+    queue.offer(operationContext);
+  }
+
+  private void updateActionResultStdOutputs(
+      ActionResult.Builder resultBuilder,
+      ImmutableList.Builder<ByteString> contents) {
+    ByteString stdoutRaw = resultBuilder.getStdoutRaw();
+    if (stdoutRaw.size() > 0) {
+      CASInsertionControl control = worker.config.getStdoutCasControl();
+      boolean withinLimit = stdoutRaw.size() <= control.getLimit();
+      if (!withinLimit) {
+        resultBuilder.setStdoutRaw(ByteString.EMPTY);
+      }
+      if (control.getPolicy() == CASInsertionControl.Policy.ALWAYS_INSERT ||
+          (!withinLimit && control.getPolicy() == CASInsertionControl.Policy.INSERT_ABOVE_LIMIT)) {
+        resultBuilder.setStdoutDigest(Digests.computeDigest(stdoutRaw));
+      }
+    }
+
+    ByteString stderrRaw = resultBuilder.getStderrRaw();
+    if (stderrRaw.size() > 0) {
+      CASInsertionControl control = worker.config.getStderrCasControl();
+      boolean withinLimit = stderrRaw.size() <= control.getLimit();
+      if (!withinLimit) {
+        resultBuilder.setStderrRaw(ByteString.EMPTY);
+      }
+      if (control.getPolicy() == CASInsertionControl.Policy.ALWAYS_INSERT ||
+          (!withinLimit && control.getPolicy() == CASInsertionControl.Policy.INSERT_ABOVE_LIMIT)) {
+        contents.add(stderrRaw);
+        resultBuilder.setStderrDigest(Digests.computeDigest(stderrRaw));
+      }
+    }
+  }
+
+  @Override
+  protected OperationContext tick(OperationContext operationContext) {
+    final String operationName = operationContext.operation.getName();
+    Poller poller = new Poller(worker.config.getOperationPollPeriod(), () -> {
+          boolean success = worker.instance.pollOperation(
+              operationName,
+              ExecuteOperationMetadata.Stage.EXECUTING);
+          return success;
+        });
+    new Thread(poller).start();
+
+    ActionResult.Builder resultBuilder;
+    try {
+      resultBuilder = operationContext
+          .operation.getResponse().unpack(ExecuteResponse.class).getResult().toBuilder();
+    } catch (InvalidProtocolBufferException ex) {
+      poller.stop();
+      return null;
+    }
+
+    ImmutableList.Builder<ByteString> contents = new ImmutableList.Builder<>();
+    CASInsertionControl control = worker.config.getFileCasControl();
+    for (String outputFile : operationContext.action.getOutputFilesList()) {
+      Path outputPath = operationContext.execDir.resolve(outputFile);
+      if (!Files.exists(outputPath)) {
+        continue;
+      }
+
+      // FIXME put the output into the fileCache
+      // FIXME this needs to be streamed to the server, not read to completion, but
+      // this is a constraint of not knowing the hash, however, if we put the entry
+      // into the cache, we can likely do so, stream the output up, and be done
+      //
+      // will run into issues if we end up blocking on the cache insertion, might
+      // want to decrement input references *before* this to ensure that we cannot
+      // cause an internal deadlock
+
+      ByteString content;
+      try {
+        InputStream inputStream = Files.newInputStream(outputPath);
+        content = ByteString.readFrom(inputStream);
+        inputStream.close();
+      } catch (IOException ex) {
+        continue;
+      }
+      OutputFile.Builder outputFileBuilder = resultBuilder.addOutputFilesBuilder()
+          .setPath(outputFile)
+          .setIsExecutable(Files.isExecutable(outputPath));
+      boolean withinLimit = content.size() <= worker.config.getFileCasControl().getLimit();
+      if (withinLimit) {
+        outputFileBuilder.setContent(content);
+      }
+      if (control.getPolicy() == CASInsertionControl.Policy.ALWAYS_INSERT ||
+          (!withinLimit && control.getPolicy() == CASInsertionControl.Policy.INSERT_ABOVE_LIMIT)) {
+        contents.add(content);
+
+        // FIXME make this happen with putAllBlobs
+        Digest outputDigest = Digests.computeDigest(content);
+        outputFileBuilder.setDigest(outputDigest);
+      }
+    }
+
+    /* put together our outputs and update the result */
+    updateActionResultStdOutputs(resultBuilder, contents);
+
+    try {
+      worker.instance.putAllBlobs(contents.build());
+    } catch (IOException ex) {
+    } catch (InterruptedException ex) {
+      poller.stop();
+      return null;
+    }
+
+    ActionResult result = resultBuilder.build();
+    if (!operationContext.action.getDoNotCache() && resultBuilder.getExitCode() == 0) {
+      worker.instance.putActionResult(operationContext.metadata.getActionDigest(), result);
+    }
+
+    ExecuteOperationMetadata metadata = operationContext.metadata.toBuilder()
+        .setStage(ExecuteOperationMetadata.Stage.COMPLETED)
+        .build();
+
+    Operation operation = operationContext.operation.toBuilder()
+        .setDone(true)
+        .setMetadata(Any.pack(metadata))
+        .setResponse(Any.pack(ExecuteResponse.newBuilder()
+            .setResult(result)
+            .setCachedResult(false)
+            .build()))
+        .build();
+
+    poller.stop();
+
+    if (!worker.instance.putOperation(operation)) {
+      return null;
+    }
+
+    return new OperationContext(
+        operation,
+        operationContext.execDir,
+        metadata,
+        operationContext.action,
+        operationContext.inputFiles);
+  }
+
+  @Override
+  protected void after(OperationContext operationContext) {
+    try {
+      Worker.removeDirectory(operationContext.execDir);
+    } catch (IOException ex) {
+    }
+  }
+}

--- a/src/main/java/build/buildfarm/worker/Worker.java
+++ b/src/main/java/build/buildfarm/worker/Worker.java
@@ -14,98 +14,38 @@
 
 package build.buildfarm.worker;
 
-import build.buildfarm.common.Digests;
 import build.buildfarm.common.Encoding;
 import build.buildfarm.instance.Instance;
 import build.buildfarm.instance.stub.StubInstance;
-import build.buildfarm.v1test.CASInsertionControl;
 import build.buildfarm.v1test.WorkerConfig;
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.io.ByteStreams;
 import com.google.devtools.common.options.OptionsParser;
-import com.google.devtools.remoteexecution.v1test.Action;
-import com.google.devtools.remoteexecution.v1test.ActionResult;
-import com.google.devtools.remoteexecution.v1test.Command;
 import com.google.devtools.remoteexecution.v1test.Digest;
-import com.google.devtools.remoteexecution.v1test.Directory;
-import com.google.devtools.remoteexecution.v1test.DirectoryNode;
-import com.google.devtools.remoteexecution.v1test.ExecuteOperationMetadata;
-import com.google.devtools.remoteexecution.v1test.ExecuteResponse;
-import com.google.devtools.remoteexecution.v1test.FileNode;
-import com.google.devtools.remoteexecution.v1test.OutputFile;
-import com.google.longrunning.Operation;
 import com.google.protobuf.Any;
-import com.google.protobuf.ByteString;
-import com.google.protobuf.Duration;
-import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.TextFormat;
 import io.grpc.ManagedChannel;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-import java.util.function.BooleanSupplier;
 import java.util.logging.Logger;
 import javax.naming.ConfigurationException;
 
 public class Worker {
   public static final Logger logger = Logger.getLogger(Worker.class.getName());
-  private final Instance instance;
-  private final WorkerConfig config;
-  private final Path root;
-  private final CASFileCache fileCache;
-
-  private static final OutputStream nullOutputStream = ByteStreams.nullOutputStream();
-
-  private static class Poller implements Runnable {
-    private final Duration period;
-    private final BooleanSupplier poll;
-    private boolean running;
-
-    public Poller(Duration period, BooleanSupplier poll) {
-      this.period = period;
-      this.poll = poll;
-      running = true;
-    }
-
-    @Override
-    public synchronized void run() {
-      while (running) {
-        try {
-          this.wait(
-              period.getSeconds() * 1000 + period.getNanos() / 1000000,
-              period.getNanos() % 1000000);
-          if (running) {
-            // FP interface with distinct returns, do not memoize!
-            running = poll.getAsBoolean();
-          }
-        } catch (InterruptedException ex) {
-          running = false;
-        }
-      }
-    }
-
-    public synchronized void stop() {
-      running = false;
-      this.notify();
-    }
-  }
+  public final Instance instance;
+  public final WorkerConfig config;
+  public final Path root;
+  public final CASFileCache fileCache;
 
   private static ManagedChannel createChannel(String target) {
     NettyChannelBuilder builder =
@@ -153,7 +93,7 @@ public class Worker {
         config.getCasCacheMaxSizeBytes());
   }
 
-  public void start() {
+  public void start() throws InterruptedException {
     try {
       Files.createDirectories(root);
       fileCache.start();
@@ -161,323 +101,30 @@ public class Worker {
       ex.printStackTrace();
       return;
     }
-    for (;;) {
-      instance.match(config.getPlatform(), config.getRequeueOnFailure(), (operation) -> {
-        try {
-          execute(operation);
-          return true;
-        } catch(Exception ex) {
-          ex.printStackTrace();
-          return false;
-        }
-      });
+
+    PipelineStage errorStage = new ReportResultStage.NullStage(); /* ErrorStage(); */
+    PipelineStage reportResultStage = new ReportResultStage(this, errorStage);
+    PipelineStage executeActionStage = new ExecuteActionStage(this, reportResultStage, errorStage);
+    reportResultStage.setInput(executeActionStage);
+    PipelineStage inputFetchStage = new InputFetchStage(this, executeActionStage, errorStage);
+    executeActionStage.setInput(inputFetchStage);
+    PipelineStage matchStage = new MatchStage(this, inputFetchStage, errorStage);
+    inputFetchStage.setInput(matchStage);
+
+    Pipeline pipeline = new Pipeline();
+    // pipeline.add(errorStage, 0);
+    pipeline.add(matchStage, 1);
+    pipeline.add(inputFetchStage, 2);
+    pipeline.add(executeActionStage, 3);
+    pipeline.add(reportResultStage, 4);
+    pipeline.start();
+    pipeline.join(); // uninterruptable
+    if (Thread.interrupted()) {
+      throw new InterruptedException();
     }
   }
 
-  private void execute(Operation operation)
-      throws InvalidProtocolBufferException, IOException,
-      CacheNotFoundException, InterruptedException {
-    final String operationName = operation.getName();
-    Poller poller = new Poller(config.getOperationPollPeriod(), () -> instance.pollOperation(
-        operationName,
-        ExecuteOperationMetadata.Stage.QUEUED));
-    new Thread(poller).start();
-
-    ExecuteOperationMetadata metadata =
-        operation.getMetadata().unpack(ExecuteOperationMetadata.class);
-    Action action = Action.parseFrom(instance.getBlob(metadata.getActionDigest()));
-
-    Path execDir = root.resolve(operation.getName());
-    Files.createDirectories(execDir);
-
-    List<String> inputs = new ArrayList<>();
-
-    try {
-      /* set up inputs */
-      /* we should update the operation status at this point to indicate input fetches have begun */
-      if (!fetchInputs(execDir, action.getInputRootDigest(), inputs) ||
-          !verifyOutputLocations(execDir, action.getOutputFilesList(), action.getOutputDirectoriesList())) {
-        poller.stop();
-        return;
-      }
-
-      ExecuteOperationMetadata executingMetadata = metadata.toBuilder()
-          .setStage(ExecuteOperationMetadata.Stage.EXECUTING)
-          .build();
-
-      operation = operation.toBuilder()
-          .setMetadata(Any.pack(executingMetadata))
-          .build();
-
-      poller.stop();
-
-      if (!instance.putOperation(operation)) {
-        return;
-      }
-
-      poller = new Poller(config.getOperationPollPeriod(), () -> instance.pollOperation(
-          operationName,
-          ExecuteOperationMetadata.Stage.EXECUTING));
-      new Thread(poller).start();
-
-      Command command = Command.parseFrom(instance.getBlob(action.getCommandDigest()));
-
-      Duration timeout;
-      if (action.hasTimeout()) {
-        timeout = action.getTimeout();
-      } else {
-        timeout = null;
-      }
-
-      /* execute command */
-      ActionResult.Builder resultBuilder = executeCommand(execDir, command, timeout, metadata.getStdoutStreamName(), metadata.getStderrStreamName());
-
-      ImmutableList.Builder<ByteString> contents = new ImmutableList.Builder<>();
-      if (resultBuilder.getExitCode() == 0) {
-        CASInsertionControl control = config.getFileCasControl();
-        for (String outputFile : action.getOutputFilesList()) {
-          Path outputPath = execDir.resolve(outputFile);
-          if (!Files.exists(outputPath)) {
-            continue;
-          }
-
-          // FIXME put the output into the fileCache
-
-          InputStream inputStream = Files.newInputStream(outputPath);
-          ByteString content = ByteString.readFrom(inputStream);
-          inputStream.close();
-          OutputFile.Builder outputFileBuilder = resultBuilder.addOutputFilesBuilder()
-              .setPath(outputFile)
-              .setIsExecutable(Files.isExecutable(outputPath));
-          boolean withinLimit = content.size() <= config.getFileCasControl().getLimit();
-          if (withinLimit) {
-            outputFileBuilder.setContent(content);
-          }
-          if (control.getPolicy() == CASInsertionControl.Policy.ALWAYS_INSERT ||
-              (!withinLimit && control.getPolicy() == CASInsertionControl.Policy.INSERT_ABOVE_LIMIT)) {
-            contents.add(content);
-
-            // FIXME make this happen with putAllBlobs
-            Digest outputDigest = Digests.computeDigest(content);
-            outputFileBuilder.setDigest(outputDigest);
-          }
-        }
-
-        instance.putAllBlobs(contents.build());
-      }
-
-      ActionResult result = resultBuilder.build();
-      if (!action.getDoNotCache()) {
-        instance.putActionResult(metadata.getActionDigest(), result);
-      }
-
-      metadata = metadata.toBuilder()
-          .setStage(ExecuteOperationMetadata.Stage.COMPLETED)
-          .build();
-
-      operation = operation.toBuilder()
-          .setDone(true)
-          .setMetadata(Any.pack(metadata))
-          .setResponse(Any.pack(ExecuteResponse.newBuilder()
-              .setResult(result)
-              .setCachedResult(false)
-              .build()))
-          .build();
-
-      poller.stop();
-
-      instance.putOperation(operation);
-    } finally {
-      // guard against IOException in particular
-      poller.stop(); // no effect if already stopped
-
-      /* cleanup */
-      removeDirectory(execDir);
-
-      fileCache.update(inputs);
-    }
-  }
-
-  private boolean linkInputs(
-      Path execDir,
-      Digest inputRoot,
-      Map<Digest, Directory> directoriesIndex,
-      List<String> inputs)
-      throws IOException, InterruptedException {
-    Directory directory = directoriesIndex.get(inputRoot);
-
-    for (FileNode fileNode : directory.getFilesList()) {
-      Path execPath = execDir.resolve(fileNode.getName());
-      String fileCacheKey = fileCache.put(fileNode.getDigest(), fileNode.getIsExecutable());
-      if (fileCacheKey == null) {
-        return false;
-      }
-      inputs.add(fileCacheKey);
-      Files.createLink(execPath, fileCache.getPath(fileCacheKey));
-    }
-
-    for (DirectoryNode directoryNode : directory.getDirectoriesList()) {
-      Digest digest = directoryNode.getDigest();
-      Path dirPath = execDir.resolve(directoryNode.getName());
-      Files.createDirectory(dirPath);
-      linkInputs(dirPath, directoryNode.getDigest(), directoriesIndex, inputs);
-    }
-
-    return true;
-  }
-
-  private boolean fetchInputs(Path execDir, Digest inputRoot, List<String> inputs)
-      throws IOException, InterruptedException {
-    ImmutableList.Builder<Directory> directories = new ImmutableList.Builder<>();
-    String pageToken = "";
-
-    do {
-      pageToken = instance.getTree(inputRoot, config.getTreePageSize(), pageToken, directories);
-    } while (!pageToken.isEmpty());
-
-    Set<Digest> directoryDigests = new HashSet<>();
-    ImmutableMap.Builder<Digest, Directory> directoriesIndex = new ImmutableMap.Builder<>();
-    for (Directory directory : directories.build()) {
-      Digest directoryDigest = Digests.computeDigest(directory);
-      if (!directoryDigests.add(directoryDigest)) {
-        continue;
-      }
-      directoriesIndex.put(directoryDigest, directory);
-    }
-
-    return linkInputs(execDir, inputRoot, directoriesIndex.build(), inputs);
-  }
-
-  private boolean verifyOutputLocations(
-      Path execDir,
-      Iterable<String> outputFiles,
-      Iterable<String> outputDirs) throws IOException {
-    for (String outputFile : outputFiles) {
-      Path outputFilePath = execDir.resolve(outputFile);
-      Files.createDirectories(outputFilePath.getParent());
-    }
-
-    for (String outputDir : outputDirs) {
-      logger.info("outputDir: " + outputDir);
-      return false;
-    }
-
-    return true;
-  }
-
-  private ActionResult.Builder executeCommand(
-      Path execDir,
-      Command command,
-      Duration timeout,
-      String stdoutStreamName,
-      String stderrStreamName)
-      throws IOException, InterruptedException {
-    ProcessBuilder processBuilder =
-        new ProcessBuilder(command.getArgumentsList())
-            .directory(execDir.toAbsolutePath().toFile());
-
-    Map<String, String> environment = processBuilder.environment();
-    environment.clear();
-    for (Command.EnvironmentVariable environmentVariable : command.getEnvironmentVariablesList()) {
-      environment.put(environmentVariable.getName(), environmentVariable.getValue());
-    }
-
-    OutputStream stdoutSink = null, stderrSink = null;
-
-    if (stdoutStreamName != null && !stdoutStreamName.isEmpty() && config.getStreamStdout()) {
-      stdoutSink = instance.getStreamOutput(stdoutStreamName);
-    } else {
-      stdoutSink = nullOutputStream;
-    }
-    if (stderrStreamName != null && !stderrStreamName.isEmpty() && config.getStreamStderr()) {
-      stderrSink = instance.getStreamOutput(stderrStreamName);
-    } else {
-      stderrSink = nullOutputStream;
-    }
-
-    long startNanoTime = System.nanoTime();
-    int exitValue = -1;
-    Process process;
-    try {
-      process = processBuilder.start();
-      process.getOutputStream().close();
-    } catch(IOException ex) {
-      // again, should we do something else here??
-      ActionResult.Builder resultBuilder = ActionResult.newBuilder()
-          .setExitCode(exitValue);
-      return resultBuilder;
-    }
-
-    InputStream stdoutStream = process.getInputStream();
-    InputStream stderrStream = process.getErrorStream();
-
-    ByteStringSinkReader stdoutReader = new ByteStringSinkReader(
-        process.getInputStream(), stdoutSink);
-    ByteStringSinkReader stderrReader = new ByteStringSinkReader(
-        process.getErrorStream(), stderrSink);
-
-    Thread stdoutReaderThread = new Thread(stdoutReader);
-    Thread stderrReaderThread = new Thread(stderrReader);
-    stdoutReaderThread.start();
-    stderrReaderThread.start();
-
-    boolean doneWaiting = false;
-    if (timeout == null) {
-      exitValue = process.waitFor();
-    } else {
-      while (!doneWaiting) {
-        long timeoutNanos = timeout.getSeconds() * 1000000000L + timeout.getNanos();
-        long remainingNanoTime = timeoutNanos - (System.nanoTime() - startNanoTime);
-        if (remainingNanoTime > 0) {
-          if (process.waitFor(remainingNanoTime, TimeUnit.NANOSECONDS)) {
-            exitValue = process.exitValue();
-            doneWaiting = true;
-          }
-        } else {
-          process.destroyForcibly();
-          process.waitFor(100, TimeUnit.MILLISECONDS); // fair trade, i think
-          doneWaiting = true;
-        }
-      }
-    }
-    if (!stdoutReader.isComplete()) {
-      stdoutReaderThread.interrupt();
-    }
-    stdoutReaderThread.join();
-    if (!stderrReader.isComplete()) {
-      stderrReaderThread.interrupt();
-    }
-    stderrReaderThread.join();
-    ActionResult.Builder resultBuilder = ActionResult.newBuilder()
-        .setExitCode(exitValue);
-    ByteString stdoutRaw = stdoutReader.getData();
-    if (stdoutRaw.size() > 0) {
-      CASInsertionControl control = config.getStdoutCasControl();
-      boolean withinLimit = stdoutRaw.size() <= control.getLimit();
-      if (withinLimit) {
-        resultBuilder.setStdoutRaw(stdoutRaw);
-      }
-      if (control.getPolicy() == CASInsertionControl.Policy.ALWAYS_INSERT ||
-          (!withinLimit && control.getPolicy() == CASInsertionControl.Policy.INSERT_ABOVE_LIMIT)) {
-        resultBuilder.setStdoutDigest(instance.putBlob(stdoutRaw));
-      }
-    }
-    ByteString stderrRaw = stderrReader.getData();
-    if (stderrRaw.size() > 0) {
-      CASInsertionControl control = config.getStderrCasControl();
-      boolean withinLimit = stderrRaw.size() <= control.getLimit();
-      if (withinLimit) {
-        resultBuilder.setStderrRaw(stderrRaw);
-      }
-      if (control.getPolicy() == CASInsertionControl.Policy.ALWAYS_INSERT ||
-          (!withinLimit && control.getPolicy() == CASInsertionControl.Policy.INSERT_ABOVE_LIMIT)) {
-        resultBuilder.setStderrDigest(instance.putBlob(stderrRaw));
-      }
-    }
-    return resultBuilder;
-  }
-
-  private void removeDirectory(Path directory) throws IOException {
+  public static void removeDirectory(Path directory) throws IOException {
     Files.walkFileTree(directory, new SimpleFileVisitor<Path>() {
       @Override
       public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -153,6 +153,9 @@ message WorkerConfig {
 
   // initial platform used to match operations
   google.devtools.remoteexecution.v1test.Platform platform = 14;
+
+  // execute width
+  int32 execute_stage_width = 15;
 }
 
 message TreeIteratorToken {


### PR DESCRIPTION
Move the major operations - Input Fetch, Execute, Writeback, of the
worker into a pipeline with concurrent stage execution. The number of
available concurrent slots for the execution stage is configurable, and
each stage will stall on a transition to the next if it is (fully)
occupied.