### PR TITLE
set write permissions on CASFileCache data

### DIFF
--- a/src/main/java/build/buildfarm/worker/CASFileCache.java
+++ b/src/main/java/build/buildfarm/worker/CASFileCache.java
@@ -1508,7 +1508,10 @@ public abstract class CASFileCache implements ContentAddressableStorage {
     decrementReferencesSynchronized(inputFiles, inputDirectories);
   }
 
-  // The different contexts in which cache files are written to disk
+  /**
+   * The different contexts in which cache files are written to disk. Files are made non-writable in
+   * order to prevent operations from deleting them.
+   */
   private void putDirectoryHardLink(Path newHardLink, Path path) throws IOException {
     Files.createLink(newHardLink, path);
     new File(newHardLink.toString()).setWritable(false, false);
@@ -1516,12 +1519,15 @@ public abstract class CASFileCache implements ContentAddressableStorage {
 
   private void putDirectoryFile(Path path, FileNode fileNode) throws IOException {
     Files.createFile(path);
-    setPermissions(path, fileNode.getIsExecutable());
     new File(path.toString()).setWritable(false, false);
+    setPermissions(path, fileNode.getIsExecutable());
   }
 
   private void putDirectory(Path path) throws IOException {
-    Files.createDirectory(path);
+    if (!Files.exists(path)) {
+      File dir = new File(path.toString());
+      dir.mkdir();
+    }
   }
 
   private void putRootHardLink(Path newHardLink, Path path) throws IOException {

--- a/src/main/java/build/buildfarm/worker/CASFileCache.java
+++ b/src/main/java/build/buildfarm/worker/CASFileCache.java
@@ -1524,10 +1524,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
   }
 
   private void putDirectory(Path path) throws IOException {
-    if (!Files.exists(path)) {
-      File dir = new File(path.toString());
-      dir.mkdir();
-    }
+    Files.createDirectory(path);
   }
 
   private void putRootHardLink(Path newHardLink, Path path) throws IOException {

--- a/src/main/java/build/buildfarm/worker/CASFileCache.java
+++ b/src/main/java/build/buildfarm/worker/CASFileCache.java
@@ -2459,6 +2459,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
                     expiredFuture,
                     (expiredKey) -> {
                       try {
+                        new File(expiredKey.toString()).setWritable(true, true);
                         Files.delete(expiredKey);
                       } catch (NoSuchFileException eNoEnt) {
                         logger.log(

--- a/src/main/java/build/buildfarm/worker/Utils.java
+++ b/src/main/java/build/buildfarm/worker/Utils.java
@@ -34,6 +34,7 @@ import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.io.File;
 
 public class Utils {
   private static final Logger logger = Logger.getLogger(Utils.class.getName());
@@ -70,14 +71,20 @@ public class Utils {
           @Override
           public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
               throws IOException {
+            new File(file.getParent().toString()).setWritable(true,true);
+            new File(file.toString()).setWritable(true,true);
             Files.delete(file);
+            //new File(file.getParent().toString()).setWritable(false,false);
             return FileVisitResult.CONTINUE;
           }
 
           @Override
           public FileVisitResult postVisitDirectory(Path dir, IOException e) throws IOException {
             if (e == null) {
+              new File(dir.getParent().toString()).setWritable(true,true);
+              new File(dir.toString()).setWritable(true,true);
               Files.delete(dir);
+              //new File(dir.getParent().toString()).setWritable(false,false);
               return FileVisitResult.CONTINUE;
             }
             // directory iteration failed


### PR DESCRIPTION
This isolates all of the calls in which we write files to the cache.  We can decide to disable write permissions on particular files here.  If we disable write permissions on the directories in the cache, we won't be able to add any more files to them without proactively enabling/disabling write permissions every time.  This is something we could consider doing if its important to protect the cache.  

Hoping this diff elicits further discussion on the issue.  I noticed the cache did not need modified for deleting invalid entries on startup.