### PR TITLE
Use worker instance name in uploads

### DIFF
--- a/src/main/java/build/buildfarm/worker/operationqueue/Worker.java
+++ b/src/main/java/build/buildfarm/worker/operationqueue/Worker.java
@@ -149,8 +149,8 @@ public class Worker {
         retryScheduler);
   }
 
-  private static ByteStreamUploader createStubUploader(Channel channel, Retrier retrier) {
-    return new ByteStreamUploader("", channel, null, 300, retrier);
+  private static ByteStreamUploader createStubUploader(String instanceName, Channel channel, Retrier retrier) {
+    return new ByteStreamUploader(instanceName, channel, null, 300, retrier);
   }
 
   private static Instance createInstance(
@@ -187,7 +187,7 @@ public class Worker {
     InstanceEndpoint casEndpoint = config.getContentAddressableStorage();
     Channel casChannel = createChannel(casEndpoint.getTarget());
     Retrier retrier = createStubRetrier();
-    uploader = createStubUploader(casChannel, retrier);
+    uploader = createStubUploader(casEndpoint.getInstanceName(), casChannel, retrier);
     casInstance = createInstance(casEndpoint.getInstanceName(), digestUtil, casChannel, uploader, retrier);
     acInstance = createInstance(config.getActionCache(), digestUtil, retrier);
     operationQueueInstance = createInstance(config.getOperationQueue(), digestUtil, retrier);


### PR DESCRIPTION
Incorrect routing of uploaded blobs will occur if the instance name is
anything other than default, and an error occurs if the default instance
name is not declared on the CAS side.