### PR TITLE
S Transform NOT_FOUND SRE on Blob Stream

### DIFF
--- a/src/test/java/build/buildfarm/BUILD
+++ b/src/test/java/build/buildfarm/BUILD
@@ -95,6 +95,7 @@ java_test(
         "//3rdparty/jvm/com/google/guava",
         "//3rdparty/jvm/com/google/protobuf:protobuf_java",
         "//3rdparty/jvm/com/google/truth",
+        "//3rdparty/jvm/io/grpc:grpc_core",
         "//src/main/java/build/buildfarm:stub-instance",
     ],
 )


### PR DESCRIPTION
When a StatusRuntimeException of NOT_FOUND is encountered on iterator
manipulations of ByteStringIteratorInputStream, translate this to an
IOException to preserve IO mask with known exception paths. This
prevents a mid-fetch expiration from forcing a worker to exit, and allow
existing handlers of IOException to enforce transactions.

Fixes #154 by making a NOT_FOUND getBlob non-catastrophic