### PR TITLE
Produce docker containers for both server and worker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 bazel-*
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 bazel-*
-.DS_Store

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -28,3 +28,29 @@ new_http_archive(
 load("//3rdparty:workspace.bzl", "maven_dependencies", "declare_maven")
 
 maven_dependencies(declare_maven)
+
+git_repository(
+    name = "io_bazel_rules_docker",
+    remote = "https://github.com/bazelbuild/rules_docker.git",
+    tag = "v0.4.0",
+)
+
+load(
+    "@io_bazel_rules_docker//container:container.bzl",
+    "container_pull",
+    container_repositories = "repositories",
+)
+
+load(
+    "@io_bazel_rules_docker//java:image.bzl",
+    _java_image_repos = "repositories",
+)
+
+_java_image_repos()
+
+container_pull(
+  name = "java_base",
+  registry = "gcr.io",
+  repository = "distroless/java",
+  digest = "sha256:625c3584876171c6d786d8d8a74b2aaceac06fef450e7fd7322247464f118aa9",
+)

--- a/src/main/java/build/buildfarm/BUILD
+++ b/src/main/java/build/buildfarm/BUILD
@@ -107,6 +107,26 @@ java_binary(
     ],
 )
 
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
+
+container_image(
+    name = "server",
+    base = "@java_base//image",
+    # leverage the implicit target of the buildfarm-server to get a fat jar.
+    # this is simply a workaround for the fact that we have so many dependencies,
+    # so we'd want some wrappy script. This seemed more straightforward.
+    # https://docs.bazel.build/versions/master/be/java.html#java_binary_implicit_outputs
+    files = [
+        "//src/main/java/build/buildfarm:buildfarm-server_deploy.jar"
+    ],
+    cmd = [
+        "buildfarm-server_deploy.jar",
+        "/config/server.config",
+        "--port",
+        "8098"
+    ],
+)
+
 java_library(
     name = "stub-instance",
     srcs = glob(["instance/stub/*.java"]),

--- a/src/main/java/build/buildfarm/BUILD
+++ b/src/main/java/build/buildfarm/BUILD
@@ -110,7 +110,7 @@ java_binary(
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 
 container_image(
-    name = "server",
+    name = "server.container",
     base = "@java_base//image",
     # leverage the implicit target of the buildfarm-server to get a fat jar.
     # this is simply a workaround for the fact that we have so many dependencies,
@@ -197,5 +197,21 @@ java_binary(
     main_class = "build.buildfarm.worker.operationqueue.Worker",
     runtime_deps = [
         ":operationqueue-worker",
+    ],
+)
+
+container_image(
+    name = "worker.container",
+    base = "@java_base//image",
+    # leverage the implicit target of the buildfarm-server to get a fat jar.
+    # this is simply a workaround for the fact that we have so many dependencies,
+    # so we'd want some wrappy script. This seemed more straightforward.
+    # https://docs.bazel.build/versions/master/be/java.html#java_binary_implicit_outputs
+    files = [
+        "//src/main/java/build/buildfarm:buildfarm-worker_deploy.jar",
+    ],
+    cmd = [
+        "buildfarm-worker_deploy.jar",
+        "/config/worker.config",
     ],
 )

--- a/src/main/java/build/buildfarm/BUILD
+++ b/src/main/java/build/buildfarm/BUILD
@@ -1,8 +1,8 @@
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
+
 package(
     default_visibility = ["//src:__subpackages__"],
 )
-
-load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 
 java_library(
     name = "common",

--- a/src/main/java/build/buildfarm/BUILD
+++ b/src/main/java/build/buildfarm/BUILD
@@ -2,6 +2,8 @@ package(
     default_visibility = ["//src:__subpackages__"],
 )
 
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
+
 java_library(
     name = "common",
     srcs = glob(["common/**/*.java"]),
@@ -107,8 +109,6 @@ java_binary(
     ],
 )
 
-load("@io_bazel_rules_docker//container:container.bzl", "container_image")
-
 container_image(
     name = "server.container",
     base = "@java_base//image",
@@ -117,7 +117,7 @@ container_image(
     # so we'd want some wrappy script. This seemed more straightforward.
     # https://docs.bazel.build/versions/master/be/java.html#java_binary_implicit_outputs
     files = [
-        "//src/main/java/build/buildfarm:buildfarm-server_deploy.jar"
+        ":buildfarm-server_deploy.jar"
     ],
     cmd = [
         "buildfarm-server_deploy.jar",
@@ -208,7 +208,7 @@ container_image(
     # so we'd want some wrappy script. This seemed more straightforward.
     # https://docs.bazel.build/versions/master/be/java.html#java_binary_implicit_outputs
     files = [
-        "//src/main/java/build/buildfarm:buildfarm-worker_deploy.jar",
+        ":buildfarm-worker_deploy.jar",
     ],
     cmd = [
         "buildfarm-worker_deploy.jar",


### PR DESCRIPTION
Hi there!

Wanted to deploy build farm using containers, figured i'd just toss up a PR to do the containerization work as it might be useful for others. Present thinking is that it would make sense to put in a custom entrypoint that can either take some params as env vars (e.g. name of config file), or otherwise always expect files mounted at a particular location as it is now (e.g. `/config/server.config`). Obviously both approaches come with downsides :-) 

This is a first pass knocked up this evening, so i'd welcome some feedback 😄 
#