### PR TITLE
add container_image target for shard worker

### DIFF
--- a/src/main/java/build/buildfarm/BUILD
+++ b/src/main/java/build/buildfarm/BUILD
@@ -299,6 +299,20 @@ java_binary(
     ],
 )
 
+container_image(
+    name = "buildfarm-shard-worker.container",
+    base = "@java_base//image",
+    # leverage the implicit target of the buildfarm-shard-worker to get a fat jar.
+    # this is simply a workaround for the fact that we have so many dependencies,
+    # so we'd want some wrappy script. This seemed more straightforward.
+    # https://docs.bazel.build/versions/master/be/java.html#java_binary_implicit_outputs
+    files = [
+        ":buildfarm-shard-worker_deploy.jar",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+
 java_library(
     name = "worker",
     srcs = glob(["worker/*.java"]),

--- a/src/main/java/build/buildfarm/BUILD
+++ b/src/main/java/build/buildfarm/BUILD
@@ -312,7 +312,6 @@ container_image(
     visibility = ["//visibility:public"],
 )
 
-
 java_library(
     name = "worker",
     srcs = glob(["worker/*.java"]),


### PR DESCRIPTION
This PR adds a `container_image` target for a deploy jar for the shard worker, similar to the existing `buildfarm-operationqueue-worker.container` and `server.container` targets for the in-memory worker and the server, respectively. (I'm using it as part of a deployment of a sharded buildfarm cluster.)