### PR TITLE
XS Remove unused WorkerContext methods

### DIFF
--- a/src/main/java/build/buildfarm/worker/WorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/WorkerContext.java
@@ -46,8 +46,6 @@ public interface WorkerContext {
   ExecutionPolicy getExecutionPolicy(String name);
   int getInlineContentLimit();
   int getExecuteStageWidth();
-  int getTreePageSize();
-  boolean getLinkInputDirectories();
   boolean hasDefaultActionTimeout();
   boolean hasMaximumActionTimeout();
   boolean getStreamStdout();

--- a/src/main/java/build/buildfarm/worker/operationqueue/Worker.java
+++ b/src/main/java/build/buildfarm/worker/operationqueue/Worker.java
@@ -361,16 +361,6 @@ public class Worker {
       }
 
       @Override
-      public int getTreePageSize() {
-        return config.getTreePageSize();
-      }
-
-      @Override
-      public boolean getLinkInputDirectories() {
-        return config.getLinkInputDirectories();
-      }
-
-      @Override
       public boolean hasDefaultActionTimeout() {
         return config.hasDefaultActionTimeout();
       }

--- a/src/test/java/build/buildfarm/worker/StubWorkerContext.java
+++ b/src/test/java/build/buildfarm/worker/StubWorkerContext.java
@@ -46,8 +46,6 @@ class StubWorkerContext implements WorkerContext {
   @Override public ExecutionPolicy getExecutionPolicy(String name) { throw new UnsupportedOperationException(); }
   @Override public int getInlineContentLimit() { throw new UnsupportedOperationException(); }
   @Override public int getExecuteStageWidth() { throw new UnsupportedOperationException(); }
-  @Override public int getTreePageSize() { throw new UnsupportedOperationException(); }
-  @Override public boolean getLinkInputDirectories() { throw new UnsupportedOperationException(); }
   @Override public boolean hasDefaultActionTimeout() { throw new UnsupportedOperationException(); }
   @Override public boolean hasMaximumActionTimeout() { throw new UnsupportedOperationException(); }
   @Override public boolean getStreamStdout() { throw new UnsupportedOperationException(); }


### PR DESCRIPTION
These methods are now implementation details of context providers, and
not required for stage consumers.