### PR TITLE
Add invocation blacklist to reject entire builds

### DIFF
--- a/examples/shard-server.config.example
+++ b/examples/shard-server.config.example
@@ -87,6 +87,16 @@ instances {
       # than a catastrophic failure.
       action_blacklist_prefix: "ActionBlacklist"
 
+      # A redis key prefix for all blacklisted invocations, suffixed
+      # with the tool invocation id. Requests on behalf of an invocation
+      # which is blacklisted should be rejected where it is identified via
+      # its RequestMetadata
+      # To meet API standards, a request which matches this condition
+      # receives a transient UNAVAILABLE response, which, in bazel's
+      # case, can induce a fallback to non-remote recovery, rather
+      # than a catastrophic failure.
+      invocation_blacklist_prefix: "InvocationBlacklist"
+
       # The ttl maintained for action_blacklist entries.
       action_blacklist_expire: 3600 # 1 hour
 

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -214,6 +214,7 @@ message RedisShardBackplaneConfig {
   int32 action_cache_expire = 4;
   string action_blacklist_prefix = 28;
   int32 action_blacklist_expire = 29;
+  string invocation_blacklist_prefix = 30;
   string operation_prefix = 5;
   int32 operation_expire = 6;
   string pre_queued_operations_list_name = 18;


### PR DESCRIPTION
The blacklist must be maintained independently for now - seek to add control for this in a separate service control plane.