### PR TITLE
Reorder instance constructor params

### DIFF
--- a/src/main/java/build/buildfarm/instance/AbstractServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/AbstractServerInstance.java
@@ -84,11 +84,11 @@ public abstract class AbstractServerInstance implements Instance {
 
   public AbstractServerInstance(
       String name,
+      DigestUtil digestUtil,
       ContentAddressableStorage contentAddressableStorage,
       Map<ActionKey, ActionResult> actionCache,
       Map<String, Operation> outstandingOperations,
-      Map<String, Operation> completedOperations,
-      DigestUtil digestUtil) {
+      Map<String, Operation> completedOperations) {
     this.name = name;
     this.contentAddressableStorage = contentAddressableStorage;
     this.actionCache = actionCache;

--- a/src/main/java/build/buildfarm/instance/memory/MemoryInstance.java
+++ b/src/main/java/build/buildfarm/instance/memory/MemoryInstance.java
@@ -76,28 +76,28 @@ public class MemoryInstance extends AbstractServerInstance {
     }
   }
 
-  public MemoryInstance(String name, MemoryInstanceConfig config, DigestUtil digestUtil) {
+  public MemoryInstance(String name, DigestUtil digestUtil, MemoryInstanceConfig config) {
     this(
         name,
+        digestUtil,
         config,
         /*contentAddressableStorage=*/ new MemoryLRUContentAddressableStorage(config.getCasMaxSizeBytes()),
-        /*outstandingOperations=*/ new TreeMap<String, Operation>(),
-        digestUtil);
+        /*outstandingOperations=*/ new TreeMap<String, Operation>());
   }
 
   private MemoryInstance(
       String name,
+      DigestUtil digestUtil,
       MemoryInstanceConfig config,
       ContentAddressableStorage contentAddressableStorage,
-      Map<String, Operation> outstandingOperations,
-      DigestUtil digestUtil) {
+      Map<String, Operation> outstandingOperations) {
     super(
         name,
+        digestUtil,
         contentAddressableStorage,
         /*actionCache=*/ new DelegateCASMap<ActionKey, ActionResult>(contentAddressableStorage, ActionResult.parser(), digestUtil),
         outstandingOperations,
-        /*completedOperations=*/ new DelegateCASMap<String, Operation>(contentAddressableStorage, Operation.parser(), digestUtil),
-        digestUtil);
+        /*completedOperations=*/ new DelegateCASMap<String, Operation>(contentAddressableStorage, Operation.parser(), digestUtil));
     this.config = config;
     watchers = new ConcurrentHashMap<String, List<Function<Operation, Boolean>>>();
     streams = new HashMap<String, ByteStringStreamSource>();

--- a/src/main/java/build/buildfarm/instance/stub/StubInstance.java
+++ b/src/main/java/build/buildfarm/instance/stub/StubInstance.java
@@ -69,14 +69,14 @@ import java.util.function.Function;
 
 public class StubInstance implements Instance {
   private final String name;
-  private final Channel channel;
   private final DigestUtil digestUtil;
+  private final Channel channel;
   private final ByteStreamUploader uploader;
 
-  public StubInstance(String name, Channel channel, DigestUtil digestUtil) {
+  public StubInstance(String name, DigestUtil digestUtil, Channel channel) {
     this.name = name;
-    this.channel = channel;
     this.digestUtil = digestUtil;
+    this.channel = channel;
 
     uploader = new ByteStreamUploader(name, channel, null, 60, new Retrier(), null);
   }

--- a/src/main/java/build/buildfarm/server/BuildFarmInstances.java
+++ b/src/main/java/build/buildfarm/server/BuildFarmInstances.java
@@ -108,6 +108,7 @@ public class BuildFarmInstances {
     for (InstanceConfig instanceConfig : instanceConfigs) {
       String name = instanceConfig.getName();
       HashFunction hashFunction = getValidHashFunction(instanceConfig);
+      DigestUtil digestUtil = new DigestUtil(hashFunction);
       InstanceConfig.TypeCase typeCase = instanceConfig.getTypeCase();
       switch (typeCase) {
         default:
@@ -116,11 +117,10 @@ public class BuildFarmInstances {
         case MEMORY_INSTANCE_CONFIG:
           instances.put(name, new MemoryInstance(
               name,
-              instanceConfig.getMemoryInstanceConfig(),
-              new DigestUtil(hashFunction)));
+              digestUtil,
+              instanceConfig.getMemoryInstanceConfig()));
           break;
       }
     }
   }
 }
-

--- a/src/main/java/build/buildfarm/worker/Worker.java
+++ b/src/main/java/build/buildfarm/worker/Worker.java
@@ -91,8 +91,8 @@ public class Worker {
     /* initialization */
     instance = new StubInstance(
         config.getInstanceName(),
-        createChannel(config.getOperationQueue()),
-        new DigestUtil(hashFunction));
+        new DigestUtil(hashFunction),
+        createChannel(config.getOperationQueue()));
     InputStreamFactory inputStreamFactory = new InputStreamFactory() {
       @Override
       public InputStream apply(Digest digest) {


### PR DESCRIPTION
Have all Instance derivatives' constructors sequence their parameters
with leading universal fields, currently name and digestUtil.