### PR TITLE
M Refine watchOperation behavior and test

### DIFF
--- a/src/main/java/build/buildfarm/instance/Instance.java
+++ b/src/main/java/build/buildfarm/instance/Instance.java
@@ -76,6 +76,11 @@ public interface Instance {
   void cancelOperation(String name);
   void deleteOperation(String name);
 
+  // returns true if the operation will be handled in all cases through the
+  // watcher.
+  // The watcher returns true to indicate it is still able to process updates,
+  // and returns false when it is complete and no longer wants updates
+  // The watcher must not be tested again after it has returned false.
   boolean watchOperation(
       String operationName,
       boolean watchInitialState,

--- a/src/main/java/build/buildfarm/instance/memory/MemoryInstance.java
+++ b/src/main/java/build/buildfarm/instance/memory/MemoryInstance.java
@@ -84,6 +84,7 @@ public class MemoryInstance extends AbstractServerInstance {
         digestUtil,
         config,
         /*contentAddressableStorage=*/ new MemoryLRUContentAddressableStorage(config.getCasMaxSizeBytes()),
+        /*watchers=*/ new ConcurrentHashMap<String, List<Predicate<Operation>>>(),
         /*outstandingOperations=*/ new TreeMap<String, Operation>());
   }
 
@@ -93,6 +94,7 @@ public class MemoryInstance extends AbstractServerInstance {
       DigestUtil digestUtil,
       MemoryInstanceConfig config,
       ContentAddressableStorage contentAddressableStorage,
+      Map<String, List<Predicate<Operation>>> watchers,
       Map<String, Operation> outstandingOperations) {
     super(
         name,
@@ -102,7 +104,7 @@ public class MemoryInstance extends AbstractServerInstance {
         outstandingOperations,
         /*completedOperations=*/ new DelegateCASMap<String, Operation>(contentAddressableStorage, Operation.parser(), digestUtil));
     this.config = config;
-    watchers = new ConcurrentHashMap<String, List<Predicate<Operation>>>();
+    this.watchers = watchers;
     streams = new HashMap<String, ByteStringStreamSource>();
     queuedOperations = new ArrayList<Operation>();
     workers = new ArrayList<Worker>();
@@ -342,10 +344,12 @@ public class MemoryInstance extends AbstractServerInstance {
     if (watchInitialState) {
       Operation operation = getOperation(operationName);
       if (!watcher.test(operation)) {
-        return false;
-      }
-      if (operation.getDone()) {
+        // watcher processed completed state
         return true;
+      }
+      if (operation == null || operation.getDone()) {
+        // watcher did not process completed state
+        return false;
       }
     }
     Operation completedOperation = null;
@@ -356,18 +360,23 @@ public class MemoryInstance extends AbstractServerInstance {
          * watchers list has been removed, making it necessary to check for the
          * operation within this context */
         Operation operation = getOperation(operationName);
-        if (operation.getDone()) {
-          completedOperation = operation;
-        } else {
-          return false;
+        if (operation == null || !watchInitialState) {
+          // missing operation with no initial state requires no handling
+          // leave non-watchInitialState watchers of missing items to linger
+          return true;
         }
+        Preconditions.checkState(
+            operation.getDone(),
+            "watchers removed on incomplete operation");
+        completedOperation = operation;
+      } else {
+        operationWatchers.add(watcher);
+        return true;
       }
-      operationWatchers.add(watcher);
     }
-    if (completedOperation != null) {
-      return watcher.test(completedOperation);
-    }
-    return true;
+    // the failed watcher test indicates that it did not handle the
+    // completed state
+    return !watcher.test(completedOperation);
   }
 
   private List<Operation> sortedOperations() {

--- a/src/test/java/build/buildfarm/instance/memory/MemoryInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/memory/MemoryInstanceTest.java
@@ -15,7 +15,12 @@
 package build.buildfarm.instance.memory;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 
 import build.buildfarm.common.ContentAddressableStorage;
 import build.buildfarm.common.ContentAddressableStorage.Blob;
@@ -26,23 +31,32 @@ import build.buildfarm.v1test.MemoryInstanceConfig;
 import com.google.common.collect.ImmutableList;
 import com.google.devtools.remoteexecution.v1test.Action;
 import com.google.devtools.remoteexecution.v1test.ActionResult;
+import com.google.devtools.remoteexecution.v1test.Digest;
+import com.google.devtools.remoteexecution.v1test.ExecuteOperationMetadata;
 import com.google.longrunning.Operation;
+import com.google.protobuf.Any;
 import com.google.protobuf.Duration;
 import com.google.protobuf.util.Durations;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 @RunWith(JUnit4.class)
 public class MemoryInstanceTest {
   private Instance instance;
 
   private Map<String, Operation> outstandingOperations;
+  private Map<String, List<Predicate<Operation>>> watchers;
 
   @Mock
   private ContentAddressableStorage storage;
@@ -51,6 +65,7 @@ public class MemoryInstanceTest {
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
     outstandingOperations = new HashMap<>();
+    watchers = new HashMap<>();
     MemoryInstanceConfig memoryInstanceConfig = MemoryInstanceConfig.newBuilder()
         .setListOperationsDefaultPageSize(1024)
         .setListOperationsMaxPageSize(16384)
@@ -67,6 +82,7 @@ public class MemoryInstanceTest {
         new DigestUtil(DigestUtil.HashFunction.SHA256),
         memoryInstanceConfig,
         storage,
+        watchers,
         outstandingOperations);
   }
 
@@ -157,5 +173,104 @@ public class MemoryInstanceTest {
         result);
     assertThat(instance.getActionResult(
         instance.getDigestUtil().computeActionKey(action))).isEqualTo(result);
+  }
+
+  @Test
+  public void missingOperationWatchInvertsWatchInitialState() {
+    Predicate<Operation> watcher = (Predicate<Operation>) mock(Predicate.class);
+    // a request for a watch on an operation that does not exist must
+    // invert watchInitialState to indicate that it will not call the watcher
+    // again if it has not handled the completed state
+    assertThat(instance.watchOperation(
+        "does-not-exist",
+        /* watchInitialState=*/ false,
+        watcher)).isTrue();
+    verifyZeroInteractions(watcher);
+
+    Predicate<Operation> watchInitialWatcher = (Predicate<Operation>) mock(Predicate.class);
+    when(watchInitialWatcher.test(eq(null))).thenReturn(true);
+    assertThat(instance.watchOperation(
+        "does-not-exist",
+        /* watchInitialState=*/ true,
+        watchInitialWatcher)).isFalse();
+    verify(watchInitialWatcher, times(1)).test(eq(null));
+  }
+
+  @Test
+  public void initialWatchWithCompletedSignalsWatching() {
+    Predicate<Operation> watcher = (Predicate<Operation>) mock(Predicate.class);
+    when(watcher.test(eq(null))).thenReturn(false);
+    assertThat(instance.watchOperation(
+        "does-not-exist",
+        /* watchInitialState=*/ true,
+        watcher)).isTrue();
+    verify(watcher, times(1)).test(eq(null));
+  }
+
+  @Test
+  public void watchOperationAddsWatcher() {
+    Operation operation = Operation.newBuilder()
+        .setName("my-watched-operation")
+        .build();
+    outstandingOperations.put(operation.getName(), operation);
+
+    List<Predicate<Operation>> operationWatchers =
+        (List<Predicate<Operation>>) mock(List.class);
+    watchers.put(operation.getName(), operationWatchers);
+
+    Predicate<Operation> watcher = (Predicate<Operation>) mock(Predicate.class);
+    assertThat(instance.watchOperation(
+        operation.getName(),
+        /* watchInitialState=*/ false,
+        watcher)).isTrue();
+    verify(operationWatchers, times(1)).add(eq(watcher));
+  }
+
+  @Test
+  public void watchOpRaceLossInvertsTestOnInitial() {
+    Operation operation = Operation.newBuilder()
+        .setName("my-watched-operation")
+        .build();
+    Operation doneOperation = operation.toBuilder()
+        .setDone(true)
+        .build();
+
+    // as a result of the initial verified test, change the operation to done
+    Answer<Boolean> initialAnswer = new Answer<Boolean>() {
+      @Override
+      public Boolean answer(InvocationOnMock invocation) throws Throwable {
+        outstandingOperations.put(operation.getName(), doneOperation);
+        return true;
+      }
+    };
+    Predicate<Operation> watcher = (Predicate<Operation>) mock(Predicate.class);
+    when(watcher.test(eq(operation))).thenAnswer(initialAnswer);
+    when(watcher.test(eq(doneOperation))).thenReturn(false);
+
+    // set for each verification
+    outstandingOperations.put(operation.getName(), operation);
+
+    assertThat(instance.watchOperation(
+        operation.getName(),
+        /* watchInitialState=*/ true,
+        watcher)).isTrue();
+    verify(watcher, times(1)).test(eq(operation));
+    verify(watcher, times(1)).test(eq(doneOperation));
+
+    outstandingOperations.clear();
+
+    Predicate<Operation> unfazedWatcher = (Predicate<Operation>) mock(Predicate.class);
+    when(unfazedWatcher.test(eq(operation))).thenAnswer(initialAnswer);
+    // unfazed watcher is not bothered by the operation's change of done
+    when(unfazedWatcher.test(eq(doneOperation))).thenReturn(true);
+
+    // set for each verification
+    outstandingOperations.put(operation.getName(), operation);
+    assertThat(instance.watchOperation(
+        operation.getName(),
+        /* watchInitialState=*/ true,
+        unfazedWatcher)).isFalse();
+    verify(unfazedWatcher, times(1)).test(eq(operation));
+    verify(unfazedWatcher, times(1)).test(eq(doneOperation));
   }
 }

--- a/src/test/java/build/buildfarm/instance/memory/MemoryInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/memory/MemoryInstanceTest.java
@@ -37,6 +37,7 @@ import com.google.longrunning.Operation;
 import com.google.protobuf.Any;
 import com.google.protobuf.Duration;
 import com.google.protobuf.util.Durations;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -214,8 +215,7 @@ public class MemoryInstanceTest {
         .build();
     outstandingOperations.put(operation.getName(), operation);
 
-    List<Predicate<Operation>> operationWatchers =
-        (List<Predicate<Operation>>) mock(List.class);
+    List<Predicate<Operation>> operationWatchers = new ArrayList<>();
     watchers.put(operation.getName(), operationWatchers);
 
     Predicate<Operation> watcher = (Predicate<Operation>) mock(Predicate.class);
@@ -223,7 +223,7 @@ public class MemoryInstanceTest {
         operation.getName(),
         /* watchInitialState=*/ false,
         watcher)).isTrue();
-    verify(operationWatchers, times(1)).add(eq(watcher));
+    assertThat(operationWatchers).containsExactly(watcher);
   }
 
   @Test


### PR DESCRIPTION
Protect watchOperation against missing operation requests, watchers
which ignore operation state, and races to operation completions or
expirations. Define watchOperation interface behavior and expectations
for watchers:

watchers will return true if they expect further tests, and false if no
subsequent tests should occur.
watchOperation will return true if the watcher will be tested for all
updates, and false otherwise or if the watcher responds with true in the
terminal cases of missing or done operations.

Fixes #165