### PR TITLE
add buildifier to ci

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,4 +1,5 @@
 ---
+buildifier: latest
 platforms:
   ubuntu1604:
     build_targets:

--- a/defs.bzl
+++ b/defs.bzl
@@ -43,7 +43,7 @@ IO_GRPC_MODULES = [
     "services",
 ]
 
-def buildfarm_init(ame="buildfarm"):
+def buildfarm_init(name="buildfarm"):
     """
     Initialize the WORKSPACE for buildfarm-related targets
     

--- a/defs.bzl
+++ b/defs.bzl
@@ -43,12 +43,12 @@ IO_GRPC_MODULES = [
     "services",
 ]
 
-def buildfarm_init(repository_name="buildfarm"):
+def buildfarm_init(ame="buildfarm"):
     """
     Initialize the WORKSPACE for buildfarm-related targets
     
     Args:
-      repository_name: the name of the repository
+      name: the name of the repository
     """
     maven_install(
         artifacts = [

--- a/defs.bzl
+++ b/defs.bzl
@@ -1,3 +1,7 @@
+"""
+buildfarm definitions that can be imported into other WORKSPACE files
+"""
+
 load("@rules_jvm_external//:defs.bzl", "maven_install")
 
 load("@remote_apis//:repository_rules.bzl", "switched_rules_by_language")
@@ -39,7 +43,10 @@ IO_GRPC_MODULES = [
     "services",
 ]
 
-def buildfarm_init():
+def buildfarm_init(name="buildfarm"):
+    """
+    Initialize the WORKSPACE for buildfarm-related targets
+    """
     maven_install(
         artifacts = [
             "com.amazonaws:aws-java-sdk-core:1.11.729",

--- a/defs.bzl
+++ b/defs.bzl
@@ -43,12 +43,12 @@ IO_GRPC_MODULES = [
     "services",
 ]
 
-def buildfarm_init(name="buildfarm"):
+def buildfarm_init(repository_name="buildfarm"):
     """
     Initialize the WORKSPACE for buildfarm-related targets
     
     Args:
-      name: the macro name
+      repository_name: the name of the repository
     """
     maven_install(
         artifacts = [

--- a/defs.bzl
+++ b/defs.bzl
@@ -47,7 +47,8 @@ def buildfarm_init(name="buildfarm"):
     """
     Initialize the WORKSPACE for buildfarm-related targets
     
-    Args: the macro name
+    Args:
+      name: the macro name
     """
     maven_install(
         artifacts = [

--- a/defs.bzl
+++ b/defs.bzl
@@ -46,6 +46,8 @@ IO_GRPC_MODULES = [
 def buildfarm_init(name="buildfarm"):
     """
     Initialize the WORKSPACE for buildfarm-related targets
+    
+    Args: the macro name
     """
     maven_install(
         artifacts = [

--- a/deps.bzl
+++ b/deps.bzl
@@ -72,7 +72,7 @@ def buildfarm_dependencies(repository_name="build_buildfarm"):
     Define all 3rd party archive rules for buildfarm
     
     Args:
-      name: the macro name
+      repository_name: the name of the repository
     """
     third_party = "@%s//third_party" % repository_name
     for dependency in archive_dependencies(third_party):

--- a/deps.bzl
+++ b/deps.bzl
@@ -71,7 +71,8 @@ def buildfarm_dependencies(repository_name="build_buildfarm"):
     """
     Define all 3rd party archive rules for buildfarm
     
-    Args: the macro name
+    Args:
+      name: the macro name
     """
     third_party = "@%s//third_party" % repository_name
     for dependency in archive_dependencies(third_party):

--- a/deps.bzl
+++ b/deps.bzl
@@ -1,3 +1,7 @@
+"""
+buildfarm dependencies that can be imported into other WORKSPACE files
+"""
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_jar")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
@@ -64,6 +68,9 @@ def archive_dependencies(third_party):
     ]
 
 def buildfarm_dependencies(repository_name="build_buildfarm"):
+    """
+    Define all 3rd party archive rules for buildfarm
+    """
     third_party = "@%s//third_party" % repository_name
     for dependency in archive_dependencies(third_party):
         params = {}

--- a/deps.bzl
+++ b/deps.bzl
@@ -70,6 +70,8 @@ def archive_dependencies(third_party):
 def buildfarm_dependencies(repository_name="build_buildfarm"):
     """
     Define all 3rd party archive rules for buildfarm
+    
+    Args: the macro name
     """
     third_party = "@%s//third_party" % repository_name
     for dependency in archive_dependencies(third_party):

--- a/images.bzl
+++ b/images.bzl
@@ -1,3 +1,7 @@
+"""
+buildfarm images that can be imported into other WORKSPACE files
+"""
+
 load("@io_bazel_rules_docker//repositories:deps.bzl", container_deps = "deps")
 load(
     "@io_bazel_rules_docker//java:image.bzl",

--- a/src/main/protobuf/BUILD.bazel
+++ b/src/main/protobuf/BUILD.bazel
@@ -1,8 +1,10 @@
 load("@rules_proto//proto:defs.bzl", "proto_library")
 
-package(default_visibility = ["//visibility:public"])
+load("@rules_java//java:defs.bzl", "java_proto_library")
 
 load("@io_grpc_grpc_java//:java_grpc_library.bzl", "java_grpc_library")
+
+package(default_visibility = ["//visibility:public"])
 
 proto_library(
     name = "build_buildfarm_v1test_buildfarm_proto",


### PR DESCRIPTION
These are the warnings we see when we run buildifier in the CI:  
```
defs.bzl:1: module-docstring: The file has no module docstring.
A module docstring is a string literal
defs.bzl:42: function-docstring: The function "buildfarm_init" has no docstring.
A docstring is a string literal
defs.bzl:42: unnamed-macro: Macro function "buildfarm_init" doesn't accept a keyword argument "name".

It is considered a macro because it calls a rule or another macro "native.bind" on line 97.
deps.bzl:1: module-docstring: The file has no module docstring.
A module docstring is a string literal
deps.bzl:66: function-docstring: The function "buildfarm_dependencies" has no docstring.
A docstring is a string literal
images.bzl:1: module-docstring: The file has no module docstring.
A module docstring is a string literal
src/main/protobuf/BUILD.bazel:5: load-on-top: Load statements should be at the top of the file.
src/main/protobuf/BUILD.bazel:20: native-java: Function "java_proto_library" is not global anymore and needs to be loaded from "@rules_java//java:defs.bzl".
```

The changes made are to resolve the above issues and integrate buildifier into the CI.