### PR TITLE
Update container build rules to point to `java_image_base`

### DIFF
--- a/src/main/java/build/buildfarm/BUILD
+++ b/src/main/java/build/buildfarm/BUILD
@@ -356,7 +356,7 @@ java_binary(
 
 container_image(
     name = "server.container",
-    base = "@java_base//image",
+    base = "@java_image_base//image",
     cmd = [
         "buildfarm-server_deploy.jar",
         "/config/server.config",
@@ -450,7 +450,7 @@ java_binary(
 
 container_image(
     name = "buildfarm-shard-worker.container",
-    base = "@java_base//image",
+    base = "@java_image_base//image",
     # leverage the implicit target of the buildfarm-shard-worker to get a fat jar.
     # this is simply a workaround for the fact that we have so many dependencies,
     # so we'd want some wrappy script. This seemed more straightforward.
@@ -579,7 +579,7 @@ java_binary(
 
 container_image(
     name = "buildfarm-operationqueue-worker.container",
-    base = "@java_base//image",
+    base = "@java_image_base//image",
     cmd = [
         "buildfarm-operationqueue-worker_deploy.jar",
         "/config/worker.config",


### PR DESCRIPTION
It seems that PR #445  didn't update the BUILD file in `src/main/java/build/buildfarm`, resulting in the following error when trying to build the container targets.

```
❯ bazel run //src/main/java/build/buildfarm:buildfarm-shard-worker.container
ERROR: /home/elyzion/workspace/github.com/bazelbuild/bazel-buildfarm/src/main/java/build/buildfarm/BUILD:451:1: no such package '@java_base//image': The repository '@java_base' could not be resolved and referenced by '//src/main/java/build/buildfarm:buildfarm-shard-worker.container'
ERROR: Analysis of target '//src/main/java/build/buildfarm:buildfarm-shard-worker.container' failed; build aborted: no such package '@java_base//image': The repository '@java_base' could not be resolved
INFO: Elapsed time: 0.061s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (0 packages loaded, 0 targets configured)
FAILED: Build did NOT complete successfully (0 packages loaded, 0 targets configured)
```

This updates the rules to point to `java_image_base`.