### PR TITLE
Remove deleted feature from config file

### DIFF
--- a/examples/worker.config.example
+++ b/examples/worker.config.example
@@ -63,11 +63,6 @@ stderr_cas_policy: ALWAYS_INSERT
 #   INSERT_ABOVE_LIMIT: output files are inserted into the CAS when it exceeds the inline limit above
 file_cas_policy: ALWAYS_INSERT
 
-# the worker will take it upon itself to requeue (exceptionally)
-# failed operations via the OperationQueue#put method with queued
-# status.
-requeue_on_failure: true
-
 # ContentAddressableStorage#getTree per-page directory count
 # value of '0' means let the server decide
 tree_page_size: 0


### PR DESCRIPTION
945544597fa39193435af475ddbb0a05376eed97 removed the `requeue_on_failure` config option but left it in the examples. If you just try to naively use the example, it fails with an exception.

For now, just remove the config line, but the error message could be better.
```
Exception in thread "main" com.google.protobuf.TextFormat$ParseException: 69:1: Input contains unknown fields and/or extensions:
69:1:	build.buildfarm.v1test.WorkerConfig.requeue_on_failure
	at com.google.protobuf.TextFormat$Parser.checkUnknownFields(TextFormat.java:1405)
	at com.google.protobuf.TextFormat$Parser.merge(TextFormat.java:1428)
	at com.google.protobuf.TextFormat$Parser.merge(TextFormat.java:1364)
	at com.google.protobuf.TextFormat$Parser.merge(TextFormat.java:1334)
	at com.google.protobuf.TextFormat.merge(TextFormat.java:1213)
	at build.buildfarm.worker.operationqueue.Worker.toWorkerConfig(Worker.java:515)
	at build.buildfarm.worker.operationqueue.Worker.main(Worker.java:543)
```