### PR TITLE
Switch file/stdout/stderr limits to total result

### DIFF
--- a/examples/worker.config.example
+++ b/examples/worker.config.example
@@ -22,7 +22,6 @@ stream_stdout: true
 # whether to insert stdout into the CAS, can be:
 #   ALWAYS_INSERT: stdout is always inserted into the CAS
 #   INSERT_ABOVE_LIMIT: stdout is inserted into the CAS when it exceeds the inline limit above
-#   NEVER_INSERT: stdout is never inserted into the CAS
 stdout_cas_policy: ALWAYS_INSERT
 
 # whether the stderr of running processes should be streamed
@@ -31,13 +30,11 @@ stream_stderr: true
 # whether to insert stderr into the CAS, can be:
 #   ALWAYS_INSERT: stderr is always inserted into the CAS
 #   INSERT_ABOVE_LIMIT: stderr is inserted into the CAS when it exceeds the inline limit above
-#   NEVER_INSERT: stderr is never inserted into the CAS
 stderr_cas_policy: ALWAYS_INSERT
 
 # whether to insert output files into the CAS, can be:
 #   ALWAYS_INSERT: output files are always inserted into the CAS
 #   INSERT_ABOVE_LIMIT: output files are inserted into the CAS when it exceeds the inline limit above
-#   NEVER_INSERT: output files are never inserted into the CAS
 file_cas_control: ALWAYS_INSERT
 
 # the worker will take it upon itself to requeue (exceptionally)

--- a/examples/worker.config.example
+++ b/examples/worker.config.example
@@ -11,47 +11,34 @@ root: "/tmp/worker"
 # the local cache location relative to the 'root', or absolute
 cas_cache_directory: "cache"
 
+# total size in bytes of inline content for action results
+# output files, stdout, and stderr content, in that order
+# will be inlined if their cumulative size does not exceed this limit.
+inline_content_limit: 1048567 # 1024 * 1024
+
 # whether the stdout of running processes should be streamed
 stream_stdout: true
 
-# policy control for stdout in results injection and CAS
-stdout_cas_control: {
-  # maximum content size above which inlined output will not be present
-  limit: 16384 # 1024 * 16
-
-  # whether to insert stdout into the CAS, can be:
-  #   ALWAYS_INSERT: stdout is always inserted into the CAS
-  #   INSERT_ABOVE_LIMIT: stdout is inserted into the CAS when it exceeds the inline limit above
-  #   NEVER_INSERT: stdout is never inserted into the CAS
-  policy: ALWAYS_INSERT
-}
+# whether to insert stdout into the CAS, can be:
+#   ALWAYS_INSERT: stdout is always inserted into the CAS
+#   INSERT_ABOVE_LIMIT: stdout is inserted into the CAS when it exceeds the inline limit above
+#   NEVER_INSERT: stdout is never inserted into the CAS
+stdout_cas_policy: ALWAYS_INSERT
 
 # whether the stderr of running processes should be streamed
 stream_stderr: true
 
-# policy control for stderr in results injection and CAS
-stderr_cas_control: {
-  # maximum content size above which inlined output will not be present
-  limit: 16384 # 1024 * 16
+# whether to insert stderr into the CAS, can be:
+#   ALWAYS_INSERT: stderr is always inserted into the CAS
+#   INSERT_ABOVE_LIMIT: stderr is inserted into the CAS when it exceeds the inline limit above
+#   NEVER_INSERT: stderr is never inserted into the CAS
+stderr_cas_policy: ALWAYS_INSERT
 
-  # whether to insert stderr into the CAS, can be:
-  #   ALWAYS_INSERT: stderr is always inserted into the CAS
-  #   INSERT_ABOVE_LIMIT: stderr is inserted into the CAS when it exceeds the inline limit above
-  #   NEVER_INSERT: stderr is never inserted into the CAS
-  policy: ALWAYS_INSERT
-}
-
-# policy control for output files
-file_cas_control: {
-  # maximum content size which inlined output will not be present
-  limit: 16384 # 1024 * 16
-
-  # whether to insert output files into the CAS, can be:
-  #   ALWAYS_INSERT: output files are always inserted into the CAS
-  #   INSERT_ABOVE_LIMIT: output files are inserted into the CAS when it exceeds the inline limit above
-  #   NEVER_INSERT: output files are never inserted into the CAS
-  policy: ALWAYS_INSERT
-}
+# whether to insert output files into the CAS, can be:
+#   ALWAYS_INSERT: output files are always inserted into the CAS
+#   INSERT_ABOVE_LIMIT: output files are inserted into the CAS when it exceeds the inline limit above
+#   NEVER_INSERT: output files are never inserted into the CAS
+file_cas_control: ALWAYS_INSERT
 
 # the worker will take it upon itself to requeue (exceptionally)
 # failed operations via the OperationQueue#put method with queued

