### PR TITLE
Present shard instance blob write errors in future

### DIFF
--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -1364,7 +1364,23 @@ public class ShardInstance extends AbstractServerInstance {
     checkState(digest.getSizeBytes() == content.size());
     SettableFuture<Long> writtenFuture = SettableFuture.create();
     Write write = getBlobWrite(digest, UUID.randomUUID(), requestMetadata);
-    write.addListener(() -> writtenFuture.set(digest.getSizeBytes()), directExecutor());
+    write.addListener(
+        () -> {
+          try {
+            long committedSize = write.getCommittedSize();
+            if (committedSize != digest.getSizeBytes()) {
+              logger.warning(
+                  format(
+                      "committed size %d did not match expectation for %s, ignoring it",
+                      committedSize, DigestUtil.toString(digest)));
+            }
+            writtenFuture.set(digest.getSizeBytes());
+          } catch (RuntimeException e) {
+            // should we wrap with an additional exception?
+            writtenFuture.setException(e);
+          }
+        },
+        directExecutor());
     try (OutputStream out = write.getOutput(60, SECONDS, () -> {})) {
       content.writeTo(out);
     } catch (IOException e) {


### PR DESCRIPTION
Write errors previously would not be presented with errors derived from
their failures if they occurred. This interface being used for
QueuedOperations, failures would have been apparent on workers, but this
is much safer.