### PR TITLE
Set configurable ownership privs for exec outputs

### DIFF
--- a/examples/shard-worker.config.example
+++ b/examples/shard-worker.config.example
@@ -212,3 +212,9 @@ redis_shard_backplane_config: {
   # When in doubt, leave this enabled.
   subscribe_to_backplane: true
 }
+
+# Create exec trees containing directories that are owned by
+# this user
+# The default (empty) value does not change the owner
+#exec_owner: "nobody"
+exec_owner: ""

--- a/src/main/java/build/buildfarm/BUILD
+++ b/src/main/java/build/buildfarm/BUILD
@@ -418,10 +418,11 @@ java_library(
         ":stub-instance",
         ":worker",
         ":worker-cgroup",
-        "//src/main/protobuf:build_buildfarm_v1test_buildfarm_java_proto",
         "//src/main/protobuf:build_buildfarm_v1test_buildfarm_java_grpc",
+        "//src/main/protobuf:build_buildfarm_v1test_buildfarm_java_proto",
         "@googleapis//:google_rpc_error_details_java_proto",
         "@maven//:com_github_pcj_google_options",
+        "@maven//:com_google_code_findbugs_jsr305",
         "@maven//:com_google_guava_guava",
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:com_google_protobuf_protobuf_java_util",
@@ -440,10 +441,10 @@ java_binary(
         ":configs",
     ],
     main_class = "build.buildfarm.worker.shard.Worker",
+    visibility = ["//visibility:public"],
     runtime_deps = [
         ":shard-worker",
     ],
-    visibility = ["//visibility:public"],
 )
 
 container_image(
@@ -526,6 +527,9 @@ java_library(
 java_library(
     name = "cas",
     srcs = glob(["cas/*.java"]),
+    runtime_deps = [
+        "@maven//:org_xerial_sqlite_jdbc",
+    ],
     deps = [
         ":common",
         ":common-grpc",
@@ -546,9 +550,6 @@ java_library(
         "@maven//:io_grpc_grpc_stub",
         "@remote_apis//:build_bazel_remote_execution_v2_remote_execution_java_grpc",
         "@remote_apis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
-    ],
-    runtime_deps = [
-        "@maven//:org_xerial_sqlite_jdbc",
     ],
 )
 
@@ -597,6 +598,7 @@ java_binary(
     name = "bf-mount",
     srcs = ["Mount.java"],
     main_class = "build.buildfarm.Mount",
+    visibility = ["//visibility:public"],
     deps = [
         ":common",
         ":instance",
@@ -613,7 +615,6 @@ java_binary(
         "@maven//:io_grpc_grpc_protobuf",
         "@maven//:io_grpc_grpc_stub",
     ],
-    visibility = ["//visibility:public"],
 )
 
 java_binary(
@@ -623,6 +624,7 @@ java_binary(
         ":configs",
     ],
     main_class = "build.buildfarm.CASTest",
+    visibility = ["//visibility:public"],
     deps = [
         ":cas",
         ":common",
@@ -632,7 +634,6 @@ java_binary(
         "@maven//:com_google_guava_guava",
         "@remote_apis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
     ],
-    visibility = ["//visibility:public"],
 )
 
 java_plugin(
@@ -649,6 +650,7 @@ java_binary(
     srcs = ["IOBenchmark.java"],
     main_class = "build.buildfarm.IOBenchmark",
     plugins = [":io-benchmark-plugins"],
+    visibility = ["//visibility:public"],
     deps = [
         ":common",
         "@maven//:com_github_jnr_jnr_constants",
@@ -656,13 +658,13 @@ java_binary(
         "@maven//:com_github_jnr_jnr_posix",
         "@maven//:org_openjdk_jmh_jmh_core",
     ],
-    visibility = ["//visibility:public"],
 )
 
 java_binary(
     name = "bf-executor",
     srcs = ["Executor.java"],
     main_class = "build.buildfarm.Executor",
+    visibility = ["//visibility:public"],
     deps = [
         ":common",
         ":stub-instance",
@@ -682,13 +684,13 @@ java_binary(
         "@remote_apis//:build_bazel_remote_execution_v2_remote_execution_java_grpc",
         "@remote_apis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
     ],
-    visibility = ["//visibility:public"],
 )
 
 java_binary(
     name = "bf-extractor",
     srcs = ["Extract.java"],
     main_class = "build.buildfarm.Extract",
+    visibility = ["//visibility:public"],
     deps = [
         ":common",
         ":common-grpc",
@@ -704,7 +706,6 @@ java_binary(
         "@maven//:io_grpc_grpc_stub",
         "@remote_apis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
     ],
-    visibility = ["//visibility:public"],
 )
 
 java_binary(
@@ -714,6 +715,7 @@ java_binary(
         ":configs",
     ],
     main_class = "build.buildfarm.Cat",
+    visibility = ["//visibility:public"],
     deps = [
         ":common",
         ":instance",
@@ -731,13 +733,13 @@ java_binary(
         "@maven//:io_grpc_grpc_protobuf",
         "@maven//:io_grpc_grpc_stub",
     ],
-    visibility = ["//visibility:public"],
 )
 
 java_binary(
     name = "bf-hist",
     srcs = ["Hist.java"],
     main_class = "build.buildfarm.Hist",
+    visibility = ["//visibility:public"],
     deps = [
         ":common",
         ":instance",
@@ -754,14 +756,13 @@ java_binary(
         "@maven//:io_grpc_grpc_stub",
         "@remote_apis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
     ],
-    visibility = ["//visibility:public"],
 )
 
 java_binary(
     name = "buildfarm-http-proxy",
     main_class = "build.buildfarm.proxy.http.HttpProxy",
-    runtime_deps = [":http-proxy"],
     visibility = ["//visibility:public"],
+    runtime_deps = [":http-proxy"],
 )
 
 java_library(
@@ -804,6 +805,7 @@ java_binary(
     name = "bf-cancel",
     srcs = ["Cancel.java"],
     main_class = "build.buildfarm.Cancel",
+    visibility = ["//visibility:public"],
     deps = [
         ":common",
         ":instance",
@@ -815,5 +817,4 @@ java_binary(
         "@maven//:io_grpc_grpc_protobuf",
         "@maven//:io_grpc_grpc_stub",
     ],
-    visibility = ["//visibility:public"],
 )

--- a/src/main/java/build/buildfarm/cas/CASFileCache.java
+++ b/src/main/java/build/buildfarm/cas/CASFileCache.java
@@ -19,6 +19,7 @@ import static build.buildfarm.common.IOUtils.listDir;
 import static build.buildfarm.common.IOUtils.listDirentSorted;
 import static build.buildfarm.common.IOUtils.stat;
 import static build.buildfarm.common.io.Directories.disableAllWriteAccess;
+import static build.buildfarm.common.io.EvenMoreFiles.setReadOnlyPerms;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.io.ByteStreams.nullOutputStream;
@@ -75,7 +76,6 @@ import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.google.protobuf.ByteString;
 import io.grpc.Deadline;
 import io.grpc.stub.ServerCallStreamObserver;
-import java.io.File;
 import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -1915,7 +1915,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
                 .submit(
                     () -> {
                       Files.createFile(filePath);
-                      setPermissions(filePath, fileNode.getIsExecutable());
+                      setReadOnlyPerms(filePath, fileNode.getIsExecutable());
                       return filePath;
                     });
       }
@@ -2642,7 +2642,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
           throw new DigestMismatchException(actual, expected);
         }
         try {
-          setPermissions(writePath, isExecutable);
+          setReadOnlyPerms(writePath, isExecutable);
         } catch (IOException e) {
           dischargeAndNotify(blobSizeInBytes);
           throw e;
@@ -2700,10 +2700,6 @@ public abstract class CASFileCache implements ContentAddressableStorage {
         }
       }
     };
-  }
-
-  private static void setPermissions(Path path, boolean isExecutable) throws IOException {
-    new File(path.toString()).setExecutable(isExecutable, true);
   }
 
   @VisibleForTesting

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -339,6 +339,9 @@ message ShardWorkerConfig {
 
   // only allow test executions to be multicore (min-cores > 1), limiting both to 1 if not a test
   bool only_multicore_tests = 30;
+
+  // user principal name for executions
+  string exec_owner = 32;
 }
 
 message ShardWorker {

--- a/src/test/java/build/buildfarm/common/io/DirectoriesTest.java
+++ b/src/test/java/build/buildfarm/common/io/DirectoriesTest.java
@@ -121,7 +121,14 @@ class DirectoriesTest {
   public static class OsXDirectoriesTest extends DirectoriesTest {
     public OsXDirectoriesTest() {
       super(
-          Iterables.getFirst(Jimfs.newFileSystem(Configuration.osX()).getRootDirectories(), null));
+          Iterables.getFirst(
+              Jimfs.newFileSystem(
+                      Configuration.osX()
+                          .toBuilder()
+                          .setAttributeViews("basic", "owner", "posix", "unix")
+                          .build())
+                  .getRootDirectories(),
+              null));
     }
   }
 
@@ -129,7 +136,14 @@ class DirectoriesTest {
   public static class UnixDirectoriesTest extends DirectoriesTest {
     public UnixDirectoriesTest() {
       super(
-          Iterables.getFirst(Jimfs.newFileSystem(Configuration.unix()).getRootDirectories(), null));
+          Iterables.getFirst(
+              Jimfs.newFileSystem(
+                      Configuration.unix()
+                          .toBuilder()
+                          .setAttributeViews("basic", "owner", "posix", "unix")
+                          .build())
+                  .getRootDirectories(),
+              null));
     }
   }
 
@@ -138,7 +152,13 @@ class DirectoriesTest {
     public WindowsDirectoriesTest() {
       super(
           Iterables.getFirst(
-              Jimfs.newFileSystem(Configuration.windows()).getRootDirectories(), null));
+              Jimfs.newFileSystem(
+                      Configuration.windows()
+                          .toBuilder()
+                          .setAttributeViews("basic", "owner", "dos", "acl", "posix", "user")
+                          .build())
+                  .getRootDirectories(),
+              null));
     }
   }
 }


### PR DESCRIPTION
Specify a user principal for ownership of directories created in the
service of exec roots - this is distinguished from ownership by
CASFileCache (determined by uid of the worker) - so that executions may
only write to directories manifested by output trees.
Refactors CASFileCache permission setting into utility library which
supports global execution of non-exec-owner files.
Generalized operations for Files and Directories now throw an error
without a matching attribute view.
BUILD file linted by buildifier