### PR TITLE
Listen on the default port number that is documented.

### DIFF
--- a/src/main/java/build/buildfarm/BUILD
+++ b/src/main/java/build/buildfarm/BUILD
@@ -124,7 +124,7 @@ container_image(
         "buildfarm-server_deploy.jar",
         "/config/server.config",
         "--port",
-        "8098"
+        "8980"
     ],
 )
 


### PR DESCRIPTION
In the README and in the example configurations we describe that the
buildfarm server listens on port 8980 by default. This container,
however, listens on 8089. Bring the two in sync.