### PR TITLE
Use PATH-available bazelisk in generate_coverage

### DIFF
--- a/generate_coverage.sh
+++ b/generate_coverage.sh
@@ -12,7 +12,7 @@ then
       target="//src/test/...:all"
 fi
 
-bazel="$(pwd)/ci/bazelisk"
+bazel=bazelisk
 COVERAGE=bazel-testlogs/coverage
 
 "${bazel}" coverage $target --test_tag_filters="-redis"


### PR DESCRIPTION
ci is no longer an available path for bazelbuild buildfarm