### PR TITLE
Rework fileStore as local and after root creation

### DIFF
--- a/src/main/java/build/buildfarm/cas/CASFileCache.java
+++ b/src/main/java/build/buildfarm/cas/CASFileCache.java
@@ -119,7 +119,6 @@ public abstract class CASFileCache implements ContentAddressableStorage {
   protected static final String DIRECTORIES_INDEX_NAME_MEMORY = ":memory:";
 
   private final Path root;
-  private final FileStore fileStore;
   private final long maxSizeInBytes;
   private final long maxEntrySizeInBytes;
   private final DigestUtil digestUtil;
@@ -271,11 +270,6 @@ public abstract class CASFileCache implements ContentAddressableStorage {
       Consumer<Iterable<Digest>> onExpire,
       @Nullable ContentAddressableStorage delegate) {
     this.root = root;
-    try {
-      this.fileStore = Files.getFileStore(root);
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
     this.maxSizeInBytes = maxSizeInBytes;
     this.maxEntrySizeInBytes = maxEntrySizeInBytes;
     this.digestUtil = digestUtil;
@@ -1290,6 +1284,10 @@ public abstract class CASFileCache implements ContentAddressableStorage {
     logger.log(Level.INFO, "Initializing cache at: " + root);
     Instant startTime = Instant.now();
 
+    Files.createDirectories(root);
+
+    FileStore fileStore = Files.getFileStore(root);
+
     // Phase 1: Scan
     // build scan cache results by analyzing each file on the root.
     CacheScanResults cacheScanResults = scanRoot();
@@ -1298,7 +1296,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
 
     // Phase 2: Compute
     // recursively construct all directory structures.
-    List<Path> invalidDirectories = computeDirectories(cacheScanResults);
+    List<Path> invalidDirectories = computeDirectories(cacheScanResults, fileStore);
     LogComputeDirectoriesResults(invalidDirectories);
     deleteInvalidFileContent(invalidDirectories, removeDirectoryService);
 
@@ -1351,9 +1349,6 @@ public abstract class CASFileCache implements ContentAddressableStorage {
   }
 
   private CacheScanResults scanRoot() throws IOException, InterruptedException {
-
-    Files.createDirectories(root);
-
     // create thread pool
     int nThreads = Runtime.getRuntime().availableProcessors();
     String threadNameFormat = "scan-cache-pool-%d";
@@ -1454,7 +1449,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
     }
   }
 
-  private List<Path> computeDirectories(CacheScanResults cacheScanResults)
+  private List<Path> computeDirectories(CacheScanResults cacheScanResults, FileStore fileStore)
       throws IOException, InterruptedException {
 
     // create thread pool
@@ -1475,7 +1470,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
               List<NamedFileKey> sortedDirent = listDirentSorted(path, fileStore);
 
               Directory directory =
-                  computeDirectory(path, sortedDirent, cacheScanResults.fileKeys, inputsBuilder);
+                  computeDirectory(path, sortedDirent, cacheScanResults.fileKeys, inputsBuilder, fileStore);
 
               Digest digest = directory == null ? null : digestUtil.compute(directory);
 
@@ -1505,7 +1500,8 @@ public abstract class CASFileCache implements ContentAddressableStorage {
       Path path,
       List<NamedFileKey> sortedDirent,
       Map<Object, Entry> fileKeys,
-      ImmutableList.Builder<String> inputsBuilder)
+      ImmutableList.Builder<String> inputsBuilder,
+      FileStore fileStore)
       throws IOException, InterruptedException {
     Directory.Builder b = Directory.newBuilder();
 
@@ -1536,7 +1532,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
       // directory
       if (isDirectory) {
         List<NamedFileKey> childDirent = listDirentSorted(entryPath, fileStore);
-        Directory dir = computeDirectory(entryPath, childDirent, fileKeys, inputsBuilder);
+        Directory dir = computeDirectory(entryPath, childDirent, fileKeys, inputsBuilder, fileStore);
         b.addDirectoriesBuilder().setName(name).setDigest(digestUtil.compute(dir));
       }
 

--- a/src/main/java/build/buildfarm/cas/CASFileCache.java
+++ b/src/main/java/build/buildfarm/cas/CASFileCache.java
@@ -1470,7 +1470,8 @@ public abstract class CASFileCache implements ContentAddressableStorage {
               List<NamedFileKey> sortedDirent = listDirentSorted(path, fileStore);
 
               Directory directory =
-                  computeDirectory(path, sortedDirent, cacheScanResults.fileKeys, inputsBuilder, fileStore);
+                  computeDirectory(
+                      path, sortedDirent, cacheScanResults.fileKeys, inputsBuilder, fileStore);
 
               Digest digest = directory == null ? null : digestUtil.compute(directory);
 
@@ -1532,7 +1533,8 @@ public abstract class CASFileCache implements ContentAddressableStorage {
       // directory
       if (isDirectory) {
         List<NamedFileKey> childDirent = listDirentSorted(entryPath, fileStore);
-        Directory dir = computeDirectory(entryPath, childDirent, fileKeys, inputsBuilder, fileStore);
+        Directory dir =
+            computeDirectory(entryPath, childDirent, fileKeys, inputsBuilder, fileStore);
         b.addDirectoriesBuilder().setName(name).setDigest(digestUtil.compute(dir));
       }
 


### PR DESCRIPTION
Prevent new workers without cache dirs from failing to start by waiting
until after a cache root may be created to acquire the FileStore.