### PR TITLE
exit worker with error message when publicName is empty

### DIFF
--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -53,7 +53,6 @@ import build.buildfarm.worker.Pipeline;
 import build.buildfarm.worker.PipelineStage;
 import build.buildfarm.worker.PutOperationStage;
 import build.buildfarm.worker.ReportResultStage;
-import build.buildfarm.worker.WorkerContext;
 import com.google.common.base.Strings;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
@@ -551,8 +550,7 @@ public class Worker extends LoggingMain {
     }
     if (!Strings.isNullOrEmpty(options.publicName)) {
       builder.setPublicName(options.publicName);
-    }
-    else{
+    } else {
       logger.log(SEVERE, "worker's public name should not be empty");
       System.exit(0);
     }
@@ -562,9 +560,8 @@ public class Worker extends LoggingMain {
 
   private static void printUsage(OptionsParser parser) {
     logger.log(INFO, "Usage: CONFIG_PATH");
-    logger.log(INFO,
-        parser.describeOptions(
-            Collections.emptyMap(), OptionsParser.HelpVerbosity.LONG));
+    logger.log(
+        INFO, parser.describeOptions(Collections.emptyMap(), OptionsParser.HelpVerbosity.LONG));
   }
 
   public static void main(String[] args) throws Exception {

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -563,7 +563,7 @@ public class Worker extends LoggingMain {
         INFO, parser.describeOptions(Collections.emptyMap(), OptionsParser.HelpVerbosity.LONG));
   }
 
-  public static void main(String[] args) throws Exception {
+  public static void main(String[] args) {
 
     try {
       startWorker(args);

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -564,7 +564,6 @@ public class Worker extends LoggingMain {
   }
 
   public static void main(String[] args) {
-
     try {
       startWorker(args);
     } catch (Exception e) {
@@ -574,7 +573,6 @@ public class Worker extends LoggingMain {
   }
 
   public static void startWorker(String[] args) throws Exception {
-
     // Only log severe log messages from Netty. Otherwise it logs warnings that look like this:
     //
     // 170714 08:16:28.552:WT 18 [io.grpc.netty.NettyServerHandler.onStreamError] Stream Error

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -542,17 +542,16 @@ public class Worker extends LoggingMain {
   }
 
   private static ShardWorkerConfig toShardWorkerConfig(Readable input, WorkerOptions options)
-      throws IOException, ConfigurationException {
+      throws ConfigurationException, IOException {
     ShardWorkerConfig.Builder builder = ShardWorkerConfig.newBuilder();
     TextFormat.merge(input, builder);
     if (!Strings.isNullOrEmpty(options.root)) {
       builder.setRoot(options.root);
     }
-    if (!Strings.isNullOrEmpty(options.publicName)) {
-      builder.setPublicName(options.publicName);
-    } else {
+    if (Strings.isNullOrEmpty(options.publicName)) {
       throw new ConfigurationException("worker's public name should not be empty");
     }
+    builder.setPublicName(options.publicName);
 
     return builder.build();
   }

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -542,7 +542,7 @@ public class Worker extends LoggingMain {
   }
 
   private static ShardWorkerConfig toShardWorkerConfig(Readable input, WorkerOptions options)
-      throws IOException {
+      throws IOException, ConfigurationException {
     ShardWorkerConfig.Builder builder = ShardWorkerConfig.newBuilder();
     TextFormat.merge(input, builder);
     if (!Strings.isNullOrEmpty(options.root)) {
@@ -551,8 +551,7 @@ public class Worker extends LoggingMain {
     if (!Strings.isNullOrEmpty(options.publicName)) {
       builder.setPublicName(options.publicName);
     } else {
-      logger.log(SEVERE, "worker's public name should not be empty");
-      System.exit(0);
+      throw new ConfigurationException("worker's public name should not be empty");
     }
 
     return builder.build();

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -552,6 +552,10 @@ public class Worker extends LoggingMain {
     if (!Strings.isNullOrEmpty(options.publicName)) {
       builder.setPublicName(options.publicName);
     }
+    else{
+      logger.log(SEVERE, "worker's public name should not be empty");
+      System.exit(0);
+    }
 
     return builder.build();
   }

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -566,36 +566,42 @@ public class Worker extends LoggingMain {
   public static void main(String[] args) throws Exception {
 
     try {
-      // Only log severe log messages from Netty. Otherwise it logs warnings that look like this:
-      //
-      // 170714 08:16:28.552:WT 18 [io.grpc.netty.NettyServerHandler.onStreamError] Stream Error
-      // io.netty.handler.codec.http2.Http2Exception$StreamException: Received DATA frame for an
-      // unknown stream 11369
-      nettyLogger.setLevel(SEVERE);
-
-      OptionsParser parser = OptionsParser.newOptionsParser(WorkerOptions.class);
-      parser.parseAndExitUponError(args);
-      List<String> residue = parser.getResidue();
-      if (residue.isEmpty()) {
-        printUsage(parser);
-        throw new IllegalArgumentException("Missing CONFIG_PATH");
-      }
-      Path configPath = Paths.get(residue.get(0));
-      String session = UUID.randomUUID().toString();
-      Worker worker;
-      try (InputStream configInputStream = Files.newInputStream(configPath)) {
-        worker =
-            new Worker(
-                session,
-                toShardWorkerConfig(
-                    new InputStreamReader(configInputStream),
-                    parser.getOptions(WorkerOptions.class)));
-      }
-      worker.start();
-      worker.blockUntilShutdown();
-      System.exit(0); // bullet to the head in case anything is stuck
+      startWorker(args);
     } catch (Exception e) {
-      Worker.logger.log(SEVERE, e.toString());
+      logger.log(SEVERE, "exception caught", e);
+      System.exit(1);
     }
+  }
+
+  public static void startWorker(String[] args) throws Exception {
+
+    // Only log severe log messages from Netty. Otherwise it logs warnings that look like this:
+    //
+    // 170714 08:16:28.552:WT 18 [io.grpc.netty.NettyServerHandler.onStreamError] Stream Error
+    // io.netty.handler.codec.http2.Http2Exception$StreamException: Received DATA frame for an
+    // unknown stream 11369
+    nettyLogger.setLevel(SEVERE);
+
+    OptionsParser parser = OptionsParser.newOptionsParser(WorkerOptions.class);
+    parser.parseAndExitUponError(args);
+    List<String> residue = parser.getResidue();
+    if (residue.isEmpty()) {
+      printUsage(parser);
+      throw new IllegalArgumentException("Missing CONFIG_PATH");
+    }
+    Path configPath = Paths.get(residue.get(0));
+    String session = UUID.randomUUID().toString();
+    Worker worker;
+    try (InputStream configInputStream = Files.newInputStream(configPath)) {
+      worker =
+          new Worker(
+              session,
+              toShardWorkerConfig(
+                  new InputStreamReader(configInputStream),
+                  parser.getOptions(WorkerOptions.class)));
+    }
+    worker.start();
+    worker.blockUntilShutdown();
+    System.exit(0); // bullet to the head in case anything is stuck
   }
 }


### PR DESCRIPTION
The worker should fail to start if it cannot parse the URL that it is being told to put in as its public name.