### PR TITLE
Provide queryWriteStatus impl for blobs

### DIFF
--- a/src/main/java/build/buildfarm/server/ByteStreamService.java
+++ b/src/main/java/build/buildfarm/server/ByteStreamService.java
@@ -14,6 +14,7 @@
 
 package build.buildfarm.server;
 
+import build.bazel.remote.execution.v2.Digest;
 import build.buildfarm.common.DigestUtil;
 import build.buildfarm.instance.Instance;
 import com.google.bytestream.ByteStreamGrpc;
@@ -23,7 +24,8 @@ import com.google.bytestream.ByteStreamProto.ReadRequest;
 import com.google.bytestream.ByteStreamProto.ReadResponse;
 import com.google.bytestream.ByteStreamProto.WriteRequest;
 import com.google.bytestream.ByteStreamProto.WriteResponse;
-import build.bazel.remote.execution.v2.Digest;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 import com.google.protobuf.ByteString;
 import io.grpc.Status;
 import io.grpc.StatusException;
@@ -165,6 +167,35 @@ public class ByteStreamService extends ByteStreamGrpc.ByteStreamImplBase {
     }
   }
 
+  private void queryBlobWriteStatus(
+      String resourceName,
+      StreamObserver<QueryWriteStatusResponse> responseObserver) {
+    try {
+      Instance instance = instances.getFromBlob(resourceName);
+      queryInstanceBlobWriteStatus(instance, resourceName, responseObserver);
+    } catch (InstanceNotFoundException e) {
+      responseObserver.onError(BuildFarmInstances.toStatusException(e));
+    }
+  }
+
+  private void queryInstanceBlobWriteStatus(
+      Instance instance,
+      String resourceName,
+      StreamObserver<QueryWriteStatusResponse> responseObserver) {
+    Digest digest = UrlPath.parseBlobDigest(resourceName, instance.getDigestUtil());
+
+    if (Iterables.isEmpty(instance.findMissingBlobs(ImmutableList.of(digest)))) {
+      responseObserver.onNext(
+          QueryWriteStatusResponse.newBuilder()
+              .setCommittedSize(digest.getSizeBytes())
+              .setComplete(true)
+              .build());
+      responseObserver.onCompleted();
+    } else {
+      responseObserver.onError(Status.NOT_FOUND.asException());
+    }
+  }
+
   @Override
   public void queryWriteStatus(
       QueryWriteStatusRequest request,
@@ -186,6 +217,9 @@ public class ByteStreamService extends ByteStreamGrpc.ByteStreamImplBase {
       break;
     case OperationStream:
       responseObserver.onError(new StatusException(Status.UNIMPLEMENTED));
+      break;
+    case Blob:
+      queryBlobWriteStatus(resourceName, responseObserver);
       break;
     default:
       String description = "Invalid service";


### PR DESCRIPTION
Blob resource names may be queried via
ByteStreamService::queryWriteStatus.