### PR TITLE
Drain queues if waiting for release

### DIFF
--- a/src/main/java/build/buildfarm/worker/ExecuteActionStage.java
+++ b/src/main/java/build/buildfarm/worker/ExecuteActionStage.java
@@ -115,9 +115,14 @@ public class ExecuteActionStage extends SuperscalarPipelineStage {
   }
 
   @Override
+  protected int claimsRequired(OperationContext operationContext) {
+    return workerContext.commandExecutionClaims(operationContext.command);
+  }
+
+  @Override
   protected void iterate() throws InterruptedException {
     OperationContext operationContext = take();
-    int claims = workerContext.commandExecutionClaims(operationContext.command);
+    int claims = claimsRequired(operationContext);
     Executor executor = new Executor(workerContext, operationContext, this);
     Thread executorThread = new Thread(() -> executor.run(claims));
 

--- a/src/main/java/build/buildfarm/worker/InputFetchStage.java
+++ b/src/main/java/build/buildfarm/worker/InputFetchStage.java
@@ -75,6 +75,11 @@ public class InputFetchStage extends SuperscalarPipelineStage {
   }
 
   @Override
+  protected int claimsRequired(OperationContext operationContext) {
+    return 1;
+  }
+
+  @Override
   protected void iterate() throws InterruptedException {
     OperationContext operationContext = take();
     Thread fetcher = new Thread(new InputFetcher(workerContext, operationContext, this));

--- a/src/test/java/build/buildfarm/worker/SuperscalarPipelineStageTest.java
+++ b/src/test/java/build/buildfarm/worker/SuperscalarPipelineStageTest.java
@@ -61,6 +61,11 @@ public class SuperscalarPipelineStageTest {
       throw new UnsupportedOperationException();
     }
 
+    @Override
+    protected int claimsRequired(OperationContext operationContext) {
+      throw new UnsupportedOperationException();
+    }
+
     boolean isFull() {
       return claims.size() == width;
     }


### PR DESCRIPTION
Ensure that SuperscalarPipelineStages drain their queues while waiting
for all claims to be released - the queue entries represent claim
holders which would be held indefinitely with nothing to relieve them if
populated, since they never made it into a thread for processing.