### PR TITLE
Run buildifier on common tests BUILD file.

### DIFF
--- a/src/test/java/build/buildfarm/common/BUILD
+++ b/src/test/java/build/buildfarm/common/BUILD
@@ -1,10 +1,10 @@
 java_test(
     name = "DigestUtilTest",
+    size = "small",
     srcs = ["DigestUtilTest.java"],
     deps = [
+        "//3rdparty/jvm/com/google/truth",
         "//src/main/java/build/buildfarm:common",
         "//src/main/protobuf:build_buildfarm_v1test_buildfarm_java_proto",
-        "//3rdparty/jvm/com/google/truth",
     ],
-    size = "small",
 )


### PR DESCRIPTION
When working on my previous PR I forgot to run an almighty `buildifier`.