### PR TITLE
Remove slf4j and point to jedis upgrade

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -72,7 +72,6 @@ def buildfarm_init():
             "org.mockito:mockito-core:2.25.0",
             "org.openjdk.jmh:jmh-core:1.23",
             "org.openjdk.jmh:jmh-generator-annprocess:1.23",
-            "org.slf4j:slf4j-api:1.7.22",
             "org.threeten:threetenbp:1.3.3",
         ],
         repositories = [

--- a/deps.bzl
+++ b/deps.bzl
@@ -74,7 +74,7 @@ def buildfarm_dependencies(repository_name="build_buildfarm"):
     maybe(
         http_jar,
         "jedis",
-        sha256 = "7a1eed5f5ae31881f0fd61b685adde3d20ec15a4abda304686c436293e3076ff",
+        sha256 = "934c416359965d5b17a8703e66c8fa221037ddf40f29caa25d2f59525ac4c32e",
         urls = [
-            "https://github.com/werkt/jedis/releases/download/jedis-3.2.0-3e25324dbe/jedis-3.2.0-3e25324dbe.jar",
+            "https://github.com/werkt/jedis/releases/download/jedis-3.2.0-d34c20f0d2/jedis-3.2.0-d34c20f0d2.jar",
         ])

--- a/third_party/jedis/BUILD
+++ b/third_party/jedis/BUILD
@@ -10,6 +10,5 @@ java_library(
     ],
     runtime_deps = [
         "@maven//:org_apache_commons_commons_pool2",
-        "@maven//:org_slf4j_slf4j_api",
     ],
 )


### PR DESCRIPTION
Inhibit slf4j logging messages for binaries that depend upon jedis by
using a newly released version which does not depend upon it.