### PR TITLE
Wait/interpret NOT_FOUND in ByteStreamHelper

### DIFF
--- a/src/main/java/build/buildfarm/Extract.java
+++ b/src/main/java/build/buildfarm/Extract.java
@@ -44,11 +44,11 @@ import io.grpc.Status.Code;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.stub.StreamObserver;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
@@ -95,7 +95,8 @@ class Extract {
       String instanceName,
       Digest digest,
       ByteStreamStub bsStub,
-      ListeningScheduledExecutorService retryService) {
+      ListeningScheduledExecutorService retryService)
+      throws IOException {
     return ByteStreamHelper.newInput(
         blobName(instanceName, digest),
         0,
@@ -174,7 +175,7 @@ class Extract {
           public void onError(Throwable t) {
             Status status = Status.fromThrowable(t);
             if (status.getCode() == Code.NOT_FOUND) {
-              t = new FileNotFoundException(digest.getHash() + "/" + digest.getSizeBytes());
+              t = new NoSuchFileException(digest.getHash() + "/" + digest.getSizeBytes());
             }
             blobFuture.setException(t);
           }

--- a/src/main/java/build/buildfarm/cas/GrpcCAS.java
+++ b/src/main/java/build/buildfarm/cas/GrpcCAS.java
@@ -99,7 +99,7 @@ public class GrpcCAS implements ContentAddressableStorage {
             }
           });
 
-  private InputStream newStreamInput(String resourceName, long offset) {
+  private InputStream newStreamInput(String resourceName, long offset) throws IOException {
     return ByteStreamHelper.newInput(
         resourceName,
         offset,
@@ -184,7 +184,7 @@ public class GrpcCAS implements ContentAddressableStorage {
   }
 
   @Override
-  public InputStream newInput(Digest digest, long offset) {
+  public InputStream newInput(Digest digest, long offset) throws IOException {
     return newStreamInput(getBlobName(digest), offset);
   }
 

--- a/src/main/java/build/buildfarm/common/IOUtils.java
+++ b/src/main/java/build/buildfarm/common/IOUtils.java
@@ -18,12 +18,12 @@ import build.buildfarm.common.io.EvenMoreFiles;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.FileStore;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.PosixFileAttributes;
@@ -215,7 +215,7 @@ public class IOUtils {
       attributes = Files.readAttributes(path, BasicFileAttributes.class, linkOpts(followSymlinks));
       isReadOnlyExecutable = EvenMoreFiles.isReadOnlyExecutable(path);
     } catch (java.nio.file.FileSystemException e) {
-      throw new FileNotFoundException(path + ERR_NO_SUCH_FILE_OR_DIR);
+      throw new NoSuchFileException(path + ERR_NO_SUCH_FILE_OR_DIR);
     }
     FileStatus status =
         new FileStatus() {

--- a/src/main/java/build/buildfarm/instance/stub/StubInstance.java
+++ b/src/main/java/build/buildfarm/instance/stub/StubInstance.java
@@ -107,6 +107,7 @@ import io.grpc.stub.ClientCallStreamObserver;
 import io.grpc.stub.ClientResponseObserver;
 import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.Iterator;
 import java.util.UUID;
@@ -420,7 +421,8 @@ public class StubInstance implements Instance {
       long offset,
       long deadlineAfter,
       TimeUnit deadlineAfterUnits,
-      RequestMetadata requestMetadata) {
+      RequestMetadata requestMetadata)
+      throws IOException {
     return newInput(resourceName, offset, deadlineAfter, deadlineAfterUnits, requestMetadata);
   }
 
@@ -429,7 +431,8 @@ public class StubInstance implements Instance {
       long offset,
       long deadlineAfter,
       TimeUnit deadlineAfterUnits,
-      RequestMetadata requestMetadata) {
+      RequestMetadata requestMetadata)
+      throws IOException {
     return ByteStreamHelper.newInput(
         resourceName,
         offset,
@@ -535,7 +538,8 @@ public class StubInstance implements Instance {
       long offset,
       long deadlineAfter,
       TimeUnit deadlineAfterUnits,
-      RequestMetadata requestMetadata) {
+      RequestMetadata requestMetadata)
+      throws IOException {
     return newInput(
         getBlobName(digest), offset, deadlineAfter, deadlineAfterUnits, requestMetadata);
   }

--- a/src/main/java/build/buildfarm/worker/Utils.java
+++ b/src/main/java/build/buildfarm/worker/Utils.java
@@ -19,8 +19,8 @@ import build.bazel.remote.execution.v2.Platform.Property;
 import build.buildfarm.common.FileStatus;
 import build.buildfarm.common.IOUtils;
 import com.google.common.collect.Iterables;
-import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 
 public class Utils {
@@ -29,7 +29,7 @@ public class Utils {
   public static FileStatus statIfFound(Path path, boolean followSymlinks) {
     try {
       return IOUtils.stat(path, followSymlinks);
-    } catch (FileNotFoundException e) {
+    } catch (NoSuchFileException e) {
       return null;
     } catch (IOException e) {
       // If this codepath is ever hit, then this method should be rewritten to properly distinguish

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -78,7 +78,6 @@ import io.grpc.Deadline;
 import io.grpc.Status;
 import io.grpc.Status.Code;
 import io.grpc.StatusException;
-import io.grpc.StatusRuntimeException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -260,11 +259,8 @@ class ShardWorkerContext implements WorkerContext {
   private ByteString getBlob(Digest digest) throws IOException, InterruptedException {
     try (InputStream in = inputStreamFactory.newInput(digest, 0)) {
       return ByteString.readFrom(in);
-    } catch (StatusRuntimeException e) {
-      if (e.getStatus().equals(Status.NOT_FOUND)) {
-        return null;
-      }
-      throw e;
+    } catch (NoSuchFileException e) {
+      return null;
     }
   }
 

--- a/src/test/java/build/buildfarm/common/grpc/ByteStreamHelperTest.java
+++ b/src/test/java/build/buildfarm/common/grpc/ByteStreamHelperTest.java
@@ -1,0 +1,101 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.common.grpc;
+
+import static build.buildfarm.common.grpc.Retrier.NO_RETRIES;
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.google.bytestream.ByteStreamGrpc;
+import com.google.bytestream.ByteStreamGrpc.ByteStreamImplBase;
+import com.google.bytestream.ByteStreamProto.ReadRequest;
+import com.google.bytestream.ByteStreamProto.ReadResponse;
+import com.google.common.base.Suppliers;
+import io.grpc.Channel;
+import io.grpc.Status;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.StreamObserver;
+import io.grpc.testing.GrpcCleanupRule;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.NoSuchFileException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.stubbing.Answer;
+
+@RunWith(JUnit4.class)
+public class ByteStreamHelperTest {
+  @Rule public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+
+  private final ByteStreamImplBase serviceImpl = mock(ByteStreamImplBase.class);
+
+  private Channel channel;
+
+  @Before
+  public void setUp() throws Exception {
+    String serverName = InProcessServerBuilder.generateName();
+
+    grpcCleanup
+        .register(
+            InProcessServerBuilder.forName(serverName)
+                .directExecutor()
+                .addService(serviceImpl)
+                .build())
+        .start();
+
+    channel =
+        grpcCleanup.register(InProcessChannelBuilder.forName(serverName).directExecutor().build());
+  }
+
+  @Test
+  public void newInputThrowsOnNotFound() {
+    String resourceName = "not/found/resource";
+    ReadRequest readRequest = ReadRequest.newBuilder().setResourceName(resourceName).build();
+    doAnswer(
+            (Answer)
+                invocation -> {
+                  StreamObserver<ReadResponse> observer = invocation.getArgument(1);
+                  observer.onError(Status.NOT_FOUND.asException());
+                  return null;
+                })
+        .when(serviceImpl)
+        .read(eq(readRequest), any(StreamObserver.class));
+
+    try (InputStream in =
+        ByteStreamHelper.newInput(
+            resourceName,
+            /* offset=*/ 0,
+            Suppliers.ofInstance(ByteStreamGrpc.newStub(channel)),
+            NO_RETRIES::newBackoff,
+            NO_RETRIES::isRetriable,
+            /* retryService=*/ null)) {
+      fail("should not get here");
+    } catch (IOException e) {
+      assertThat(e).isInstanceOf(NoSuchFileException.class);
+    }
+
+    verify(serviceImpl, times(1)).read(eq(readRequest), any(StreamObserver.class));
+  }
+}


### PR DESCRIPTION
In order to properly failover from the local shard CAS to remote, the
FailoverInputStreamFactory must observe NoSuchFileException on
InputStream creation for the primary. This comes into play when a
CASFileCache is delegating to a grpc CAS as the primary.

An eventual target here may be the return of a modified InputStream that
can failover at any point in its lifecycle, so that blob disappearances
can be compensated for over multple requests, due to deadline
expiration or transiency.