### PR TITLE
Extend null operation match to DEADLINE_EXCEEDED

### DIFF
--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -74,7 +74,6 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.rpc.PreconditionFailure;
 import io.grpc.Deadline;
 import io.grpc.Status;
-import io.grpc.Status.Code;
 import io.grpc.StatusException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -289,10 +288,17 @@ class ShardWorkerContext implements WorkerContext {
       queueEntry = backplane.dispatchOperation(platform.getPropertiesList());
     } catch (IOException e) {
       Status status = Status.fromThrowable(e);
-      if (status.getCode() != Code.UNAVAILABLE) {
-        throw e;
+      switch (status.getCode()) {
+        case DEADLINE_EXCEEDED:
+          logger.log(Level.WARNING, "backplane timed out for match during bookkeeping");
+          break;
+        case UNAVAILABLE:
+          logger.log(Level.WARNING, "backplane was unavailable for match");
+          break;
+        default:
+          throw e;
       }
-      // unavailable backplane will propagate a null queueEntry
+      // transient backplane errors will propagate a null queueEntry
     }
     listener.onWaitEnd();
     if (queueEntry == null || satisfiesRequirements(matchProvisions, queueEntry.getPlatform())) {


### PR DESCRIPTION
Failure to match when performing backplane bookkeeping due to socket
read timeouts should be handled with a null operation, resulting in
either DispatchedMonitor or failsafe operation watches picking up a
dropped operation, and preventing a total worker shutdown.