### PR TITLE
Allow public visibility on java_binary targets

### DIFF
--- a/src/main/java/build/buildfarm/BUILD
+++ b/src/main/java/build/buildfarm/BUILD
@@ -107,6 +107,7 @@ java_binary(
     runtime_deps = [
         ":buildfarm",
     ],
+    visibility = ["//visibility:public"],
 )
 
 container_image(
@@ -198,6 +199,7 @@ java_binary(
     runtime_deps = [
         ":operationqueue-worker",
     ],
+    visibility = ["//visibility:public"],
 )
 
 container_image(


### PR DESCRIPTION
Exposes the server and worker binaries to other rules.

Closes #147