### PR TITLE
Properly handle wrapper argument substitutions.

### DIFF
--- a/src/main/java/build/buildfarm/worker/Executor.java
+++ b/src/main/java/build/buildfarm/worker/Executor.java
@@ -307,6 +307,8 @@ class Executor {
 
     arguments.add(wrapper.getPath());
     for (String argument : wrapper.getArgumentsList()) {
+      // If the argument is of the form <propertyName>, substitute the value of
+      // the property from the platform specification.
       if (!argument.equals("<>")
           && argument.charAt(0) == '<'
           && argument.charAt(argument.length() - 1) == '>') {
@@ -318,8 +320,10 @@ class Executor {
           return ImmutableList.of();
         }
         arguments.add(property.getValue());
+      } else {
+        // If the argument isn't of the form <propertyName>, add the argument directly:
+        arguments.add(argument);
       }
-      arguments.add(argument);
     }
     return arguments.build();
   }


### PR DESCRIPTION
When encountering a wrapper argument of the form `<propertyName>`, the
Executor will currently add both the value of the property named
propertyName as well as the original string `'<propertyName>'`. This seems
incorrect.

This change makes it so that the executor will only add the property
value corresponding to propertyName and not the original argument string
`'<propertyName>'`