### PR TITLE
enable RedisClientTest

### DIFF
--- a/src/test/java/build/buildfarm/common/redis/RedisClientTest.java
+++ b/src/test/java/build/buildfarm/common/redis/RedisClientTest.java
@@ -29,7 +29,7 @@ import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 
 @RunWith(JUnit4.class)
-class RedisClientTest {
+public class RedisClientTest {
   @Test
   public void runExceptionEndOfStreamIsUnavailable() throws IOException, InterruptedException {
     RedisClient client = new RedisClient(mock(JedisCluster.class));


### PR DESCRIPTION
JUnit doesn't run test methods when the class is not public.