### PR TITLE
Pipe startup error messages to STDERR on the worker

### DIFF
--- a/src/main/java/build/buildfarm/worker/Executor.java
+++ b/src/main/java/build/buildfarm/worker/Executor.java
@@ -311,6 +311,7 @@ class Executor implements Runnable {
       logger.log(SEVERE, "error starting process for " + operationName, e);
       // again, should we do something else here??
       resultBuilder.setExitCode(INCOMPLETE_EXIT_CODE);
+      resultBuilder.setStderrRaw(ByteString.copyFromUtf8(e.getMessage()));
       return Code.INVALID_ARGUMENT;
     }
 


### PR DESCRIPTION
If the worker fails to start the action (e.g., the requested binary is
missing), return the error message in the STDERR so that Bazel will
print it out.