### PR TITLE
Fail putOperation on nonexistent action

### DIFF
--- a/src/main/java/build/buildfarm/instance/memory/MemoryInstance.java
+++ b/src/main/java/build/buildfarm/instance/memory/MemoryInstance.java
@@ -433,6 +433,10 @@ public class MemoryInstance extends AbstractServerInstance {
       // This is in effect if the worker does not respond
       // within a configured delay with operation action timeout results
       Action action = expectAction(operation);
+      if (action == null) {
+        // cannot determine action timeout, action content does not exist
+        return false;
+      }
       Duration actionTimeout = null;
       if (action.hasTimeout()) {
         actionTimeout = action.getTimeout();


### PR DESCRIPTION
A putOperation that cannot properly determine the action timeout
information for watchdog must fail.