### PR TITLE
Log pipeline run exceptions causing shutdowns

### DIFF
--- a/src/main/java/build/buildfarm/worker/PipelineStage.java
+++ b/src/main/java/build/buildfarm/worker/PipelineStage.java
@@ -51,6 +51,10 @@ public abstract class PipelineStage implements Runnable {
       runInterruptible();
     } catch (InterruptedException e) {
       // ignore
+    } catch (Exception e) {
+      getLogger()
+          .log(
+              Level.SEVERE, String.format("%s::run(): stage terminated due to exception", name), e);
     } finally {
       boolean wasInterrupted = Thread.interrupted();
       try {


### PR DESCRIPTION
Use the provided logger explicitly to log exceptions encountered during
PipelineStage::run. All stage terminations due to non-interrupt should
be considered a bug.