### PR TITLE
M Default max action timeout

### DIFF
--- a/examples/server.config.example
+++ b/examples/server.config.example
@@ -39,6 +39,19 @@ instances {
 
     # limit for CAS total content size in bytes
     cas_max_size_bytes: 1073741824 # 1024 * 1024 * 1024
+
+    # an imposed action-key-invariant timeout used in the unspecified timeout case
+    default_action_timeout: {
+      seconds: 600
+      nanos: 0
+    }
+
+    # a limit on the action timeout specified in the action, above which
+    # the operation will report a failed result immediately
+    maximum_action_timeout: {
+      seconds: 3600
+      nanos: 0
+    }
   }
 }
 
@@ -67,6 +80,16 @@ instances {
     }
 
     cas_max_size_bytes: 655360 # 640k
+
+    default_action_timeout: {
+      seconds: 600
+      nanos: 0
+    }
+
+    maximum_action_timeout: {
+      seconds: 3600
+      nanos: 0
+    }
   }
 }
 

--- a/examples/worker.config.example
+++ b/examples/worker.config.example
@@ -80,3 +80,16 @@ cas_cache_max_size_bytes: 2147483648 # 2 * 1024 * 1024 * 1024
 
 # the number of concurrently available slots in the execute phase
 execute_stage_width: 1
+
+# an imposed action-key-invariant timeout used in the unspecified timeout case
+default_action_timeout: {
+  seconds: 600
+  nanos: 0
+}
+
+# a limit on the action timeout specified in the action, above which
+# the operation will report a failed result immediately
+maximum_action_timeout: {
+  seconds: 3600
+  nanos: 0
+}

--- a/src/main/java/build/buildfarm/BUILD
+++ b/src/main/java/build/buildfarm/BUILD
@@ -148,6 +148,7 @@ java_library(
         "//3rdparty/jvm/io/grpc:grpc_protobuf",
         "//3rdparty/jvm/io/grpc:grpc_stub",
         "//src/main/protobuf:build_buildfarm_v1test_buildfarm_java_proto",
+        "@googleapis//:google_rpc_code_java_proto",
     ],
 )
 

--- a/src/main/java/build/buildfarm/instance/AbstractServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/AbstractServerInstance.java
@@ -572,6 +572,9 @@ public abstract class AbstractServerInstance implements Instance {
             .build()))
         .setResponse(Any.pack(ExecuteResponse.newBuilder()
             .setResult(actionResult)
+            .setStatus(com.google.rpc.Status.newBuilder()
+                .setCode(com.google.rpc.Code.DEADLINE_EXCEEDED.getNumber())
+                .build())
             .setCachedResult(cachedResult)
             .build()))
         .build());

--- a/src/main/java/build/buildfarm/instance/AbstractServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/AbstractServerInstance.java
@@ -35,6 +35,7 @@ import com.google.longrunning.Operation;
 import com.google.protobuf.Any;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.rpc.Code;
 import io.grpc.Status;
 import java.util.HashSet;
 import java.util.Map;
@@ -372,6 +373,9 @@ public abstract class AbstractServerInstance implements Instance {
           .setDone(true)
           .setResponse(Any.pack(ExecuteResponse.newBuilder()
               .setResult(actionResult)
+              .setStatus(com.google.rpc.Status.newBuilder()
+                  .setCode(Code.OK.getNumber())
+                  .build())
               .setCachedResult(actionResult != null)
               .build()));
     } else {
@@ -545,7 +549,7 @@ public abstract class AbstractServerInstance implements Instance {
     putOperation(operation.toBuilder()
         .setDone(true)
         .setError(com.google.rpc.Status.newBuilder()
-            .setCode(com.google.rpc.Code.CANCELLED.getNumber())
+            .setCode(Code.CANCELLED.getNumber())
             .build())
         .build());
   }
@@ -558,9 +562,8 @@ public abstract class AbstractServerInstance implements Instance {
         .build();
     ExecuteResponse executeResponse = ExecuteResponse.newBuilder()
         .setResult(actionResult)
-        .setCachedResult(false)
         .setStatus(com.google.rpc.Status.newBuilder()
-            .setCode(com.google.rpc.Code.DEADLINE_EXCEEDED.getNumber())
+            .setCode(Code.DEADLINE_EXCEEDED.getNumber())
             .build())
         .build();
     ExecuteOperationMetadata metadata = expectExecuteOperationMetadata(operation);

--- a/src/main/java/build/buildfarm/instance/AbstractServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/AbstractServerInstance.java
@@ -564,9 +564,6 @@ public abstract class AbstractServerInstance implements Instance {
           .setStderrRaw(ByteString.copyFromUtf8(
               "[BUILDFARM]: Action timed out with no response from worker"))
           .build();
-      if (!action.getDoNotCache()) {
-        putActionResult(actionKey, actionResult);
-      }
     }
     putOperation(operation.newBuilder()
         .setDone(true)

--- a/src/main/java/build/buildfarm/instance/AbstractServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/AbstractServerInstance.java
@@ -301,7 +301,7 @@ public abstract class AbstractServerInstance implements Instance {
     validateActionInputDirectory(root, path, new HashSet<>(), inputDigests);
   }
 
-  private void validateAction(Action action) {
+  protected void validateAction(Action action) {
     Digest commandDigest = action.getCommandDigest();
     ImmutableSet.Builder<Digest> inputDigests = new ImmutableSet.Builder<>();
     inputDigests.add(commandDigest);

--- a/src/main/java/build/buildfarm/worker/Executor.java
+++ b/src/main/java/build/buildfarm/worker/Executor.java
@@ -86,6 +86,10 @@ class Executor implements Runnable {
       timeout = null;
     }
 
+    if (timeout == null && worker.config.hasDefaultActionTimeout()) {
+      timeout = worker.config.getDefaultActionTimeout();
+    }
+
     /* execute command */
     ActionResult.Builder resultBuilder;
     try {

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -80,6 +80,17 @@ message MemoryInstanceConfig {
 
   // limit for CAS total content size
   int64 cas_max_size_bytes = 7;
+
+  // default timeout for actions
+  // if a timeout is unspecified for an action, this value
+  // is imposed on it, after which the operation will be
+  // cancelled
+  google.protobuf.Duration default_action_timeout = 8;
+
+  // maximum selectable timeout
+  // a maximum threshold for an action's specified timeout,
+  // beyond which an action will be rejected for execution
+  google.protobuf.Duration maximum_action_timeout = 9;
 }
 
 message InstanceConfig {
@@ -169,6 +180,17 @@ message WorkerConfig {
 
   // symlink cas input-only directories
   bool link_input_directories = 18;
+
+  // default timeout for actions
+  // if a timeout is unspecified for an action, this value
+  // is imposed on it, after which the operation will
+  // be killed
+  google.protobuf.Duration default_action_timeout = 19;
+
+  // maximum selectable timeout
+  // a maximum threshold for an action's specified timeout,
+  // beyond which an action will be rejected for execution
+  google.protobuf.Duration maximum_action_timeout = 20;
 }
 
 message TreeIteratorToken {


### PR DESCRIPTION
Add instance and worker specifications for action default and maximum
timeouts. These timeouts will not affect the action definition - results
will be stored with the requested action message digest key.
Supplement example configs with action timeouts