### PR TITLE
Stop testing against deprecated platforms.

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,26 +1,11 @@
 ---
 platforms:
-  ubuntu1404:
-    build_targets:
-    - "..."
-    test_targets:
-    - "..."
   ubuntu1604:
     build_targets:
     - "..."
     test_targets:
     - "..."
   ubuntu1804:
-    build_targets:
-    - "..."
-    test_targets:
-    - "..."
-  ubuntu1804_java9:
-    build_targets:
-    - "..."
-    test_targets:
-    - "..."
-  ubuntu1804_java10:
     build_targets:
     - "..."
     test_targets:


### PR DESCRIPTION
ubuntu1404 will be removed in the next weeks, because Ubuntu 14.04 is about to be EOL.

ubuntu1804_java9 and ubuntu1804_java10 are hopefully going away soon, because Java 9 and 10 are also EOL since quite a few months.