### PR TITLE
HTTP Proxy fixes

### DIFF
--- a/src/main/java/build/buildfarm/instance/AbstractServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/AbstractServerInstance.java
@@ -58,8 +58,8 @@ import com.google.rpc.Code;
 import com.google.rpc.PreconditionFailure;
 import com.google.rpc.PreconditionFailure.Violation;
 import io.grpc.Status;
-import java.io.IOException;
 import io.grpc.StatusException;
+import io.grpc.StatusRuntimeException;
 import io.grpc.protobuf.StatusProto;
 import java.io.IOException;
 import java.io.InputStream;
@@ -164,7 +164,18 @@ public abstract class AbstractServerInstance implements Instance {
 
   @Override
   public ActionResult getActionResult(ActionKey actionKey) {
-    return actionCache.get(actionKey);
+    ActionResult actionResult;
+    try {
+      actionResult = actionCache.get(actionKey);
+    } catch (StatusRuntimeException ex) {
+      if (ex.getStatus().getCode() == Status.Code.NOT_FOUND) {
+        // Return null to indicate that it was a cache miss.
+        actionResult = null;
+      } else {
+        throw ex;
+      }
+    }
+    return actionResult;
   }
 
   @Override

--- a/src/main/java/build/buildfarm/proxy/http/BlobWriteObserver.java
+++ b/src/main/java/build/buildfarm/proxy/http/BlobWriteObserver.java
@@ -97,6 +97,7 @@ class BlobWriteObserver implements WriteObserver {
       committedSize += data.size();
       shutdownBuffer = false;
       if (request.getFinishWrite()) {
+        buffer.writeEndOfFile();
         putThread.join();
         complete = true;
       }

--- a/src/main/java/build/buildfarm/proxy/http/ByteStreamService.java
+++ b/src/main/java/build/buildfarm/proxy/http/ByteStreamService.java
@@ -226,7 +226,14 @@ public class ByteStreamService extends ByteStreamGrpc.ByteStreamImplBase {
           .build());
       responseObserver.onCompleted();
     } else {
-      responseObserver.onError(Status.NOT_FOUND.asException());
+      // responseObserver.onError(Status.NOT_FOUND.asException());
+      // queryWriteStatus can be called before a write has started. Return
+      // empty blob status.
+      responseObserver.onNext(QueryWriteStatusResponse.newBuilder()
+          .setCommittedSize(0)
+          .setComplete(false)
+          .build());
+      responseObserver.onCompleted();
     }
   }
 

--- a/src/main/java/build/buildfarm/proxy/http/ContentAddressableStorageService.java
+++ b/src/main/java/build/buildfarm/proxy/http/ContentAddressableStorageService.java
@@ -165,6 +165,13 @@ public class ContentAddressableStorageService extends ContentAddressableStorageG
   }
 
   @Override
