### PR TITLE
Fix patch file for protobuf

### DIFF
--- a/third_party/com_google_protobuf/7e1d9e419e.patch
+++ b/third_party/com_google_protobuf/7e1d9e419e.patch
@@ -16,7 +16,7 @@ diff --git a/BUILD b/BUILD
 index 0189fd9b51..0a279412a9 100644
 --- a/BUILD
 +++ b/BUILD
-@@ -639,6 +639,7 @@ java_library(
+@@ -638,6 +638,7 @@ java_library(
      visibility = ["//visibility:public"],
      deps = [
          "protobuf_java",


### PR DESCRIPTION
The line number doesn't match the exact location of the position of the content. This is tolerable with patch command line tool, but it won't work with a more strict patch implementation.
Context: https://github.com/bazelbuild/bazel/pulls