### PR TITLE
Make the container images public.

### DIFF
--- a/src/main/java/build/buildfarm/BUILD
+++ b/src/main/java/build/buildfarm/BUILD
@@ -126,6 +126,7 @@ container_image(
         "--port",
         "8098"
     ],
+    visibility = ["//visibility:public"],
 )
 
 java_library(
@@ -216,4 +217,5 @@ container_image(
         "buildfarm-worker_deploy.jar",
         "/config/worker.config",
     ],
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This allows them to be pushed into a registry from within a different
workspace.