### PR TITLE
Interpret NOT_FOUND from BS::QWS as reset

### DIFF
--- a/3rdparty/jvm/io/grpc/BUILD
+++ b/3rdparty/jvm/io/grpc/BUILD
@@ -155,7 +155,7 @@ java_library(
 java_library(
     name = "grpc_testing",
     visibility = [
-        "//3rdparty/jvm:__subpackages__",
+        "//visibility:public",
     ],
     exports = [
         "//external:jar/io/grpc/grpc_testing",

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -86,7 +86,7 @@ dependencies:
 
     grpc:
       lang: java
-      modules: [ "api", "auth", "core", "context", "netty", "stub", "protobuf" ]
+      modules: [ "api", "auth", "core", "context", "netty", "stub", "protobuf", "testing" ]
       version: "1.23.0"
 
   junit:

--- a/src/main/java/build/buildfarm/common/grpc/StubWriteOutputStream.java
+++ b/src/main/java/build/buildfarm/common/grpc/StubWriteOutputStream.java
@@ -78,7 +78,8 @@ public class StubWriteOutputStream extends FeedbackOutputStream implements Write
             return response;
           } catch (StatusRuntimeException e) {
             Status status = Status.fromThrowable(e);
-            if (status.getCode() == Code.UNIMPLEMENTED) {
+            if (status.getCode() == Code.UNIMPLEMENTED ||
+                status.getCode() == Code.NOT_FOUND) {
               return resetResponse;
             }
             throw e;

--- a/src/main/java/build/buildfarm/instance/Utils.java
+++ b/src/main/java/build/buildfarm/instance/Utils.java
@@ -84,13 +84,15 @@ public class Utils {
               .asRuntimeException());
     }
     Write write = instance.getBlobWrite(digest, UUID.randomUUID(), requestMetadata);
+    // indicate that we know this write is novel
+    write.reset();
     SettableFuture<Digest> future = SettableFuture.create();
     write.addListener(
         () -> future.set(digest),
         directExecutor());
     try (OutputStream out = write.getOutput(writeDeadlineAfter, writeDeadlineAfterUnits, () -> {})) {
       data.writeTo(out);
-    } catch (IOException e) {
+    } catch (Exception e) {
       future.setException(e);
     }
     return future;

--- a/src/test/java/build/buildfarm/BUILD
+++ b/src/test/java/build/buildfarm/BUILD
@@ -40,8 +40,16 @@ java_test(
         "//3rdparty/jvm/com/google/guava",
         "//3rdparty/jvm/com/google/protobuf:protobuf_java",
         "//3rdparty/jvm/com/google/truth",
+        "//3rdparty/jvm/io/grpc:grpc_api",
+        "//3rdparty/jvm/io/grpc:grpc_core",
+        "//3rdparty/jvm/io/grpc:grpc_stub",
+        "//3rdparty/jvm/io/grpc:grpc_testing",
+        "//3rdparty/jvm/org/mockito:mockito_core",
         "//src/main/java/build/buildfarm:common",
+        "//src/main/java/build/buildfarm:common-grpc",
         "//src/main/protobuf:build_buildfarm_v1test_buildfarm_java_proto",
+        "@googleapis//:google_bytestream_bytestream_java_grpc",
+        "@googleapis//:google_bytestream_bytestream_java_proto",
     ],
 )
 
@@ -97,7 +105,10 @@ config_setting(
 java_test(
     name = "worker-tests",
     size = "small",
-    srcs = glob(["worker/*.java"], exclude = ["worker/FuseCASTest.java"]) + select({
+    srcs = glob(
+        ["worker/*.java"],
+        exclude = ["worker/FuseCASTest.java"],
+    ) + select({
         "//conditions:default": [],
         ":fuse": ["worker/FuseCASTest.java"],
     }),

--- a/src/test/java/build/buildfarm/common/grpc/StubWriteOutputStreamTest.java
+++ b/src/test/java/build/buildfarm/common/grpc/StubWriteOutputStreamTest.java
@@ -1,0 +1,155 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.common.grpc;
+
+import static com.google.common.truth.Truth.assertThat;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.mockito.AdditionalAnswers.delegatesTo;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.bytestream.ByteStreamGrpc;
+import com.google.bytestream.ByteStreamGrpc.ByteStreamImplBase;
+import com.google.bytestream.ByteStreamProto.QueryWriteStatusRequest;
+import com.google.bytestream.ByteStreamProto.QueryWriteStatusResponse;
+import com.google.bytestream.ByteStreamProto.WriteRequest;
+import com.google.bytestream.ByteStreamProto.WriteResponse;
+import com.google.common.base.Suppliers;
+import com.google.protobuf.ByteString;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.List;
+import io.grpc.Channel;
+import io.grpc.Status;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.StreamObserver;
+import io.grpc.testing.GrpcCleanupRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
+import org.mockito.stubbing.Answer;
+
+@RunWith(JUnit4.class)
+public class StubWriteOutputStreamTest {
+  @Rule
+  public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+
+  private final StreamObserver<WriteRequest> writeObserver = mock(StreamObserver.class);
+
+  private final ByteStreamImplBase serviceImpl =
+      mock(ByteStreamImplBase.class, delegatesTo(
+          new ByteStreamImplBase() {
+            @Override
+            public StreamObserver<WriteRequest> write(StreamObserver<WriteResponse> responseObserver) {
+              return writeObserver;
+            }
+          }));
+
+  private Channel channel;
+
+  @Before
+  public void setUp() throws Exception {
+    String serverName = InProcessServerBuilder.generateName();
+
+    grpcCleanup.register(InProcessServerBuilder
+        .forName(serverName)
+        .directExecutor()
+        .addService(serviceImpl)
+        .build()).start();
+
+    channel = grpcCleanup.register(InProcessChannelBuilder
+        .forName(serverName)
+        .directExecutor()
+        .build());
+  }
+
+  @Test
+  public void resetExceptionsAreInterpreted() {
+    String unimplementedResourceName = "unimplemented-resource";
+    QueryWriteStatusRequest unimplementedRequest = QueryWriteStatusRequest.newBuilder()
+        .setResourceName(unimplementedResourceName)
+        .build();
+    doAnswer((Answer) invocation -> {
+      StreamObserver<QueryWriteStatusResponse> observer = invocation.getArgument(1);
+      observer.onError(Status.UNIMPLEMENTED.asException());
+      return null;
+    }).when(serviceImpl).queryWriteStatus(
+        eq(unimplementedRequest),
+        any(StreamObserver.class));
+
+    String notFoundResourceName = "not-found-resource";
+    QueryWriteStatusRequest notFoundRequest = QueryWriteStatusRequest.newBuilder()
+        .setResourceName(notFoundResourceName)
+        .build();
+    doAnswer((Answer) invocation -> {
+      StreamObserver<QueryWriteStatusResponse> observer = invocation.getArgument(1);
+      observer.onError(Status.NOT_FOUND.asException());
+      return null;
+    }).when(serviceImpl).queryWriteStatus(
+        eq(notFoundRequest),
+        any(StreamObserver.class));
+
+    StubWriteOutputStream write = new StubWriteOutputStream(
+        Suppliers.ofInstance(ByteStreamGrpc.newBlockingStub(channel)),
+        Suppliers.ofInstance(ByteStreamGrpc.newStub(channel)),
+        unimplementedResourceName,
+        /* expectedSize=*/ StubWriteOutputStream.UNLIMITED_EXPECTED_SIZE,
+        /* autoflush=*/ true);
+    assertThat(write.getCommittedSize()).isEqualTo(0);
+    verify(serviceImpl, times(1)).queryWriteStatus(eq(unimplementedRequest), any(StreamObserver.class));
+
+    write = new StubWriteOutputStream(
+        Suppliers.ofInstance(ByteStreamGrpc.newBlockingStub(channel)),
+        Suppliers.ofInstance(ByteStreamGrpc.newStub(channel)),
+        notFoundResourceName,
+        /* expectedSize=*/ StubWriteOutputStream.UNLIMITED_EXPECTED_SIZE,
+        /* autoflush=*/ true);
+    assertThat(write.getCommittedSize()).isEqualTo(0);
+    verify(serviceImpl, times(1)).queryWriteStatus(eq(notFoundRequest), any(StreamObserver.class));
+  }
+
+  @Test
+  public void resetIsRespectedOnSubsequentWrite() throws IOException {
+    String resourceName = "reset-resource";
+    StubWriteOutputStream write = new StubWriteOutputStream(
+        Suppliers.ofInstance(ByteStreamGrpc.newBlockingStub(channel)),
+        Suppliers.ofInstance(ByteStreamGrpc.newStub(channel)),
+        resourceName,
+        /* expectedSize=*/ StubWriteOutputStream.UNLIMITED_EXPECTED_SIZE,
+        /* autoflush=*/ true);
+    ByteString content = ByteString.copyFromUtf8("Hello, World");
+    try (OutputStream out = write.getOutput(1, SECONDS, () -> {})) {
+      content.writeTo(out);
+      write.reset();
+      content.writeTo(out);
+    }
+    verify(serviceImpl, times(1)).write(any(StreamObserver.class));
+    ArgumentCaptor<WriteRequest> writeRequestCaptor = ArgumentCaptor.forClass(WriteRequest.class);
+    verify(writeObserver, times(3)).onNext(writeRequestCaptor.capture());
+    List<WriteRequest> requests = writeRequestCaptor.getAllValues();
+    assertThat(requests.get(0).getWriteOffset()).isEqualTo(requests.get(1).getWriteOffset());
+    assertThat(requests.get(2).getFinishWrite()).isTrue();
+  }
+}


### PR DESCRIPTION
ByteStream API docs detail responding with NOT_FOUND as an expected
behavior when requesting writes which have not yet begun. Interpret this
as a reset in StubWriteOutputStream, and call reset() for good measure
in instance.Utils putBlobFuture to avoid a guaranteed novel write.