### PR TITLE
ensure build status badge is scoped to master

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build status](https://badge.buildkite.com/45f4fd4c0cfb95f7705156a4119641c6d5d6c310452d6e65a4.svg)](https://buildkite.com/bazel/buildfarm-postsubmit)
+[![Build status](https://badge.buildkite.com/45f4fd4c0cfb95f7705156a4119641c6d5d6c310452d6e65a4.svg?branch=master)](https://buildkite.com/bazel/buildfarm-postsubmit)
 
 # Bazel Buildfarm
 


### PR DESCRIPTION
By default the build status badge shows the last build status.  This means any recently failing branches or pull-requests will cause the badge to be failed.  Instead, we scope it to master branch.