### PR TITLE
Clear interrupted during exec limit/error put

### DIFF
--- a/src/main/java/build/buildfarm/worker/Executor.java
+++ b/src/main/java/build/buildfarm/worker/Executor.java
@@ -271,6 +271,8 @@ class Executor {
         Thread.currentThread().interrupt();
       }
     } catch (Exception e) {
+      // clear interrupt flag for error put
+      boolean wasInterrupted = Thread.interrupted();
       logger.log(Level.SEVERE, format("errored during execution of %s", operationName), e);
       try {
         owner.error().put(operationContext);
@@ -282,6 +284,9 @@ class Executor {
       } catch (Exception errorEx) {
         logger.log(
             Level.SEVERE, format("errored while erroring %s after error", operationName), errorEx);
+      }
+      if (wasInterrupted) {
+        Thread.currentThread().interrupt();
       }
       throw e;
     } finally {

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -921,10 +921,15 @@ class ShardWorkerContext implements WorkerContext {
           cpu.setShares(mincores * 1024);
         }
       } catch (IOException e) {
+        // clear interrupt flag if set due to ClosedByInterruptException
+        boolean wasInterrupted = Thread.interrupted();
         try {
           cpu.close();
         } catch (IOException closeEx) {
           e.addSuppressed(closeEx);
+        }
+        if (wasInterrupted) {
+          Thread.currentThread().interrupt();
         }
         throw new RuntimeException(e);
       }


### PR DESCRIPTION
Prevent interrupted from being observed after operation stage
cancellation during rollback of execution limiting and error stage put.

This speaks to some considerable limitations of the pipeline stage
activity that should be reworked to incorporate another form of
notification.