### PR TITLE
Pass platform execution properties for queue selection

### DIFF
--- a/src/main/java/build/buildfarm/common/ShardBackplane.java
+++ b/src/main/java/build/buildfarm/common/ShardBackplane.java
@@ -17,19 +17,21 @@ package build.buildfarm.common;
 import build.bazel.remote.execution.v2.ActionResult;
 import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.ExecutionStage;
+import build.bazel.remote.execution.v2.Platform;
 import build.bazel.remote.execution.v2.RequestMetadata;
 import build.buildfarm.common.DigestUtil.ActionKey;
 import build.buildfarm.common.ThreadSafety.ThreadSafe;
 import build.buildfarm.common.function.InterruptingRunnable;
 import build.buildfarm.v1test.DispatchedOperation;
 import build.buildfarm.v1test.ExecuteEntry;
+import build.buildfarm.v1test.OperationsStatus;
 import build.buildfarm.v1test.QueueEntry;
 import build.buildfarm.v1test.ShardWorker;
-import build.buildfarm.v1test.OperationsStatus;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.longrunning.Operation;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -136,8 +138,8 @@ public interface ShardBackplane {
 
   /** Remove or add workers to a blob's location set as requested */
   @ThreadSafe
-  void adjustBlobLocations(
-    Digest blobDigest, Set<String> addWorkers, Set<String> removeWorkers) throws IOException;
+  void adjustBlobLocations(Digest blobDigest, Set<String> addWorkers, Set<String> removeWorkers)
+      throws IOException;
 
   /**
    * The CAS is represented as a map where the key is the digest of the blob that is being stored
@@ -215,7 +217,8 @@ public interface ShardBackplane {
    * <p>Moves an operation from the list of queued operations to the list of dispatched operations.
    */
   @ThreadSafe
-  QueueEntry dispatchOperation() throws IOException, InterruptedException;
+  QueueEntry dispatchOperation(List<Platform.Property> provisions)
+      throws IOException, InterruptedException;
 
   /**
    * Pushes an operation onto the head of the list of queued operations after a rejection which does
@@ -286,7 +289,7 @@ public interface ShardBackplane {
   /** Test for whether an operation may be prequeued */
   @ThreadSafe
   boolean canPrequeue() throws IOException;
-  
+
   @ThreadSafe
   OperationsStatus operationsStatus() throws IOException;
 }

