### PR TITLE
Validate maxActionTimeout for shard instance

### DIFF
--- a/src/main/java/build/buildfarm/worker/PutOperationStage.java
+++ b/src/main/java/build/buildfarm/worker/PutOperationStage.java
@@ -44,9 +44,11 @@ public class PutOperationStage extends PipelineStage.NullStage {
   public void put(OperationContext operationContext) throws InterruptedException {
     onPut.acceptInterruptibly(operationContext.operation);
     synchronized (this) {
-      for (AverageTimeCostOfLastPeriod average : averagesWithinDifferentPeriods) {
-        average.addOperation(
-            operationContext.executeResponse.build().getResult().getExecutionMetadata());
+      if (operationContext.operation.getDone()) {
+        for (AverageTimeCostOfLastPeriod average : averagesWithinDifferentPeriods) {
+          average.addOperation(
+              operationContext.executeResponse.build().getResult().getExecutionMetadata());
+        }
       }
     }
   }

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -246,6 +246,11 @@ message ShardInstanceConfig {
   }
 
   int64 max_blob_size = 5;
+
+  // maximum selectable timeout
+  // a maximum threshold for an action's specified timeout,
+  // beyond which an action will be rejected for execution
+  google.protobuf.Duration maximum_action_timeout = 7;
 }
 
 message ShardWorkerInstanceConfig {
@@ -266,17 +271,6 @@ message ShardWorkerInstanceConfig {
 
   // page size for getTree request
   uint32 tree_page_size = 12;
-
-  // default timeout for actions
-  // if a timeout is unspecified for an action, this value
-  // is imposed on it, after which the operation will
-  // be killed
-  google.protobuf.Duration default_action_timeout = 13;
-
-  // maximum selectable timeout
-  // a maximum threshold for an action's specified timeout,
-  // beyond which an action will be rejected for execution
-  google.protobuf.Duration maximum_action_timeout = 14;
 }
 
 message ShardWorkerConfig {

--- a/src/test/java/build/buildfarm/instance/shard/ShardInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/shard/ShardInstanceTest.java
@@ -73,6 +73,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.longrunning.Operation;
 import com.google.protobuf.Any;
 import com.google.protobuf.ByteString;
+import com.google.protobuf.Duration;
 import com.google.rpc.Code;
 import com.google.rpc.PreconditionFailure;
 import com.google.rpc.PreconditionFailure.Violation;
@@ -130,6 +131,7 @@ public class ShardInstanceTest {
             /* dispatchedMonitorIntervalSeconds=*/ 0,
             /* runOperationQueuer=*/ false,
             /* maxBlobSize=*/ 0,
+            /* maxActionTimeout=*/ Duration.getDefaultInstance(),
             mockOnStop,
             CacheBuilder.newBuilder().build(mockInstanceLoader));
     instance.start();


### PR DESCRIPTION
Prevent scheduling of actions which exceed a configured (default
unlimited) timeout.