### PR TITLE
Intercept StatusRuntimeExceptions

### DIFF
--- a/src/main/java/build/buildfarm/server/BuildFarmServer.java
+++ b/src/main/java/build/buildfarm/server/BuildFarmServer.java
@@ -20,6 +20,7 @@ import com.google.devtools.common.options.OptionsParser;
 import com.google.protobuf.TextFormat;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
+import io.grpc.util.TransmitStatusRuntimeExceptionInterceptor;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -59,6 +60,7 @@ public class BuildFarmServer {
         .addService(new OperationQueueService(instances))
         .addService(new OperationsService(instances))
         .addService(new WatcherService(instances))
+        .intercept(TransmitStatusRuntimeExceptionInterceptor.instance())
         .build();
   }
 

--- a/src/main/java/build/buildfarm/server/ExecutionService.java
+++ b/src/main/java/build/buildfarm/server/ExecutionService.java
@@ -40,14 +40,19 @@ public class ExecutionService extends ExecutionGrpc.ExecutionImplBase {
       return;
     }
 
-    instance.execute(
-        request.getAction(),
-        request.getSkipCacheLookup(),
-        request.getTotalInputFileCount(),
-        request.getTotalInputFileBytes(),
-        (operation) -> {
-          responseObserver.onNext(operation);
-          responseObserver.onCompleted();
-        });
+    try {
+      instance.execute(
+          request.getAction(),
+          request.getSkipCacheLookup(),
+          request.getTotalInputFileCount(),
+          request.getTotalInputFileBytes(),
+          (operation) -> {
+            responseObserver.onNext(operation);
+            responseObserver.onCompleted();
+          });
+    } catch (IllegalStateException e) {
+      responseObserver.onError(new StatusException(
+          Status.FAILED_PRECONDITION.withDescription(e.getMessage())));
+    }
   }
 }


### PR DESCRIPTION
The TransmitStatusRuntimeExceptionInterceptor can be used to translate
our StatusRuntimeExceptions into onError responses.