### PR TITLE
Prevent error flood on removed entry during expire

### DIFF
--- a/src/main/java/build/buildfarm/cas/CASFileCache.java
+++ b/src/main/java/build/buildfarm/cas/CASFileCache.java
@@ -1855,6 +1855,16 @@ public abstract class CASFileCache implements ContentAddressableStorage {
       }
       if (removedEntry == null) {
         logger.log(Level.SEVERE, format("entry %s was already removed during expiration", e.key));
+        if (e.isLinked()) {
+          logger.log(Level.SEVERE, format("removing spuriously non-existent entry %s", e.key));
+          e.unlink();
+        } else {
+          logger.log(
+              Level.SEVERE,
+              format(
+                  "spuriously non-existent entry %s was somehow unlinked, should not appear again",
+                  e.key));
+        }
       } else {
         logger.log(
             Level.SEVERE,
@@ -2733,6 +2743,10 @@ public abstract class CASFileCache implements ContentAddressableStorage {
       this.size = size;
       referenceCount = 1;
       this.existsDeadline = existsDeadline;
+    }
+
+    public boolean isLinked() {
+      return before != null && after != null;
     }
 
     public void unlink() {


### PR DESCRIPTION
Entries appear to be capable of being removed from storage, but not
unlinked, when they reach the head of the LRU for expiration. Guard
against this loop by unlinking an entry if it expresses linkage.

This is not a correction for the inconsistency, which appears to be
guarded correctly, but for avoiding the unresolvable state of the same
entry being removed from the LRU list.