### PR TITLE
Clean up MI monitors on expiry and requeue

### DIFF
--- a/src/main/java/build/buildfarm/instance/AbstractServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/AbstractServerInstance.java
@@ -1242,7 +1242,7 @@ public abstract class AbstractServerInstance implements Instance {
     }
   }
 
-  protected static boolean isQueued(Operation operation) {
+  public static boolean isQueued(Operation operation) {
     return isStage(operation, ExecutionStage.Value.QUEUED);
   }
 


### PR DESCRIPTION
When a worker deliberately attempts to requeue an operation, deregister
all monitors associated with it to avoid spurious queue state
violations, or even full reexecutions.

Partially addresses #316