### PR TITLE
Asynchronous access recordings for CFC

### DIFF
--- a/src/main/java/build/buildfarm/CASTest.java
+++ b/src/main/java/build/buildfarm/CASTest.java
@@ -14,6 +14,7 @@
 
 package build.buildfarm;
 
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 
 import build.bazel.remote.execution.v2.Digest;
@@ -24,6 +25,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 
 class CASTest {
@@ -32,8 +34,9 @@ class CASTest {
         Path root,
         long maxSizeInBytes,
         DigestUtil digestUtil,
-        ExecutorService expireService) {
-      super(root, maxSizeInBytes, maxSizeInBytes, digestUtil, expireService);
+        ExecutorService expireService,
+        Executor accessRecorder) {
+      super(root, maxSizeInBytes, maxSizeInBytes, digestUtil, expireService, accessRecorder);
     }
 
     @Override
@@ -48,7 +51,8 @@ class CASTest {
         root,
         /* maxSizeInBytes=*/ 100l * 1024 * 1024 * 1024,
         new DigestUtil(HashFunction.SHA1),
-        /* expireService=*/ newDirectExecutorService());
+        /* expireService=*/ newDirectExecutorService(),
+        /* accessRecorder=*/ directExecutor());
     fileCache.start(newDirectExecutorService());
     System.out.println("Done with start, ready to roll...");
   }

--- a/src/main/java/build/buildfarm/worker/operationqueue/InjectedCASFileCache.java
+++ b/src/main/java/build/buildfarm/worker/operationqueue/InjectedCASFileCache.java
@@ -21,6 +21,7 @@ import build.buildfarm.worker.CASFileCache;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 
@@ -33,8 +34,9 @@ class InjectedCASFileCache extends CASFileCache {
       long maxSizeInBytes,
       long maxEntrySizeInBytes,
       DigestUtil digestUtil,
-      ExecutorService expireService) {
-    super(root, maxSizeInBytes, maxEntrySizeInBytes, digestUtil, expireService);
+      ExecutorService expireService,
+      Executor accessRecorder) {
+    super(root, maxSizeInBytes, maxEntrySizeInBytes, digestUtil, expireService, accessRecorder);
     this.inputStreamFactory = inputStreamFactory;
   }
 

--- a/src/main/java/build/buildfarm/worker/operationqueue/Worker.java
+++ b/src/main/java/build/buildfarm/worker/operationqueue/Worker.java
@@ -20,8 +20,9 @@ import static build.buildfarm.worker.CASFileCache.getInterruptiblyOrIOException;
 import static build.buildfarm.worker.Utils.removeDirectory;
 import static com.google.common.collect.Maps.uniqueIndex;
 import static com.google.common.util.concurrent.Futures.allAsList;
-import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static com.google.common.util.concurrent.MoreExecutors.listeningDecorator;
+import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static com.google.common.util.concurrent.MoreExecutors.shutdownAndAwaitTermination;
 import static java.lang.String.format;
 import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
@@ -236,7 +237,8 @@ public class Worker {
         config.getCasCacheMaxSizeBytes(),
         config.getCasCacheMaxEntrySizeBytes(),
         casInstance.getDigestUtil(),
-        newDirectExecutorService());
+        newDirectExecutorService(),
+        directExecutor());
   }
 
   private void fetchInputs(

--- a/src/main/java/build/buildfarm/worker/shard/CFCExecFileSystem.java
+++ b/src/main/java/build/buildfarm/worker/shard/CFCExecFileSystem.java
@@ -73,6 +73,7 @@ class CFCExecFileSystem implements ExecFileSystem {
   private final Map<Path, Iterable<Digest>> rootInputDirectories = new ConcurrentHashMap<>();
   private final ExecutorService fetchService = newWorkStealingPool(128);
   private final ExecutorService removeDirectoryService;
+  private final ExecutorService accessRecorder;
   private final long deadlineAfter;
   private final TimeUnit deadlineAfterUnits;
 
@@ -81,12 +82,14 @@ class CFCExecFileSystem implements ExecFileSystem {
       CASFileCache fileCache,
       boolean linkInputDirectories,
       ExecutorService removeDirectoryService,
+      ExecutorService accessRecorder,
       long deadlineAfter,
       TimeUnit deadlineAfterUnits) {
     this.root = root;
     this.fileCache = fileCache;
     this.linkInputDirectories = linkInputDirectories;
     this.removeDirectoryService = removeDirectoryService;
+    this.accessRecorder = accessRecorder;
     this.deadlineAfter = deadlineAfter;
     this.deadlineAfterUnits = deadlineAfterUnits;
   }
@@ -125,6 +128,9 @@ class CFCExecFileSystem implements ExecFileSystem {
     }
     if (!shutdownAndAwaitTermination(removeDirectoryService, 1, MINUTES)) {
       logger.severe("could not terminate removeDirectoryService");
+    }
+    if (!shutdownAndAwaitTermination(accessRecorder, 1, MINUTES)) {
+      logger.severe("could not terminate accessRecorder");
     }
   }
 

--- a/src/main/java/build/buildfarm/worker/shard/ShardCASFileCache.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardCASFileCache.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Maps;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 
@@ -36,6 +37,7 @@ class ShardCASFileCache extends CASFileCache {
       long maxEntrySizeInBytes,
       DigestUtil digestUtil,
       ExecutorService expireService,
+      Executor accessRecorder,
       Consumer<Digest> onPut,
       Consumer<Iterable<Digest>> onExpire,
       ContentAddressableStorage delegate) {
@@ -45,6 +47,7 @@ class ShardCASFileCache extends CASFileCache {
         maxEntrySizeInBytes,
         digestUtil,
         expireService,
+        accessRecorder,
         /* storage=*/ Maps.newConcurrentMap(),
         onPut,
         onExpire,


### PR DESCRIPTION
Prevent locks from delaying responses to contains, which can cause
substantial request queuing and memory contention.