### PR TITLE
Remove arbitrary putOperation from onEntry

### DIFF
--- a/src/main/java/build/buildfarm/instance/memory/MemoryInstance.java
+++ b/src/main/java/build/buildfarm/instance/memory/MemoryInstance.java
@@ -686,6 +686,8 @@ public class MemoryInstance extends AbstractServerInstance {
           matched = true;
           if (listener.onEntry(queueEntry)) {
             onDispatched(operation);
+          } else {
+            enqueueOperation(operation);
           }
         } catch (StatusException|IOException e) {
           logger.log(SEVERE, format("could not emplace queued operation: %s", operationName), e);

--- a/src/main/java/build/buildfarm/server/OperationQueueService.java
+++ b/src/main/java/build/buildfarm/server/OperationQueueService.java
@@ -94,7 +94,6 @@ public class OperationQueueService extends OperationQueueGrpc.OperationQueueImpl
           responseObserver.onError(e);
         }
       }
-      instance.putOperation(instance.getOperation(queueEntry.getExecuteEntry().getOperationName()));
       return false;
     };
   }


### PR DESCRIPTION
Prevent a reentry into matchOperation when a match listener has failed
with cancellation. A re-enqueue should take place only in the listener-
centric failure case. Operation-centric behaviors will queue
automatically.