### PR TITLE
Update the patch to make gRPC Java work.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -28,9 +28,9 @@ http_archive(
     patches = [
         "//third_party/io_grpc_grpc_java:054def3c63.patch",
         "//third_party/io_grpc_grpc_java:0959a846c8.patch",
-        "//third_party/io_grpc_grpc_java:1111913510.patch",
         "//third_party/io_grpc_grpc_java:952a767b9c.patch",
         "//third_party/io_grpc_grpc_java:c63752789e.patch",
+        "//third_party/io_grpc_grpc_java:1111913510.patch",
     ],
     sha256 = "f5d0bdebc2a50d0e28f0d228d6c35081d3e973e6159f2695aa5c8c7f93d1e4d6",
     strip_prefix = "grpc-java-1.19.0",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -28,9 +28,9 @@ http_archive(
     patches = [
         "//third_party/io_grpc_grpc_java:054def3c63.patch",
         "//third_party/io_grpc_grpc_java:0959a846c8.patch",
+        "//third_party/io_grpc_grpc_java:1111913510.patch",
         "//third_party/io_grpc_grpc_java:952a767b9c.patch",
         "//third_party/io_grpc_grpc_java:c63752789e.patch",
-        "//third_party/io_grpc_grpc_java:fac9edbce1.patch",
     ],
     sha256 = "f5d0bdebc2a50d0e28f0d228d6c35081d3e973e6159f2695aa5c8c7f93d1e4d6",
     strip_prefix = "grpc-java-1.19.0",

--- a/third_party/io_grpc_grpc_java/1111913510.patch
+++ b/third_party/io_grpc_grpc_java/1111913510.patch
@@ -1,25 +1,22 @@
-From fac9edbce161f8f9ce7f607e34de2a6568bebb35 Mon Sep 17 00:00:00 2001
+From 1111913510c64b174f798d63ba8f27d4d1c8219d Mon Sep 17 00:00:00 2001
 From: "Lukacs T. Berki" <lberki@google.com>
 Date: Tue, 9 Jul 2019 13:20:10 +0200
 Subject: [PATCH] Make java_grpc_library work properly with proto_library rules
  with strip_import_prefix and import_prefix.
 
 ---
- java_grpc_library.bzl | 15 ++++++++++++++-
- 1 file changed, 14 insertions(+), 1 deletion(-)
+ java_grpc_library.bzl | 17 +++++++++++++++--
+ 1 file changed, 15 insertions(+), 2 deletions(-)
 
 diff --git a/java_grpc_library.bzl b/java_grpc_library.bzl
-index 7c1b1f2b8..2c00ee956 100644
+index 7c1b1f2b8..edfee072d 100644
 --- a/java_grpc_library.bzl
 +++ b/java_grpc_library.bzl
-@@ -62,7 +62,20 @@ java_rpc_toolchain = rule(
+@@ -62,5 +62,18 @@ java_rpc_toolchain = rule(
  def _path_ignoring_repository(f):
-     if len(f.owner.workspace_root) == 0:
-         return f.short_path
--    return f.path[f.path.find(f.owner.workspace_root) + len(f.owner.workspace_root) + 1:]
-+
+-    if len(f.owner.workspace_root) == 0:
 +    # Bazel creates a _virtual_imports directory in case the .proto source files
-+    # need to a accessed at a path that's different from their source path:
++    # need to be accessed at a path that's different from their source path:
 +    # https://github.com/bazelbuild/bazel/blob/0.27.1/src/main/java/com/google/devtools/build/lib/rules/proto/ProtoCommon.java#L289
 +    #
 +    # In that case, the import path of the .proto file is the path relative to
@@ -27,13 +24,15 @@ index 7c1b1f2b8..2c00ee956 100644
 +    virtual_imports = "/_virtual_imports/"
 +    if virtual_imports in f.path:
 +        return f.path.split(virtual_imports)[1].split("/", 1)[1]
++    elif len(f.owner.workspace_root) == 0:
++        # |f| is in the main repository
+         return f.short_path
+-    return f.path[f.path.find(f.owner.workspace_root) + len(f.owner.workspace_root) + 1:]
 +    else:
 +        # If |f| is a generated file, it will have "bazel-out/*/genfiles" prefix
 +        # before "external/workspace", so we need to add the starting index of "external/workspace"
 +        return f.path[f.path.find(f.owner.workspace_root) + len(f.owner.workspace_root) + 1:]
  
- def _java_rpc_library_impl(ctx):
-     if len(ctx.attr.srcs) != 1:
 -- 
 2.22.0.410.gd8fdbe21b5-goog
 


### PR DESCRIPTION
A change to the fix was requested by the gRPC folks, so let's keep it tidy and replicate the change here.