### PR TITLE
Remove the worker container image.

### DIFF
--- a/src/main/java/build/buildfarm/BUILD
+++ b/src/main/java/build/buildfarm/BUILD
@@ -202,20 +202,3 @@ java_binary(
     ],
     visibility = ["//visibility:public"],
 )
-
-container_image(
-    name = "worker.container",
-    base = "@java_base//image",
-    # leverage the implicit target of the buildfarm-server to get a fat jar.
-    # this is simply a workaround for the fact that we have so many dependencies,
-    # so we'd want some wrappy script. This seemed more straightforward.
-    # https://docs.bazel.build/versions/master/be/java.html#java_binary_implicit_outputs
-    files = [
-        ":buildfarm-worker_deploy.jar",
-    ],
-    cmd = [
-        "buildfarm-worker_deploy.jar",
-        "/config/worker.config",
-    ],
-    visibility = ["//visibility:public"],
-)


### PR DESCRIPTION
The container image for the worker process that we currently ship is
effectively useless. It's based on a distroless container image, meaning
it doesn't even include a shell interpreter. Because of this, it is not
able to spawn any subprocesses.

People who want to run workers through Docker should create their own
container images with the development tools they need.