### PR TITLE
Moving HashFunction into InstanceConfig

### DIFF
--- a/src/main/java/build/buildfarm/common/DigestUtil.java
+++ b/src/main/java/build/buildfarm/common/DigestUtil.java
@@ -13,7 +13,7 @@
 // limitations under the License.
 package build.buildfarm.common;
 
-import build.buildfarm.v1test.InstanceHashFunction;
+import build.buildfarm.v1test.InstanceConfig;
 import com.google.common.base.Preconditions;
 import com.google.common.hash.HashCode;
 import com.google.common.hash.Hashing;
@@ -47,7 +47,7 @@ public class DigestUtil {
       empty = this.hash.newHasher().hash();
     }
 
-    public static HashFunction get(InstanceHashFunction hashFunction) throws IllegalArgumentException {
+    public static HashFunction get(InstanceConfig.HashFunction hashFunction) throws IllegalArgumentException {
       switch(hashFunction) {
       default:
       case UNRECOGNIZED:

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -82,15 +82,17 @@ message MemoryInstanceConfig {
   int64 cas_max_size_bytes = 7;
 }
 
-enum InstanceHashFunction {
-  MD5 = 0;
-  SHA1 = 1;
-  SHA256 = 2;
-}
-
 message InstanceConfig {
   string name = 1;
-  InstanceHashFunction hash_function = 2;
+
+  enum HashFunction {
+    UNKNOWN = 0;
+    MD5 = 1;
+    SHA1 = 2;
+    SHA256 = 3;
+  }
+
+  HashFunction hash_function = 2;
 
   oneof type {
     MemoryInstanceConfig memory_instance_config = 3;
@@ -110,7 +112,7 @@ message WorkerConfig {
   string instance_name = 1;
 
   // the hash function used for digests
-  InstanceHashFunction hash_function = 2;
+  InstanceConfig.HashFunction hash_function = 2;
 
   // server address for all buildfarm requests
   // like actioncache or execution in bazel, this

--- a/src/test/java/build/buildfarm/BuildFarmServerTest.java
+++ b/src/test/java/build/buildfarm/BuildFarmServerTest.java
@@ -19,7 +19,7 @@ import static com.google.common.truth.Truth.assertThat;
 import build.buildfarm.common.DigestUtil;
 import build.buildfarm.server.BuildFarmServer;
 import build.buildfarm.v1test.BuildFarmServerConfig;
-import build.buildfarm.v1test.InstanceHashFunction;
+import build.buildfarm.v1test.InstanceConfig.HashFunction;
 import build.buildfarm.v1test.MemoryInstanceConfig;
 import com.google.devtools.remoteexecution.v1test.BatchUpdateBlobsRequest;
 import com.google.devtools.remoteexecution.v1test.BatchUpdateBlobsResponse;
@@ -71,7 +71,7 @@ public class BuildFarmServerTest {
         BuildFarmServerConfig.newBuilder().setPort(0);
     configBuilder.addInstancesBuilder()
         .setName("memory")
-        .setHashFunction(InstanceHashFunction.SHA256)
+        .setHashFunction(HashFunction.SHA256)
         .setMemoryInstanceConfig(memoryInstanceConfig);
 
     server = new BuildFarmServer(


### PR DESCRIPTION
The 'must start at 0' enum means we can't offset our meaningful
HashFunction names. Trying to use 'UNKNOWN' conflicts with existing
CASFilePolicy enum; do proto enums act like C enums? Moving the enum
into the InstanceConfig definition to allow us to have a nonspecific
default of UNKNOWN.