### PR TITLE
XS Wrap existing operation in expireOperation

### DIFF
--- a/src/main/java/build/buildfarm/instance/AbstractServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/AbstractServerInstance.java
@@ -564,7 +564,7 @@ public abstract class AbstractServerInstance implements Instance {
         putActionResult(actionKey, actionResult);
       }
     }
-    putOperation(operation.newBuilder()
+    putOperation(operation.toBuilder()
         .setDone(true)
         .setMetadata(Any.pack(ExecuteOperationMetadata.newBuilder()
             .setStage(ExecuteOperationMetadata.Stage.COMPLETED)


### PR DESCRIPTION
We must use toBuilder rather than newBuilder here to re-put an
operation.