### PR TITLE
S Handle IOException in fetchDirectory with rollback

### DIFF
--- a/src/main/java/build/buildfarm/worker/CASFileCache.java
+++ b/src/main/java/build/buildfarm/worker/CASFileCache.java
@@ -242,7 +242,7 @@ public class CASFileCache {
   private void expireDirectory(Digest digest) throws IOException {
     DirectoryEntry e = directoryStorage.remove(digest);
     purgeDirectoryFromInputs(digest, e.inputs);
-    CASFileCache.removeDirectory(getDirectoryPath(digest));
+    removeDirectory(getDirectoryPath(digest));
   }
 
   /** must be called in synchronized context */
@@ -318,7 +318,7 @@ public class CASFileCache {
         purgeDirectoryFromInputs(digest, inputs);
         decrementReferencesSynchronized(inputs, ImmutableList.<Digest>of());
       }
-      CASFileCache.removeDirectory(path);
+      removeDirectory(path);
       throw e;
     }
 

--- a/src/main/java/build/buildfarm/worker/CASFileCache.java
+++ b/src/main/java/build/buildfarm/worker/CASFileCache.java
@@ -189,7 +189,8 @@ public class CASFileCache {
     return root.resolve(filename);
   }
 
-  private Path getDirectoryPath(Digest digest) {
+  @VisibleForTesting
+  public Path getDirectoryPath(Digest digest) {
     return root.resolve(digestFilename(digest));
   }
 

--- a/src/main/java/build/buildfarm/worker/CASFileCache.java
+++ b/src/main/java/build/buildfarm/worker/CASFileCache.java
@@ -318,7 +318,12 @@ public class CASFileCache {
         purgeDirectoryFromInputs(digest, inputs);
         decrementReferencesSynchronized(inputs, ImmutableList.<Digest>of());
       }
-      removeDirectory(path);
+      try {
+        removeDirectory(path);
+      } catch (IOException rmdirEx) {
+        // unexpected failure removing directory, log and maintain original exception
+        rmdirEx.printStackTrace();
+      }
       throw e;
     }
 


### PR DESCRIPTION
An IOException encountered during fetchDirectory should be met with a
rollback of a putDirectory operation. References to inputs are
decremented, and the target directory is removed, recursively.