### PR TITLE
Guard error put and pipeline close for interrupts

### DIFF
--- a/src/main/java/build/buildfarm/worker/Executor.java
+++ b/src/main/java/build/buildfarm/worker/Executor.java
@@ -249,8 +249,14 @@ class Executor {
     } else {
       // FIXME we need to release the action root
       workerContext.logInfo("Executor: Operation " + operationName + " Failed to claim output");
-
-      owner.error().put(operationContext);
+      boolean wasInterrupted = Thread.interrupted();
+      try {
+        owner.error().put(operationContext);
+      } finally {
+        if (wasInterrupted) {
+          Thread.currentThread().interrupt();
+        }
+      }
     }
     return stopwatch.elapsed(MICROSECONDS) - executeUSecs;
   }

--- a/src/main/java/build/buildfarm/worker/PipelineStage.java
+++ b/src/main/java/build/buildfarm/worker/PipelineStage.java
@@ -52,7 +52,14 @@ public abstract class PipelineStage implements Runnable {
     } catch (InterruptedException e) {
       // ignore
     } finally {
-      close();
+      boolean wasInterrupted = Thread.interrupted();
+      try {
+        close();
+      } finally {
+        if (wasInterrupted) {
+          Thread.currentThread().interrupt();
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Interruptions should not prevent attempted closeout of executor error
puts and pipeline stage shutdowns. These routines may be independently
interrupted if desired.