### PR TITLE
MemoryInstance now revalidates action on requeueing

### DIFF
--- a/src/main/java/build/buildfarm/BUILD
+++ b/src/main/java/build/buildfarm/BUILD
@@ -73,6 +73,7 @@ java_library(
         "//3rdparty/jvm/io/grpc:grpc_stub",
         "//src/main/protobuf:build_buildfarm_v1test_buildfarm_java_proto",
         "@googleapis//:google_longrunning_operations_java_proto",
+        "@googleapis//:google_rpc_code_java_proto",
         "@googleapis//:google_rpc_status_java_proto",
         "@remote_apis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
     ],
@@ -110,27 +111,27 @@ java_library(
 java_binary(
     name = "buildfarm-server",
     main_class = "build.buildfarm.server.BuildFarmServer",
+    visibility = ["//visibility:public"],
     runtime_deps = [
         ":buildfarm",
     ],
-    visibility = ["//visibility:public"],
 )
 
 container_image(
     name = "server.container",
     base = "@java_base//image",
+    cmd = [
+        "buildfarm-server_deploy.jar",
+        "/config/server.config",
+        "--port",
+        "8980",
+    ],
     # leverage the implicit target of the buildfarm-server to get a fat jar.
     # this is simply a workaround for the fact that we have so many dependencies,
     # so we'd want some wrappy script. This seemed more straightforward.
     # https://docs.bazel.build/versions/master/be/java.html#java_binary_implicit_outputs
     files = [
-        ":buildfarm-server_deploy.jar"
-    ],
-    cmd = [
-        "buildfarm-server_deploy.jar",
-        "/config/server.config",
-        "--port",
-        "8980"
+        ":buildfarm-server_deploy.jar",
     ],
     visibility = ["//visibility:public"],
 )
@@ -184,10 +185,10 @@ java_library(
     name = "operationqueue-worker",
     srcs = glob(["worker/operationqueue/*.java"]),
     deps = [
-        ":worker",
         ":common",
         ":instance",
         ":stub-instance",
+        ":worker",
         "//3rdparty/jvm/com/github/pcj:google_options",
         "//3rdparty/jvm/com/google/guava",
         "//3rdparty/jvm/com/google/protobuf:protobuf_java",
@@ -233,25 +234,25 @@ java_library(
 java_binary(
     name = "buildfarm-worker",
     main_class = "build.buildfarm.worker.operationqueue.Worker",
+    visibility = ["//visibility:public"],
     runtime_deps = [
         ":operationqueue-worker",
     ],
-    visibility = ["//visibility:public"],
 )
 
 container_image(
     name = "worker.container",
     base = "@java_base//image",
+    cmd = [
+        "buildfarm-worker_deploy.jar",
+        "/config/worker.config",
+    ],
     # leverage the implicit target of the buildfarm-server to get a fat jar.
     # this is simply a workaround for the fact that we have so many dependencies,
     # so we'd want some wrappy script. This seemed more straightforward.
     # https://docs.bazel.build/versions/master/be/java.html#java_binary_implicit_outputs
     files = [
         ":buildfarm-worker_deploy.jar",
-    ],
-    cmd = [
-        "buildfarm-worker_deploy.jar",
-        "/config/worker.config",
     ],
     visibility = ["//visibility:public"],
 )

--- a/src/main/java/build/buildfarm/instance/AbstractServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/AbstractServerInstance.java
@@ -47,7 +47,6 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.rpc.Code;
 import io.grpc.Status;
-
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -207,7 +206,6 @@ public abstract class AbstractServerInstance implements Instance {
   }
 
   protected abstract int getTreeDefaultPageSize();
-
   protected abstract int getTreeMaxPageSize();
 
   protected abstract TokenizableIterator<Directory> createTreeIterator(
@@ -653,7 +651,6 @@ public abstract class AbstractServerInstance implements Instance {
   }
 
   abstract protected boolean matchOperation(Operation operation);
-
   abstract protected void enqueueOperation(Operation operation);
 
   @Override
@@ -710,9 +707,7 @@ public abstract class AbstractServerInstance implements Instance {
   }
 
   protected abstract int getListOperationsDefaultPageSize();
-
   protected abstract int getListOperationsMaxPageSize();
-
   protected abstract TokenizableIterator<Operation> createOperationsIterator(String pageToken);
 
   @Override
@@ -784,10 +779,7 @@ public abstract class AbstractServerInstance implements Instance {
   protected void errorOperation(String name, com.google.rpc.Status status) throws InterruptedException {
     Operation operation = getOperation(name);
     if (operation == null) {
-      // throw new IllegalStateException("Trying to error nonexistent operation [" + name + "]");
-      operation = Operation.newBuilder()
-          .setName(name)
-          .build();
+      throw new IllegalStateException("Trying to error nonexistent operation [" + name + "]");
     }
     if (operation.getDone()) {
       throw new IllegalStateException("Trying to error already completed operation [" + name + "]");

--- a/src/main/java/build/buildfarm/instance/memory/MemoryInstance.java
+++ b/src/main/java/build/buildfarm/instance/memory/MemoryInstance.java
@@ -59,6 +59,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import io.grpc.Channel;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
+
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
@@ -331,7 +332,7 @@ public class MemoryInstance extends AbstractServerInstance {
       Duration maximum = config.getMaximumActionTimeout();
       Preconditions.checkState(
           timeout.getSeconds() < maximum.getSeconds() ||
-          (timeout.getSeconds() == maximum.getSeconds() && timeout.getNanos() < maximum.getNanos()));
+              (timeout.getSeconds() == maximum.getSeconds() && timeout.getNanos() < maximum.getNanos()));
     }
 
     super.validateAction(action);
@@ -403,7 +404,7 @@ public class MemoryInstance extends AbstractServerInstance {
 
   private void onDispatched(Operation operation) {
     Duration timeout = config.getOperationPollTimeout();
-    Watchdog requeuer = new Watchdog(timeout, () -> putOperation(operation));
+    Watchdog requeuer = new Watchdog(timeout, () -> requeueOperation(operation));
     requeuers.put(operation.getName(), requeuer);
     new Thread(requeuer).start();
   }
@@ -472,7 +473,7 @@ public class MemoryInstance extends AbstractServerInstance {
     // string compare only
     // no duplicate names
     ImmutableMap.Builder<String, String> provisionsBuilder =
-      new ImmutableMap.Builder<String, String>();
+        new ImmutableMap.Builder<String, String>();
     for (Platform.Property property : platform.getPropertiesList()) {
       provisionsBuilder.put(property.getName(), property.getValue());
     }

--- a/src/main/java/build/buildfarm/instance/memory/MemoryInstance.java
+++ b/src/main/java/build/buildfarm/instance/memory/MemoryInstance.java
@@ -59,7 +59,6 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import io.grpc.Channel;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
-
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;

--- a/src/test/java/build/buildfarm/BUILD
+++ b/src/test/java/build/buildfarm/BUILD
@@ -155,6 +155,7 @@ java_test(
         "//src/main/java/build/buildfarm:server-instance",
         "//src/main/protobuf:build_buildfarm_v1test_buildfarm_java_proto",
         "@googleapis//:google_longrunning_operations_java_grpc",
+        "@googleapis//:google_rpc_code_java_proto",
         "@remote_apis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
     ],
 )

--- a/src/test/java/build/buildfarm/instance/memory/MemoryInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/memory/MemoryInstanceTest.java
@@ -22,20 +22,18 @@ import static build.bazel.remote.execution.v2.ExecuteOperationMetadata.Stage.UNK
 import static com.google.common.collect.Multimaps.synchronizedSetMultimap;
 import static com.google.common.truth.Truth.assertThat;
 import static java.util.concurrent.Executors.newFixedThreadPool;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
 
 import build.bazel.remote.execution.v2.ExecuteOperationMetadata;
 import build.bazel.remote.execution.v2.ExecuteOperationMetadata.Stage;
 import build.buildfarm.cas.ContentAddressableStorage;
 import build.buildfarm.cas.ContentAddressableStorage.Blob;
 import build.buildfarm.common.DigestUtil;
-import build.buildfarm.common.DigestUtil.HashFunction;
-import build.buildfarm.instance.Instance;
 import build.buildfarm.instance.OperationsMap;
 import build.buildfarm.v1test.ActionCacheConfig;
 import build.buildfarm.v1test.DelegateCASConfig;
@@ -47,18 +45,18 @@ import build.bazel.remote.execution.v2.Action;
 import build.bazel.remote.execution.v2.ActionResult;
 import com.google.longrunning.Operation;
 import com.google.protobuf.Any;
-import com.google.protobuf.Duration;
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.Durations;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
+
+import com.google.rpc.Code;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
@@ -66,10 +64,11 @@ import org.mockito.stubbing.Answer;
 
 @RunWith(JUnit4.class)
 public class MemoryInstanceTest {
-  private Instance instance;
+  private MemoryInstance instance;
 
   private OperationsMap outstandingOperations;
   private SetMultimap<String, Predicate<Operation>> watchers;
+  private ExecutorService watchersThreadPool;
 
   @Mock
   private ContentAddressableStorage storage;
@@ -83,6 +82,7 @@ public class MemoryInstanceTest {
             .hashKeys()
             .hashSetValues(/* expectedValuesPerKey=*/ 1)
             .build());
+    watchersThreadPool =newFixedThreadPool(1);
     MemoryInstanceConfig memoryInstanceConfig = MemoryInstanceConfig.newBuilder()
         .setListOperationsDefaultPageSize(1024)
         .setListOperationsMaxPageSize(16384)
@@ -103,7 +103,7 @@ public class MemoryInstanceTest {
         memoryInstanceConfig,
         storage,
         watchers,
-        newFixedThreadPool(1),
+        watchersThreadPool,
         outstandingOperations);
   }
 
@@ -179,7 +179,7 @@ public class MemoryInstanceTest {
     Action action = Action.getDefaultInstance();
 
     assertThat(instance.getActionResult(
-          instance.getDigestUtil().computeActionKey(action))).isNull();
+        instance.getDigestUtil().computeActionKey(action))).isNull();
   }
 
   @Test
@@ -277,13 +277,58 @@ public class MemoryInstanceTest {
     verify(unfazedWatcher, times(1)).test(eq(doneOperation));
   }
 
-  private boolean putNovelOperation(Stage stage) throws InterruptedException {
-    return instance.putOperation(Operation.newBuilder()
-        .setName("does-not-exist")
+  @Test
+  public void requeueFailOnInvalid() throws InterruptedException, InvalidProtocolBufferException {
+    // These new operations are invalid as they're missing content.
+    Operation queuedOperation = createOperation("my-queued-operation", QUEUED);
+    outstandingOperations.put(queuedOperation.getName(), queuedOperation);
+
+    watchers.put(queuedOperation.getName(), new Predicate<Operation>() {
+      @Override
+      public boolean test(Operation operation) {
+        assertThat(operation.getError().getCode()).isEqualTo(Code.FAILED_PRECONDITION);
+        return false;
+      }
+    });
+
+    instance.requeueOperation(queuedOperation);
+
+    watchersThreadPool.shutdown();
+    watchersThreadPool.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
+  }
+
+  @Test
+  public void requeueFailOnNotQueued() throws InterruptedException, InvalidProtocolBufferException {
+    Operation queuedOperation = createOperation("my-queued-operation", QUEUED);
+    outstandingOperations.put(queuedOperation.getName(), queuedOperation);
+    Operation executingOperation = createOperation("my-executing-operation", EXECUTING);
+    outstandingOperations.put(executingOperation.getName(), executingOperation);
+
+    try {
+      instance.requeueOperation(executingOperation);
+      fail("Method should throw if operation is not QUEUED.");
+    } catch (IllegalStateException e) {
+      assertThat(e.getMessage()).isEqualTo("Operation stage is not QUEUED");
+    }
+
+    try {
+      instance.requeueOperation(queuedOperation);
+    } catch (IllegalStateException e) {
+      fail("Method should not throw if operation is QUEUED.");
+    }
+  }
+
+  private Operation createOperation(String name, Stage stage) {
+    return Operation.newBuilder()
+        .setName(name)
         .setMetadata(Any.pack(ExecuteOperationMetadata.newBuilder()
             .setStage(stage)
             .build()))
-        .build());
+        .build();
+  }
+
+  private boolean putNovelOperation(Stage stage) throws InterruptedException {
+    return instance.putOperation(createOperation("does-not-exist", stage));
   }
 
   @Test

--- a/src/test/java/build/buildfarm/instance/memory/MemoryInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/memory/MemoryInstanceTest.java
@@ -47,11 +47,9 @@ import com.google.longrunning.Operation;
 import com.google.protobuf.Any;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.Durations;
-
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
-
 import com.google.rpc.Code;
 import org.junit.Before;
 import org.junit.Test;
@@ -82,7 +80,7 @@ public class MemoryInstanceTest {
             .hashKeys()
             .hashSetValues(/* expectedValuesPerKey=*/ 1)
             .build());
-    watchersThreadPool =newFixedThreadPool(1);
+    watchersThreadPool = newFixedThreadPool(1);
     MemoryInstanceConfig memoryInstanceConfig = MemoryInstanceConfig.newBuilder()
         .setListOperationsDefaultPageSize(1024)
         .setListOperationsMaxPageSize(16384)
@@ -311,11 +309,7 @@ public class MemoryInstanceTest {
       assertThat(e.getMessage()).isEqualTo("Operation stage is not QUEUED");
     }
 
-    try {
-      instance.requeueOperation(queuedOperation);
-    } catch (IllegalStateException e) {
-      fail("Method should not throw if operation is QUEUED.");
-    }
+    instance.requeueOperation(queuedOperation);
   }
 
   private Operation createOperation(String name, Stage stage) {


### PR DESCRIPTION
An instance should revalidate the action before requeueing if it did not receive a poll from the worker within the `operation_poll_timeout`.

This PR adds this functionality together with tests.