### PR TITLE
Allow stub match requests to expire, simplify dls

### DIFF
--- a/examples/worker.config.example
+++ b/examples/worker.config.example
@@ -11,6 +11,9 @@ operation_queue: {
   # the instance domain that this worker will execute work in
   # all requests will be tagged with this instance name
   instance_name: "default_memory_instance"
+
+  # the deadline in seconds for requests (default or <= 0 is unlimited)
+  deadline_after_seconds: 60
 }
 
 # the endpoint used for cas interactions
@@ -20,6 +23,9 @@ content_addressable_storage: {
   # the instance domain that this worker will make resource requests in
   # all requests will be tagged with this instance name
   instance_name: "default_memory_instance"
+
+  # the deadline in seconds for requests (default or <= 0 is unlimited)
+  deadline_after_seconds: 60
 }
 
 # the endpoint used for action cache interactions
@@ -29,6 +35,9 @@ action_cache: {
   # the instance domain that this worker will make resource requests in
   # all requests will be tagged with this instance name
   instance_name: "default_memory_instance"
+
+  # the deadline in seconds for requests (default or <= 0 is unlimited)
+  deadline_after_seconds: 60
 }
 
 # all content for the operations will be stored under this path

--- a/src/main/java/build/buildfarm/instance/Instance.java
+++ b/src/main/java/build/buildfarm/instance/Instance.java
@@ -128,6 +128,9 @@ public interface Instance {
     boolean onEntry(@Nullable QueueEntry queueEntry) throws InterruptedException;
 
     void onError(Throwable t);
+
+    // method that should be called when this match is cancelled and no longer valid
+    void setOnCancelHandler(Runnable onCancelHandler);
   }
 
   public static class PutAllBlobsException extends RuntimeException {

--- a/src/main/java/build/buildfarm/instance/Instance.java
+++ b/src/main/java/build/buildfarm/instance/Instance.java
@@ -126,6 +126,8 @@ public interface Instance {
 
     // returns false if this listener will not handle this match
     boolean onEntry(@Nullable QueueEntry queueEntry) throws InterruptedException;
+
+    void onError(Throwable t);
   }
 
   public static class PutAllBlobsException extends RuntimeException {

--- a/src/main/java/build/buildfarm/server/OperationQueueService.java
+++ b/src/main/java/build/buildfarm/server/OperationQueueService.java
@@ -19,25 +19,18 @@ import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static com.google.common.util.concurrent.Futures.transformAsync;
 import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 
-import build.bazel.remote.execution.v2.Digest;
-import build.bazel.remote.execution.v2.ExecuteOperationMetadata;
 import build.buildfarm.instance.Instance;
 import build.buildfarm.instance.Instance.MatchListener;
 import build.buildfarm.common.function.InterruptingPredicate;
 import build.buildfarm.v1test.OperationQueueGrpc;
 import build.buildfarm.v1test.PollOperationRequest;
 import build.buildfarm.v1test.QueueEntry;
-import build.buildfarm.v1test.QueuedOperation;
 import build.buildfarm.v1test.TakeOperationRequest;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
+import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.longrunning.Operation;
-import com.google.protobuf.Any;
-import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.rpc.Code;
 import io.grpc.Status;
-import io.grpc.StatusException;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 import java.util.concurrent.ExecutionException;
@@ -78,6 +71,12 @@ public class OperationQueueService extends OperationQueueGrpc.OperationQueueImpl
     @Override
     public boolean onEntry(QueueEntry queueEntry) throws InterruptedException {
       return onMatch.testInterruptibly(queueEntry);
+    }
+
+    @Override
+    public void onError(Throwable t) {
+      Throwables.throwIfUnchecked(t);
+      throw new RuntimeException(t);
     }
   }
 

--- a/src/main/java/build/buildfarm/worker/MatchStage.java
+++ b/src/main/java/build/buildfarm/worker/MatchStage.java
@@ -24,6 +24,7 @@ import build.buildfarm.v1test.ExecuteEntry;
 import build.buildfarm.v1test.QueueEntry;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
+import com.google.common.base.Throwables;
 import com.google.longrunning.Operation;
 import com.google.protobuf.Any;
 import com.google.protobuf.Timestamp;
@@ -78,6 +79,12 @@ public class MatchStage extends PipelineStage {
       Preconditions.checkState(poller == null);
       Poller poller = workerContext.createPoller("MatchStage", queueEntry, QUEUED);
       return onOperationPolled(queueEntry, poller);
+    }
+
+    @Override
+    public void onError(Throwable t) {
+      Throwables.throwIfUnchecked(t);
+      throw new RuntimeException(t);
     }
 
     private boolean onOperationPolled(QueueEntry queueEntry, Poller poller) throws InterruptedException {

--- a/src/main/java/build/buildfarm/worker/MatchStage.java
+++ b/src/main/java/build/buildfarm/worker/MatchStage.java
@@ -47,6 +47,7 @@ public class MatchStage extends PipelineStage {
     private Poller poller = null;
     private QueueEntry queueEntry = null;
     private boolean matched = false;
+    private Runnable onCancelHandler = null; // never called, only blocking stub used
 
     public MatchOperationListener(Stopwatch stopwatch) {
       this.stopwatch = stopwatch;
@@ -85,6 +86,11 @@ public class MatchStage extends PipelineStage {
     public void onError(Throwable t) {
       Throwables.throwIfUnchecked(t);
       throw new RuntimeException(t);
+    }
+
+    @Override
+    public void setOnCancelHandler(Runnable onCancelHandler) {
+      this.onCancelHandler = onCancelHandler;
     }
 
     private boolean onOperationPolled(QueueEntry queueEntry, Poller poller) throws InterruptedException {

--- a/src/main/java/build/buildfarm/worker/operationqueue/Worker.java
+++ b/src/main/java/build/buildfarm/worker/operationqueue/Worker.java
@@ -520,6 +520,11 @@ public class Worker {
             Throwables.throwIfUnchecked(t);
             throw new RuntimeException(t);
           }
+
+          @Override
+          public void setOnCancelHandler(Runnable onCancelHandler) {
+            listener.setOnCancelHandler(onCancelHandler);
+          }
         };
         while (!dedupMatchListener.getMatched()) {
           operationQueueInstance.match(config.getPlatform(), dedupMatchListener);

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -291,6 +291,12 @@ class ShardWorkerContext implements WorkerContext {
         }
         return success;
       }
+
+      @Override
+      public void onError(Throwable t) {
+        Throwables.throwIfUnchecked(t);
+        throw new RuntimeException(t);
+      }
     };
     while (!dedupMatchListener.getMatched()) {
       try {

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -297,6 +297,11 @@ class ShardWorkerContext implements WorkerContext {
         Throwables.throwIfUnchecked(t);
         throw new RuntimeException(t);
       }
+
+      @Override
+      public void setOnCancelHandler(Runnable onCancelHandler) {
+        listener.setOnCancelHandler(onCancelHandler);
+      }
     };
     while (!dedupMatchListener.getMatched()) {
       try {

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -440,6 +440,9 @@ message InstanceEndpoint {
 
   // instance to be used
   string instance_name = 2;
+
+  // deadline for requests in seconds
+  int32 deadline_after_seconds = 3;
 }
 
 message ExecutionWrapper {


### PR DESCRIPTION
Long lived requests can be problematic to rely on for functionality.
Constrain the match OperationQueue::take request to a deadline to allow
a request to complete under an SLA - the default match behavior will be
to ignore successive DEADLINE_EXCEEDED statuses and translate all other
exceptions to listeners (who currently only throw them).

InstanceEndpoints can now specify `deadline_after_seconds` to control
the worker's stub deadline for each of the ac/cas/oq services.

Simplified the stub-with-deadline creation code dramaticaly in the stub
instance in the process.