### PR TITLE
Provide and use findMissingBlobs on CAS

### DIFF
--- a/src/main/java/build/buildfarm/cas/ContentAddressableStorage.java
+++ b/src/main/java/build/buildfarm/cas/ContentAddressableStorage.java
@@ -55,9 +55,9 @@ public interface ContentAddressableStorage {
     }
   }
 
-  /** Indicates presence in the CAS for a digest. */
+  /** Indicates presence in the CAS for a sequence of digests. */
   @ThreadSafe
-  boolean contains(Digest digest);
+  Iterable<Digest> findMissingBlobs(Iterable<Digest> digests);
 
   /** Retrieve a value from the CAS. */
   @ThreadSafe

--- a/src/main/java/build/buildfarm/cas/ContentAddressableStorages.java
+++ b/src/main/java/build/buildfarm/cas/ContentAddressableStorages.java
@@ -19,6 +19,7 @@ import build.buildfarm.instance.stub.ByteStreamUploader;
 import build.buildfarm.instance.stub.Retrier;
 import build.buildfarm.v1test.ContentAddressableStorageConfig;
 import build.buildfarm.v1test.GrpcCASConfig;
+import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ByteString;
 import io.grpc.Channel;
 import io.grpc.netty.NegotiationType;
@@ -60,8 +61,14 @@ public final class ContentAddressableStorages {
   public static ContentAddressableStorage casMapDecorator(Map<Digest, ByteString> map) {
     return new ContentAddressableStorage() {
       @Override
-      public boolean contains(Digest digest) {
-        return map.containsKey(digest);
+      public Iterable<Digest> findMissingBlobs(Iterable<Digest> digests) {
+        ImmutableList.Builder<Digest> missing = ImmutableList.builder();
+        for (Digest digest : digests) {
+          if (digest.getSizeBytes() != 0 && !map.containsKey(digest)) {
+            missing.add(digest);
+          }
+        }
+        return missing.build();
       }
 
       @Override

--- a/src/main/java/build/buildfarm/cas/MemoryCAS.java
+++ b/src/main/java/build/buildfarm/cas/MemoryCAS.java
@@ -15,6 +15,7 @@
 package build.buildfarm.cas;
 
 import build.bazel.remote.execution.v2.Digest;
+import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -38,9 +39,15 @@ class MemoryCAS implements ContentAddressableStorage {
   }
 
   @Override
-  public synchronized boolean contains(Digest digest) {
+  public synchronized Iterable<Digest> findMissingBlobs(Iterable<Digest> digests) {
+    ImmutableList.Builder<Digest> missing = ImmutableList.builder();
     // incur access use of the digest
-    return get(digest) != null;
+    for (Digest digest : digests) {
+      if (digest.getSizeBytes() != 0 && get(digest) == null) {
+        missing.add(digest);
+      }
+    }
+    return missing.build();
   }
 
   @Override

--- a/src/main/java/build/buildfarm/instance/AbstractServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/AbstractServerInstance.java
@@ -197,14 +197,7 @@ public abstract class AbstractServerInstance implements Instance {
 
   @Override
   public Iterable<Digest> findMissingBlobs(Iterable<Digest> digests) {
-    ImmutableList.Builder<Digest> missingBlobs = new ImmutableList.Builder<>();
-    for (Digest digest : digests) {
-      if (digest.getSizeBytes() == 0 || contentAddressableStorage.contains(digest)) {
-        continue;
-      }
-      missingBlobs.add(digest);
-    }
-    return missingBlobs.build();
+    return contentAddressableStorage.findMissingBlobs(digests);
   }
 
   protected abstract int getTreeDefaultPageSize();


### PR DESCRIPTION
Use findMissingBlobs for a bulk contains test, rather than requiring
multiple trips through contains.