### PR TITLE
Synchronize on singleton to prevent ETXTBSY

### DIFF
--- a/src/main/java/build/buildfarm/worker/Executor.java
+++ b/src/main/java/build/buildfarm/worker/Executor.java
@@ -56,6 +56,8 @@ class Executor implements Runnable {
   private static final int INCOMPLETE_EXIT_CODE = -1;
   private static final Logger logger = Logger.getLogger(Executor.class.getName());
 
+  private static final Object execLock = new Object();
+
   private final WorkerContext workerContext;
   private final OperationContext operationContext;
   private final ExecuteActionStage owner;
@@ -303,7 +305,7 @@ class Executor implements Runnable {
     long startNanoTime = System.nanoTime();
     Process process;
     try {
-      synchronized (this) {
+      synchronized (execLock) {
         process = processBuilder.start();
       }
       process.getOutputStream().close();


### PR DESCRIPTION
We must synchronize on a process-global object in order to successfully
prevent ETXTBSY; do so with an Executor static member instead of an
Executor instance.