### PR TITLE
Correct existing executable CFC entries on fs

### DIFF
--- a/src/main/java/build/buildfarm/cas/CASFileCache.java
+++ b/src/main/java/build/buildfarm/cas/CASFileCache.java
@@ -19,6 +19,7 @@ import static build.buildfarm.common.IOUtils.listDir;
 import static build.buildfarm.common.IOUtils.listDirentSorted;
 import static build.buildfarm.common.IOUtils.stat;
 import static build.buildfarm.common.io.Directories.disableAllWriteAccess;
+import static build.buildfarm.common.io.EvenMoreFiles.isReadOnlyExecutable;
 import static build.buildfarm.common.io.EvenMoreFiles.setReadOnlyPerms;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
@@ -1418,7 +1419,8 @@ public abstract class CASFileCache implements ContentAddressableStorage {
           FileEntryKey fileEntryKey = parseFileEntryKey(basename, stat.getSize());
 
           // if key entry file name cannot be parsed, mark file for later deletion.
-          if (fileEntryKey == null) {
+          if (fileEntryKey == null
+              || stat.isReadOnlyExecutable() != fileEntryKey.getIsExecutable()) {
             synchronized (deleteFiles) {
               deleteFiles.add(file);
             }
@@ -1529,7 +1531,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
 
       // empty file
       else if (isEmptyFile) {
-        boolean isExecutable = Files.isExecutable(entryPath);
+        boolean isExecutable = isReadOnlyExecutable(entryPath);
         b.addFilesBuilder()
             .setName(name)
             .setDigest(digestUtil.empty())

--- a/src/main/java/build/buildfarm/common/FileStatus.java
+++ b/src/main/java/build/buildfarm/common/FileStatus.java
@@ -69,4 +69,6 @@ public interface FileStatus {
 
   /** see BasicFileAttributes.fileKey() */
   Object fileKey();
+
+  boolean isReadOnlyExecutable();
 }

--- a/src/main/java/build/buildfarm/common/IOUtils.java
+++ b/src/main/java/build/buildfarm/common/IOUtils.java
@@ -14,6 +14,7 @@
 
 package build.buildfarm.common;
 
+import build.buildfarm.common.io.EvenMoreFiles;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import java.io.File;
@@ -209,8 +210,10 @@ public class IOUtils {
    */
   public static FileStatus stat(final Path path, final boolean followSymlinks) throws IOException {
     final BasicFileAttributes attributes;
+    boolean isReadOnlyExecutable;
     try {
       attributes = Files.readAttributes(path, BasicFileAttributes.class, linkOpts(followSymlinks));
+      isReadOnlyExecutable = EvenMoreFiles.isReadOnlyExecutable(path);
     } catch (java.nio.file.FileSystemException e) {
       throw new FileNotFoundException(path + ERR_NO_SUCH_FILE_OR_DIR);
     }
@@ -266,6 +269,11 @@ public class IOUtils {
             } catch (Exception e) {
               return attributes.fileKey();
             }
+          }
+
+          @Override
+          public boolean isReadOnlyExecutable() {
+            return isReadOnlyExecutable;
           }
         };
 

--- a/src/test/java/build/buildfarm/cas/CASFileCacheTest.java
+++ b/src/test/java/build/buildfarm/cas/CASFileCacheTest.java
@@ -45,6 +45,7 @@ import build.buildfarm.common.InputStreamFactory;
 import build.buildfarm.common.Write;
 import build.buildfarm.common.Write.NullWrite;
 import build.buildfarm.common.io.Directories;
+import build.buildfarm.common.io.EvenMoreFiles;
 import build.buildfarm.common.io.FeedbackOutputStream;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -306,7 +307,9 @@ class CASFileCacheTest {
     Path path = root.resolve(fileCache.getKey(blobDigest, false));
     Path execPath = root.resolve(fileCache.getKey(blobDigest, true));
     Files.write(path, blob.toByteArray());
+    EvenMoreFiles.setReadOnlyPerms(path, false);
     Files.write(execPath, blob.toByteArray());
+    EvenMoreFiles.setReadOnlyPerms(execPath, true);
 
     StartupCacheResults results = fileCache.start();
 


### PR DESCRIPTION
Accomodate existing CFC file entries which would have only had owner
executable set, and use FileStatus isReadOnlyExecutable to correct valid
entries.