### PR TITLE
Put maxTimeout validation in impl for shard

### DIFF
--- a/src/main/java/build/buildfarm/instance/AbstractServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/AbstractServerInstance.java
@@ -898,7 +898,7 @@ public abstract class AbstractServerInstance implements Instance {
     }
   }
 
-  private void validateAction(
+  protected void validateAction(
       Action action,
       @Nullable Command command,
       Map<Digest, Directory> directoriesIndex,

--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -124,6 +124,7 @@ import java.util.Collections;
 import java.util.Deque;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Queue;
 import java.util.Random;
 import java.util.Set;
@@ -137,6 +138,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -1446,11 +1448,11 @@ public class ShardInstance extends AbstractServerInstance {
 
   @Override
   protected void validateAction(
-      String operationName,
       Action action,
-      PreconditionFailure.Builder preconditionFailure,
-      RequestMetadata requestMetadata)
-      throws InterruptedException, StatusException {
+      @Nullable Command command,
+      Map<Digest, Directory> directoriesIndex,
+      Consumer<Digest> onInputDigest,
+      PreconditionFailure.Builder preconditionFailure) {
     if (action.hasTimeout() && hasMaxActionTimeout()) {
       Duration timeout = action.getTimeout();
       if (timeout.getSeconds() > maxActionTimeout.getSeconds()
@@ -1464,7 +1466,7 @@ public class ShardInstance extends AbstractServerInstance {
       }
     }
 
-    super.validateAction(operationName, action, preconditionFailure, requestMetadata);
+    super.validateAction(action, command, directoriesIndex, onInputDigest, preconditionFailure);
   }
 
   private ListenableFuture<Void> validateAndRequeueOperation(


### PR DESCRIPTION
The maximum timeout validation override must match the implementation
used for actions. This properly enables scheduler rejection, including
requeue.

Note that a mismatched timeout on workers will result in operation
looping due to non-terminal operation status - a worker does not know
that an action is definitively invalid for all cases.