### PR TITLE
Clean up claims acquisition, test for queue drain

### DIFF
--- a/src/main/java/build/buildfarm/worker/ExecuteActionStage.java
+++ b/src/main/java/build/buildfarm/worker/ExecuteActionStage.java
@@ -60,11 +60,6 @@ public class ExecuteActionStage extends SuperscalarPipelineStage {
   }
 
   @Override
-  public boolean claim(OperationContext operationContext) throws InterruptedException {
-    return claim(workerContext.commandExecutionClaims(operationContext.command));
-  }
-
-  @Override
   protected Logger getLogger() {
     return logger;
   }

--- a/src/main/java/build/buildfarm/worker/SuperscalarPipelineStage.java
+++ b/src/main/java/build/buildfarm/worker/SuperscalarPipelineStage.java
@@ -121,7 +121,7 @@ abstract class SuperscalarPipelineStage extends PipelineStage {
     return String.format("%s/%d", size, width);
   }
 
-  protected boolean claim(int count) throws InterruptedException {
+  private boolean claim(int count) throws InterruptedException {
     Object handle = new Object();
     int claimed = 0;
     synchronized (claimLock) {
@@ -155,7 +155,7 @@ abstract class SuperscalarPipelineStage extends PipelineStage {
 
   @Override
   public boolean claim(OperationContext operationContext) throws InterruptedException {
-    return claim(1);
+    return claim(claimsRequired(operationContext));
   }
 
   @Override

--- a/src/test/java/build/buildfarm/worker/PipelineStageTest.java
+++ b/src/test/java/build/buildfarm/worker/PipelineStageTest.java
@@ -27,12 +27,12 @@ import org.junit.runners.JUnit4;
 public class PipelineStageTest {
   private static final Logger logger = Logger.getLogger(PipelineStageTest.class.getName());
 
-  abstract static class AbstractPipelineStage extends PipelineStage {
-    public AbstractPipelineStage(String name) {
+  static class StubPipelineStage extends PipelineStage {
+    public StubPipelineStage(String name) {
       this(name, null, null, null);
     }
 
-    public AbstractPipelineStage(
+    public StubPipelineStage(
         String name, WorkerContext workerContext, PipelineStage output, PipelineStage error) {
       super(name, workerContext, output, error);
     }
@@ -56,7 +56,7 @@ public class PipelineStageTest {
   @Test
   public void cancelTickInterruptsOperation() throws InterruptedException {
     PipelineStage output =
-        new AbstractPipelineStage("singleOutput") {
+        new StubPipelineStage("singleOutput") {
           @Override
           public void put(OperationContext operationContext) {
             close();
@@ -64,7 +64,7 @@ public class PipelineStageTest {
         };
     AtomicInteger errorCount = new AtomicInteger();
     PipelineStage error =
-        new AbstractPipelineStage("error") {
+        new StubPipelineStage("error") {
           @Override
           public void put(OperationContext operationContext) {
             errorCount.getAndIncrement();
@@ -74,7 +74,7 @@ public class PipelineStageTest {
         OperationContext.newBuilder().setOperation(Operation.getDefaultInstance()).build();
     AtomicInteger count = new AtomicInteger();
     PipelineStage stage =
-        new AbstractPipelineStage("waiter", new StubWorkerContext(), output, error) {
+        new StubPipelineStage("waiter", new StubWorkerContext(), output, error) {
           Object lock = new Object();
 
           @Override

--- a/src/test/java/build/buildfarm/worker/SuperscalarPipelineStageTest.java
+++ b/src/test/java/build/buildfarm/worker/SuperscalarPipelineStageTest.java
@@ -18,6 +18,9 @@ import static com.google.common.truth.Truth.assertThat;
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
 import static org.junit.Assert.fail;
 
+import com.google.longrunning.Operation;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
 import java.util.logging.Logger;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -28,8 +31,8 @@ public class SuperscalarPipelineStageTest {
   private static final Logger logger = Logger.getLogger(PipelineStageTest.class.getName());
 
   static class AbstractSuperscalarPipelineStage extends SuperscalarPipelineStage {
-    public AbstractSuperscalarPipelineStage(String name, int width) {
-      this(name, null, null, null, width);
+    public AbstractSuperscalarPipelineStage(String name, PipelineStage output, int width) {
+      this(name, null, output, null, width);
     }
 
     public AbstractSuperscalarPipelineStage(
@@ -52,7 +55,7 @@ public class SuperscalarPipelineStageTest {
     }
 
     @Override
-    OperationContext take() {
+    OperationContext take() throws InterruptedException {
       throw new UnsupportedOperationException();
     }
 
@@ -74,10 +77,10 @@ public class SuperscalarPipelineStageTest {
   @Test
   public void interruptedClaimReleasesPartial() throws InterruptedException {
     AbstractSuperscalarPipelineStage stage =
-        new AbstractSuperscalarPipelineStage("too-narrow", /* width=*/ 3) {
+        new AbstractSuperscalarPipelineStage("too-narrow", /* output=*/ null, /* width=*/ 3) {
           @Override
-          public boolean claim(OperationContext operationContext) throws InterruptedException {
-            return claim(5);
+          protected int claimsRequired(OperationContext operationContext) {
+            return 5;
           }
         };
 
@@ -106,6 +109,38 @@ public class SuperscalarPipelineStageTest {
     } finally {
       interruptor.join();
       assertThat(stage.isClaimed()).isFalse();
+    }
+  }
+
+  @Test
+  public void takeReleasesQueueClaims() throws InterruptedException {
+    OperationContext context =
+        OperationContext.newBuilder()
+            .setOperation(Operation.newBuilder().setName("operation-in-queue").build())
+            .build();
+    BlockingQueue<OperationContext> queue = new ArrayBlockingQueue<>(1);
+    PipelineStage output = new PipelineStageTest.StubPipelineStage("unclosed-sink");
+    PipelineStage stage =
+        new AbstractSuperscalarPipelineStage("queue-claimed", output, /* width=*/ 3) {
+          @Override
+          protected int claimsRequired(OperationContext operationContext) {
+            return 2;
+          }
+
+          @Override
+          public OperationContext take() throws InterruptedException {
+            return takeOrDrain(queue);
+          }
+        };
+    stage.claim(context);
+    queue.put(context);
+
+    stage.close();
+    try {
+      stage.take();
+      fail("should not get here");
+    } catch (InterruptedException e) {
+      // ignore
     }
   }
 }


### PR DESCRIPTION
claimsRequired can now be used to put into stages cleanly. Add tests to
verify that queued entries are drained and released on wait.