### PR TITLE
Use execution policies with platform match

### DIFF
--- a/examples/worker.config.example
+++ b/examples/worker.config.example
@@ -92,7 +92,7 @@ platform: {
   # 'platform' is a sufficient starting point without specifying
   # any platform requirements on the actions' side
   ###
-  # property: {
+  # properties: {
   #   name: "key_name"
   #   value: "value_string"
   # }
@@ -133,6 +133,8 @@ maximum_action_timeout: {
   nanos: 0
 }
 
+# execution policies are automatically added to the advertised
+# platform for a worker
 # prefix command executions with this path
 #execution_policies: {
 #  name: "test"

--- a/src/main/java/build/buildfarm/worker/WorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/WorkerContext.java
@@ -43,8 +43,6 @@ public interface WorkerContext {
   Poller createPoller(String name, QueueEntry queueEntry, ExecutionStage.Value stage);
   void resumePoller(Poller poller, String name, QueueEntry queueEntry, ExecutionStage.Value stage, Runnable onFailure, Deadline deadline);
   void match(MatchListener listener) throws InterruptedException;
-  void requeue(Operation operation) throws InterruptedException;
-  void deactivate(String operationName);
   void logInfo(String msg);
   CASInsertionPolicy getFileCasPolicy();
   CASInsertionPolicy getStdoutCasPolicy();

--- a/src/main/java/build/buildfarm/worker/operationqueue/OperationQueueClient.java
+++ b/src/main/java/build/buildfarm/worker/operationqueue/OperationQueueClient.java
@@ -1,0 +1,163 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.worker.operationqueue;
+
+import static java.util.logging.Level.SEVERE;
+
+import build.bazel.remote.execution.v2.ExecuteOperationMetadata;
+import build.bazel.remote.execution.v2.ExecutionStage;
+import build.bazel.remote.execution.v2.Platform;
+import build.buildfarm.common.Write;
+import build.buildfarm.instance.Instance;
+import build.buildfarm.instance.Instance.MatchListener;
+import build.buildfarm.v1test.ExecuteEntry;
+import build.buildfarm.v1test.ExecutionPolicy;
+import build.buildfarm.v1test.QueueEntry;
+import build.buildfarm.v1test.QueuedOperationMetadata;
+import build.buildfarm.worker.RetryingMatchListener;
+import com.google.common.base.Throwables;
+import com.google.longrunning.Operation;
+import com.google.protobuf.Any;
+import com.google.protobuf.InvalidProtocolBufferException;
+import java.util.Set;
+import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
+
+class OperationQueueClient {
+  private static final Logger logger = Logger.getLogger(Worker.class.getName());
+
+  private final Instance instance;
+  private final Platform matchPlatform;
+  private final Set<String> activeOperations = new ConcurrentSkipListSet<>();
+
+  static Platform getMatchPlatform(Platform platform, Iterable<ExecutionPolicy> policies) {
+    Platform.Builder builder = platform.toBuilder();
+    for (ExecutionPolicy policy : policies) {
+      String name = policy.getName();
+      if (!name.isEmpty()) {
+        builder.addPropertiesBuilder()
+            .setName("execution-policy")
+            .setValue(policy.getName());
+      }
+    }
+    return builder.build();
+  }
+
+  OperationQueueClient(Instance instance, Platform platform, Iterable<ExecutionPolicy> policies) {
+    this.instance = instance;
+    matchPlatform = getMatchPlatform(platform, policies);
+  }
+
+  void match(MatchListener listener) throws InterruptedException {
+    RetryingMatchListener dedupMatchListener = new RetryingMatchListener() {
+      boolean matched = false;
+
+      @Override
+      public boolean getMatched() {
+        return matched;
+      }
+
+      @Override
+      public void onWaitStart() {
+        listener.onWaitStart();
+      }
+
+      @Override
+      public void onWaitEnd() {
+        listener.onWaitEnd();
+      }
+
+      @Override
+      public boolean onEntry(@Nullable QueueEntry queueEntry) throws InterruptedException {
+        if (queueEntry == null) {
+          matched = true;
+          return listener.onEntry(null);
+        }
+        ExecuteEntry executeEntry = queueEntry.getExecuteEntry();
+        String operationName = executeEntry.getOperationName();
+        if (activeOperations.contains(operationName)) {
+          logger.severe("WorkerContext::match: WARNING matched duplicate operation " + operationName);
+          return false;
+        }
+        matched = true;
+        activeOperations.add(operationName);
+        boolean success = listener.onEntry(queueEntry);
+        if (!success) {
+          requeue(Operation.newBuilder()
+              .setName(operationName)
+              .setMetadata(Any.pack(QueuedOperationMetadata.newBuilder()
+                  .setExecuteOperationMetadata(ExecuteOperationMetadata.newBuilder()
+                      .setActionDigest(executeEntry.getActionDigest())
+                      .setStdoutStreamName(executeEntry.getStdoutStreamName())
+                      .setStderrStreamName(executeEntry.getStderrStreamName())
+                      .setStage(ExecutionStage.Value.QUEUED))
+                  .setQueuedOperationDigest(queueEntry.getQueuedOperationDigest())
+                  .build()))
+              .build());
+        }
+        return success;
+      }
+
+      @Override
+      public void onError(Throwable t) {
+        listener.onError(t);
+      }
+
+      @Override
+      public void setOnCancelHandler(Runnable onCancelHandler) {
+        listener.setOnCancelHandler(onCancelHandler);
+      }
+    };
+    while (!dedupMatchListener.getMatched()) {
+      instance.match(matchPlatform, dedupMatchListener);
+    }
+  }
+
+  void requeue(Operation operation) throws InterruptedException {
+    try {
+      deactivate(operation.getName());
+      ExecuteOperationMetadata metadata =
+          operation.getMetadata().unpack(ExecuteOperationMetadata.class);
+
+      ExecuteOperationMetadata executingMetadata = metadata.toBuilder()
+          .setStage(ExecutionStage.Value.QUEUED)
+          .build();
+
+      operation = operation.toBuilder()
+          .setMetadata(Any.pack(executingMetadata))
+          .build();
+      instance.putOperation(operation);
+    } catch (InvalidProtocolBufferException e) {
+      logger.log(SEVERE, "error unpacking execute operation metadata for " + operation.getName(), e);
+    }
+  }
+
+  void deactivate(String name) {
+    activeOperations.remove(name);
+  }
+
+  boolean put(Operation operation) throws InterruptedException {
+    return instance.putOperation(operation);
+  }
+
+  public Write getStreamWrite(String name) {
+    return instance.getOperationStreamWrite(name);
+  }
+
+  public boolean poll(String name, ExecutionStage.Value stage) {
+    return instance.pollOperation(name, stage);
+  }
+}

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -199,7 +199,7 @@ public class Worker {
         .addService(new ByteStreamService(instances, /* writeDeadlineAfter=*/ 1, DAYS))
         .build();
 
-    WorkerContext context = new ShardWorkerContext(
+    ShardWorkerContext context = new ShardWorkerContext(
         config.getPublicName(),
         config.getPlatform(),
         config.getOperationPollPeriod(),

--- a/src/test/java/build/buildfarm/BUILD
+++ b/src/test/java/build/buildfarm/BUILD
@@ -204,6 +204,7 @@ java_test(
     test_class = "build.buildfarm.AllTests",
     deps = [
         ":test_runner",
+        "//3rdparty/jvm/com/google/code/findbugs:jsr305",
         "//3rdparty/jvm/com/google/guava",
         "//3rdparty/jvm/com/google/jimfs",
         "//3rdparty/jvm/com/google/protobuf:protobuf_java",
@@ -212,6 +213,7 @@ java_test(
         "//3rdparty/jvm/io/grpc:grpc_core",
         "//3rdparty/jvm/org/mockito:mockito_core",
         "//src/main/java/build/buildfarm:common",
+        "//src/main/java/build/buildfarm:instance",
         "//src/main/java/build/buildfarm:operationqueue-worker",
         "//src/main/java/build/buildfarm:stub-instance",
         "//src/main/java/build/buildfarm:worker",

--- a/src/test/java/build/buildfarm/worker/StubWorkerContext.java
+++ b/src/test/java/build/buildfarm/worker/StubWorkerContext.java
@@ -44,8 +44,6 @@ class StubWorkerContext implements WorkerContext {
   @Override public Poller createPoller(String name, QueueEntry queueEntry, ExecutionStage.Value stage) { throw new UnsupportedOperationException(); }
   @Override public void resumePoller(Poller poller, String name, QueueEntry queueEntry, ExecutionStage.Value stage, Runnable onFailure, Deadline deadline) { throw new UnsupportedOperationException(); }
   @Override public void match(MatchListener listener) throws InterruptedException { throw new UnsupportedOperationException(); }
-  @Override public void requeue(Operation operation) { throw new UnsupportedOperationException(); }
-  @Override public void deactivate(String operationName) { throw new UnsupportedOperationException(); }
   @Override public void logInfo(String msg) { }
   @Override public CASInsertionPolicy getFileCasPolicy() { throw new UnsupportedOperationException(); }
   @Override public CASInsertionPolicy getStdoutCasPolicy() { throw new UnsupportedOperationException(); }

--- a/src/test/java/build/buildfarm/worker/operationqueue/OperationQueueClientTest.java
+++ b/src/test/java/build/buildfarm/worker/operationqueue/OperationQueueClientTest.java
@@ -1,0 +1,88 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.worker.operationqueue;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import build.bazel.remote.execution.v2.Platform;
+import build.bazel.remote.execution.v2.Platform.Property;
+import build.buildfarm.instance.Instance;
+import build.buildfarm.instance.Instance.MatchListener;
+import build.buildfarm.v1test.ExecutionPolicy;
+import build.buildfarm.v1test.QueueEntry;
+import com.google.common.collect.ImmutableList;
+import javax.annotation.Nullable;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+@RunWith(JUnit4.class)
+public class OperationQueueClientTest {
+  @Test
+  public void matchPlatformContainsExecutionPolicies() throws InterruptedException {
+    Instance instance = mock(Instance.class);
+    doAnswer(new Answer<Void>() {
+      @Override
+      public Void answer(InvocationOnMock invocation) throws InterruptedException {
+        MatchListener listener = (MatchListener) invocation.getArguments()[1];
+        listener.onEntry(null);
+        return null;
+      }
+    }).when(instance).match(any(Platform.class), any(MatchListener.class));
+    OperationQueueClient client = new OperationQueueClient(
+        instance,
+        Platform.getDefaultInstance(),
+        ImmutableList.of(ExecutionPolicy.newBuilder().setName("foo").build()));
+    MatchListener listener = new MatchListener() {
+      @Override
+      public void onWaitStart() {
+      }
+
+      @Override
+      public void onWaitEnd() {
+      }
+
+      @Override
+      public boolean onEntry(@Nullable QueueEntry queueEntry) {
+        return true;
+      }
+
+      @Override
+      public void onError(Throwable t) {
+        t.printStackTrace();
+      }
+
+      @Override
+      public void setOnCancelHandler(Runnable onCancelHandler) {
+      }
+    };
+    client.match(listener);
+    Platform matchPlatform = Platform.newBuilder()
+        .addProperties(
+            Property.newBuilder()
+                .setName("execution-policy")
+                .setValue("foo")
+                .build())
+        .build();
+    verify(instance, times(1)).match(eq(matchPlatform), any(MatchListener.class));
+  }
+}


### PR DESCRIPTION
The Platform used to match with executions must include execution
policies advertised. This was a regression from earlier behavior present
with policy introduction. Functionality is now guarded by tests.