### PR TITLE
Remove duplicated exec dir destroy in executor

### DIFF
--- a/src/main/java/build/buildfarm/worker/Executor.java
+++ b/src/main/java/build/buildfarm/worker/Executor.java
@@ -103,11 +103,6 @@ class Executor implements Runnable {
           String.format(
               "Executor::run(%s): could not transition to EXECUTING",
               operation.getName()));
-      try {
-        workerContext.destroyExecDir(operationContext.execDir);
-      } catch (IOException e) {
-        logger.log(SEVERE, "error while destroying " + operationContext.execDir, e);
-      }
       owner.error().put(operationContext);
       return 0;
     }


### PR DESCRIPTION
The removal of exec dirs is automatically handled through
ExecuteActionStage's error path, the Executor does not need to perform
it directly.