--- a/src/main/java/build/buildfarm/instance/shard/OperationQueue.java
+++ b/src/main/java/build/buildfarm/instance/shard/OperationQueue.java
@@ -108,7 +108,7 @@ public class OperationQueue {
   /// @note    Suggested return identifier: name.
   ///
   public String getDequeueName() {
-    return queues.get(0).queue().getDequeueName();
+    return "operation_dequeue";
   }
   ///
   /// @brief   Get dequeue name.

--- a/src/main/java/build/buildfarm/instance/shard/OperationQueue.java
+++ b/src/main/java/build/buildfarm/instance/shard/OperationQueue.java
@@ -14,9 +14,13 @@
 
 package build.buildfarm.instance.shard;
 
+import build.bazel.remote.execution.v2.Platform;
 import build.buildfarm.common.StringVisitor;
+import build.buildfarm.common.redis.BalancedRedisQueue;
 import build.buildfarm.common.redis.ProvisionedRedisQueue;
 import build.buildfarm.v1test.QueueStatus;
+import com.google.common.collect.LinkedHashMultimap;
+import com.google.common.collect.SetMultimap;
 import java.util.List;
 import redis.clients.jedis.JedisCluster;
 
@@ -100,19 +104,47 @@ public class OperationQueue {
   ///          each internal queue has their own dequeue, this name is generic
   ///          without the hashtag.
   /// @return  The name of the queue.
+  /// @note    Overloaded.
   /// @note    Suggested return identifier: name.
   ///
   public String getDequeueName() {
     return queues.get(0).queue().getDequeueName();
   }
   ///
+  /// @brief   Get dequeue name.
+  /// @details Get the name of the internal dequeue used by the queue. since
+  ///          each internal queue has their own dequeue, this name is generic
+  ///          without the hashtag.
+  /// @param   provisions Provisions used to select an eligible queue.
+  /// @return  The name of the queue.
+  /// @note    Overloaded.
+  /// @note    Suggested return identifier: name.
+  ///
+  public String getDequeueName(List<Platform.Property> provisions) {
+    BalancedRedisQueue queue = chooseEligibleQueue(provisions);
+    return queue.getDequeueName();
+  }
+  ///
   /// @brief   Push a value onto the queue.
   /// @details Adds the value into one of the internal backend redis queues.
   /// @param   jedis Jedis cluster client.
   /// @param   val   The value to push onto the queue.
+  /// @note    Overloaded.
   ///
   public void push(JedisCluster jedis, String val) {
     queues.get(0).queue().push(jedis, val);
+  }
+  ///
+  /// @brief   Push a value onto the queue.
+  /// @details Adds the value into one of the internal backend redis queues.
+  /// @param   jedis      Jedis cluster client.
+  /// @param   provisions Provisions used to select an eligible queue.
+  /// @param   val        The value to push onto the queue.
+  /// @note    Overloaded.
+  ///
+  public void push(JedisCluster jedis, List<Platform.Property> provisions, String val) {
+    BalancedRedisQueue queue = chooseEligibleQueue(provisions);
+    queue.push(jedis, val);
   }
   ///
   /// @brief   Pop element into internal dequeue and return value.
@@ -121,10 +153,27 @@ public class OperationQueue {
   ///          Null is returned if the overall backoff times out.
   /// @param   jedis Jedis cluster client.
   /// @return  The value of the transfered element. null if the thread was interrupted.
+  /// @note    Overloaded.
   /// @note    Suggested return identifier: val.
   ///
   public String dequeue(JedisCluster jedis) throws InterruptedException {
     return queues.get(0).queue().dequeue(jedis);
+  }
+  ///
+  /// @brief   Pop element into internal dequeue and return value.
+  /// @details This pops the element from one queue atomically into an internal
+  ///          list called the dequeue. It will perform an exponential backoff.
+  ///          Null is returned if the overall backoff times out.
+  /// @param   jedis      Jedis cluster client.
+  /// @param   provisions Provisions used to select an eligible queue.
+  /// @return  The value of the transfered element. null if the thread was interrupted.
+  /// @note    Overloaded.
+  /// @note    Suggested return identifier: val.
+  ///
+  public String dequeue(JedisCluster jedis, List<Platform.Property> provisions)
+      throws InterruptedException {
+    BalancedRedisQueue queue = chooseEligibleQueue(provisions);
+    return queue.dequeue(jedis);
   }
   ///
   /// @brief   Get status information about the queue.
@@ -132,9 +181,57 @@ public class OperationQueue {
   ///          elements are balanced.
   /// @param   jedis Jedis cluster client.
   /// @return  The current status of the queue.
+  /// @note    Overloaded.
   /// @note    Suggested return identifier: status.
   ///
   public QueueStatus status(JedisCluster jedis) {
     return queues.get(0).queue().status(jedis);
+  }
+  ///
+  /// @brief   Get status information about the queue.
+  /// @details Helpful for understanding the current load on the queue and how
+  ///          elements are balanced.
+  /// @param   jedis      Jedis cluster client.
+  /// @param   provisions Provisions used to select an eligible queue.
+  /// @return  The current status of the queue.
+  /// @note    Overloaded.
+  /// @note    Suggested return identifier: status.
+  ///
+  public QueueStatus status(JedisCluster jedis, List<Platform.Property> provisions) {
+    BalancedRedisQueue queue = chooseEligibleQueue(provisions);
+    return queue.status(jedis);
+  }
+  ///
+  /// @brief   Choose an eligible queue based on given properties.
+  /// @details We use the platform execution properties of a queue entry to
+  ///          determine the appropriate queue. If there no eligible queues, an
+  ///          exception is thrown.
+  /// @param   provisions Provisions to check that requirements are met.
+  /// @return  The chosen queue.
+  /// @note    Suggested return identifier: queue.
+  ///
+  private BalancedRedisQueue chooseEligibleQueue(List<Platform.Property> provisions) {
+    for (ProvisionedRedisQueue pQueue : queues) {
+      if (pQueue.isEligible(toMultimap(provisions))) {
+        return pQueue.queue();
+      }
+    }
+    throw new RuntimeException(
+        "there are no eligible queues for the provided execution requirements");
+  }
+  ///
+  /// @brief   Convert proto provisions into java multimap.
+  /// @details This conversion is done to more easily check if a key/value
+  ///          exists in the provisions.
+  /// @param   provisions Provisions list to convert.
+  /// @return  The provisions as a set.
+  /// @note    Suggested return identifier: provisionSet.
+  ///
+  private SetMultimap<String, String> toMultimap(List<Platform.Property> provisions) {
+    SetMultimap<String, String> set = LinkedHashMultimap.create();
+    for (Platform.Property property : provisions) {
+      set.put(property.getName(), property.getValue());
+    }
+    return set;
   }
 }

--- a/src/main/java/build/buildfarm/instance/shard/OperationQueue.java
+++ b/src/main/java/build/buildfarm/instance/shard/OperationQueue.java
@@ -127,20 +127,9 @@ public class OperationQueue {
   ///
   /// @brief   Push a value onto the queue.
   /// @details Adds the value into one of the internal backend redis queues.
-  /// @param   jedis Jedis cluster client.
-  /// @param   val   The value to push onto the queue.
-  /// @note    Overloaded.
-  ///
-  public void push(JedisCluster jedis, String val) {
-    queues.get(0).queue().push(jedis, val);
-  }
-  ///
-  /// @brief   Push a value onto the queue.
-  /// @details Adds the value into one of the internal backend redis queues.
   /// @param   jedis      Jedis cluster client.
   /// @param   provisions Provisions used to select an eligible queue.
   /// @param   val        The value to push onto the queue.
-  /// @note    Overloaded.
   ///
   public void push(JedisCluster jedis, List<Platform.Property> provisions, String val) {
     BalancedRedisQueue queue = chooseEligibleQueue(provisions);
@@ -151,23 +140,9 @@ public class OperationQueue {
   /// @details This pops the element from one queue atomically into an internal
   ///          list called the dequeue. It will perform an exponential backoff.
   ///          Null is returned if the overall backoff times out.
-  /// @param   jedis Jedis cluster client.
-  /// @return  The value of the transfered element. null if the thread was interrupted.
-  /// @note    Overloaded.
-  /// @note    Suggested return identifier: val.
-  ///
-  public String dequeue(JedisCluster jedis) throws InterruptedException {
-    return queues.get(0).queue().dequeue(jedis);
-  }
-  ///
-  /// @brief   Pop element into internal dequeue and return value.
-  /// @details This pops the element from one queue atomically into an internal
-  ///          list called the dequeue. It will perform an exponential backoff.
-  ///          Null is returned if the overall backoff times out.
   /// @param   jedis      Jedis cluster client.
   /// @param   provisions Provisions used to select an eligible queue.
   /// @return  The value of the transfered element. null if the thread was interrupted.
-  /// @note    Overloaded.
   /// @note    Suggested return identifier: val.
   ///
   public String dequeue(JedisCluster jedis, List<Platform.Property> provisions)

--- a/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
@@ -1120,7 +1120,7 @@ public class RedisShardBackplane implements ShardBackplane {
     client.run(
         jedis -> {
           if (jedis.hdel(config.getDispatchedOperationsHashName(), operationName) == 1) {
-            operationQueue.push(jedis, queueEntryJson);
+            operationQueue.push(jedis, queueEntry.getPlatform().getPropertiesList(), queueEntryJson);
           }
         });
   }

--- a/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
@@ -21,6 +21,7 @@ import build.bazel.remote.execution.v2.ActionResult;
 import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.ExecuteOperationMetadata;
 import build.bazel.remote.execution.v2.ExecutionStage;
+import build.bazel.remote.execution.v2.Platform;
 import build.bazel.remote.execution.v2.RequestMetadata;
 import build.buildfarm.common.DigestUtil;
 import build.buildfarm.common.DigestUtil.ActionKey;
@@ -491,8 +492,9 @@ public class RedisShardBackplane implements ShardBackplane {
     client = new RedisClient(jedisClusterFactory.get());
     List<String> hashtags = client.call(jedis -> RedisNodeHashes.getEvenlyDistributedHashes(jedis));
     this.prequeue = new BalancedRedisQueue(config.getPreQueuedOperationsListName(), hashtags);
-    
-    // The operations queue can be divided into multiple queues handling different platform executions.
+
+    // The operations queue can be divided into multiple queues handling different platform
+    // executions.
     // In this case, we have a single with no explicitly required platform executions.
     ProvisionedRedisQueue defaultQueue =
         new ProvisionedRedisQueue(
@@ -937,11 +939,15 @@ public class RedisShardBackplane implements ShardBackplane {
     return true;
   }
 
-  private void queue(JedisCluster jedis, String operationName, String queueEntryJson) {
+  private void queue(
+      JedisCluster jedis,
+      String operationName,
+      List<Platform.Property> provisions,
+      String queueEntryJson) {
     if (jedis.hdel(config.getDispatchedOperationsHashName(), operationName) == 1) {
       logger.log(Level.WARNING, format("removed dispatched operation %s", operationName));
     }
-    operationQueue.push(jedis, queueEntryJson);
+    operationQueue.push(jedis, provisions, queueEntryJson);
   }
 
   @Override
@@ -953,7 +959,11 @@ public class RedisShardBackplane implements ShardBackplane {
     client.run(
         jedis -> {
           jedis.setex(operationKey(operationName), config.getOperationExpire(), operationJson);
-          queue(jedis, operation.getName(), queueEntryJson);
+          queue(
+              jedis,
+              operation.getName(),
+              queueEntry.getPlatform().getPropertiesList(),
+              queueEntryJson);
           publishReset(jedis, publishOperation);
         });
   }
@@ -1057,9 +1067,10 @@ public class RedisShardBackplane implements ShardBackplane {
     return client.blockingCall(this::deprequeueOperation);
   }
 
-  private QueueEntry dispatchOperation(JedisCluster jedis) throws InterruptedException {
+  private QueueEntry dispatchOperation(JedisCluster jedis, List<Platform.Property> provisions)
+      throws InterruptedException {
 
-    String queueEntryJson = operationQueue.dequeue(jedis);
+    String queueEntryJson = operationQueue.dequeue(jedis, provisions);
     if (queueEntryJson == null) {
       return null;
     }
@@ -1109,8 +1120,12 @@ public class RedisShardBackplane implements ShardBackplane {
   }
 
   @Override
-  public QueueEntry dispatchOperation() throws IOException, InterruptedException {
-    return client.blockingCall(this::dispatchOperation);
+  public QueueEntry dispatchOperation(List<Platform.Property> provisions)
+      throws IOException, InterruptedException {
+    return client.blockingCall(
+        jedis -> {
+          return dispatchOperation(jedis, provisions);
+        });
   }
 
   @Override
@@ -1120,7 +1135,8 @@ public class RedisShardBackplane implements ShardBackplane {
     client.run(
         jedis -> {
           if (jedis.hdel(config.getDispatchedOperationsHashName(), operationName) == 1) {
-            operationQueue.push(jedis, queueEntry.getPlatform().getPropertiesList(), queueEntryJson);
+            operationQueue.push(
+                jedis, queueEntry.getPlatform().getPropertiesList(), queueEntryJson);
           }
         });
   }
@@ -1186,7 +1202,7 @@ public class RedisShardBackplane implements ShardBackplane {
     Operation publishOperation = keepaliveOperation(operationName);
     client.run(
         jedis -> {
-          queue(jedis, operationName, queueEntryJson);
+          queue(jedis, operationName, queueEntry.getPlatform().getPropertiesList(), queueEntryJson);
           publishReset(jedis, publishOperation);
         });
   }

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -409,10 +409,14 @@ message QueueStatus {
   repeated int64 internal_sizes = 2;
 }
 
+message OperationQueueStatus {
+  repeated QueueStatus provisions = 1;
+}
+
 message OperationsStatus {
   QueueStatus prequeue = 1;
 
-  QueueStatus operation_queue = 2;
+  OperationQueueStatus operation_queue = 2;
 
   int64 dispatched_size = 3;
 }

--- a/src/test/java/build/buildfarm/worker/shard/ShardWorkerContextTest.java
+++ b/src/test/java/build/buildfarm/worker/shard/ShardWorkerContextTest.java
@@ -15,6 +15,7 @@
 package build.buildfarm.worker.shard;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -41,6 +42,7 @@ import com.google.protobuf.Duration;
 import io.grpc.StatusException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -70,9 +72,7 @@ public class ShardWorkerContextTest {
   }
 
   WorkerContext createTestContext() {
-    return createTestContext(
-        Platform.getDefaultInstance(),
-        /* policies=*/ ImmutableList.of());
+    return createTestContext(Platform.getDefaultInstance(), /* policies=*/ ImmutableList.of());
   }
 
   WorkerContext createTestContext(Platform platform, Iterable<ExecutionPolicy> policies) {
@@ -114,20 +114,17 @@ public class ShardWorkerContextTest {
 
   @Test
   public void queueEntryWithExecutionPolicyPlatformMatches() throws Exception {
-    WorkerContext context = createTestContext(
-        Platform.getDefaultInstance(),
-        ImmutableList.of(ExecutionPolicy.newBuilder().setName("foo").build()));
-    Platform matchPlatform = Platform.newBuilder()
-        .addProperties(
-            Property.newBuilder()
-                .setName("execution-policy")
-                .setValue("foo")
-                .build())
-        .build();
-    QueueEntry queueEntry = QueueEntry.newBuilder()
-        .setPlatform(matchPlatform)
-        .build();
-    when(backplane.dispatchOperation())
+    WorkerContext context =
+        createTestContext(
+            Platform.getDefaultInstance(),
+            ImmutableList.of(ExecutionPolicy.newBuilder().setName("foo").build()));
+    Platform matchPlatform =
+        Platform.newBuilder()
+            .addProperties(
+                Property.newBuilder().setName("execution-policy").setValue("foo").build())
+            .build();
+    QueueEntry queueEntry = QueueEntry.newBuilder().setPlatform(matchPlatform).build();
+    when(backplane.dispatchOperation(any(List.class)))
         .thenReturn(queueEntry)
         .thenReturn(null); // provide a match completion in failure case
     MatchListener listener = mock(MatchListener.class);

--- a/src/test/java/build/buildfarm/worker/shard/ShardWorkerInstanceTest.java
+++ b/src/test/java/build/buildfarm/worker/shard/ShardWorkerInstanceTest.java
@@ -39,6 +39,7 @@ import com.google.protobuf.ByteString;
 import io.grpc.StatusRuntimeException;
 import java.io.IOException;
 import java.net.SocketException;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import org.junit.Before;
@@ -75,7 +76,7 @@ public class ShardWorkerInstanceTest {
 
   @Test(expected = SocketException.class)
   public void dispatchOperationThrowsOnSocketException() throws IOException, InterruptedException {
-    when(backplane.dispatchOperation()).thenThrow(SocketException.class);
+    when(backplane.dispatchOperation(any(List.class))).thenThrow(SocketException.class);
     MatchListener listener = mock(MatchListener.class);
     instance.dispatchOperation(listener);
   }
@@ -86,10 +87,10 @@ public class ShardWorkerInstanceTest {
         QueueEntry.newBuilder()
             .setExecuteEntry(ExecuteEntry.newBuilder().setOperationName("op"))
             .build();
-    when(backplane.dispatchOperation()).thenReturn(null).thenReturn(queueEntry);
+    when(backplane.dispatchOperation(any(List.class))).thenReturn(null).thenReturn(queueEntry);
     MatchListener listener = mock(MatchListener.class);
     assertThat(instance.dispatchOperation(listener)).isEqualTo(queueEntry);
-    verify(backplane, times(2)).dispatchOperation();
+    verify(backplane, times(2)).dispatchOperation(any(List.class));
   }
 
   @Test(expected = StatusRuntimeException.class)
@@ -131,7 +132,11 @@ public class ShardWorkerInstanceTest {
 
   @Test(expected = UnsupportedOperationException.class)
   public void getTreeIsUnsupported() {
-    instance.getTree(/* rootDigest=*/ Digest.getDefaultInstance(), /* pageSize=*/ 0, /* pageToken=*/ "", /* tree=*/ Tree.newBuilder());
+    instance.getTree(
+        /* rootDigest=*/ Digest.getDefaultInstance(),
+        /* pageSize=*/ 0,
+        /* pageToken=*/ "",
+        /* tree=*/ Tree.newBuilder());
   }
 
   @Test(expected = UnsupportedOperationException.class)


### PR DESCRIPTION
**OperationQueue API change**
This modifies the  `push` / `dequeue` methods of the `OperationQueue` so that they now take in a list of "platform execution properties".  These properties are used internally by the OperationQueue to determine the eligible provisioned queue to push/dequeue from (think "cpu provisioned queue" / "gpu provisioned queue").  

**Backplane API change** + callers
These OperationQueue methods are called from within the backplane, which in some cases, needed its own APIs extended to pass in execution properties from various contexts.  The worker context will now give platform properties when performing a dequeue (these platform properties are already a part of the worker's configuration).

**Updated grpc**
The OperationQueue can now divide operations by their platform properties.  This is reflected in the grpc status call and proto message.