### PR TITLE
Error messages/flow fixes for config file/start

### DIFF
--- a/src/main/java/build/buildfarm/common/IOUtils.java
+++ b/src/main/java/build/buildfarm/common/IOUtils.java
@@ -1,0 +1,38 @@
+package build.buildfarm.common;
+
+import java.io.IOException;
+
+public class IOUtils {
+  private IOUtils() {
+  }
+
+  enum IOErrorFormatter {
+    AccessDeniedException("access denied"),
+    FileSystemException(""),
+    IOException(""),
+    NoSuchFileException("no such file");
+
+    private final String description;
+
+    IOErrorFormatter(String description) {
+      this.description = description;
+    }
+
+    String toString(IOException e) {
+      if (description.isEmpty()) {
+        return e.getMessage();
+      }
+      return String.format("%s: %s", e.getMessage(), description);
+    }
+  }
+
+  public static String formatIOError(IOException e) {
+    IOErrorFormatter formatter;
+    try {
+      formatter = IOErrorFormatter.valueOf(e.getClass().getSimpleName());
+    } catch (IllegalArgumentException eUnknown) {
+      formatter = IOErrorFormatter.valueOf("IOException");
+    }
+    return formatter.toString(e);
+  }
+}

--- a/src/main/java/build/buildfarm/common/IOUtils.java
+++ b/src/main/java/build/buildfarm/common/IOUtils.java
@@ -1,3 +1,16 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package build.buildfarm.common;
 
 import java.io.IOException;

--- a/src/main/java/build/buildfarm/server/BuildFarmServer.java
+++ b/src/main/java/build/buildfarm/server/BuildFarmServer.java
@@ -14,6 +14,8 @@
 
 package build.buildfarm.server;
 
+import static build.buildfarm.common.IOUtils.formatIOError;
+
 import build.buildfarm.v1test.BuildFarmServerConfig;
 import com.google.common.io.ByteStreams;
 import com.google.devtools.common.options.OptionsParser;
@@ -103,36 +105,6 @@ public class BuildFarmServer {
                                               OptionsParser.HelpVerbosity.LONG));
   }
 
-  enum IOExceptionHelper {
-    AccessDeniedException("access denied"),
-    FileSystemException(""),
-    IOException(""),
-    NoSuchFileException("no such file");
-
-    private final String description;
-
-    IOExceptionHelper(String description) {
-      this.description = description;
-    }
-
-    String toString(IOException e) {
-      if (description.isEmpty()) {
-        return e.getMessage();
-      }
-      return String.format("%s: %s", e.getMessage(), description);
-    }
-  }
-
-  static String toIOError(IOException e) {
-    IOExceptionHelper category;
-    try {
-      category = IOExceptionHelper.valueOf(e.getClass().getSimpleName());
-    } catch (IllegalArgumentException eUnknown) {
-      category = IOExceptionHelper.valueOf("IOException");
-    }
-    return "error: " + category.toString(e);
-  }
-
   /**
    * returns success or failure
    */
@@ -163,7 +135,7 @@ public class BuildFarmServer {
       server.blockUntilShutdown();
       return true;
     } catch (IOException e) {
-      System.err.println(toIOError(e));
+      System.err.println("error: " + formatIOError(e));
     } catch (ConfigurationException e) {
       System.err.println("error: " + e.getMessage());
     } catch (InterruptedException e) {

--- a/src/main/java/build/buildfarm/server/BuildFarmServer.java
+++ b/src/main/java/build/buildfarm/server/BuildFarmServer.java
@@ -131,6 +131,7 @@ public class BuildFarmServer {
               toBuildFarmServerConfig(
                   new InputStreamReader(configInputStream),
                   parser.getOptions(BuildFarmServerOptions.class)));
+      configInputStream.close();
       server.start();
       server.blockUntilShutdown();
       return true;

--- a/src/main/java/build/buildfarm/worker/operationqueue/Worker.java
+++ b/src/main/java/build/buildfarm/worker/operationqueue/Worker.java
@@ -544,6 +544,7 @@ public class Worker {
     Path configPath = Paths.get(residue.get(0));
     try (InputStream configInputStream = Files.newInputStream(configPath)) {
       Worker worker = new Worker(toWorkerConfig(new InputStreamReader(configInputStream), parser.getOptions(WorkerOptions.class)));
+      configInputStream.close();
       worker.start();
       return true;
     } catch (IOException e) {

--- a/src/main/java/build/buildfarm/worker/operationqueue/Worker.java
+++ b/src/main/java/build/buildfarm/worker/operationqueue/Worker.java
@@ -14,6 +14,7 @@
 
 package build.buildfarm.worker.operationqueue;
 
+import static build.buildfarm.common.IOUtils.formatIOError;
 import static com.google.common.collect.Maps.uniqueIndex;
 
 import build.buildfarm.common.DigestUtil;
@@ -529,19 +530,33 @@ public class Worker {
                                               OptionsParser.HelpVerbosity.LONG));
   }
 
-  public static void main(String[] args) throws Exception {
+  /**
+   * returns success or failure
+   */
+  static boolean workerMain(String[] args) {
     OptionsParser parser = OptionsParser.newOptionsParser(WorkerOptions.class);
     parser.parseAndExitUponError(args);
     List<String> residue = parser.getResidue();
     if (residue.isEmpty()) {
       printUsage(parser);
-      throw new IllegalArgumentException("Missing CONFIG_PATH");
+      return false;
     }
     Path configPath = Paths.get(residue.get(0));
-    Worker worker;
     try (InputStream configInputStream = Files.newInputStream(configPath)) {
-      worker = new Worker(toWorkerConfig(new InputStreamReader(configInputStream), parser.getOptions(WorkerOptions.class)));
+      Worker worker = new Worker(toWorkerConfig(new InputStreamReader(configInputStream), parser.getOptions(WorkerOptions.class)));
+      worker.start();
+      return true;
+    } catch (IOException e) {
+      System.err.println("error: " + formatIOError(e));
+    } catch (ConfigurationException e) {
+      System.err.println("error: " + e.getMessage());
+    } catch (InterruptedException e) {
+      System.err.println("error: interrupted");
     }
-    worker.start();
+    return false;
+  }
+
+  public static void main(String[] args) {
+    System.exit(workerMain(args) ? 0 : 1);
   }
 }


### PR DESCRIPTION
Improve the readability of the server and worker failures to load config
files or start operations. Simplify the main routine to translate to
exit status.