--- a/src/main/java/build/buildfarm/worker/Executor.java
+++ b/src/main/java/build/buildfarm/worker/Executor.java
@@ -14,7 +14,6 @@
 
 package build.buildfarm.worker;
 
-import build.buildfarm.v1test.CASInsertionControl;
 import com.google.common.io.ByteStreams;
 import com.google.devtools.remoteexecution.v1test.ActionResult;
 import com.google.devtools.remoteexecution.v1test.Command;

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -90,21 +90,12 @@ message InstanceConfig {
   }
 }
 
-message CASInsertionControl {
-  // the size limit of inline content
-  int64 limit = 1;
+enum CASInsertionPolicy {
+  UNKNOWN = 0;
 
-  enum Policy {
-    UNKNOWN = 0;
+  ALWAYS_INSERT = 1;
 
-    ALWAYS_INSERT = 1;
-
-    INSERT_ABOVE_LIMIT = 2;
-
-    NEVER_INSERT = 3;
-  }
-
-  Policy policy = 2;
+  INSERT_ABOVE_LIMIT = 2;
 };
 
 message WorkerConfig {
@@ -128,37 +119,41 @@ message WorkerConfig {
   // from CAS in the cache
   int64 cas_cache_max_size_bytes = 5;
 
-  // whether to stream stdout from processes
-  bool stream_stdout = 6;
+  // total size of the inline content for
+  // action results
+  int32 inline_content_limit = 6;
 
-  // control for process stdout
-  CASInsertionControl stdout_cas_control = 7;
+  // whether to stream stdout from processes
+  bool stream_stdout = 7;
+
+  // policy for process stdout
+  CASInsertionPolicy stdout_cas_policy = 8;
 
   // whether to stream stderr from processes
-  bool stream_stderr = 8;
+  bool stream_stderr = 9;
 
-  // control for process stdout
-  CASInsertionControl stderr_cas_control = 9;
+  // policy for process stdout
+  CASInsertionPolicy stderr_cas_policy = 10;
 
-  // control for process output files
-  CASInsertionControl file_cas_control = 10;
+  // policy for process output files
+  CASInsertionPolicy file_cas_policy = 11;
 
   // whether the worker should attempt to requeue
   // an operation when an unexpected failure
   // occurs during an execution
-  bool requeue_on_failure = 11;
+  bool requeue_on_failure = 12;
 
   // page size for getTree request
-  uint32 tree_page_size = 12;
+  uint32 tree_page_size = 13;
 
   // period of poll requests during execution
-  google.protobuf.Duration operation_poll_period = 13;
+  google.protobuf.Duration operation_poll_period = 14;
 
   // initial platform used to match operations
-  google.devtools.remoteexecution.v1test.Platform platform = 14;
+  google.devtools.remoteexecution.v1test.Platform platform = 15;
 
   // execute width
-  int32 execute_stage_width = 15;
+  int32 execute_stage_width = 16;
 }
 
 message TreeIteratorToken {

--- a/src/test/java/build/buildfarm/BUILD
+++ b/src/test/java/build/buildfarm/BUILD
@@ -18,6 +18,7 @@ java_test(
         "@googleapis//:google_longrunning_operations_java_grpc",
         "@googleapis//:google_rpc_code_java_proto",
     ],
+    size = "small",
 )
 
 java_test(
@@ -27,6 +28,7 @@ java_test(
         "//src/main/java/build/buildfarm:buildfarm-worker-impl",
         "//src/main/protobuf:build_buildfarm_v1test_buildfarm_java_proto",
     ],
+    size = "small",
 )
 
 java_test(
@@ -38,4 +40,5 @@ java_test(
         "//3rdparty/jvm/com/google/truth",
         "//src/main/java/build/buildfarm:stub-instance",
     ],
+    size = "small",
 )


### PR DESCRIPTION
The individual limits per-file could not prevent a large number of small
files from exceeding the reasonable limit of a grpc-handled inbound
message. Prevent a cumulative limit from being exceeded for variable-
sized inline output content. Updated example configs for new limit
field. Improves behavior for #83