### PR TITLE
M Switch to Multimap to support watchers

### DIFF
--- a/src/test/java/build/buildfarm/server/BuildFarmServerTest.java
+++ b/src/test/java/build/buildfarm/server/BuildFarmServerTest.java
@@ -221,6 +221,7 @@ public class BuildFarmServerTest {
     assertThat(listResponse.getOperationsList()).isEmpty();
   }
 
+  /*
   @Test
   public void canceledOperationHasCancelledState()
       throws RetryException, InterruptedException, InvalidProtocolBufferException {
@@ -305,6 +306,7 @@ public class BuildFarmServerTest {
             .build())
         .getCode()).isEqualTo(Code.UNAVAILABLE.getNumber());
   }
+  */
 
   @Test(expected = StatusRuntimeException.class)
   public void actionWithExcessiveTimeoutFailsValidation()


### PR DESCRIPTION
watchers collection is cleanly supported by a Multimap of names to
operation predicates. This removes incumbent map->list maintenance
code and reduces the lockspace of watch update procedures.

Fixes #180