### PR TITLE
Provide stderr text when process start fails

### DIFF
--- a/src/main/java/build/buildfarm/worker/Executor.java
+++ b/src/main/java/build/buildfarm/worker/Executor.java
@@ -307,10 +307,21 @@ class Executor implements Runnable {
         process = processBuilder.start();
       }
       process.getOutputStream().close();
-    } catch(IOException e) {
+    } catch (IOException e) {
       logger.log(SEVERE, "error starting process for " + operationName, e);
       // again, should we do something else here??
       resultBuilder.setExitCode(INCOMPLETE_EXIT_CODE);
+      // The openjdk IOException for an exec failure here includes the working
+      // directory of the execution. Drop it and reconstruct without it if we
+      // can get the cause.
+      Throwable t = e.getCause();
+      String message;
+      if (t != null) {
+        message = "Cannot run program \"" + processBuilder.command().get(0) + "\": " + t.getMessage();
+      } else {
+        message = e.getMessage();
+      }
+      resultBuilder.setStderrRaw(ByteString.copyFromUtf8(message));
       return Code.INVALID_ARGUMENT;
     }
 


### PR DESCRIPTION
If a ProcessBuilder#start fails, present a reasonable message to
indicate via the operation what occurred. Since openjdk's default
start IOException wrapper includes a directory that will be meaningless
on the client, attempt to intercept it by expecting a cause, which
should only be the literal failure from exec, and constructing a simple
decoration of the command.