### PR TITLE
Wrap oq worker in LoggingMain, interpret interrupt

### DIFF
--- a/src/main/java/build/buildfarm/instance/stub/StubInstance.java
+++ b/src/main/java/build/buildfarm/instance/stub/StubInstance.java
@@ -686,6 +686,11 @@ public class StubInstance implements Instance {
         complete = true;
       } catch (Exception e) {
         Status status = Status.fromThrowable(e);
+        if (status.getCode() == Status.Code.CANCELLED && Thread.currentThread().isInterrupted()) {
+          InterruptedException intEx = new InterruptedException();
+          intEx.addSuppressed(e);
+          throw intEx;
+        }
         if (status.getCode() != Status.Code.DEADLINE_EXCEEDED) {
           listener.onError(e);
           complete = true;


### PR DESCRIPTION
Allow for clean shutdown of operationqueue worker, including logging,
when an interrupt is received in pipeline join. Interpret a cancellation
in StubInstance operationqueue match as an InterruptedException if so
indicated.