### PR TITLE
M delinting code under src

### DIFF
--- a/src/main/java/build/buildfarm/instance/stub/ByteStreamUploader.java
+++ b/src/main/java/build/buildfarm/instance/stub/ByteStreamUploader.java
@@ -16,6 +16,7 @@ package build.buildfarm.instance.stub;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Throwables.throwIfUnchecked;
 import static java.lang.String.format;
 import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -26,7 +27,6 @@ import com.google.bytestream.ByteStreamProto.WriteRequest;
 import com.google.bytestream.ByteStreamProto.WriteResponse;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
-import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListenableScheduledFuture;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
@@ -160,11 +160,9 @@ public final class ByteStreamUploader {
       if (cause instanceof RetryException) {
         throw (RetryException) cause;
       } else {
-        throw Throwables.propagate(cause);
+        throwIfUnchecked(cause);
+        throw new RuntimeException(cause);
       }
-    } catch (InterruptedException e) {
-      Thread.interrupted();
-      throw e;
     }
   }
 

--- a/src/main/java/build/buildfarm/instance/stub/Retrier.java
+++ b/src/main/java/build/buildfarm/instance/stub/Retrier.java
@@ -47,6 +47,8 @@ import java.util.concurrent.TimeUnit;
 public class Retrier {
   /** Wraps around a StatusRuntimeException to make it pass through a single layer of retries. */
   public static class PassThroughException extends Exception {
+    private static final long serialVersionUID = 1;
+
     public PassThroughException(StatusRuntimeException e) {
       super(e);
     }

--- a/src/main/java/build/buildfarm/instance/stub/RetryException.java
+++ b/src/main/java/build/buildfarm/instance/stub/RetryException.java
@@ -21,6 +21,8 @@ import java.io.IOException;
 
 /** An exception to indicate failed retry attempts. */
 public final class RetryException extends IOException {
+  private static final long serialVersionUID = 1;
+
   private final int attempts;
 
   RetryException(Throwable cause, int retryAttempts) {

--- a/src/main/java/build/buildfarm/instance/stub/StubInstance.java
+++ b/src/main/java/build/buildfarm/instance/stub/StubInstance.java
@@ -167,7 +167,7 @@ public class StubInstance implements Instance {
     // sort of a blatant misuse - one chunker per input, query digests before exhausting iterators
     Iterable<Chunker> chunkers = Iterables.transform(
         blobs, blob -> new Chunker(blob, digestUtil));
-    List<Digest> digests = new ImmutableList.Builder()
+    List<Digest> digests = new ImmutableList.Builder<Digest>()
         .addAll(Iterables.transform(chunkers, chunker -> chunker.digest()))
         .build();
     uploader.uploadBlobs(chunkers);

--- a/src/main/java/build/buildfarm/server/ActionCacheService.java
+++ b/src/main/java/build/buildfarm/server/ActionCacheService.java
@@ -14,6 +14,7 @@
 
 package build.buildfarm.server;
 
+import build.buildfarm.common.DigestUtil;
 import build.buildfarm.instance.Instance;
 import com.google.devtools.remoteexecution.v1test.ActionCacheGrpc;
 import com.google.devtools.remoteexecution.v1test.ActionResult;
@@ -43,7 +44,7 @@ public class ActionCacheService extends ActionCacheGrpc.ActionCacheImplBase {
     }
 
     ActionResult actionResult = instance.getActionResult(
-        instance.getDigestUtil().asActionKey(request.getActionDigest()));
+        DigestUtil.asActionKey(request.getActionDigest()));
     if (actionResult == null) {
       responseObserver.onError(new StatusException(Status.NOT_FOUND));
       return;
@@ -67,7 +68,7 @@ public class ActionCacheService extends ActionCacheGrpc.ActionCacheImplBase {
 
     ActionResult actionResult = request.getActionResult();
     instance.putActionResult(
-        instance.getDigestUtil().asActionKey(request.getActionDigest()),
+        DigestUtil.asActionKey(request.getActionDigest()),
         actionResult);
 
     responseObserver.onNext(actionResult);

--- a/src/main/java/build/buildfarm/server/BuildFarmServer.java
+++ b/src/main/java/build/buildfarm/server/BuildFarmServer.java
@@ -119,11 +119,11 @@ public class BuildFarmServer {
       throw new IllegalArgumentException("Missing CONFIG_PATH");
     }
     Path configPath = Paths.get(residue.get(0));
+    BuildFarmServer server;
     try (InputStream configInputStream = Files.newInputStream(configPath)) {
-      BuildFarmServer server = new BuildFarmServer(toBuildFarmServerConfig(new InputStreamReader(configInputStream), parser.getOptions(BuildFarmServerOptions.class)));
-      configInputStream.close();
-      server.start();
-      server.blockUntilShutdown();
+      server = new BuildFarmServer(toBuildFarmServerConfig(new InputStreamReader(configInputStream), parser.getOptions(BuildFarmServerOptions.class)));
     }
+    server.start();
+    server.blockUntilShutdown();
   }
 }

--- a/src/main/java/build/buildfarm/server/InstanceNotFoundException.java
+++ b/src/main/java/build/buildfarm/server/InstanceNotFoundException.java
@@ -1,6 +1,8 @@
 package build.buildfarm.server;
 
 class InstanceNotFoundException extends Exception {
+  private static final long serialVersionUID = 1;
+
   public final String instanceName;
 
   InstanceNotFoundException( String instanceName ) {

--- a/src/main/java/build/buildfarm/worker/CacheNotFoundException.java
+++ b/src/main/java/build/buildfarm/worker/CacheNotFoundException.java
@@ -20,6 +20,8 @@ import com.google.devtools.remoteexecution.v1test.Digest;
  * An exception to indicate cache misses.
  */
 public final class CacheNotFoundException extends Exception {
+  private static final long serialVersionUID = 1;
+
   private final Digest missingDigest;
 
   CacheNotFoundException(Digest missingDigest) {

--- a/src/main/java/build/buildfarm/worker/ReportResultStage.java
+++ b/src/main/java/build/buildfarm/worker/ReportResultStage.java
@@ -84,7 +84,7 @@ class ReportResultStage extends PipelineStage {
   private static int inlineOrDigest(
       ByteString content,
       CASInsertionPolicy policy,
-      ImmutableList.Builder contents,
+      ImmutableList.Builder<ByteString> contents,
       int inlineContentBytes,
       int inlineContentLimit,
       Runnable setInline,
@@ -208,7 +208,7 @@ class ReportResultStage extends PipelineStage {
 
     ActionResult result = resultBuilder.build();
     if (!operationContext.action.getDoNotCache() && resultBuilder.getExitCode() == 0) {
-      worker.instance.putActionResult(getDigestUtil().asActionKey(operationContext.metadata.getActionDigest()), result);
+      worker.instance.putActionResult(DigestUtil.asActionKey(operationContext.metadata.getActionDigest()), result);
     }
 
     ExecuteOperationMetadata metadata = operationContext.metadata.toBuilder()


### PR DESCRIPTION
static method calling on instances removed
Removed explicit close for try-with-resources on autoclose
  Triggered cleanup for CASFileCache exception handling
Removed Throwables.propagate usage for deprecated (ignored for md5 and sha1)
Specified Builder generic modifiers for rawtypes