### PR TITLE
M Fix operation paging, reinforce with tests

### DIFF
--- a/src/test/java/build/buildfarm/BUILD
+++ b/src/test/java/build/buildfarm/BUILD
@@ -108,6 +108,7 @@ java_test(
         ":test_runner",
         "//3rdparty/jvm/com/google/guava",
         "//3rdparty/jvm/com/google/protobuf:protobuf_java",
+        "//3rdparty/jvm/com/google/protobuf:protobuf_java_util",
         "//3rdparty/jvm/com/google/truth",
         "//3rdparty/jvm/org/mockito:mockito_core",
         "//src/main/java/build/buildfarm:common",

--- a/src/test/java/build/buildfarm/BUILD
+++ b/src/test/java/build/buildfarm/BUILD
@@ -106,11 +106,14 @@ java_test(
     test_class = "build.buildfarm.AllTests",
     deps = [
         ":test_runner",
+        "//3rdparty/jvm/com/google/guava",
         "//3rdparty/jvm/com/google/protobuf:protobuf_java",
         "//3rdparty/jvm/com/google/truth",
         "//3rdparty/jvm/org/mockito:mockito_core",
         "//src/main/java/build/buildfarm:common",
         "//src/main/java/build/buildfarm:memory-instance",
+        "//src/main/protobuf:build_buildfarm_v1test_buildfarm_java_proto",
         "@googleapis//:google_devtools_remoteexecution_v1test_remote_execution_java_proto",
+        "@googleapis//:google_longrunning_operations_java_grpc",
     ],
 )

--- a/src/test/java/build/buildfarm/instance/memory/MemoryInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/memory/MemoryInstanceTest.java
@@ -22,6 +22,7 @@ import build.buildfarm.common.DigestUtil;
 import com.google.common.collect.ImmutableList;
 import com.google.longrunning.Operation;
 import com.google.protobuf.Duration;
+import com.google.protobuf.util.Durations;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.Before;
@@ -49,18 +50,10 @@ public class MemoryInstanceTest {
         .setListOperationsMaxPageSize(16384)
         .setTreeDefaultPageSize(1024)
         .setTreeMaxPageSize(16384)
-        .setOperationPollTimeout(Duration.newBuilder()
-            .setSeconds(10)
-            .setNanos(0))
-        .setOperationCompletedDelay(Duration.newBuilder()
-            .setSeconds(10)
-            .setNanos(0))
-        .setDefaultActionTimeout(Duration.newBuilder()
-            .setSeconds(600)
-            .setNanos(0))
-        .setMaximumActionTimeout(Duration.newBuilder()
-            .setSeconds(3600)
-            .setNanos(0))
+        .setOperationPollTimeout(Durations.fromSeconds(10))
+        .setOperationCompletedDelay(Durations.fromSeconds(10))
+        .setDefaultActionTimeout(Durations.fromSeconds(600))
+        .setMaximumActionTimeout(Durations.fromSeconds(3600))
         .build();
 
     instance = new MemoryInstance(

--- a/src/test/java/build/buildfarm/instance/memory/MemoryInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/memory/MemoryInstanceTest.java
@@ -1,0 +1,161 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.instance.memory;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import build.buildfarm.v1test.MemoryInstanceConfig;
+import build.buildfarm.common.ContentAddressableStorage;
+import build.buildfarm.common.DigestUtil;
+import com.google.common.collect.ImmutableList;
+import com.google.longrunning.Operation;
+import com.google.protobuf.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+@RunWith(JUnit4.class)
+public class MemoryInstanceTest {
+  private MemoryInstance instance;
+
+  private Map<String, Operation> outstandingOperations;
+
+  @Mock
+  private ContentAddressableStorage storage;
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+    outstandingOperations = new HashMap<>();
+    MemoryInstanceConfig memoryInstanceConfig = MemoryInstanceConfig.newBuilder()
+        .setListOperationsDefaultPageSize(1024)
+        .setListOperationsMaxPageSize(16384)
+        .setTreeDefaultPageSize(1024)
+        .setTreeMaxPageSize(16384)
+        .setOperationPollTimeout(Duration.newBuilder()
+            .setSeconds(10)
+            .setNanos(0))
+        .setOperationCompletedDelay(Duration.newBuilder()
+            .setSeconds(10)
+            .setNanos(0))
+        .setDefaultActionTimeout(Duration.newBuilder()
+            .setSeconds(600)
+            .setNanos(0))
+        .setMaximumActionTimeout(Duration.newBuilder()
+            .setSeconds(3600)
+            .setNanos(0))
+        .build();
+
+    instance = new MemoryInstance(
+        "memory",
+        new DigestUtil(DigestUtil.HashFunction.SHA256),
+        memoryInstanceConfig,
+        storage,
+        outstandingOperations);
+  }
+
+  @Test
+  public void listOperationsForEmptyOutstanding() {
+    ImmutableList.Builder<Operation> operations = new ImmutableList.Builder<>();
+
+    String nextToken = instance.listOperations(
+        /* pageSize=*/ 1,
+        /* pageToken=*/ "",
+        /* filter=*/ "",
+        operations);
+    assertThat(nextToken).isEqualTo("");
+    assertThat(operations.build()).isEmpty();
+  }
+
+  @Test
+  public void listOperationsForOutstandingOperations() {
+    Operation operation = Operation.newBuilder()
+        .setName("test-operation")
+        .build();
+
+    outstandingOperations.put(operation.getName(), operation);
+
+    ImmutableList.Builder<Operation> operations = new ImmutableList.Builder<>();
+
+    String nextToken = instance.listOperations(
+        /* pageSize=*/ 1,
+        /* pageToken=*/ "",
+        /* filter=*/ "",
+        operations);
+    // we should have reached the end of list
+    assertThat(nextToken).isEqualTo("");
+    assertThat(operations.build()).containsExactly(operation);
+  }
+
+  @Test
+  public void listOperationsLimitsPages() {
+    Operation testOperation1 = Operation.newBuilder()
+        .setName("test-operation1")
+        .build();
+
+    Operation testOperation2 = Operation.newBuilder()
+        .setName("test-operation2")
+        .build();
+
+    outstandingOperations.put(testOperation1.getName(), testOperation1);
+    outstandingOperations.put(testOperation2.getName(), testOperation2);
+
+    ImmutableList.Builder<Operation> operations = new ImmutableList.Builder<>();
+
+    String nextToken = instance.listOperations(
+        /* pageSize=*/ 1,
+        /* pageToken=*/ "",
+        /* filter=*/ "",
+        operations);
+    // we should not be at the end
+    assertThat(nextToken).isNotEqualTo("");
+    assertThat(operations.build().size()).isEqualTo(1);
+  }
+
+  @Test
+  public void listOperationsPages() {
+    Operation testOperation1 = Operation.newBuilder()
+        .setName("test-operation1")
+        .build();
+
+    Operation testOperation2 = Operation.newBuilder()
+        .setName("test-operation2")
+        .build();
+
+    outstandingOperations.put(testOperation1.getName(), testOperation1);
+    outstandingOperations.put(testOperation2.getName(), testOperation2);
+
+    ImmutableList.Builder<Operation> operations = new ImmutableList.Builder<>();
+
+    String nextToken = instance.listOperations(
+        /* pageSize=*/ 1,
+        /* pageToken=*/ "",
+        /* filter=*/ "",
+        operations);
+    nextToken = instance.listOperations(
+        /* pageSize=*/ 1,
+        /* pageToken=*/ nextToken,
+        /* filter=*/ "",
+        operations);
+    // we should have reached the end
+    assertThat(nextToken).isEqualTo("");
+    assertThat(operations.build()).containsExactly(testOperation1, testOperation2);
+  }
+}

--- a/src/test/java/build/buildfarm/instance/memory/MemoryInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/memory/MemoryInstanceTest.java
@@ -120,28 +120,7 @@ public class MemoryInstanceTest {
     // we should not be at the end
     assertThat(nextToken).isNotEqualTo("");
     assertThat(operations.build().size()).isEqualTo(1);
-  }
 
-  @Test
-  public void listOperationsPages() {
-    Operation testOperation1 = Operation.newBuilder()
-        .setName("test-operation1")
-        .build();
-
-    Operation testOperation2 = Operation.newBuilder()
-        .setName("test-operation2")
-        .build();
-
-    outstandingOperations.put(testOperation1.getName(), testOperation1);
-    outstandingOperations.put(testOperation2.getName(), testOperation2);
-
-    ImmutableList.Builder<Operation> operations = new ImmutableList.Builder<>();
-
-    String nextToken = instance.listOperations(
-        /* pageSize=*/ 1,
-        /* pageToken=*/ "",
-        /* filter=*/ "",
-        operations);
     nextToken = instance.listOperations(
         /* pageSize=*/ 1,
         /* pageToken=*/ nextToken,


### PR DESCRIPTION
The memory instance would not progress beyond the initial page due to an
incorrect test against the token itself rather than the deserialized
OperationIteratorToken's name, and the paged test was initialized to
true, making the paging loop break on the first entry anyway.

Added tests to guard operation list retrieval.