### PR TITLE
[Digest] Use a configured digest function instead of hard-coded SHA1.

### DIFF
--- a/src/main/java/build/buildfarm/common/DigestUtil.java
+++ b/src/main/java/build/buildfarm/common/DigestUtil.java
@@ -103,7 +103,7 @@ public class DigestUtil {
             public InputStream openStream() throws IOException {
               return blob.newInput();
             }
-          }.hash(Hashing.sha1()).toString(),
+          }.hash(hashFn.getHash()).toString(),
           blob.size());
     } catch(IOException ex) {
       /* impossible */

--- a/src/test/java/build/buildfarm/BuildFarmServerTest.java
+++ b/src/test/java/build/buildfarm/BuildFarmServerTest.java
@@ -19,6 +19,7 @@ import static com.google.common.truth.Truth.assertThat;
 import build.buildfarm.common.DigestUtil;
 import build.buildfarm.server.BuildFarmServer;
 import build.buildfarm.v1test.BuildFarmServerConfig;
+import build.buildfarm.v1test.InstanceHashFunction;
 import build.buildfarm.v1test.MemoryInstanceConfig;
 import com.google.devtools.remoteexecution.v1test.BatchUpdateBlobsRequest;
 import com.google.devtools.remoteexecution.v1test.BatchUpdateBlobsResponse;
@@ -70,6 +71,7 @@ public class BuildFarmServerTest {
         BuildFarmServerConfig.newBuilder().setPort(0);
     configBuilder.addInstancesBuilder()
         .setName("memory")
+        .setHashFunction(InstanceHashFunction.SHA256)
         .setMemoryInstanceConfig(memoryInstanceConfig);
 
     server = new BuildFarmServer(

--- a/src/test/java/build/buildfarm/common/BUILD
+++ b/src/test/java/build/buildfarm/common/BUILD
@@ -3,6 +3,8 @@ java_test(
     size = "small",
     srcs = ["DigestUtilTest.java"],
     deps = [
+        "//3rdparty/jvm/com/google/guava",
+        "//3rdparty/jvm/com/google/protobuf:protobuf_java",
         "//3rdparty/jvm/com/google/truth",
         "//src/main/java/build/buildfarm:common",
         "//src/main/protobuf:build_buildfarm_v1test_buildfarm_java_proto",

--- a/src/test/java/build/buildfarm/common/DigestUtilTest.java
+++ b/src/test/java/build/buildfarm/common/DigestUtilTest.java
@@ -17,6 +17,7 @@ package build.buildfarm.common;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.devtools.remoteexecution.v1test.Digest;
+import com.google.protobuf.ByteString;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -43,5 +44,22 @@ public class DigestUtilTest {
     Digest digest = util.build(bazelMd5Hash, payloadSizeInBytes);
     assertThat(digest.getHash()).isEqualTo(bazelMd5Hash);
     assertThat(digest.getSizeBytes()).isEqualTo(payloadSizeInBytes);
+  }
+
+  @Test
+  public void computesMd5Hash() {
+    ByteString content = ByteString.copyFromUtf8("bazel");
+    DigestUtil util = new DigestUtil(DigestUtil.HashFunction.MD5);
+    Digest digest = util.compute(content);
+    assertThat(digest.getHash()).isEqualTo("24ef4c36ec66c15ef9f0c96fe27c0e0b");
+  }
+
+  @Test
+  public void computesSha256Hash() {
+    ByteString content = ByteString.copyFromUtf8("bazel");
+    DigestUtil util = new DigestUtil(DigestUtil.HashFunction.SHA256);
+    Digest digest = util.compute(content);
+    assertThat(digest.getHash())
+        .isEqualTo("aa0e09c406dd0db1a3bb250216045e81644d26c961c0e8c34e8a0354476ca6d4");
   }
 }


### PR DESCRIPTION
Previously `DigestUtil#compute` function would ignoer the digest
passed to `DigestUtil` constructor and use a hard-coded SHA1,
which is wrong.

This PR unfortunately also has some formatting changes, because
google-java-format was not very happy about existing code :(

Fixes #103