### PR TITLE
Fixed erroneous use of File.setExecutable().

### DIFF
--- a/src/main/java/build/buildfarm/worker/CASFileCache.java
+++ b/src/main/java/build/buildfarm/worker/CASFileCache.java
@@ -346,7 +346,7 @@ public class CASFileCache {
   }
 
   private static void setPermissions(Path path, boolean isExecutable) throws IOException {
-    new File(path.toString()).setExecutable(false, isExecutable);
+    new File(path.toString()).setExecutable(isExecutable, true);
   }
 
   private static class Entry {


### PR DESCRIPTION
Hi.

Please kindly merge fix of the error which I introduced to Buildfarm earlier in #134.

Kind regards,
Vladimir.