+  public void batchReadBlobs(
+      BatchReadBlobsRequest batchRequest,
+      StreamObserver<BatchReadBlobsResponse> responseObserver) {
+    throw new UnsupportedOperationException("HTTP Caching does not use this method.");
+  }
+
+  @Override
   public void getTree(
       GetTreeRequest request,
       StreamObserver<GetTreeResponse> responseObserver) {

--- a/src/main/java/build/buildfarm/proxy/http/DownloadCommand.java
+++ b/src/main/java/build/buildfarm/proxy/http/DownloadCommand.java
@@ -24,12 +24,14 @@ final class DownloadCommand {
   private final boolean casDownload;
   private final String hash;
   private final OutputStream out;
+  private final boolean downloadContent;
 
-  protected DownloadCommand(URI uri, boolean casDownload, String hash, OutputStream out) {
+  protected DownloadCommand(URI uri, boolean casDownload, String hash, OutputStream out, boolean downloadContent) {
     this.uri = Preconditions.checkNotNull(uri);
     this.casDownload = casDownload;
     this.hash = Preconditions.checkNotNull(hash);
     this.out = Preconditions.checkNotNull(out);
+    this.downloadContent = downloadContent;
   }
 
   public URI uri() {
@@ -46,5 +48,9 @@ final class DownloadCommand {
 
   public OutputStream out() {
     return out;
+  }
+
+  public boolean downloadContent() {
+    return downloadContent;
   }
 }

--- a/src/main/java/build/buildfarm/proxy/http/HttpBlobStore.java
+++ b/src/main/java/build/buildfarm/proxy/http/HttpBlobStore.java
@@ -362,11 +362,11 @@ public final class HttpBlobStore implements SimpleBlobStore {
 
   @Override
   public ListenableFuture<Boolean> get(String key, OutputStream out) {
-    return get(key, out, true);
+    return get(key, out, true, true);
   }
 
   @SuppressWarnings("FutureReturnValueIgnored")
-  private ListenableFuture<Boolean> get(String key, final OutputStream out, boolean casDownload) {
+  private ListenableFuture<Boolean> get(String key, final OutputStream out, boolean casDownload, boolean downloadContent) {
     final AtomicBoolean dataWritten = new AtomicBoolean();
     OutputStream wrappedOut =
         new OutputStream() {
@@ -391,7 +391,7 @@ public final class HttpBlobStore implements SimpleBlobStore {
             out.flush();
           }
         };
-    DownloadCommand download = new DownloadCommand(uri, casDownload, key, wrappedOut);
+    DownloadCommand download = new DownloadCommand(uri, casDownload, key, wrappedOut, downloadContent);
     SettableFuture<Boolean> outerF = SettableFuture.create();
     acquireDownloadChannel()
         .addListener(
@@ -475,7 +475,7 @@ public final class HttpBlobStore implements SimpleBlobStore {
   @Override
   public boolean getActionResult(String actionKey, OutputStream out)
       throws IOException, InterruptedException {
-    return getFromFuture(get(actionKey, out, false));
+    return getFromFuture(get(actionKey, out, false, true));
   }
 
   @Override

--- a/src/main/java/build/buildfarm/proxy/http/HttpBlobStore.java
+++ b/src/main/java/build/buildfarm/proxy/http/HttpBlobStore.java
@@ -14,6 +14,7 @@
 package build.buildfarm.proxy.http;
 
 import static build.buildfarm.proxy.http.Utils.getFromFuture;
+import static com.google.common.io.ByteStreams.nullOutputStream;
 
 import com.google.auth.Credentials;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -374,8 +375,8 @@ public final class HttpBlobStore implements SimpleBlobStore {
   }
 
   @Override
-  public boolean containsKey(String key) {
-    throw new UnsupportedOperationException("HTTP Caching does not use this method.");
+  public ListenableFuture<Boolean> containsKey(String key) {
+    return get(key, nullOutputStream(), true, false);
   }
 
   @Override

--- a/src/main/java/build/buildfarm/proxy/http/HttpBlobStore.java
+++ b/src/main/java/build/buildfarm/proxy/http/HttpBlobStore.java
@@ -258,7 +258,16 @@ public final class HttpBlobStore implements SimpleBlobStore {
                   p.addLast(new HttpUploadHandler(creds));
                 }
 
-                channelReady.setSuccess(ch);
+                if (!ch.eventLoop().inEventLoop()) {
+                  // If addLast is called outside an event loop, then it doesn't complete until the
+                  // event loop is run again. In that case, a message sent to the last handler gets
+                  // delivered to the last non-pending handler, which will most likely end up
+                  // throwing UnsupportedMessageTypeException. Therefore, we only complete the
+                  // promise in the event loop.
+                  ch.eventLoop().execute(() -> channelReady.setSuccess(ch));
+                } else {
+                  channelReady.setSuccess(ch);
+                }
               } catch (Throwable t) {
                 channelReady.setFailure(t);
               }
@@ -320,7 +329,16 @@ public final class HttpBlobStore implements SimpleBlobStore {
                   p.addLast(new HttpDownloadHandler(creds));
                 }
 
-                channelReady.setSuccess(ch);
+                if (!ch.eventLoop().inEventLoop()) {
+                  // If addLast is called outside an event loop, then it doesn't complete until the
+                  // event loop is run again. In that case, a message sent to the last handler gets
+                  // delivered to the last non-pending handler, which will most likely end up
+                  // throwing UnsupportedMessageTypeException. Therefore, we only complete the
+                  // promise in the event loop.
+                  ch.eventLoop().execute(() -> channelReady.setSuccess(ch));
+                } else {
+                  channelReady.setSuccess(ch);
+                }
               } catch (Throwable t) {
                 channelReady.setFailure(t);
               }

--- a/src/main/java/build/buildfarm/proxy/http/HttpDownloadHandler.java
+++ b/src/main/java/build/buildfarm/proxy/http/HttpDownloadHandler.java
@@ -134,7 +134,7 @@ final class HttpDownloadHandler extends AbstractHttpHandler<HttpObject> {
     HttpRequest httpRequest =
         new DefaultFullHttpRequest(
             HttpVersion.HTTP_1_1,
-            HttpMethod.GET,
+            request.downloadContent() ? HttpMethod.GET : HttpMethod.HEAD,
             constructPath(request.uri(), request.hash(), request.casDownload()));
     httpRequest.headers().set(HttpHeaderNames.HOST, constructHost(request.uri()));
     httpRequest.headers().set(HttpHeaderNames.CONNECTION, HttpHeaderValues.KEEP_ALIVE);

--- a/src/main/java/build/buildfarm/proxy/http/HttpDownloadHandler.java
+++ b/src/main/java/build/buildfarm/proxy/http/HttpDownloadHandler.java
@@ -75,7 +75,7 @@ final class HttpDownloadHandler extends AbstractHttpHandler<HttpObject> {
       if (!HttpUtil.isContentLengthSet(response) && !HttpUtil.isTransferEncodingChunked(response)) {
         HttpException error =
             new HttpException(
-                response, "Missing 'Content-Length' or 'Transfer-Encoding: chunked' header", null);
+                response, String.format("Missing 'Content-Length' or 'Transfer-Encoding: chunked' header %s", response), null);
         failAndClose(error, ctx);
         return;
       }

--- a/src/main/java/build/buildfarm/proxy/http/SimpleBlobStore.java
+++ b/src/main/java/build/buildfarm/proxy/http/SimpleBlobStore.java
@@ -28,7 +28,7 @@ public interface SimpleBlobStore {
   /**
    * Returns {@code key} if the provided {@code key} is stored in the CAS.
    */
-  boolean containsKey(String key) throws IOException, InterruptedException;
+  ListenableFuture<Boolean> containsKey(String key);
 
   /**
    * Fetches the BLOB associated with the {@code key} from the CAS and writes it to {@code out}.

--- a/src/main/java/build/buildfarm/proxy/http/WriteStreamObserver.java
+++ b/src/main/java/build/buildfarm/proxy/http/WriteStreamObserver.java
@@ -42,15 +42,13 @@ class WriteStreamObserver implements StreamObserver<WriteRequest> {
             "write onNext supplied with empty WriteRequest for %s at %d",
             request.getResourceName(),
             request.getWriteOffset()));
-    if (request.getData().size() != 0) {
-      try {
-        writeOnNext(request);
-        if (request.getFinishWrite()) {
-          writeObserverSource.remove(request.getResourceName());
-        }
-      } catch (Throwable t) {
-        onError(t);
+    try {
+      writeOnNext(request);
+      if (request.getFinishWrite()) {
+        writeObserverSource.remove(request.getResourceName());
       }
+    } catch (Throwable t) {
+      onError(t);
     }
   }
 

--- a/src/main/java/build/buildfarm/proxy/http/WriteStreamObserver.java
+++ b/src/main/java/build/buildfarm/proxy/http/WriteStreamObserver.java
@@ -27,7 +27,7 @@ class WriteStreamObserver implements StreamObserver<WriteRequest> {
       write = writeObserverSource.get(request.getResourceName());
     }
     write.onNext(request);
-    if (request.getFinishWrite()) {
+    if (write.getComplete()) {
       responseObserver.onNext(WriteResponse.newBuilder()
           .setCommittedSize(write.getCommittedSize())
           .build());


### PR DESCRIPTION
When trying to use a [HTTP cache](https://github.com/buchgr/bazel-remote/) in combination with BuildFarm, I started to experiment by letting my the CAS configuration point to a grpc->http proxy. I found the proxy implementation in this bazel-buildfarm repository, added in #144, but soon discovered problems. The problems are a mixture of bugs and adaptions of behavior to get Bazel to work.

After all, I abandoned the trials but would like to contribute with my findings. Please feel free to pick and polish the changes as I do not intend to do so myself.