### PR TITLE
Patch and upgrade protobuf for new bazel

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,9 +6,11 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Needed for "well-known protos" and @com_google_protobuf//:protoc.
 http_archive(
     name = "com_google_protobuf",
-    sha256 = "091d4263d9a55eccb6d3c8abde55c26eaaa933dea9ecabb185cdf3795f9b5ca2",
-    strip_prefix = "protobuf-3.5.1.1",
-    urls = ["https://github.com/google/protobuf/archive/v3.5.1.1.zip"],
+    patch_args = ["-p1"],
+    patches = ["//third_party/protobuf:4fcb36c.patch"],
+    sha256 = "d7a221b3d4fb4f05b7473795ccea9e05dab3b8721f6286a95fffbffc2d926f8b",
+    strip_prefix = "protobuf-3.6.1",
+    urls = ["https://github.com/google/protobuf/archive/v3.6.1.zip"],
 )
 
 # Needed for @grpc_java//compiler:grpc_java_plugin.

--- a/third_party/protobuf/4fcb36c.patch
+++ b/third_party/protobuf/4fcb36c.patch
@@ -1,0 +1,25 @@
+From 4fcb36c51c1c0355c2a23b1f06ec583f2428cd30 Mon Sep 17 00:00:00 2001
+From: Ittai Zeidman <ittaiz@gmail.com>
+Date: Mon, 21 May 2018 23:48:10 +0300
+Subject: [PATCH] remove PACKAGE_NAME and REPOSITORY_NAME deprecated usage
+ (#4650)
+
+---
+ protobuf.bzl | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/protobuf.bzl b/protobuf.bzl
+index 78f19c621a..4226a1424c 100644
+--- a/protobuf.bzl
++++ b/protobuf.bzl
+@@ -266,8 +266,8 @@ def internal_gen_well_known_protos_java(srcs):
+   Args:
+     srcs: the well known protos
+   """
+-  root = Label("%s//protobuf_java" % (REPOSITORY_NAME)).workspace_root
+-  pkg = PACKAGE_NAME + "/" if PACKAGE_NAME else ""
++  root = Label("%s//protobuf_java" % (native.repository_name())).workspace_root
++  pkg = native.package_name() + "/" if native.package_name() else ""
+   if root == "":
+     include = " -I%ssrc " % pkg
+   else:


### PR DESCRIPTION
Current bazels error on REPOSITORY_NAME. Apply a patch present in
protobuf master to correct this, and upgrade to latest release.