### PR TITLE
Handle empty directory digest as default instance

### DIFF
--- a/src/main/java/build/buildfarm/worker/CASFileCache.java
+++ b/src/main/java/build/buildfarm/worker/CASFileCache.java
@@ -284,7 +284,12 @@ public class CASFileCache {
       Digest digest,
       Map<Digest, Directory> directoriesIndex,
       ImmutableList.Builder<Path> inputsBuilder) throws IOException, InterruptedException {
-    Directory directory = directoriesIndex.get(digest);
+    Directory directory;
+    if (digest.getSizeBytes() == 0) {
+      directory = Directory.getDefaultInstance();
+    } else {
+      directory = directoriesIndex.get(digest);
+    }
     Files.createDirectory(path);
     putDirectoryFiles(directory.getFilesList(), path, containingDirectory, inputsBuilder);
     for (DirectoryNode directoryNode : directory.getDirectoriesList()) {
@@ -328,6 +333,12 @@ public class CASFileCache {
       throw e;
     }
 
+    Directory directory;
+    if (digest.getSizeBytes() == 0) {
+      directory = Directory.getDefaultInstance();
+    } else {
+      directory = directoriesIndex.get(digest);
+    }
     DirectoryEntry e = new DirectoryEntry(directoriesIndex.get(digest), inputsBuilder.build());
 
     directoryStorage.put(digest, e);

--- a/src/main/java/build/buildfarm/worker/operationqueue/Worker.java
+++ b/src/main/java/build/buildfarm/worker/operationqueue/Worker.java
@@ -238,9 +238,14 @@ public class Worker {
       ImmutableList.Builder<Path> inputFiles,
       ImmutableList.Builder<Digest> inputDirectories)
       throws IOException, InterruptedException {
-    Directory directory = directoriesIndex.get(inputRoot);
-    if (directory == null) {
-      throw new IOException("Directory " + DigestUtil.toString(inputRoot) + " is not in input index");
+    Directory directory;
+    if (inputRoot.getSizeBytes() == 0) {
+      directory = Directory.getDefaultInstance();
+    } else {
+      directory = directoriesIndex.get(inputRoot);
+      if (directory == null) {
+        throw new IOException("Directory " + DigestUtil.toString(inputRoot) + " is not in input index");
+      }
     }
 
     fileCache.putFiles(directory.getFilesList(), execDir, inputFiles);


### PR DESCRIPTION
For all situations where an empty blob-derived directory would be
fetched from an index, acquire the default Directory instance instead.