### PR TITLE
Fix MemoryInstance action timeout validation

### DIFF
--- a/src/main/java/build/buildfarm/BUILD
+++ b/src/main/java/build/buildfarm/BUILD
@@ -66,6 +66,7 @@ java_library(
         ":server-instance",
         "//3rdparty/jvm/com/google/guava",
         "//3rdparty/jvm/com/google/protobuf:protobuf_java",
+        "//3rdparty/jvm/com/google/protobuf:protobuf_java_util",
         "//3rdparty/jvm/io/grpc:grpc_context",
         "//3rdparty/jvm/io/grpc:grpc_core",
         "//3rdparty/jvm/io/grpc:grpc_netty",

--- a/src/main/java/build/buildfarm/instance/memory/MemoryInstance.java
+++ b/src/main/java/build/buildfarm/instance/memory/MemoryInstance.java
@@ -56,6 +56,7 @@ import com.google.longrunning.Operation;
 import com.google.protobuf.Any;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Duration;
+import com.google.protobuf.util.Durations;
 import com.google.protobuf.InvalidProtocolBufferException;
 import io.grpc.Channel;
 import io.grpc.netty.NegotiationType;
@@ -334,8 +335,12 @@ public class MemoryInstance extends AbstractServerInstance {
       Duration timeout = action.getTimeout();
       Duration maximum = config.getMaximumActionTimeout();
       Preconditions.checkState(
-          timeout.getSeconds() < maximum.getSeconds() ||
-              (timeout.getSeconds() == maximum.getSeconds() && timeout.getNanos() < maximum.getNanos()));
+          timeout.getSeconds() < maximum.getSeconds()
+              || (timeout.getSeconds() == maximum.getSeconds() && timeout.getNanos() <= maximum.getNanos()),
+          String.format(
+              "action timeout %s exceeds the maximum timeout %s",
+              Durations.toString(timeout),
+              Durations.toString(maximum)));
     }
 
     super.validateAction(action);

--- a/src/test/java/build/buildfarm/BUILD
+++ b/src/test/java/build/buildfarm/BUILD
@@ -77,6 +77,7 @@ java_test(
         ":test_runner",
         "//3rdparty/jvm/com/google/guava",
         "//3rdparty/jvm/com/google/protobuf:protobuf_java",
+        "//3rdparty/jvm/com/google/protobuf:protobuf_java_util",
         "//3rdparty/jvm/com/google/truth",
         "//3rdparty/jvm/io/grpc:grpc_context",
         "//3rdparty/jvm/io/grpc:grpc_core",

--- a/src/test/java/build/buildfarm/server/BuildFarmServerTest.java
+++ b/src/test/java/build/buildfarm/server/BuildFarmServerTest.java
@@ -308,15 +308,6 @@ public class BuildFarmServerTest {
   }
   */
 
-  @Test(expected = StatusRuntimeException.class)
-  public void actionWithExcessiveTimeoutFailsValidation()
-      throws RetryException, InterruptedException, InvalidProtocolBufferException {
-    Digest actionDigestWithExcessiveTimeout = createAction(Action.newBuilder()
-        .setTimeout(Duration.newBuilder().setSeconds(9000)));
-
-    executeAction(actionDigestWithExcessiveTimeout);
-  }
-
   private Digest createSimpleAction() throws RetryException, InterruptedException {
     return createAction(Action.newBuilder());
   }


### PR DESCRIPTION
Comparisions to the maximum action timeout should not fail validation.
Adding tests to this effect, moved timeout-validation tests to
MemoryInstanceTest, and simplified the CAS interactions in that suite to
use a CAS decorator for Map.

Fixes #205