### PR TITLE
Transform a directoriesIndex miss into IOException

### DIFF
--- a/src/main/java/build/buildfarm/worker/InputFetchStage.java
+++ b/src/main/java/build/buildfarm/worker/InputFetchStage.java
@@ -14,6 +14,7 @@
 
 package build.buildfarm.worker;
 
+import build.buildfarm.common.DigestUtil;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
@@ -185,6 +186,9 @@ class InputFetchStage extends PipelineStage {
       List<Digest> inputDirectories)
       throws IOException, InterruptedException {
     Directory directory = directoriesIndex.get(inputRoot);
+    if (directory == null) {
+      throw new IOException("Directory " + DigestUtil.toString(inputRoot) + " is not in input index");
+    }
 
     for (FileNode fileNode : directory.getFilesList()) {
       Path execPath = execDir.resolve(fileNode.getName());


### PR DESCRIPTION
A worker at this stage would throw a NullPointerException for a missing
directory entry and stall the pipeline. This is easily encountered with
a mismatched hash function configuration between worker, server, and/or
client.