### PR TITLE
(XS) Use a synchronized sorted map for Outstanding Ops

### DIFF
--- a/src/main/java/build/buildfarm/instance/memory/MemoryInstance.java
+++ b/src/main/java/build/buildfarm/instance/memory/MemoryInstance.java
@@ -61,6 +61,7 @@ import io.grpc.netty.NettyChannelBuilder;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -103,7 +104,7 @@ public class MemoryInstance extends AbstractServerInstance {
   }
 
   static class OutstandingOperations implements OperationsMap {
-    private final Map<String, Operation> map = new TreeMap<>();
+    private final Map<String, Operation> map = Collections.synchronizedSortedMap(new TreeMap<>());
 
     @Override
     public Operation remove(String name) {


### PR DESCRIPTION
Prevents unsafe access to the outstanding operations, which can yield
inconsistent responses to execute requests - null operations passed to
watcher routines which result in no-response stream response
completions.