### PR TITLE
Correct directoriesIndex dir removal ownership

### DIFF
--- a/src/main/java/build/buildfarm/cas/FileDirectoriesIndex.java
+++ b/src/main/java/build/buildfarm/cas/FileDirectoriesIndex.java
@@ -107,8 +107,8 @@ class FileDirectoriesIndex implements DirectoriesIndex {
     opened = false;
   }
 
-  @GuardedBy("this")
-  private Set<Digest> removeEntryDirectories(String entry) {
+  @Override
+  public synchronized Set<Digest> removeEntry(String entry) {
     open();
 
     String selectSql = "SELECT directory FROM entries WHERE path = ?";
@@ -133,19 +133,6 @@ class FileDirectoriesIndex implements DirectoriesIndex {
 
   Path path(Digest digest) {
     return root.resolve(digest.getHash() + "_" + digest.getSizeBytes() + "_dir_inputs");
-  }
-
-  @Override
-  public synchronized Set<Digest> removeEntry(String entry) {
-    Set<Digest> directories = removeEntryDirectories(entry);
-    try {
-      for (Digest directory : directories) {
-        Files.delete(path(directory));
-      }
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
-    return directories;
   }
 
   @Override

--- a/src/main/java/build/buildfarm/cas/MemoryDirectoriesIndex.java
+++ b/src/main/java/build/buildfarm/cas/MemoryDirectoriesIndex.java
@@ -41,11 +41,7 @@ class MemoryDirectoriesIndex implements DirectoriesIndex {
 
   @Override
   public synchronized Set<Digest> removeEntry(String entry) {
-    Set<Digest> directories = entryDirectories.removeAll(entry);
-    for (Digest directory : directories) {
-      directories.remove(directory);
-    }
-    return directories;
+    return entryDirectories.removeAll(entry);
   }
 
   @Override


### PR DESCRIPTION
FileDirectoriesIndex was not deleting directories correctly, or
appropriately, when removeEntry was called. This ownership is best left
to CFC for now, and it would result in immediate hang of a worker on
expiration when a directory had to be removed.