### PR TITLE
(M) Provide ExecutionPolicy specification on workers

### DIFF
--- a/examples/worker.config.example
+++ b/examples/worker.config.example
@@ -113,3 +113,11 @@ maximum_action_timeout: {
   seconds: 3600
   nanos: 0
 }
+
+# prefix command executions with this path
+#execution_policies: {
+#  name: "test"
+#  wrapper: {
+#    path: "/path/to/execution/wrapper"
+#  }
+#}

--- a/src/main/java/build/buildfarm/worker/Executor.java
+++ b/src/main/java/build/buildfarm/worker/Executor.java
@@ -69,6 +69,10 @@ class Executor implements Runnable {
 
     Platform platform = operationContext.command.getPlatform();
     ImmutableList.Builder<ExecutionPolicy> policies = ImmutableList.builder();
+    ExecutionPolicy defaultPolicy = workerContext.getExecutionPolicy("");
+    if (defaultPolicy != null) {
+      policies.add(defaultPolicy);
+    }
     for (Property property : platform.getPropertiesList()) {
       if (property.getName().equals("execution-policy")) {
         policies.add(workerContext.getExecutionPolicy(property.getValue()));

--- a/src/main/java/build/buildfarm/worker/WorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/WorkerContext.java
@@ -19,6 +19,7 @@ import build.buildfarm.common.DigestUtil.ActionKey;
 import build.buildfarm.instance.Instance;
 import build.buildfarm.instance.stub.ByteStreamUploader;
 import build.buildfarm.v1test.CASInsertionPolicy;
+import build.buildfarm.v1test.ExecutionPolicy;
 import build.bazel.remote.execution.v2.Action;
 import build.bazel.remote.execution.v2.ActionResult;
 import build.bazel.remote.execution.v2.Command;
@@ -40,6 +41,7 @@ public interface WorkerContext {
   CASInsertionPolicy getStdoutCasPolicy();
   CASInsertionPolicy getStderrCasPolicy();
   DigestUtil getDigestUtil();
+  ExecutionPolicy getExecutionPolicy(String name);
   int getInlineContentLimit();
   int getExecuteStageWidth();
   int getTreePageSize();

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -158,6 +158,18 @@ message InstanceEndpoint {
   string instance_name = 2;
 }
 
+message ExecutionWrapper {
+  string path = 1;
+}
+
+message ExecutionPolicy {
+  string name = 1;
+
+  oneof policy {
+    ExecutionWrapper wrapper = 2;
+  }
+}
+
 message WorkerConfig {
   build.bazel.remote.execution.v2.DigestFunction digest_function = 1;
 
@@ -230,6 +242,10 @@ message WorkerConfig {
   // a maximum threshold for an action's specified timeout,
   // beyond which an action will be rejected for execution
   google.protobuf.Duration maximum_action_timeout = 21;
+
+  // available execution policies, will be used to match
+  // with an action's platform for selection
+  repeated ExecutionPolicy execution_policies = 22;
 }
 
 message TreeIteratorToken {

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -162,6 +162,8 @@ message ExecutionWrapper {
   string path = 1;
 }
 
+// selectable controls for executions
+// a universal policy can be specified with an empty name
 message ExecutionPolicy {
   string name = 1;
 

--- a/src/test/java/build/buildfarm/worker/StubWorkerContext.java
+++ b/src/test/java/build/buildfarm/worker/StubWorkerContext.java
@@ -20,6 +20,7 @@ import build.buildfarm.worker.CASFileCache;
 import build.buildfarm.instance.Instance;
 import build.buildfarm.instance.stub.ByteStreamUploader;
 import build.buildfarm.v1test.CASInsertionPolicy;
+import build.buildfarm.v1test.ExecutionPolicy;
 import build.bazel.remote.execution.v2.Action;
 import build.bazel.remote.execution.v2.ActionResult;
 import build.bazel.remote.execution.v2.Command;
@@ -40,6 +41,7 @@ class StubWorkerContext implements WorkerContext {
   @Override public CASInsertionPolicy getStdoutCasPolicy() { throw new UnsupportedOperationException(); }
   @Override public CASInsertionPolicy getStderrCasPolicy() { throw new UnsupportedOperationException(); }
   @Override public DigestUtil getDigestUtil() { throw new UnsupportedOperationException(); }
+  @Override public ExecutionPolicy getExecutionPolicy(String name) { throw new UnsupportedOperationException(); }
   @Override public int getInlineContentLimit() { throw new UnsupportedOperationException(); }
   @Override public int getExecuteStageWidth() { throw new UnsupportedOperationException(); }
   @Override public int getTreePageSize() { throw new UnsupportedOperationException(); }


### PR DESCRIPTION
Workers may declare a series of execution policies that can be referred
to by platform properties of name `execution-policy`. The available
policy is an ExecutionWrapper, where a path string will be concatenated
with the current command arguments to be executed. These policies can be
specified multiple times in the platform properties, where later
wrappers will wrap earlier ones.