### PR TITLE
add operation queue size and names to status api

### DIFF
--- a/src/main/java/build/buildfarm/common/redis/BalancedRedisQueue.java
+++ b/src/main/java/build/buildfarm/common/redis/BalancedRedisQueue.java
@@ -268,7 +268,7 @@ public class BalancedRedisQueue {
     }
 
     // build proto
-    QueueStatus status = QueueStatus.newBuilder().setSize(size).addAllInternalSizes(sizes).build();
+    QueueStatus status = QueueStatus.newBuilder().setName(name).setSize(size).addAllInternalSizes(sizes).build();
     return status;
   }
 

--- a/src/main/java/build/buildfarm/common/redis/BalancedRedisQueue.java
+++ b/src/main/java/build/buildfarm/common/redis/BalancedRedisQueue.java
@@ -268,7 +268,8 @@ public class BalancedRedisQueue {
     }
 
     // build proto
-    QueueStatus status = QueueStatus.newBuilder().setName(name).setSize(size).addAllInternalSizes(sizes).build();
+    QueueStatus status =
+        QueueStatus.newBuilder().setName(name).setSize(size).addAllInternalSizes(sizes).build();
     return status;
   }
 

--- a/src/main/java/build/buildfarm/instance/shard/OperationQueue.java
+++ b/src/main/java/build/buildfarm/instance/shard/OperationQueue.java
@@ -170,7 +170,7 @@ public class OperationQueue {
 
     // build proto
     OperationQueueStatus status =
-        OperationQueueStatus.newBuilder().addAllProvisions(provisions).build();
+        OperationQueueStatus.newBuilder().setSize(size(jedis)).addAllProvisions(provisions).build();
     return status;
   }
   ///

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -439,10 +439,14 @@ message QueueStatus {
   int64 size = 1;
 
   repeated int64 internal_sizes = 2;
+  
+  string name = 3;
 }
 
 message OperationQueueStatus {
   repeated QueueStatus provisions = 1;
+  
+  int64 size = 2;
 }
 
 message OperationsStatus {


### PR DESCRIPTION
 - give the operation queue message a total size (across all provisions)
 - give the individual queue statuses a name which will be helpful for identifying provisions