### PR TITLE
S Remove .bazelrc digest directive for example

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,7 @@ To have bazel use the bazel buildfarm configured using the example configs provi
 
 ```
 $ cat .bazelrc
-startup --host_jvm_args=-Dbazel.DigestFunction=SHA1
-build --spawn_strategy=remote --genrule_strategy=remote --strategy=Javac=remote --strategy=Closure=remote  --remote_executor=localhost:8980
+build --spawn_strategy=remote --genrule_strategy=remote --strategy=Javac=remote --strategy=Closure=remote --remote_executor=localhost:8980
 ```
 
 Then run your build as you would normally do.


### PR DESCRIPTION
The example now uses a SHA256 instance, make the README.md instructions
match it.

Fixes #166