### PR TITLE
Reconfigure queue provision filtering

### DIFF
--- a/examples/shard-server.config.example
+++ b/examples/shard-server.config.example
@@ -87,6 +87,9 @@ instances {
       # than a catastrophic failure.
       action_blacklist_prefix: "ActionBlacklist"
 
+      # The ttl maintained for action_blacklist entries.
+      action_blacklist_expire: 3600 # 1 hour
+
       # A redis key prefix for all blacklisted invocations, suffixed
       # with the tool invocation id. Requests on behalf of an invocation
       # which is blacklisted should be rejected where it is identified via
@@ -96,9 +99,6 @@ instances {
       # case, can induce a fallback to non-remote recovery, rather
       # than a catastrophic failure.
       invocation_blacklist_prefix: "InvocationBlacklist"
-
-      # The ttl maintained for action_blacklist entries.
-      action_blacklist_expire: 3600 # 1 hour
 
       # A redis key prefix for all Operations, suffixed with the
       # operation's name and mapping to an Operation which reflects
@@ -213,6 +213,27 @@ instances {
       # safety check for the backplane storage.
       # Redis cluster storage size should influence safe values here.
       max_pre_queue_depth: 1000000
+
+      # Specify a queue that supports min/max cpu core specification
+      provisioned_queues: {
+        queues: {
+          name: "cpu"
+
+          platform: {
+            # Any specification (including non-specification) of min/max-cores
+            # will be allowed to support cpu controls and worker resource
+            # delegation.
+            properties: {
+              name: "min-cores"
+              value: "*"
+            }
+            properties: {
+              name: "max-cores"
+              value: "*"
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/examples/shard-worker.config.example
+++ b/examples/shard-worker.config.example
@@ -148,6 +148,16 @@ redis_shard_backplane_config: {
   # The ttl maintained for action_blacklist entries.
   action_blacklist_expire: 3600 # 1 hour
 
+  # A redis key prefix for all blacklisted invocations, suffixed
+  # with the tool invocation id. Requests on behalf of an invocation
+  # which is blacklisted should be rejected where it is identified via
+  # its RequestMetadata
+  # To meet API standards, a request which matches this condition
+  # receives a transient UNAVAILABLE response, which, in bazel's
+  # case, can induce a fallback to non-remote recovery, rather
+  # than a catastrophic failure.
+  invocation_blacklist_prefix: "InvocationBlacklist"
+
   # A redis key prefix for all Operations, suffixed with the
   # operation's name and mapping to an Operation which reflects
   # the cluster perceived state of that Operation
@@ -211,6 +221,27 @@ redis_shard_backplane_config: {
   # CAS is reduced.
   # When in doubt, leave this enabled.
   subscribe_to_backplane: true
+
+  ## Specify a queue that supports min/max cpu core specification
+  provisioned_queues: {
+    queues: {
+      name: "cpu"
+
+      platform: {
+        # Any specification (including non-specification) of min/max-cores
+        # will be allowed to support cpu controls and worker resource
+        # delegation.
+        properties: {
+          name: "min-cores"
+          value: "*"
+        }
+        properties: {
+          name: "max-cores"
+          value: "*"
+        }
+      }
+    }
+  }
 }
 
 # Create exec trees containing directories that are owned by

--- a/src/main/java/build/buildfarm/instance/shard/OperationQueue.java
+++ b/src/main/java/build/buildfarm/instance/shard/OperationQueue.java
@@ -189,13 +189,13 @@ public class OperationQueue {
   }
   ///
   /// @brief   Decide if the properties are valid based on having eligibility into a queue
-  /// @param   provisions Provisions to check validity of.
-  /// @return  Whether the provisions are valid for a queue.
+  /// @param   properties Properties to check validity of.
+  /// @return  Whether the properties are valid for a queue.
   /// @note    Suggested return identifier: validProperties.
   ///
-  public Boolean validProperties(List<Platform.Property> provisions) {
+  public Boolean validProperties(List<Platform.Property> properties) {
     for (ProvisionedRedisQueue provisionedQueue : queues) {
-      if (provisionedQueue.isEligible(toMultimap(provisions))) {
+      if (provisionedQueue.isEligible(toMultimap(properties))) {
         return true;
       }
     }

--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -1456,18 +1456,6 @@ public class ShardInstance extends AbstractServerInstance {
                       "property '%s' value was not a valid integer: %s",
                       property.getName(), property.getValue()));
         }
-        // An individual platform property may not be valid on its own,
-        // but instead, valid in the context of the full platform where the configured
-        // OperationQueue checks the eligibility.
-        // Therefore, we do not consider an individual property invalid when it has been previously
-        // validated against the OperationQueue.
-      } else if (validForOperationQueue) {
-      } else {
-        preconditionFailure
-            .addViolationsBuilder()
-            .setType(VIOLATION_TYPE_INVALID)
-            .setSubject(INVALID_PLATFORM)
-            .setDescription(format("property name '%s' is invalid", property.getName()));
       }
     }
     if (maxCores != -1 && minCores > 0 && maxCores < minCores) {


### PR DESCRIPTION
ProvisionedQueues will now accept wildcard property names (making them
completely accepting), wildcard property values (making them accept all
values, including non-specification), and specific property name/value
pairs, and insist that all required pairs are specified.

The default ProvisionedQueue will be a wildcard property queue.
Specifying any ProvisionedQueue in config will remove the default queue
from consideration.

An example config which supports min/max-cores platform property values
is provided, and it will reject all other keyed platforms.

The shard-worker InvocationBlacklist was introduced to ensure that
rejected operations can be completed due to blacklisting.