### PR TITLE
Reject matches for in-worker operations

### DIFF
--- a/src/main/java/build/buildfarm/worker/MatchStage.java
+++ b/src/main/java/build/buildfarm/worker/MatchStage.java
@@ -51,14 +51,18 @@ public class MatchStage extends PipelineStage {
     long stallUSecs = stopwatch.elapsed(MICROSECONDS);
     logStart();
     workerContext.match((operation) -> {
-      logStart(operation.getName());
-      boolean fetched = fetch(operation);
-      long usecs = stopwatch.elapsed(MICROSECONDS);
-      if (!fetched) {
+      if (operation == null) {
         output.release();
-        workerContext.requeue(operation);
+      } else {
+        logStart(operation.getName());
+        boolean fetched = fetch(operation);
+        long usecs = stopwatch.elapsed(MICROSECONDS);
+        if (!fetched) {
+          output.release();
+          workerContext.requeue(operation);
+        }
+        logComplete(operation.getName(), usecs, stallUSecs, fetched);
       }
-      logComplete(operation.getName(), usecs, stallUSecs, fetched);
     });
   }
 

--- a/src/main/java/build/buildfarm/worker/PipelineStage.java
+++ b/src/main/java/build/buildfarm/worker/PipelineStage.java
@@ -156,4 +156,29 @@ public abstract class PipelineStage implements Runnable {
   abstract Logger getLogger();
   abstract OperationContext take() throws InterruptedException;
   abstract void put(OperationContext operationContext) throws InterruptedException;
+
+  public static class NullStage extends PipelineStage {
+    public NullStage() {
+      super("NullStage", null, null, null);
+    }
+
+    @Override
+    public Logger getLogger() { return null; }
+    @Override
+    public boolean claim() { return true; }
+    @Override
+    public void release() { }
+    @Override
+    public OperationContext take() { throw new UnsupportedOperationException(); }
+    @Override
+    public void put(OperationContext operation) throws InterruptedException { }
+    @Override
+    public void setInput(PipelineStage input) { }
+    @Override
+    public void run() { }
+    @Override
+    public void close() { }
+    @Override
+    public boolean isClosed() { return false; }
+  }
 }

--- a/src/main/java/build/buildfarm/worker/PutOperationStage.java
+++ b/src/main/java/build/buildfarm/worker/PutOperationStage.java
@@ -1,0 +1,35 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.worker;
+
+import com.google.longrunning.Operation;
+
+public class PutOperationStage extends PipelineStage.NullStage {
+  private final InterruptingConsumer<Operation> onPut;
+
+  @FunctionalInterface
+  public interface InterruptingConsumer<T> {
+    void accept(T t) throws InterruptedException;
+  }
+
+  public PutOperationStage(InterruptingConsumer<Operation> onPut) {
+    this.onPut = onPut;
+  }
+
+  @Override
+  public void put(OperationContext operationContext) throws InterruptedException {
+    onPut.accept(operationContext.operation);
+  }
+}

--- a/src/main/java/build/buildfarm/worker/ReportResultStage.java
+++ b/src/main/java/build/buildfarm/worker/ReportResultStage.java
@@ -61,33 +61,8 @@ public class ReportResultStage extends PipelineStage {
 
   private final BlockingQueue<OperationContext> queue;
 
-  public static class NullStage extends PipelineStage {
-    public NullStage(String name) {
-      super(name, null, null, null);
-    }
-
-    @Override
-    public Logger getLogger() { return null; }
-    @Override
-    public boolean claim() { return true; }
-    @Override
-    public void release() { }
-    @Override
-    public OperationContext take() { throw new UnsupportedOperationException(); }
-    @Override
-    public void put(OperationContext operation) { }
-    @Override
-    public void setInput(PipelineStage input) { }
-    @Override
-    public void run() { }
-    @Override
-    public void close() { }
-    @Override
-    public boolean isClosed() { return false; }
-  }
-
-  public ReportResultStage(WorkerContext workerContext, PipelineStage error) {
-    super("ReportResultStage", workerContext, new NullStage("Terminal"), error);
+  public ReportResultStage(WorkerContext workerContext, PipelineStage output, PipelineStage error) {
+    super("ReportResultStage", workerContext, output, error);
     queue = new ArrayBlockingQueue<>(1);
   }
 

--- a/src/main/java/build/buildfarm/worker/WorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/WorkerContext.java
@@ -39,6 +39,7 @@ public interface WorkerContext {
   Poller createPoller(String name, String operationName, Stage stage, Runnable onFailure);
   void match(InterruptingConsumer<Operation> onMatch) throws InterruptedException;
   void requeue(Operation operation) throws InterruptedException;
+  void deactivate(Operation operation);
   CASInsertionPolicy getFileCasPolicy();
   CASInsertionPolicy getStdoutCasPolicy();
   CASInsertionPolicy getStderrCasPolicy();

--- a/src/main/java/build/buildfarm/worker/operationqueue/Worker.java
+++ b/src/main/java/build/buildfarm/worker/operationqueue/Worker.java
@@ -38,6 +38,7 @@ import build.buildfarm.worker.OutputDirectory;
 import build.buildfarm.worker.Pipeline;
 import build.buildfarm.worker.PipelineStage;
 import build.buildfarm.worker.Poller;
+import build.buildfarm.worker.PutOperationStage;
 import build.buildfarm.worker.ReportResultStage;
 import build.buildfarm.worker.WorkerContext;
 import com.google.common.base.Strings;
@@ -80,6 +81,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.Executors;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
@@ -100,6 +102,7 @@ public class Worker {
 
   private static final ListeningScheduledExecutorService retryScheduler =
       MoreExecutors.listeningDecorator(Executors.newScheduledThreadPool(1));
+  private final Set<String> activeOperations = new ConcurrentSkipListSet<>();
 
   private static Channel createChannel(String target) {
     NettyChannelBuilder builder =
@@ -311,7 +314,12 @@ public class Worker {
         operationQueueInstance.match(
             getPlatform(),
             (operation) -> {
-              onMatch.accept(operation);
+              if (activeOperations.contains(operation.getName())) {
+                onMatch.accept(null);
+              } else {
+                activeOperations.add(operation.getName());
+                onMatch.accept(operation);
+              }
               return true;
             });
       }
@@ -319,6 +327,7 @@ public class Worker {
       @Override
       public void requeue(Operation operation) throws InterruptedException {
         try {
+          deactivate(operation);
           ExecuteOperationMetadata metadata =
               operation.getMetadata().unpack(ExecuteOperationMetadata.class);
 
@@ -457,6 +466,11 @@ public class Worker {
       }
 
       @Override
+      public void deactivate(Operation operation) {
+        activeOperations.remove(operation.getName());
+      }
+
+      @Override
       public boolean putOperation(Operation operation) throws InterruptedException {
         return operationQueueInstance.putOperation(operation);
       }
@@ -473,11 +487,12 @@ public class Worker {
       }
     };
 
-    PipelineStage errorStage = new ReportResultStage.NullStage("ErrorStage"); /* ErrorStage(); */
-    PipelineStage reportResultStage = new ReportResultStage(workerContext, errorStage);
+    PipelineStage completeStage = new PutOperationStage(workerContext::deactivate);
+    PipelineStage errorStage = completeStage; /* new ErrorStage(); */
+    PipelineStage reportResultStage = new ReportResultStage(workerContext, completeStage, errorStage);
     PipelineStage executeActionStage = new ExecuteActionStage(workerContext, reportResultStage, errorStage);
     reportResultStage.setInput(executeActionStage);
-    PipelineStage inputFetchStage = new InputFetchStage(workerContext, executeActionStage, errorStage);
+    PipelineStage inputFetchStage = new InputFetchStage(workerContext, executeActionStage, new PutOperationStage(workerContext::requeue));
     executeActionStage.setInput(inputFetchStage);
     PipelineStage matchStage = new MatchStage(workerContext, inputFetchStage, errorStage);
     inputFetchStage.setInput(matchStage);

--- a/src/test/java/build/buildfarm/worker/ReportResultStageTest.java
+++ b/src/test/java/build/buildfarm/worker/ReportResultStageTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.verify;
 import build.buildfarm.common.DigestUtil;
 import build.buildfarm.instance.stub.ByteStreamUploader;
 import build.buildfarm.instance.stub.Chunker;
+import build.buildfarm.worker.PipelineStage.NullStage;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.jimfs.Configuration;
@@ -75,7 +76,8 @@ public class ReportResultStageTest {
     when(mockWorkerContext.getUploader()).thenReturn(mockUploader);
     when(mockWorkerContext.getDigestUtil()).thenReturn(digestUtil);
     PipelineStage error = mock(PipelineStage.class);
-    reportResultStage = new ReportResultStage(mockWorkerContext, error);
+    reportResultStage = new ReportResultStage(
+        mockWorkerContext, new NullStage(), error);
     fileSystem = Jimfs.newFileSystem(config);
   }
 

--- a/src/test/java/build/buildfarm/worker/StubWorkerContext.java
+++ b/src/test/java/build/buildfarm/worker/StubWorkerContext.java
@@ -39,6 +39,7 @@ class StubWorkerContext implements WorkerContext {
   @Override public Poller createPoller(String name, String operationName, Stage stage, Runnable onFailure) { throw new UnsupportedOperationException(); }
   @Override public void match(InterruptingConsumer<Operation> onMatch) throws InterruptedException { throw new UnsupportedOperationException(); }
   @Override public void requeue(Operation operation) { throw new UnsupportedOperationException(); }
+  @Override public void deactivate(Operation operation) { throw new UnsupportedOperationException(); }
   @Override public CASInsertionPolicy getFileCasPolicy() { throw new UnsupportedOperationException(); }
   @Override public CASInsertionPolicy getStdoutCasPolicy() { throw new UnsupportedOperationException(); }
   @Override public CASInsertionPolicy getStderrCasPolicy() { throw new UnsupportedOperationException(); }


### PR DESCRIPTION
Prevent an operation which is already present in the worker from being
accepted to a match. This is accomplished through the addition to
a Set of operations immediately after unique match and removed on result
upload, requeue, or error through the creation of a put-synchronous
stage.