### PR TITLE
Add health-check-probe for use with k8s

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -1,4 +1,4 @@
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_jar")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_jar", "http_file")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
 RULES_JVM_EXTERNAL_TAG = "3.0"
@@ -78,3 +78,15 @@ def buildfarm_dependencies(repository_name="build_buildfarm"):
         urls = [
             "https://github.com/werkt/jedis/releases/download/jedis-3.2.0-3e25324dbe/jedis-3.2.0-3e25324dbe.jar",
         ])
+
+    maybe(
+        http_file,
+        "grpc-health-probe",
+        sha256 = "fc7e9f992f882c6f55e549c1038a31fc5ed47880bf4b91601cea64f93ef7f442",
+        executable = True,
+        downloaded_file_path = "grpc_health_probe",
+        urls = [
+            "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.3.2/grpc_health_probe-linux-amd64",
+        ])
+
+

--- a/src/main/java/build/buildfarm/BUILD
+++ b/src/main/java/build/buildfarm/BUILD
@@ -354,6 +354,7 @@ java_binary(
     ],
 )
 
+
 container_image(
     name = "server.container",
     base = "@java_base//image",
@@ -369,6 +370,7 @@ container_image(
     # https://docs.bazel.build/versions/master/be/java.html#java_binary_implicit_outputs
     files = [
         ":buildfarm-server_deploy.jar",
+        "@grpc-health-probe//file",
     ],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Adds https://github.com/grpc-ecosystem/grpc-health-probe to the container image so we can run grpc healtcheck in k8s. 