### PR TITLE
M Mitigate stalls during match stage

### DIFF
--- a/src/test/java/build/buildfarm/BUILD
+++ b/src/test/java/build/buildfarm/BUILD
@@ -38,7 +38,9 @@ java_test(
         "//3rdparty/jvm/com/google/protobuf:protobuf_java",
         "//3rdparty/jvm/com/google/truth",
         "//src/main/java/build/buildfarm:common",
+        "//src/main/java/build/buildfarm:instance",
         "//src/main/java/build/buildfarm:worker",
+        "//src/main/protobuf:build_buildfarm_v1test_buildfarm_java_proto",
         "@googleapis//:google_devtools_remoteexecution_v1test_remote_execution_java_proto",
     ],
 )

--- a/src/test/java/build/buildfarm/worker/MatchStageTest.java
+++ b/src/test/java/build/buildfarm/worker/MatchStageTest.java
@@ -1,0 +1,104 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.worker;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import build.buildfarm.v1test.WorkerConfig;
+import com.google.devtools.remoteexecution.v1test.Action;
+import com.google.devtools.remoteexecution.v1test.Digest;
+import com.google.devtools.remoteexecution.v1test.ExecuteOperationMetadata;
+import com.google.longrunning.Operation;
+import com.google.protobuf.Any;
+import com.google.protobuf.ByteString;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
+import javax.naming.ConfigurationException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class MatchStageTest {
+  class PipelineSink extends PipelineStage {
+    Predicate<OperationContext> onPutShouldClose;
+
+    PipelineSink(Predicate<OperationContext> onPutShouldClose) {
+      super(null, null, null);
+      this.onPutShouldClose = onPutShouldClose;
+    }
+
+    @Override
+    public void put(OperationContext operationContext) {
+      if (onPutShouldClose.test(operationContext)) {
+        close();
+      }
+    }
+
+    @Override
+    public OperationContext take() {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  @Test
+  public void fetchFailureReentry() throws ConfigurationException {
+    List<Operation> queue = new ArrayList<>();
+    List<Boolean> results = new ArrayList<>();
+
+    WorkerContext workerContext = new StubWorkerContext() {
+      @Override
+      public void match(Predicate<Operation> onMatch) {
+        assertThat(onMatch.test(queue.remove(0))).isEqualTo(results.remove(0));
+      }
+
+      @Override
+      public ByteString getBlob(Digest digest) {
+        if (digest.getHash().equals("action")) {
+          return Action.newBuilder().build().toByteString();
+        }
+        return super.getBlob(digest);
+      }
+
+      @Override
+      public Path getRoot() {
+        return FileSystems.getDefault().getPath("tmp");
+      }
+    };
+
+    queue.add(Operation.newBuilder()
+        .setName("bad")
+        // inspire InvalidProtocolBufferException from operation metadata unpack
+        .build());
+    results.add(false);
+
+    queue.add(Operation.newBuilder()
+        .setName("good")
+        .setMetadata(Any.pack(ExecuteOperationMetadata.newBuilder()
+            .setActionDigest(Digest.newBuilder().setHash("action").build())
+            .build()))
+        .build());
+    results.add(true);
+
+    final PipelineStage output = new PipelineSink((operationContext) -> operationContext.operation.getName().equals("good"));
+
+    PipelineStage matchStage = new MatchStage(workerContext, output, null);
+    matchStage.run();
+  }
+}

--- a/src/test/java/build/buildfarm/worker/StubWorkerContext.java
+++ b/src/test/java/build/buildfarm/worker/StubWorkerContext.java
@@ -1,0 +1,52 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.worker;
+
+import build.buildfarm.common.DigestUtil;
+import build.buildfarm.worker.CASFileCache;
+import build.buildfarm.instance.Instance;
+import build.buildfarm.v1test.CASInsertionPolicy;
+import com.google.devtools.remoteexecution.v1test.Digest;
+import com.google.devtools.remoteexecution.v1test.ExecuteOperationMetadata.Stage;
+import com.google.longrunning.Operation;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Duration;
+import java.nio.file.Path;
+import java.util.function.Predicate;
+
+class StubWorkerContext implements WorkerContext {
+  @Override public Poller createPoller(String name, String operationName, Stage stage) { throw new UnsupportedOperationException(); }
+  @Override public Poller createPoller(String name, String operationName, Stage stage, Runnable onFailure) { throw new UnsupportedOperationException(); }
+  @Override public void match(Predicate<Operation> onMatch) { throw new UnsupportedOperationException(); }
+  @Override public CASInsertionPolicy getFileCasPolicy() { throw new UnsupportedOperationException(); }
+  @Override public CASInsertionPolicy getStdoutCasPolicy() { throw new UnsupportedOperationException(); }
+  @Override public CASInsertionPolicy getStderrCasPolicy() { throw new UnsupportedOperationException(); }
+  @Override public DigestUtil getDigestUtil() { throw new UnsupportedOperationException(); }
+  @Override public int getInlineContentLimit() { throw new UnsupportedOperationException(); }
+  @Override public int getExecuteStageWidth() { throw new UnsupportedOperationException(); }
+  @Override public int getTreePageSize() { throw new UnsupportedOperationException(); }
+  @Override public boolean getLinkInputDirectories() { throw new UnsupportedOperationException(); }
+  @Override public boolean hasDefaultActionTimeout() { throw new UnsupportedOperationException(); }
+  @Override public boolean hasMaximumActionTimeout() { throw new UnsupportedOperationException(); }
+  @Override public boolean getStreamStdout() { throw new UnsupportedOperationException(); }
+  @Override public boolean getStreamStderr() { throw new UnsupportedOperationException(); }
+  @Override public Duration getDefaultActionTimeout() { throw new UnsupportedOperationException(); }
+  @Override public Duration getMaximumActionTimeout() { throw new UnsupportedOperationException(); }
+  @Override public Instance getInstance() { throw new UnsupportedOperationException(); }
+  @Override public ByteString getBlob(Digest digest) { throw new UnsupportedOperationException(); }
+  @Override public CASFileCache getCASFileCache() { throw new UnsupportedOperationException(); }
+  @Override public Path getRoot() { throw new UnsupportedOperationException(); }
+  @Override public void removeDirectory(Path path) { throw new UnsupportedOperationException(); }
+};


### PR DESCRIPTION
Matches are subject to failures on the fetch method which must not
prevent the continued operation of the stage. Guard against invalid
content in the match callback by releasing the subsequent stage, and
expand possible invalid content exceptions to include null pointers.
Adding tests to validate a failed fetch can continue to a second fetch
undeterred, having released the following stage that it claims again in
order to prevent overfetching.