### PR TITLE
Create writable dirs for test command env vars

### DIFF
--- a/src/main/java/build/buildfarm/worker/operationqueue/Worker.java
+++ b/src/main/java/build/buildfarm/worker/operationqueue/Worker.java
@@ -562,7 +562,9 @@ public class Worker {
               throws IOException, InterruptedException {
             OutputDirectory outputDirectory =
                 OutputDirectory.parse(
-                    command.getOutputFilesList(), command.getOutputDirectoriesList());
+                    command.getOutputFilesList(),
+                    command.getOutputDirectoriesList(),
+                    command.getEnvironmentVariablesList());
 
             Path execDir = root.resolve(operationName);
             if (Files.exists(execDir)) {

--- a/src/main/java/build/buildfarm/worker/shard/CFCExecFileSystem.java
+++ b/src/main/java/build/buildfarm/worker/shard/CFCExecFileSystem.java
@@ -283,7 +283,10 @@ class CFCExecFileSystem implements ExecFileSystem {
       String operationName, Map<Digest, Directory> directoriesIndex, Action action, Command command)
       throws IOException, InterruptedException {
     OutputDirectory outputDirectory =
-        OutputDirectory.parse(command.getOutputFilesList(), command.getOutputDirectoriesList());
+        OutputDirectory.parse(
+            command.getOutputFilesList(),
+            command.getOutputDirectoriesList(),
+            command.getEnvironmentVariablesList());
 
     Path execDir = root.resolve(operationName);
     if (Files.exists(execDir)) {


### PR DESCRIPTION
To adhere to bazel test encyclopedia initial condition, create all
directories from environment variables under the execution root.