### PR TITLE
S Merge fix with native executable test

### DIFF
--- a/src/main/java/build/buildfarm/worker/CASFileCache.java
+++ b/src/main/java/build/buildfarm/worker/CASFileCache.java
@@ -346,7 +346,7 @@ public class CASFileCache {
   }
 
   private static void setPermissions(Path path, boolean isExecutable) throws IOException {
-    new File(path.toString()).setExecutable(false, isExecutable);
+    new File(path.toString()).setExecutable(isExecutable, true);
   }
 
   private static class Entry {

--- a/src/test/java/build/buildfarm/worker/CASFileCacheTest.java
+++ b/src/test/java/build/buildfarm/worker/CASFileCacheTest.java
@@ -20,9 +20,6 @@ import build.buildfarm.common.DigestUtil;
 import build.buildfarm.common.DigestUtil.HashFunction;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
-import com.google.common.jimfs.Configuration;
-import com.google.common.jimfs.Jimfs;
 import com.google.devtools.remoteexecution.v1test.Digest;
 import com.google.devtools.remoteexecution.v1test.Directory;
 import com.google.devtools.remoteexecution.v1test.DirectoryNode;
@@ -32,7 +29,6 @@ import java.io.InputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.FileSystem;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
@@ -40,24 +36,19 @@ import org.junit.Before;
 import org.junit.Test;
 
 class CASFileCacheTest {
-  private final Configuration config;
-
   private CASFileCache fileCache;
   private DigestUtil digestUtil;
-  private FileSystem fileSystem;
   private Path root;
   private Map<Digest, ByteString> blobs;
 
-  protected CASFileCacheTest(Configuration config) {
-    this.config = config;
+  protected CASFileCacheTest(Path root) {
+    this.root = root;
   }
 
   @Before
   public void setUp() {
     digestUtil = new DigestUtil(HashFunction.SHA256);
-    fileSystem = Jimfs.newFileSystem(config);
     blobs = new HashMap<Digest, ByteString>();
-    root = Iterables.getFirst(fileSystem.getRootDirectories(), null);
     fileCache = new CASFileCache(
         new InputStreamFactory() {
           @Override

--- a/src/test/java/build/buildfarm/worker/OsXCASFileCacheTest.java
+++ b/src/test/java/build/buildfarm/worker/OsXCASFileCacheTest.java
@@ -14,13 +14,17 @@
 
 package build.buildfarm.worker;
 
+import com.google.common.collect.Iterables;
 import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class OsXCASFileCacheTest extends CASFileCacheTest {
   public OsXCASFileCacheTest() {
-    super(Configuration.osX());
+    super(Iterables.getFirst(
+        Jimfs.newFileSystem(Configuration.osX()).getRootDirectories(),
+        null));
   }
 }

--- a/src/test/java/build/buildfarm/worker/UnixCASFileCacheTest.java
+++ b/src/test/java/build/buildfarm/worker/UnixCASFileCacheTest.java
@@ -14,13 +14,17 @@
 
 package build.buildfarm.worker;
 
+import com.google.common.collect.Iterables;
 import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class UnixCASFileCacheTest extends CASFileCacheTest {
   public UnixCASFileCacheTest() {
-    super(Configuration.unix());
+    super(Iterables.getFirst(
+        Jimfs.newFileSystem(Configuration.unix()).getRootDirectories(),
+        null));
   }
 }

--- a/src/test/java/build/buildfarm/worker/WindowsCASFileCacheTest.java
+++ b/src/test/java/build/buildfarm/worker/WindowsCASFileCacheTest.java
@@ -14,13 +14,17 @@
 
 package build.buildfarm.worker;
 
+import com.google.common.collect.Iterables;
 import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class WindowsCASFileCacheTest extends CASFileCacheTest {
   public WindowsCASFileCacheTest() {
-    super(Configuration.windows());
+    super(Iterables.getFirst(
+        Jimfs.newFileSystem(Configuration.windows()).getRootDirectories(),
+        null));
   }
 }


### PR DESCRIPTION
 Fixed erroneous use of File.setExecutable(), see #134.

Add native filesystem test

Jimfs has exhibited some inconsistent behavior with regard to executable
permissions. Institute this test so that native filesystem behavior will
be tested.