### PR TITLE
Reverse order of shutdown sequence in OQ worker

### DIFF
--- a/src/main/java/build/buildfarm/worker/operationqueue/Worker.java
+++ b/src/main/java/build/buildfarm/worker/operationqueue/Worker.java
@@ -759,10 +759,10 @@ public class Worker {
 
     Pipeline pipeline = new Pipeline();
     // pipeline.add(errorStage, 0);
-    pipeline.add(matchStage, 1);
-    pipeline.add(inputFetchStage, 2);
-    pipeline.add(executeActionStage, 3);
-    pipeline.add(reportResultStage, 4);
+    pipeline.add(matchStage, 4);
+    pipeline.add(inputFetchStage, 3);
+    pipeline.add(executeActionStage, 2);
+    pipeline.add(reportResultStage, 1);
     pipeline.start();
     pipeline.join(); // uninterruptable
     if (Thread.interrupted()) {


### PR DESCRIPTION
The Superscalar stage will wait indefinitely while claimed for a
release, assuming that it is held by a running worker. Since the
MatchStage holds a claim while waiting for a match to prevent
oversubscription, the InputFetchStage will not shut down while a match
is waiting. Interrupting the match stage at highest priority, and
downstream stages in descending order of the pipeline allows a full
flush in ideal circumstances.