### PR TITLE
XS ByteStringStreamSource zero read

### DIFF
--- a/src/test/java/build/buildfarm/instance/memory/ByteStringStreamSourceTest.java
+++ b/src/test/java/build/buildfarm/instance/memory/ByteStringStreamSourceTest.java
@@ -113,4 +113,11 @@ public class ByteStringStreamSourceTest {
       Thread.sleep(10);
     }
   }
+
+  @Test
+  public void readZeroBytesIgnoresBuffer() throws IOException {
+    ByteStringStreamSource source = new ByteStringStreamSource(() -> {});
+    InputStream inputStream = source.openStream();
+    assertThat(inputStream.read(null, -1, 0)).isEqualTo(0);
+  }
 }


### PR DESCRIPTION
Zero bytes read from ByteStringStreamSource InputStream should exercise
short circuit and ignore buffer availability.