### PR TITLE
Reduce empty directory entries

### DIFF
--- a/src/main/java/build/buildfarm/worker/CASFileCache.java
+++ b/src/main/java/build/buildfarm/worker/CASFileCache.java
@@ -234,9 +234,14 @@ class CASFileCache {
     Directory directory = directoriesIndex.get(digest);
     Files.createDirectory(path);
     for (FileNode fileNode : directory.getFilesList()) {
-      Path fileCacheKey = put(fileNode.getDigest(), fileNode.getIsExecutable(), containingDirectory);
-      Files.createLink(path.resolve(fileNode.getName()), fileCacheKey);
-      inputsBuilder.add(fileCacheKey);
+      if (fileNode.getDigest().getSizeBytes() != 0) {
+        Path fileCacheKey = put(fileNode.getDigest(), fileNode.getIsExecutable(), containingDirectory);
+        // FIXME this can die with 'too many links'... needs some cascading fallout
+        Files.createLink(path.resolve(fileNode.getName()), fileCacheKey);
+        inputsBuilder.add(fileCacheKey);
+      } else {
+        Files.createFile(path.resolve(fileNode.getName()));
+      }
     }
     for (DirectoryNode directoryNode : directory.getDirectoriesList()) {
       fetchDirectory(


### PR DESCRIPTION
Deduplicating symlinked directory entries with hard links can result in
createLink failing with 'too many links'. Since the most widely
duplicated entry is the empty blob (and fetching it is pure overhead),
short circuit its file (in directory only) creation and avoid adding it
as an input.