### PR TITLE
Retain a single FileStore for a cfc root

### DIFF
--- a/src/main/java/build/buildfarm/common/IOUtils.java
+++ b/src/main/java/build/buildfarm/common/IOUtils.java
@@ -192,9 +192,9 @@ public class IOUtils {
     return dirents;
   }
 
-  public static List<NamedFileKey> listDirentSorted(Path path) throws IOException {
+  public static List<NamedFileKey> listDirentSorted(Path path, FileStore fileStore)
+      throws IOException {
     final List<NamedFileKey> dirents;
-    FileStore fileStore = Files.getFileStore(path);
     if (fileStore.supportsFileAttributeView("posix")) {
       dirents = ffiReaddir(libc.get(), runtime(), path);
     } else {

--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -1364,7 +1364,23 @@ public class ShardInstance extends AbstractServerInstance {
     checkState(digest.getSizeBytes() == content.size());
     SettableFuture<Long> writtenFuture = SettableFuture.create();
     Write write = getBlobWrite(digest, UUID.randomUUID(), requestMetadata);
-    write.addListener(() -> writtenFuture.set(digest.getSizeBytes()), directExecutor());
+    write.addListener(
+        () -> {
+          try {
+            long committedSize = write.getCommittedSize();
+            if (committedSize != digest.getSizeBytes()) {
+              logger.warning(
+                  format(
+                      "committed size %d did not match expectation for %s, ignoring it",
+                      committedSize, DigestUtil.toString(digest)));
+            }
+            writtenFuture.set(digest.getSizeBytes());
+          } catch (RuntimeException e) {
+            // should we wrap with an additional exception?
+            writtenFuture.setException(e);
+          }
+        },
+        directExecutor());
     try (OutputStream out = write.getOutput(60, SECONDS, () -> {})) {
       content.writeTo(out);
     } catch (IOException e) {

--- a/src/test/java/build/buildfarm/common/IOUtilsTest.java
+++ b/src/test/java/build/buildfarm/common/IOUtilsTest.java
@@ -19,6 +19,7 @@ import static com.google.common.truth.Truth.assertThat;
 import build.buildfarm.common.io.Directories;
 import com.google.protobuf.ByteString;
 import java.io.IOException;
+import java.nio.file.FileStore;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -32,9 +33,12 @@ import org.junit.runners.JUnit4;
 class IOUtilsTest {
   private Path root;
 
+  private FileStore fileStore;
+
   @Before
   public void setUp() throws IOException {
     root = Files.createTempDirectory("native-cas-test");
+    fileStore = Files.getFileStore(root);
   }
 
   @After
@@ -49,7 +53,7 @@ class IOUtilsTest {
     Files.write(path, blob.toByteArray());
     Files.createLink(root.resolve("b"), path);
 
-    List<NamedFileKey> files = IOUtils.listDirentSorted(root);
+    List<NamedFileKey> files = IOUtils.listDirentSorted(root, fileStore);
     assertThat(files.size()).isEqualTo(2);
     Object firstKey = files.get(0).fileKey();
     Object secondKey = files.get(1).fileKey();
@@ -66,7 +70,7 @@ class IOUtilsTest {
     ByteString blobB = ByteString.copyFromUtf8("content for b");
     Files.write(pathB, blobB.toByteArray());
 
-    List<NamedFileKey> files = IOUtils.listDirentSorted(root);
+    List<NamedFileKey> files = IOUtils.listDirentSorted(root, fileStore);
     assertThat(files.size()).isEqualTo(2);
     Object firstKey = files.get(0).fileKey();
     Object secondKey = files.get(1).fileKey();


### PR DESCRIPTION
Under the assumption that a cfc root does not cross filesystems, use a
single reference to the fileStore to make util decisions (this could
also be done by providing a specific IOUtils instance per-fs-type).

The FileStore's computation was observably painful and appears to be
parsing a mountset on each invocation of Files.getFileStore.