### PR TITLE
Switch PipelineStage 'offer' to 'put' for blocking

### DIFF
--- a/src/main/java/build/buildfarm/instance/stub/StubInstance.java
+++ b/src/main/java/build/buildfarm/instance/stub/StubInstance.java
@@ -336,7 +336,7 @@ public class StubInstance implements Instance {
         .setPlatform(platform)
         .build());
     boolean successful = onMatch.apply(operation);
-    if (!successful && requeueOnFailure) {
+    if (!Thread.currentThread().isInterrupted() && !successful && requeueOnFailure) {
       requeue(operation);
     }
   }

--- a/src/main/java/build/buildfarm/worker/ExecuteActionStage.java
+++ b/src/main/java/build/buildfarm/worker/ExecuteActionStage.java
@@ -31,8 +31,8 @@ class ExecuteActionStage extends PipelineStage {
   }
 
   @Override
-  public void offer(OperationContext operationContext) {
-    queue.offer(operationContext);
+  public void put(OperationContext operationContext) throws InterruptedException {
+    queue.put(operationContext);
   }
 
   @Override

--- a/src/main/java/build/buildfarm/worker/InputFetchStage.java
+++ b/src/main/java/build/buildfarm/worker/InputFetchStage.java
@@ -56,7 +56,7 @@ class InputFetchStage extends PipelineStage {
   }
 
   @Override
-  protected OperationContext tick(OperationContext operationContext) {
+  protected OperationContext tick(OperationContext operationContext) throws InterruptedException {
     final String operationName = operationContext.operation.getName();
     Poller poller = new Poller(worker.config.getOperationPollPeriod(), () -> {
           boolean success = worker.instance.pollOperation(
@@ -90,8 +90,8 @@ class InputFetchStage extends PipelineStage {
           execDir,
           operationContext.action.getOutputFilesList(),
           operationContext.action.getOutputDirectoriesList());
-    } catch (IOException|InterruptedException ex) {
-      ex.printStackTrace();
+    } catch (IOException e) {
+      e.printStackTrace();
       success = false;
     }
 

--- a/src/main/java/build/buildfarm/worker/InputFetchStage.java
+++ b/src/main/java/build/buildfarm/worker/InputFetchStage.java
@@ -51,8 +51,8 @@ class InputFetchStage extends PipelineStage {
   }
 
   @Override
-  public void offer(OperationContext operationContext) {
-    queue.offer(operationContext);
+  public void put(OperationContext operationContext) throws InterruptedException {
+    queue.put(operationContext);
   }
 
   @Override

--- a/src/main/java/build/buildfarm/worker/MatchStage.java
+++ b/src/main/java/build/buildfarm/worker/MatchStage.java
@@ -36,6 +36,10 @@ class MatchStage extends PipelineStage {
     worker.instance.match(worker.config.getPlatform(), worker.config.getRequeueOnFailure(), (operation) -> {
       return fetch(operation);
     });
+    // trigger stage shutdown if interrupted during fetch
+    if (Thread.currentThread().interrupted()) {
+      throw new InterruptedException();
+    }
   }
 
   private boolean fetch(Operation operation) {

--- a/src/main/java/build/buildfarm/worker/MatchStage.java
+++ b/src/main/java/build/buildfarm/worker/MatchStage.java
@@ -33,11 +33,9 @@ class MatchStage extends PipelineStage {
     if (!output.claim()) {
       return;
     }
-    worker.instance.match(worker.config.getPlatform(), worker.config.getRequeueOnFailure(), (operation) -> {
-      return fetch(operation);
-    });
+    worker.instance.match(worker.config.getPlatform(), worker.config.getRequeueOnFailure(), this::fetch);
     // trigger stage shutdown if interrupted during fetch
-    if (Thread.currentThread().interrupted()) {
+    if (Thread.interrupted()) {
       throw new InterruptedException();
     }
   }
@@ -60,7 +58,7 @@ class MatchStage extends PipelineStage {
           action,
           new ArrayList<>(),
           new ArrayList<>()));
-    } catch (InterruptedException intEx) {
+    } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       return false;
     }

--- a/src/main/java/build/buildfarm/worker/MatchStage.java
+++ b/src/main/java/build/buildfarm/worker/MatchStage.java
@@ -57,6 +57,7 @@ class MatchStage extends PipelineStage {
           new ArrayList<>(),
           new ArrayList<>()));
     } catch (InterruptedException intEx) {
+      Thread.currentThread().interrupt();
       return false;
     }
     return true;

--- a/src/main/java/build/buildfarm/worker/MatchStage.java
+++ b/src/main/java/build/buildfarm/worker/MatchStage.java
@@ -48,13 +48,17 @@ class MatchStage extends PipelineStage {
       return false;
     }
     Path execDir = worker.root.resolve(operation.getName());
-    output.offer(new OperationContext(
-        operation,
-        execDir,
-        metadata,
-        action,
-        new ArrayList<>(),
-        new ArrayList<>()));
+    try {
+      output.put(new OperationContext(
+          operation,
+          execDir,
+          metadata,
+          action,
+          new ArrayList<>(),
+          new ArrayList<>()));
+    } catch (InterruptedException intEx) {
+      return false;
+    }
     return true;
   }
 
@@ -74,7 +78,7 @@ class MatchStage extends PipelineStage {
   }
 
   @Override
-  public void offer(OperationContext operation) {
+  public void put(OperationContext operation) {
     throw new UnsupportedOperationException();
   }
 

--- a/src/main/java/build/buildfarm/worker/PipelineStage.java
+++ b/src/main/java/build/buildfarm/worker/PipelineStage.java
@@ -37,12 +37,16 @@ abstract class PipelineStage implements Runnable {
     this.input = input;
   }
 
+  private void runInterruptible() throws InterruptedException {
+    while (!output.isClosed() || isClaimed()) {
+      iterate();
+    }
+  }
+
   @Override
   public void run() {
     try {
-      while (!output.isClosed() || isClaimed()) {
-        iterate();
-      }
+      runInterruptible();
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
     } finally {
@@ -66,7 +70,7 @@ abstract class PipelineStage implements Runnable {
     after(operationContext);
   }
 
-  protected OperationContext tick(OperationContext operationContext) {
+  protected OperationContext tick(OperationContext operationContext) throws InterruptedException {
     return operationContext;
   }
 

--- a/src/main/java/build/buildfarm/worker/PipelineStage.java
+++ b/src/main/java/build/buildfarm/worker/PipelineStage.java
@@ -56,9 +56,9 @@ abstract class PipelineStage implements Runnable {
       operationContext = take();
       OperationContext nextOperationContext = tick(operationContext);
       if (nextOperationContext != null && output.claim()) {
-        output.offer(nextOperationContext);
+        output.put(nextOperationContext);
       } else {
-        error.offer(operationContext);
+        error.put(operationContext);
       }
     } finally {
       release();
@@ -109,5 +109,5 @@ abstract class PipelineStage implements Runnable {
   }
 
   abstract OperationContext take() throws InterruptedException;
-  abstract void offer(OperationContext operationContext);
+  abstract void put(OperationContext operationContext) throws InterruptedException;
 }

--- a/src/main/java/build/buildfarm/worker/ReportResultStage.java
+++ b/src/main/java/build/buildfarm/worker/ReportResultStage.java
@@ -138,7 +138,7 @@ class ReportResultStage extends PipelineStage {
   }
 
   @Override
-  protected OperationContext tick(OperationContext operationContext) {
+  protected OperationContext tick(OperationContext operationContext) throws InterruptedException {
     final String operationName = operationContext.operation.getName();
     Poller poller = new Poller(worker.config.getOperationPollPeriod(), () -> {
           boolean success = worker.instance.pollOperation(
@@ -201,8 +201,7 @@ class ReportResultStage extends PipelineStage {
 
     try {
       worker.instance.putAllBlobs(contents.build());
-    } catch (IOException ex) {
-    } catch (InterruptedException ex) {
+    } catch (IOException e) {
       poller.stop();
       return null;
     }

--- a/src/main/java/build/buildfarm/worker/ReportResultStage.java
+++ b/src/main/java/build/buildfarm/worker/ReportResultStage.java
@@ -51,7 +51,7 @@ class ReportResultStage extends PipelineStage {
     @Override
     public OperationContext take() { throw new UnsupportedOperationException(); }
     @Override
-    public void offer(OperationContext operation) { }
+    public void put(OperationContext operation) { }
     @Override
     public void setInput(PipelineStage input) { }
     @Override
@@ -73,8 +73,8 @@ class ReportResultStage extends PipelineStage {
   }
 
   @Override
-  public void offer(OperationContext operationContext) {
-    queue.offer(operationContext);
+  public void put(OperationContext operationContext) throws InterruptedException {
+    queue.put(operationContext);
   }
 
   private DigestUtil getDigestUtil() {


### PR DESCRIPTION
Reflect the patterned blocking queue's 'put' method in PipelineStage's
transfer, indicating and properly behaving with a blocking, rather than
offer with an unchecked response.