### PR TITLE
Extract all url path handling code to new UrlPath class

### DIFF
--- a/src/main/java/build/buildfarm/server/BuildFarmInstances.java
+++ b/src/main/java/build/buildfarm/server/BuildFarmInstances.java
@@ -17,7 +17,6 @@ package build.buildfarm.server;
 import build.buildfarm.instance.Instance;
 import build.buildfarm.instance.memory.MemoryInstance;
 import build.buildfarm.v1test.InstanceConfig;
-import com.google.common.collect.Iterables;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -59,56 +58,31 @@ public class BuildFarmInstances {
 
   public Instance getFromOperationsCollectionName(
       String operationsCollectionName) throws InstanceNotFoundException {
-    // {instance_name=**}/operations
-    String[] components = operationsCollectionName.split("/");
-    String instanceName = String.join(
-        "/", Iterables.limit(
-            Arrays.asList(components),
-            components.length - 1));
+    String instanceName = UrlPath.fromOperationsCollectionName(operationsCollectionName);
     return get(instanceName);
   }
 
   public Instance getFromOperationName(String operationName)
       throws InstanceNotFoundException {
-    // {instance_name=**}/operations/{uuid}
-    String[] components = operationName.split("/");
-    String instanceName = String.join(
-        "/", Iterables.limit(
-            Arrays.asList(components),
-            components.length - 2));
+    String instanceName = UrlPath.fromOperationName(operationName);
     return get(instanceName);
   }
 
   public Instance getFromOperationStream(String operationStream)
       throws InstanceNotFoundException {
-    // {instance_name=**}/operations/{uuid}/streams/{stream}
-    String[] components = operationStream.split("/");
-    String instanceName = String.join(
-        "/", Iterables.limit(
-            Arrays.asList(components),
-            components.length - 4));
+    String instanceName = UrlPath.fromOperationStream(operationStream);
     return get(instanceName);
   }
 
   public Instance getFromBlob(String blobName)
       throws InstanceNotFoundException {
-    // {instance_name=**}/blobs/{hash}/{size}
-    String[] components = blobName.split("/");
-    String instanceName = String.join(
-        "/", Iterables.limit(
-            Arrays.asList(components),
-            components.length - 3));
+    String instanceName = UrlPath.fromBlobName(blobName);
     return get(instanceName);
   }
 
   public Instance getFromUploadBlob(String uploadBlobName)
       throws InstanceNotFoundException {
-    // {instance_name=**}/uploads/{uuid}/blobs/{hash}/{size}
-    String[] components = uploadBlobName.split("/");
-    String instanceName = String.join(
-        "/", Iterables.limit(
-            Arrays.asList(components),
-            components.length - 5));
+    String instanceName = UrlPath.fromUploadBlobName(uploadBlobName);
     return get(instanceName);
   }
 

--- a/src/main/java/build/buildfarm/server/ByteStreamService.java
+++ b/src/main/java/build/buildfarm/server/ByteStreamService.java
@@ -35,6 +35,7 @@ import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 public class ByteStreamService extends ByteStreamGrpc.ByteStreamImplBase {
   private static final long DEFAULT_CHUNK_SIZE = 1024 * 16;
@@ -45,50 +46,6 @@ public class ByteStreamService extends ByteStreamGrpc.ByteStreamImplBase {
   public ByteStreamService(BuildFarmInstances instances) {
     active_write_requests = new HashMap<String, ByteString>();
     this.instances = instances;
-  }
-
-  private static boolean isBlob(String resourceName) {
-    // {instance_name=**}/blobs/{hash}/{size}
-    String[] components = resourceName.split("/");
-    return components.length >= 3 &&
-      components[components.length - 3].equals("blobs");
-  }
-
-  private static boolean isUploadBlob(String resourceName) {
-    // {instance_name=**}/uploads/{uuid}/blobs/{hash}/{size}
-    String[] components = resourceName.split("/");
-    return components.length >= 5 &&
-      components[components.length - 3].equals("blobs") &&
-      components[components.length - 5].equals("uploads");
-  }
-
-  private static boolean isOperationStream(String resourceName) {
-    // {instance_name=**}/operations/{uuid}/streams/{stream}
-    String[] components = resourceName.split("/");
-    return components.length >= 4 &&
-        components[components.length - 2].equals("streams") &&
-        components[components.length - 4].equals("operations");
-  }
-
-  private static Digest parseBlobDigest(String resourceName)
-      throws IllegalArgumentException {
-    String[] components = resourceName.split("/");
-    String hash = components[components.length - 2];
-    long size = Long.parseLong(components[components.length - 1]);
-    return Digests.buildDigest(hash, size);
-  }
-
-  private static Digest parseUploadBlobDigest(String resourceName)
-      throws IllegalArgumentException {
-    String[] components = resourceName.split("/");
-    String hash = components[components.length - 2];
-    long size = Long.parseLong(components[components.length - 1]);
-    return Digests.buildDigest(hash, size);
-  }
-
-  public String parseOperationStream(String resourceName) {
-    String[] components = resourceName.split("/");
-    return String.join("/", Arrays.asList(components).subList(components.length - 4, components.length));
   }
 
   private void readBlob(
@@ -104,7 +61,7 @@ public class ByteStreamService extends ByteStreamGrpc.ByteStreamImplBase {
       return;
     }
 
-    Digest digest = parseBlobDigest(resourceName);
+    Digest digest = UrlPath.parseBlobDigest(resourceName);
 
     ByteString blob = instance.getBlob(
         digest, request.getReadOffset(), request.getReadLimit());
@@ -143,7 +100,7 @@ public class ByteStreamService extends ByteStreamGrpc.ByteStreamImplBase {
       return;
     }
 
-    String operationStream = parseOperationStream(resourceName);
+    String operationStream = UrlPath.parseOperationStream(resourceName);
 
     InputStream input = instance.newStreamInput(operationStream);
     long readLimit = request.getReadLimit();
@@ -187,12 +144,24 @@ public class ByteStreamService extends ByteStreamGrpc.ByteStreamImplBase {
     }
 
     try {
-      if (isBlob(resourceName)) {
+      Optional<UrlPath.ServiceType> serviceType = Optional.empty();
+      try {
+        serviceType = Optional.of(UrlPath.detectServiceType(resourceName));
+      } catch (IllegalArgumentException ex) {
+        String description = ex.getLocalizedMessage();
+        responseObserver.onError(new StatusException(Status.INVALID_ARGUMENT.withDescription(description)));
+        return;
+      }
+      switch (serviceType.get()) {
+      case Blob:
         readBlob(request, responseObserver);
-      } else if (isOperationStream(resourceName)) {
+        break;
+      case OperationStream:
         readOperationStream(request, responseObserver);
-      } else {
+        break;
+      default:
         responseObserver.onError(new StatusException(Status.INVALID_ARGUMENT));
+        break;
       }
     } catch(IOException ex) {
       responseObserver.onError(new StatusException(Status.fromThrowable(ex)));
@@ -205,12 +174,25 @@ public class ByteStreamService extends ByteStreamGrpc.ByteStreamImplBase {
       StreamObserver<QueryWriteStatusResponse> responseObserver) {
     String resourceName = request.getResourceName();
 
-    if (isUploadBlob(resourceName)) {
+    Optional<UrlPath.ServiceType> serviceType = Optional.empty();
+    try {
+      serviceType = Optional.of(UrlPath.detectServiceType(resourceName));
+    } catch (IllegalArgumentException ex) {
+      String description = ex.getLocalizedMessage();
+      responseObserver.onError(new StatusException(Status.INVALID_ARGUMENT.withDescription(description)));
+      return;
+    }
+
+    switch (serviceType.get()) {
+    case UploadBlob:
       responseObserver.onError(new StatusException(Status.UNIMPLEMENTED));
-    } else if (isOperationStream(resourceName)) {
+      break;
+    case OperationStream:
       responseObserver.onError(new StatusException(Status.UNIMPLEMENTED));
-    } else {
+      break;
+    default:
       responseObserver.onError(new StatusException(Status.INVALID_ARGUMENT));
+      break;
     }
   }
 
@@ -230,7 +212,7 @@ public class ByteStreamService extends ByteStreamGrpc.ByteStreamImplBase {
           WriteRequest request, StreamObserver<WriteResponse> responseObserver)
           throws InterruptedException {
         if (data == null) {
-          digest = parseUploadBlobDigest(writeResourceName);
+          digest = UrlPath.parseUploadBlobDigest(writeResourceName);
           if (digest == null) {
             responseObserver.onError(new StatusException(Status.INVALID_ARGUMENT));
             failed = true;
@@ -293,7 +275,7 @@ public class ByteStreamService extends ByteStreamGrpc.ByteStreamImplBase {
           return;
         }
 
-        String operationStream = parseOperationStream(writeResourceName);
+        String operationStream = UrlPath.parseOperationStream(writeResourceName);
 
         OutputStream outputStream = instance.getStreamOutput(operationStream);
         request.getData().writeTo(outputStream);
@@ -325,25 +307,44 @@ public class ByteStreamService extends ByteStreamGrpc.ByteStreamImplBase {
           }
         }
 
-        if (!failed) {
-          try {
-            if (isUploadBlob(writeResourceName)) {
-              writeBlob(request, responseObserver);
-              finished = request.getFinishWrite();
-            } else if (isOperationStream(writeResourceName)) {
-              writeOperationStream(request, responseObserver);
-              finished = request.getFinishWrite();
-            } else {
-              responseObserver.onError(new StatusException(Status.INVALID_ARGUMENT));
-              failed = true;
-            }
-          } catch(InterruptedException ex) {
-            responseObserver.onError(new StatusException(Status.fromThrowable(ex)));
+        if (failed) {
+          return;
+        }
+        
+        Optional<UrlPath.ServiceType> serviceType = Optional.empty();
+        try {
+          serviceType = Optional.of(UrlPath.detectServiceType(writeResourceName));
+        } catch (IllegalArgumentException ex) {
+            String description = ex.getLocalizedMessage();
+            responseObserver.onError(new StatusException(Status.INVALID_ARGUMENT.withDescription(description)));
             failed = true;
-          } catch(IOException ex) {
-            responseObserver.onError(new StatusException(Status.fromThrowable(ex)));
+        }
+
+        if (failed) {
+          return;
+        }
+
+        try {
+          switch (serviceType.get()) {
+          case UploadBlob:
+            writeBlob(request, responseObserver);
+            finished = request.getFinishWrite();
+            break;
+          case OperationStream:
+            writeOperationStream(request, responseObserver);
+            finished = request.getFinishWrite();
+            break;
+          default:
+            responseObserver.onError(new StatusException(Status.INVALID_ARGUMENT));
             failed = true;
+            break;
           }
+        } catch(InterruptedException ex) {
+          responseObserver.onError(new StatusException(Status.fromThrowable(ex)));
+          failed = true;
+        } catch(IOException ex) {
+          responseObserver.onError(new StatusException(Status.fromThrowable(ex)));
+          failed = true;
         }
       }
 

--- a/src/main/java/build/buildfarm/server/ByteStreamService.java
+++ b/src/main/java/build/buildfarm/server/ByteStreamService.java
@@ -144,9 +144,9 @@ public class ByteStreamService extends ByteStreamGrpc.ByteStreamImplBase {
     }
 
     try {
-      Optional<UrlPath.ServiceType> serviceType = Optional.empty();
+      Optional<UrlPath.ResourceOperation> serviceType = Optional.empty();
       try {
-        serviceType = Optional.of(UrlPath.detectServiceType(resourceName));
+        serviceType = Optional.of(UrlPath.detectResourceOperation(resourceName));
       } catch (IllegalArgumentException ex) {
         String description = ex.getLocalizedMessage();
         responseObserver.onError(new StatusException(Status.INVALID_ARGUMENT.withDescription(description)));
@@ -174,9 +174,9 @@ public class ByteStreamService extends ByteStreamGrpc.ByteStreamImplBase {
       StreamObserver<QueryWriteStatusResponse> responseObserver) {
     String resourceName = request.getResourceName();
 
-    Optional<UrlPath.ServiceType> serviceType = Optional.empty();
+    Optional<UrlPath.ResourceOperation> serviceType = Optional.empty();
     try {
-      serviceType = Optional.of(UrlPath.detectServiceType(resourceName));
+      serviceType = Optional.of(UrlPath.detectResourceOperation(resourceName));
     } catch (IllegalArgumentException ex) {
       String description = ex.getLocalizedMessage();
       responseObserver.onError(new StatusException(Status.INVALID_ARGUMENT.withDescription(description)));
@@ -311,9 +311,9 @@ public class ByteStreamService extends ByteStreamGrpc.ByteStreamImplBase {
           return;
         }
         
-        Optional<UrlPath.ServiceType> serviceType = Optional.empty();
+        Optional<UrlPath.ResourceOperation> serviceType = Optional.empty();
         try {
-          serviceType = Optional.of(UrlPath.detectServiceType(writeResourceName));
+          serviceType = Optional.of(UrlPath.detectResourceOperation(writeResourceName));
         } catch (IllegalArgumentException ex) {
             String description = ex.getLocalizedMessage();
             responseObserver.onError(new StatusException(Status.INVALID_ARGUMENT.withDescription(description)));

--- a/src/main/java/build/buildfarm/server/ByteStreamService.java
+++ b/src/main/java/build/buildfarm/server/ByteStreamService.java
@@ -144,15 +144,15 @@ public class ByteStreamService extends ByteStreamGrpc.ByteStreamImplBase {
     }
 
     try {
-      Optional<UrlPath.ResourceOperation> serviceType = Optional.empty();
+      Optional<UrlPath.ResourceOperation> resourceOperation = Optional.empty();
       try {
-        serviceType = Optional.of(UrlPath.detectResourceOperation(resourceName));
+        resourceOperation = Optional.of(UrlPath.detectResourceOperation(resourceName));
       } catch (IllegalArgumentException ex) {
         String description = ex.getLocalizedMessage();
         responseObserver.onError(new StatusException(Status.INVALID_ARGUMENT.withDescription(description)));
         return;
       }
-      switch (serviceType.get()) {
+      switch (resourceOperation.get()) {
       case Blob:
         readBlob(request, responseObserver);
         break;
@@ -174,16 +174,16 @@ public class ByteStreamService extends ByteStreamGrpc.ByteStreamImplBase {
       StreamObserver<QueryWriteStatusResponse> responseObserver) {
     String resourceName = request.getResourceName();
 
-    Optional<UrlPath.ResourceOperation> serviceType = Optional.empty();
+    Optional<UrlPath.ResourceOperation> resourceOperation = Optional.empty();
     try {
-      serviceType = Optional.of(UrlPath.detectResourceOperation(resourceName));
+      resourceOperation = Optional.of(UrlPath.detectResourceOperation(resourceName));
     } catch (IllegalArgumentException ex) {
       String description = ex.getLocalizedMessage();
       responseObserver.onError(new StatusException(Status.INVALID_ARGUMENT.withDescription(description)));
       return;
     }
 
-    switch (serviceType.get()) {
+    switch (resourceOperation.get()) {
     case UploadBlob:
       responseObserver.onError(new StatusException(Status.UNIMPLEMENTED));
       break;
@@ -311,9 +311,9 @@ public class ByteStreamService extends ByteStreamGrpc.ByteStreamImplBase {
           return;
         }
         
-        Optional<UrlPath.ResourceOperation> serviceType = Optional.empty();
+        Optional<UrlPath.ResourceOperation> resourceOperation = Optional.empty();
         try {
-          serviceType = Optional.of(UrlPath.detectResourceOperation(writeResourceName));
+          resourceOperation = Optional.of(UrlPath.detectResourceOperation(writeResourceName));
         } catch (IllegalArgumentException ex) {
             String description = ex.getLocalizedMessage();
             responseObserver.onError(new StatusException(Status.INVALID_ARGUMENT.withDescription(description)));
@@ -325,7 +325,7 @@ public class ByteStreamService extends ByteStreamGrpc.ByteStreamImplBase {
         }
 
         try {
-          switch (serviceType.get()) {
+          switch (resourceOperation.get()) {
           case UploadBlob:
             writeBlob(request, responseObserver);
             finished = request.getFinishWrite();

--- a/src/main/java/build/buildfarm/server/UrlPath.java
+++ b/src/main/java/build/buildfarm/server/UrlPath.java
@@ -20,29 +20,29 @@ import com.google.devtools.remoteexecution.v1test.Digest;
 import java.util.Arrays;
 
 public class UrlPath {
-  public enum ServiceType {
+  public enum ResourceOperation {
     Blob(3),
     UploadBlob(5),
     OperationStream(4);
 
     private final int minComponentLength;
-    private ServiceType(int minComponentLength) {
+    private ResourceOperation(int minComponentLength) {
       this.minComponentLength = minComponentLength;
     }
   }
 
-  public static ServiceType detectServiceType(String resourceName) {
+  public static ResourceOperation detectResourceOperation(String resourceName) {
     // TODO: Replace this with proper readonly parser should this become
     // a bottleneck
     String[] components = resourceName.split("/");
     
     // Keep following checks ordered by descending minComponentLength
-    if (components.length >= ServiceType.UploadBlob.minComponentLength && isUploadBlob(components)) {
-      return ServiceType.UploadBlob;
-    } else if (components.length >= ServiceType.OperationStream.minComponentLength && isOperationStream(components)) {
-      return ServiceType.OperationStream;
-    } else if (components.length >= ServiceType.Blob.minComponentLength && isBlob(components)) {
-      return ServiceType.Blob;
+    if (components.length >= ResourceOperation.UploadBlob.minComponentLength && isUploadBlob(components)) {
+      return ResourceOperation.UploadBlob;
+    } else if (components.length >= ResourceOperation.OperationStream.minComponentLength && isOperationStream(components)) {
+      return ResourceOperation.OperationStream;
+    } else if (components.length >= ResourceOperation.Blob.minComponentLength && isBlob(components)) {
+      return ResourceOperation.Blob;
     }
 
     throw new IllegalArgumentException("Url path not recognized: " + resourceName);

--- a/src/main/java/build/buildfarm/server/UrlPath.java
+++ b/src/main/java/build/buildfarm/server/UrlPath.java
@@ -1,0 +1,134 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.server;
+
+import build.buildfarm.common.Digests;
+import com.google.common.collect.Iterables;
+import com.google.devtools.remoteexecution.v1test.Digest;
+import java.util.Arrays;
+
+public class UrlPath {
+  public enum ServiceType {
+    Blob(3),
+    UploadBlob(5),
+    OperationStream(4);
+
+    private final int minComponentLength;
+    private ServiceType(int minComponentLength) {
+      this.minComponentLength = minComponentLength;
+    }
+  }
+
+  public static ServiceType detectServiceType(String resourceName) {
+    // TODO: Replace this with proper readonly parser should this become
+    // a bottleneck
+    String[] components = resourceName.split("/");
+    
+    // Keep following checks ordered by descending minComponentLength
+    if (components.length >= ServiceType.UploadBlob.minComponentLength && isUploadBlob(components)) {
+      return ServiceType.UploadBlob;
+    } else if (components.length >= ServiceType.OperationStream.minComponentLength && isOperationStream(components)) {
+      return ServiceType.OperationStream;
+    } else if (components.length >= ServiceType.Blob.minComponentLength && isBlob(components)) {
+      return ServiceType.Blob;
+    }
+
+    throw new IllegalArgumentException("Url path not recognized: " + resourceName);
+  }
+    
+  private static boolean isBlob(String[] components) {
+    // {instance_name=**}/blobs/{hash}/{size}
+    return components[components.length - 3].equals("blobs");
+  }
+
+  private static boolean isUploadBlob(String[] components) {
+    // {instance_name=**}/uploads/{uuid}/blobs/{hash}/{size}
+    return components[components.length - 3].equals("blobs") &&
+      components[components.length - 5].equals("uploads");
+  }
+
+  private static boolean isOperationStream(String[] components) {
+    // {instance_name=**}/operations/{uuid}/streams/{stream}
+    return components[components.length - 2].equals("streams") &&
+        components[components.length - 4].equals("operations");
+  }
+
+  public static String fromOperationsCollectionName(String operationsCollectionName) {
+    // {instance_name=**}/operations
+    String[] components = operationsCollectionName.split("/");
+    return String.join(
+        "/", Iterables.limit(
+            Arrays.asList(components),
+            components.length - 1));
+  }
+
+  public static String fromOperationName(String operationName) {
+    // {instance_name=**}/operations/{uuid}
+    String[] components = operationName.split("/");
+    return String.join(
+        "/", Iterables.limit(
+            Arrays.asList(components),
+            components.length - 2));
+  }
+
+  public static String fromOperationStream(String operationStream) {
+    // {instance_name=**}/operations/{uuid}/streams/{stream}
+    String[] components = operationStream.split("/");
+    return String.join(
+        "/", Iterables.limit(
+            Arrays.asList(components),
+            components.length - 4));
+  }
+
+  public static String fromBlobName(String blobName) {
+    // {instance_name=**}/blobs/{hash}/{size}
+    String[] components = blobName.split("/");
+    return String.join(
+        "/", Iterables.limit(
+            Arrays.asList(components),
+            components.length - 3));
+  }
+
+  public static String fromUploadBlobName(String uploadBlobName) {
+    // {instance_name=**}/uploads/{uuid}/blobs/{hash}/{size}
+    String[] components = uploadBlobName.split("/");
+    return String.join(
+        "/", Iterables.limit(
+            Arrays.asList(components),
+            components.length - 5));
+  }
+
+  public static Digest parseBlobDigest(String resourceName)
+      throws IllegalArgumentException {
+    String[] components = resourceName.split("/");
+    String hash = components[components.length - 2];
+    long size = Long.parseLong(components[components.length - 1]);
+    return Digests.buildDigest(hash, size);
+  }
+
+  public static Digest parseUploadBlobDigest(String resourceName)
+      throws IllegalArgumentException {
+    String[] components = resourceName.split("/");
+    String hash = components[components.length - 2];
+    long size = Long.parseLong(components[components.length - 1]);
+    return Digests.buildDigest(hash, size);
+  }
+
+  public static String parseOperationStream(String resourceName) {
+    String[] components = resourceName.split("/");
+    return String.join("/", Arrays.asList(components).subList(components.length - 4, components.length));
+  }
+}
+


### PR DESCRIPTION
Remove is* methods since implementation is inefficient and repetitive.
Instead introduce a UrlPath.detectServiceType, which is only a bit inefficient.