### PR TITLE
Restore stub read impl, refactor, test

### DIFF
--- a/src/main/java/build/buildfarm/instance/stub/StubInstance.java
+++ b/src/main/java/build/buildfarm/instance/stub/StubInstance.java
@@ -16,6 +16,7 @@ package build.buildfarm.instance.stub;
 
 import static build.buildfarm.common.grpc.Retrier.NO_RETRIES;
 import static build.buildfarm.common.grpc.TracingMetadataUtils.attachMetadataInterceptor;
+import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.util.concurrent.Futures.catching;
 import static com.google.common.util.concurrent.Futures.transform;
@@ -113,13 +114,12 @@ import java.util.Iterator;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
 
 public class StubInstance implements Instance {
   private static final Logger logger = Logger.getLogger(StubInstance.class.getName());
@@ -136,7 +136,6 @@ public class StubInstance implements Instance {
   private final @Nullable ListeningScheduledExecutorService retryService;
   private boolean isStopped = false;
   private final int maxBatchUpdateBlobsSize = 3 * 1024 * 1024;
-  private final ExecutorService byteStreamExecutorService = Executors.newSingleThreadExecutor();
 
   public StubInstance(String name, DigestUtil digestUtil, ManagedChannel channel) {
     this(name, "no-identifier", digestUtil, channel, DEFAULT_DEADLINE_DAYS, TimeUnit.DAYS);
@@ -312,10 +311,6 @@ public class StubInstance implements Instance {
     if (retryService != null && !shutdownAndAwaitTermination(retryService, 10, TimeUnit.SECONDS)) {
       logger.log(Level.SEVERE, format("Could not shut down retry service for %s", identifier));
     }
-    if (!shutdownAndAwaitTermination(byteStreamExecutorService, 5, TimeUnit.SECONDS)) {
-      logger.log(
-          Level.SEVERE, String.format("Failed to shutdown blockStore executor for %s", identifier));
-    }
   }
 
   private void throwIfStopped() {
@@ -454,6 +449,80 @@ public class StubInstance implements Instance {
     return format("%s/blobs/%s", getName(), DigestUtil.toString(blobDigest));
   }
 
+  static class ReadBlobInterchange implements ClientResponseObserver<ReadRequest, ReadResponse> {
+    private final ServerCallStreamObserver<ByteString> blobObserver;
+
+    private ClientCallStreamObserver<ReadRequest> requestStream;
+    // Guard against spurious onReady() calls caused by a race between onNext() and
+    // onReady(). If the transport toggles isReady() from false to true while onNext()
+    // is executing, but before onNext() checks isReady(). request(1) would be called
+    // twice - once by onNext() and once by the onReady() scheduled during onNext()'s
+    // execution.
+    @GuardedBy("this")
+    private boolean wasReady = false;
+    // We must not attempt to call request(1) on the stub until the call has been started.
+    @GuardedBy("this")
+    private boolean wasStarted = false;
+    // Indicator for request completion, so that callbacks throw or are ignored
+    AtomicBoolean wasCompleted = new AtomicBoolean(false);
+
+    ReadBlobInterchange(ServerCallStreamObserver<ByteString> blobObserver) {
+      this.blobObserver = blobObserver;
+    }
+
+    @Override
+    public void beforeStart(final ClientCallStreamObserver<ReadRequest> requestStream) {
+      this.requestStream = requestStream;
+
+      requestStream.disableAutoInboundFlowControl();
+
+      blobObserver.setOnCancelHandler(
+          () -> {
+            if (!wasCompleted.get()) {
+              requestStream.onError(Status.CANCELLED.asException());
+            }
+          });
+      blobObserver.setOnReadyHandler(this::onReady);
+    }
+
+    void onReady() {
+      if (wasCompleted.get()) {
+        throw Status.CANCELLED.withDescription("request was completed").asRuntimeException();
+      }
+      synchronized (this) {
+        if (wasStarted && blobObserver.isReady() && !wasReady) {
+          wasReady = true;
+          checkNotNull(requestStream).request(1);
+        }
+      }
+    }
+
+    @Override
+    public void onNext(ReadResponse response) {
+      blobObserver.onNext(response.getData());
+      synchronized (this) {
+        if (blobObserver.isReady()) {
+          checkNotNull(requestStream).request(1);
+        } else {
+          wasReady = false;
+        }
+        wasStarted = true;
+      }
+    }
+
+    @Override
+    public void onCompleted() {
+      wasCompleted.set(true);
+      blobObserver.onCompleted();
+    }
+
+    @Override
+    public void onError(Throwable t) {
+      wasCompleted.set(true);
+      blobObserver.onError(t);
+    }
+  }
+
   @Override
   public void getBlob(
       Digest blobDigest,
@@ -471,83 +540,7 @@ public class StubInstance implements Instance {
                 .setReadOffset(offset)
                 .setReadLimit(limit)
                 .build(),
-            new ClientResponseObserver<ReadRequest, ReadResponse>() {
-              ClientCallStreamObserver<ReadRequest> requestStream;
-              // Guard against spurious onReady() calls caused by a race between onNext() and
-              // onReady(). If the transport toggles isReady() from false to true while onNext()
-              // is executing, but before onNext() checks isReady(). request(1) would be called
-              // twice - once by onNext() and once by the onReady() scheduled during onNext()'s
-              // execution.
-              boolean wasReady = false;
-              // Indicator for request completion, so that callbacks throw or are ignored
-              AtomicBoolean wasCompleted = new AtomicBoolean(false);
-
-              @Override
-              public void beforeStart(final ClientCallStreamObserver<ReadRequest> requestStream) {
-                this.requestStream = requestStream;
-
-                requestStream.disableAutoInboundFlowControl();
-
-                blobObserver.setOnCancelHandler(
-                    () -> {
-                      if (!wasCompleted.get()) {
-                        requestStream.onError(Status.CANCELLED.asException());
-                      }
-                    });
-                blobObserver.setOnReadyHandler(this::onReady);
-              }
-
-              // Called by the server inbound event loop
-              void onReady() {
-                // Ensure that onReady and onNext are executed sequentially by moving them
-                // both to a separate single threaded executor.
-                byteStreamExecutorService.execute(
-                    () -> {
-                      if (wasCompleted.get()) {
-                        // onReady enqueued after onComplete enequeued.
-                        return;
-                      }
-                      if (blobObserver.isReady() && !wasReady) {
-                        wasReady = true;
-                        requestStream.request(1);
-                      }
-                    });
-              }
-
-              // Called from the event loop handling client-inbound events.
-              @Override
-              public void onNext(ReadResponse response) {
-                // Ensure that onReady and onNext are executed sequentially by moving them
-                // both to a separate single threaded executor.
-                byteStreamExecutorService.execute(
-                    () -> {
-                      blobObserver.onNext(response.getData());
-                      if (blobObserver.isReady()) {
-                        requestStream.request(1);
-                      } else {
-                        wasReady = false;
-                      }
-                    });
-              }
-
-              @Override
-              public void onCompleted() {
-                byteStreamExecutorService.execute(
-                    () -> {
-                      wasCompleted.set(true);
-                      blobObserver.onCompleted();
-                    });
-              }
-
-              @Override
-              public void onError(Throwable t) {
-                byteStreamExecutorService.execute(
-                    () -> {
-                      wasCompleted.set(true);
-                      blobObserver.onError(t);
-                    });
-              }
-            });
+            new ReadBlobInterchange(blobObserver));
   }
 
   @Override

--- a/src/test/java/build/buildfarm/instance/stub/StubInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/stub/StubInstanceTest.java
@@ -19,6 +19,8 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
 import build.bazel.remote.execution.v2.Action;
@@ -38,6 +40,7 @@ import build.buildfarm.common.DigestUtil;
 import build.buildfarm.common.DigestUtil.ActionKey;
 import build.buildfarm.common.Write;
 import build.buildfarm.instance.Instance;
+import build.buildfarm.instance.stub.StubInstance.ReadBlobInterchange;
 import com.google.bytestream.ByteStreamGrpc.ByteStreamImplBase;
 import com.google.bytestream.ByteStreamProto.QueryWriteStatusRequest;
 import com.google.bytestream.ByteStreamProto.QueryWriteStatusResponse;
@@ -54,6 +57,8 @@ import io.grpc.Status;
 import io.grpc.Status.Code;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.ClientCallStreamObserver;
+import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
 import io.grpc.util.MutableHandlerRegistry;
 import java.io.ByteArrayOutputStream;
@@ -67,6 +72,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
 
 @RunWith(JUnit4.class)
 public class StubInstanceTest {
@@ -442,5 +448,23 @@ public class StubInstanceTest {
     assertThat(status.getCode()).isEqualTo(Code.DEADLINE_EXCEEDED);
     verifyZeroInteractions(out);
     instance.stop();
+  }
+
+  @Test
+  public void readBlobInterchangeDoesNotRequestUntilStarted() {
+    ServerCallStreamObserver<ByteString> mockBlobObserver = mock(ServerCallStreamObserver.class);
+    ReadBlobInterchange interchange = new ReadBlobInterchange(mockBlobObserver);
+
+    ClientCallStreamObserver<ReadRequest> mockRequestStream = mock(ClientCallStreamObserver.class);
+    interchange.beforeStart(mockRequestStream);
+    // verify our flow control call so that we can verify no further interactions
+    verify(mockRequestStream, times(1)).disableAutoInboundFlowControl();
+    // capture onReady from mockBlobObserver
+    ArgumentCaptor<Runnable> onReadyCaptor = ArgumentCaptor.forClass(Runnable.class);
+    verify(mockBlobObserver, times(1)).setOnReadyHandler(onReadyCaptor.capture());
+    // call it
+    onReadyCaptor.getValue().run();
+    // verify zero interactions with mockRequestStream
+    verifyZeroInteractions(mockRequestStream);
   }
 }


### PR DESCRIPTION
The recent modifications to guard against a race between isReady and
wasReady for stub getBlobs left the possibility of an onReady call from
a blobObserver before the requestStream was started. Calling
`request(1)` on this stream would result in an invalid state and ensuing
exception.

This change moves the class declaration to a static member scope of
StubInstance, removes the required ExecutorService member, simplifies
the state tracking to remove atomics, and clarifies guards for accessing
the state indicators. wasCompleted is left as it represents a unique
volatility, but might not be needed as a wrapper.

The constraints of the original issue #440 are satisfied here, as well
as some additional testing for this scenario, where a request(1) does
not occur without an onNext (the only guarantee that a client call has
started) call.