### PR TITLE
S Make ActionKey delegate equality and hashCode

### DIFF
--- a/src/main/java/build/buildfarm/common/DigestUtil.java
+++ b/src/main/java/build/buildfarm/common/DigestUtil.java
@@ -86,6 +86,20 @@ public class DigestUtil {
     private ActionKey(Digest digest) {
       this.digest = digest;
     }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o instanceof ActionKey) {
+        ActionKey actionKey = (ActionKey) o;
+        return digest.equals(actionKey.getDigest());
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      return digest.hashCode();
+    }
   }
 
   private final HashFunction hashFn;

--- a/src/main/java/build/buildfarm/instance/memory/DelegateCASMap.java
+++ b/src/main/java/build/buildfarm/instance/memory/DelegateCASMap.java
@@ -122,7 +122,11 @@ class DelegateCASMap<K,V extends Message> implements Map<K,V> {
 
   private V expectValueType(Digest valueDigest) {
     try {
-      return parser.parseFrom(contentAddressableStorage.get(valueDigest).getData());
+      Blob blob = contentAddressableStorage.get(valueDigest);
+      if (blob == null) {
+        return null;
+      }
+      return parser.parseFrom(blob.getData());
     } catch (InvalidProtocolBufferException ex) {
       return null;
     }

--- a/src/test/java/build/buildfarm/BUILD
+++ b/src/test/java/build/buildfarm/BUILD
@@ -112,6 +112,7 @@ java_test(
         "//3rdparty/jvm/com/google/truth",
         "//3rdparty/jvm/org/mockito:mockito_core",
         "//src/main/java/build/buildfarm:common",
+        "//src/main/java/build/buildfarm:instance",
         "//src/main/java/build/buildfarm:memory-instance",
         "//src/main/protobuf:build_buildfarm_v1test_buildfarm_java_proto",
         "@googleapis//:google_devtools_remoteexecution_v1test_remote_execution_java_proto",


### PR DESCRIPTION
To the digest it contains. Rely on the equality and hashability of
protobuf generated messages to [Hash]Map ActionKeys