### PR TITLE
Force TLS for workers

### DIFF
--- a/src/main/java/build/buildfarm/worker/operationqueue/Worker.java
+++ b/src/main/java/build/buildfarm/worker/operationqueue/Worker.java
@@ -139,7 +139,7 @@ public class Worker {
   private static ManagedChannel createChannel(String target) {
     NettyChannelBuilder builder =
         NettyChannelBuilder.forTarget(target)
-            .negotiationType(NegotiationType.PLAINTEXT);
+            .negotiationType(NegotiationType.TLS);
     return builder.build();
   }
 


### PR DESCRIPTION
Depending on your deploy configuration connecting to the main service
over plain text may not be acceptable.