### PR TITLE
Clear interrupted flag during releaseClaim

### DIFF
--- a/src/main/java/build/buildfarm/worker/SuperscalarPipelineStage.java
+++ b/src/main/java/build/buildfarm/worker/SuperscalarPipelineStage.java
@@ -86,6 +86,8 @@ abstract class SuperscalarPipelineStage extends PipelineStage {
   }
 
   protected synchronized void releaseClaim(String operationName, int slots) {
+    // clear interrupted flag for take
+    boolean interrupted = Thread.interrupted();
     try {
       for (int i = 0; i < slots; i++) {
         claims.take();
@@ -101,6 +103,9 @@ abstract class SuperscalarPipelineStage extends PipelineStage {
       close();
     } finally {
       notify();
+      if (interrupted) {
+        Thread.currentThread().interrupt();
+      }
     }
   }
 


### PR DESCRIPTION
The blocking claims.take will throw an InterruptedException immediately
if the current thread is interrupted. Only allow an interrupt during the
call itself to interrupt the claim procedure. The presumption is that a
release will not be called without a substantiated claim.