### PR TITLE
Configurable symlink of input-only directories

### DIFF
--- a/src/main/java/build/buildfarm/worker/CASFileCache.java
+++ b/src/main/java/build/buildfarm/worker/CASFileCache.java
@@ -189,7 +189,6 @@ class CASFileCache {
     while (header.before == header.after) {
       wait();
     }
-    // should assert that e.referenceCount == 0
     Entry e = header.after;
     if (e.referenceCount != 0) {
       throw new RuntimeException("ERROR: Reference counts lru ordering has not been maintained correctly, attempting to expire referenced (or negatively counted) content");

--- a/src/main/java/build/buildfarm/worker/CASFileCache.java
+++ b/src/main/java/build/buildfarm/worker/CASFileCache.java
@@ -220,7 +220,7 @@ class CASFileCache {
   /** must be called in synchronized context */
   private void incrementReferences(Iterable<Path> inputs) {
     for (Path input : inputs) {
-      storage.get(input).incrementReference(header);
+      storage.get(input).incrementReference();
     }
   }
 
@@ -283,7 +283,7 @@ class CASFileCache {
         if (containingDirectory != null) {
           e.containingDirectories.add(containingDirectory);
         }
-        e.incrementReference(header);
+        e.incrementReference();
         return key;
       }
 
@@ -387,7 +387,7 @@ class CASFileCache {
       before.after = this;
     }
 
-    public void incrementReference(Entry header) {
+    public void incrementReference() {
       if (referenceCount == 0) {
         remove();
       }
@@ -419,7 +419,7 @@ class CASFileCache {
     }
 
     @Override
-    public void incrementReference(Entry header) {
+    public void incrementReference() {
       throw new UnsupportedOperationException("sentinal cannot be referenced");
     }
 

--- a/src/main/java/build/buildfarm/worker/Executor.java
+++ b/src/main/java/build/buildfarm/worker/Executor.java
@@ -117,7 +117,8 @@ class Executor implements Runnable {
             operationContext.execDir,
             operationContext.metadata,
             operationContext.action,
-            operationContext.inputFiles));
+            operationContext.inputFiles,
+            operationContext.inputDirectories));
       } else {
         owner.error().offer(operationContext);
       }
@@ -127,7 +128,7 @@ class Executor implements Runnable {
 
     owner.release();
 
-    worker.fileCache.update(operationContext.inputFiles);
+    worker.fileCache.update(operationContext.inputFiles, operationContext.inputDirectories);
   }
 
   private ActionResult.Builder executeCommand(

--- a/src/main/java/build/buildfarm/worker/InputFetchStage.java
+++ b/src/main/java/build/buildfarm/worker/InputFetchStage.java
@@ -152,7 +152,7 @@ class InputFetchStage extends PipelineStage {
       Path execDir,
       Digest inputRoot,
       OutputDirectory outputDirectory,
-      List<String> inputFiles,
+      List<Path> inputFiles,
       List<Digest> inputDirectories) throws IOException, InterruptedException {
     ImmutableList.Builder<Directory> directories = new ImmutableList.Builder<>();
     String pageToken = "";
@@ -181,19 +181,19 @@ class InputFetchStage extends PipelineStage {
       Digest inputRoot,
       Map<Digest, Directory> directoriesIndex,
       OutputDirectory outputDirectory,
-      List<String> inputFiles,
+      List<Path> inputFiles,
       List<Digest> inputDirectories)
       throws IOException, InterruptedException {
     Directory directory = directoriesIndex.get(inputRoot);
 
     for (FileNode fileNode : directory.getFilesList()) {
       Path execPath = execDir.resolve(fileNode.getName());
-      String fileCacheKey = worker.fileCache.put(fileNode.getDigest(), fileNode.getIsExecutable());
+      Path fileCacheKey = worker.fileCache.put(fileNode.getDigest(), fileNode.getIsExecutable());
       if (fileCacheKey == null) {
         throw new IOException("InputFetchStage: Failed to create cache entry for " + execPath);
       }
       inputFiles.add(fileCacheKey);
-      Files.createLink(execPath, worker.fileCache.getPath(fileCacheKey));
+      Files.createLink(execPath, fileCacheKey);
     }
 
     for (DirectoryNode directoryNode : directory.getDirectoriesList()) {

--- a/src/main/java/build/buildfarm/worker/MatchStage.java
+++ b/src/main/java/build/buildfarm/worker/MatchStage.java
@@ -53,6 +53,7 @@ class MatchStage extends PipelineStage {
         execDir,
         metadata,
         action,
+        new ArrayList<>(),
         new ArrayList<>()));
     return true;
   }

--- a/src/main/java/build/buildfarm/worker/OperationContext.java
+++ b/src/main/java/build/buildfarm/worker/OperationContext.java
@@ -26,7 +26,7 @@ final class OperationContext {
   final Path execDir;
   final ExecuteOperationMetadata metadata;
   final Action action;
-  final List<String> inputFiles;
+  final List<Path> inputFiles;
   final List<Digest> inputDirectories;
 
   public OperationContext(
@@ -34,7 +34,7 @@ final class OperationContext {
       Path execDir,
       ExecuteOperationMetadata metadata,
       Action action,
-      List<String> inputFiles,
+      List<Path> inputFiles,
       List<Digest> inputDirectories) {
     this.operation = operation;
     this.execDir = execDir;

--- a/src/main/java/build/buildfarm/worker/OperationContext.java
+++ b/src/main/java/build/buildfarm/worker/OperationContext.java
@@ -27,17 +27,20 @@ final class OperationContext {
   final ExecuteOperationMetadata metadata;
   final Action action;
   final List<String> inputFiles;
+  final List<Digest> inputDirectories;
 
   public OperationContext(
       Operation operation,
       Path execDir,
       ExecuteOperationMetadata metadata,
       Action action,
-      List<String> inputFiles) {
+      List<String> inputFiles,
+      List<Digest> inputDirectories) {
     this.operation = operation;
     this.execDir = execDir;
     this.metadata = metadata;
     this.action = action;
     this.inputFiles = inputFiles;
+    this.inputDirectories = inputDirectories;
   }
 }

--- a/src/main/java/build/buildfarm/worker/ReportResultStage.java
+++ b/src/main/java/build/buildfarm/worker/ReportResultStage.java
@@ -236,7 +236,8 @@ class ReportResultStage extends PipelineStage {
         operationContext.execDir,
         metadata,
         operationContext.action,
-        operationContext.inputFiles);
+        operationContext.inputFiles,
+        operationContext.inputDirectories);
   }
 
   @Override

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -164,6 +164,9 @@ message WorkerConfig {
 
   // execute width
   int32 execute_stage_width = 17;
+
+  // symlink cas input-only directories
+  bool link_input_directories = 18;
 }
 
 message TreeIteratorToken {


### PR DESCRIPTION
Provide the option of symlinking directories which are present in the
input tree and have no intersection with output file paths. This results
in substantial throughput improvement for the IF->EX transition,
allowing extremely large input trees to be coherently factored out of
the input fetch stage. Invalidation of expired content of a directory
occurs recursively in the CASFileCache.