### PR TITLE
Improve error message for invalid hashes.

### DIFF
--- a/src/main/java/build/buildfarm/common/DigestUtil.java
+++ b/src/main/java/build/buildfarm/common/DigestUtil.java
@@ -128,7 +128,9 @@ public class DigestUtil {
 
   public Digest build(String hexHash, long size) {
     if (!hashFn.isValidHexDigest(hexHash)) {
-      throw new NumberFormatException("Invalid hash size");
+      throw new NumberFormatException(
+        String.format("[%s] is not a valid %s hash.", hexHash, hashFn.name())
+      );
     }
     return buildDigest(hexHash, size);
   }

--- a/src/test/java/build/buildfarm/common/BUILD
+++ b/src/test/java/build/buildfarm/common/BUILD
@@ -1,0 +1,10 @@
+java_test(
+    name = "DigestUtilTest",
+    srcs = ["DigestUtilTest.java"],
+    deps = [
+        "//src/main/java/build/buildfarm:common",
+        "//src/main/protobuf:build_buildfarm_v1test_buildfarm_java_proto",
+        "//3rdparty/jvm/com/google/truth",
+    ],
+    size = "small",
+)

--- a/src/test/java/build/buildfarm/common/DigestUtilTest.java
+++ b/src/test/java/build/buildfarm/common/DigestUtilTest.java
@@ -1,0 +1,49 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.common;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import build.buildfarm.common.DigestUtil;
+import com.google.devtools.remoteexecution.v1test.Digest;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class DigestUtilTest {
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void invalidHashCodeIsDetectedDuringConstruction() {
+        DigestUtil util = new DigestUtil(DigestUtil.HashFunction.MD5);
+        thrown.expect(NumberFormatException.class);
+        thrown.expectMessage("[foo] is not a valid MD5 hash.");
+        util.build("foo", 3);
+    }
+
+    @Test
+    public void canBuildAValidDigest() {
+        DigestUtil util = new DigestUtil(DigestUtil.HashFunction.MD5);
+        String bazelMd5Hash = "24ef4c36ec66c15ef9f0c96fe27c0e0b";
+        long payloadSizeInBytes = 5;
+        Digest digest = util.build(bazelMd5Hash, payloadSizeInBytes);
+        assertThat(digest.getHash()).isEqualTo(bazelMd5Hash);
+        assertThat(digest.getSizeBytes()).isEqualTo(payloadSizeInBytes);
+    }
+}


### PR DESCRIPTION
In case client and server are not using the same
digest hash function, server would fail with a message
like:
```
java.lang.NumberFormatException: Invalid hash size
```

PR changes the error message to make it clear which algorithm
was expected on the server side and which hash was checked:
```
java.lang.NumberFormatException: [8029246214105a97ea1eb37977679dab8a238f80d2d4ca4980f142f669b4bbce] is not a valid MD5 hash.
```

This is very useful for people trying to setup build farm
infra for the first time. This is especially useful, since
Bazel has changed the default digest hash from MD5 to SHA256,
but looks like BuildServer is expecting MD5.