### PR TITLE
Complete response after delivering WriteResponse

### DIFF
--- a/src/main/java/build/buildfarm/server/ByteStreamService.java
+++ b/src/main/java/build/buildfarm/server/ByteStreamService.java
@@ -361,6 +361,7 @@ class ByteStreamService extends ByteStreamImplBase {
                       responseObserver.onNext(WriteResponse.newBuilder()
                           .setCommittedSize(write.getCommittedSize())
                           .build());
+                      responseObserver.onCompleted();
                     } catch (Throwable t) {
                       logger.log(SEVERE, format("error delivering committedSize to %s", resourceName), t);
                     }
@@ -460,8 +461,7 @@ class ByteStreamService extends ByteStreamImplBase {
 
       @Override
       public void onCompleted() {
-        logger.finer("calling completed for " + name);
-        responseObserver.onCompleted();
+        logger.finer("got completed for " + name);
       }
     };
   }


### PR DESCRIPTION
A completed (half close) must be delivered after a WriteResponse on the
server side in order to trigger a client onClose, which successfully
completes a call. This will allow already existing entries or
upload-race loss to trigger completion.

Fixes #243