### PR TITLE
Fix hash of protobuf archive.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -31,6 +31,7 @@ http_archive(
         "//third_party/io_grpc_grpc_java:952a767b9c.patch",
         "//third_party/io_grpc_grpc_java:c63752789e.patch",
         "//third_party/io_grpc_grpc_java:1111913510.patch",
+        "//third_party/io_grpc_grpc_java:ced33960cd.patch",
     ],
     sha256 = "f5d0bdebc2a50d0e28f0d228d6c35081d3e973e6159f2695aa5c8c7f93d1e4d6",
     strip_prefix = "grpc-java-1.19.0",

--- a/third_party/io_grpc_grpc_java/ced33960cd.patch
+++ b/third_party/io_grpc_grpc_java/ced33960cd.patch
@@ -1,0 +1,24 @@
+From ced33960cdc90a492ac2c7b46ef36029d0cac9bd Mon Sep 17 00:00:00 2001
+From: Uri Baghin <uri@canva.com>
+Date: Wed, 11 Sep 2019 22:37:36 +1000
+Subject: [PATCH] Fix sha of protobuf archive.
+
+---
+ repositories.bzl | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/repositories.bzl b/repositories.bzl
+index fe945f613..a6b34884c 100644
+--- a/repositories.bzl
++++ b/repositories.bzl
+@@ -214,7 +214,7 @@ def com_google_protobuf_javalite():
+     # java_lite_proto_library rules implicitly depend on @com_google_protobuf_javalite
+     http_archive(
+         name = "com_google_protobuf_javalite",
+-        sha256 = "d8a2fed3708781196f92e1e7e7e713cf66804bd2944894401057214aff4f468f",
++        sha256 = "79d102c61e2a479a0b7e5fc167bcfaa4832a0c6aad4a75fa7da0480564931bcc",
+         strip_prefix = "protobuf-384989534b2246d413dbcd750744faab2607b516",
+         urls = ["https://github.com/google/protobuf/archive/384989534b2246d413dbcd750744faab2607b516.zip"],
+     )
+--
+2.23.0


### PR DESCRIPTION
It looks like the hash that was pinned for `protobuf` in `grpc-java` is wrong. This is unfortunate but not completely unexpected: https://github.com/Homebrew/homebrew-core/issues/18044#issuecomment-329313468

This fixes it without updating `grpc-java`.