### PR TITLE
Poll ExecuteActionStage put and drain wait

### DIFF
--- a/src/main/java/build/buildfarm/worker/SuperscalarPipelineStage.java
+++ b/src/main/java/build/buildfarm/worker/SuperscalarPipelineStage.java
@@ -49,7 +49,7 @@ abstract class SuperscalarPipelineStage extends PipelineStage {
         interruptAll();
       }
       try {
-        wait();
+        wait(/* timeout=*/ 10);
       } catch (InterruptedException e) {
         interrupted = Thread.interrupted() || interrupted;
         // ignore, we will throw it eventually


### PR DESCRIPTION
Out-of-priority-order pipeline shutdowns can allow the
ExecuteActionStage to halt processing. Attempts to put into its queue
must fail exceptionally in this condition. Switch the
SuperscalarPipelineStage drain to poll-wait due to the opportunity to
miss notifications of releases.