### PR TITLE
Validate configuration before creating channels

### DIFF
--- a/src/main/java/build/buildfarm/worker/Worker.java
+++ b/src/main/java/build/buildfarm/worker/Worker.java
@@ -135,7 +135,12 @@ public class Worker {
 
   public Worker(WorkerConfig config) throws ConfigurationException {
     this.config = config;
+
+    /* configuration validation */
     root = getValidRoot(config);
+    Path casCacheDirectory = getValidCasCacheDirectory(config, root);
+
+    /* initialization */
     instance = new StubInstance(
         config.getInstanceName(),
         createChannel(config.getOperationQueue()));
@@ -147,7 +152,7 @@ public class Worker {
     };
     fileCache = new CASFileCache(
         inputStreamFactory,
-        root.resolve(getValidCasCacheDirectory(config, root)),
+        root.resolve(casCacheDirectory),
         config.getCasCacheMaxSizeBytes());
   }
 


### PR DESCRIPTION
Worker validation should occur prior to (possibly failing to) create a
channel based on the configuration. An invalid URI in the
operation_queue field should not be the primary exception when a path
configuration is invalid according to tests.