### PR TITLE
Restore canPrequeue validation for arriving execs

### DIFF
--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -1703,6 +1703,11 @@ public class ShardInstance extends AbstractServerInstance {
       RequestMetadata requestMetadata,
       Watcher watcher) {
     try {
+      if (!backplane.canPrequeue()) {
+        return immediateFailedFuture(
+            Status.RESOURCE_EXHAUSTED.withDescription("Too many jobs pending").asException());
+      }
+
       String operationName = createOperationName(UUID.randomUUID().toString());
 
       logger.log(


### PR DESCRIPTION
The prequeue limit should be enforced. The negative size may be used to
negate this test, if it is not desirable.