### PR TITLE
Set of http proxy fixes.

### DIFF
--- a/src/main/java/build/buildfarm/proxy/http/DownloadCommand.java
+++ b/src/main/java/build/buildfarm/proxy/http/DownloadCommand.java
@@ -25,12 +25,15 @@ final class DownloadCommand {
   private final boolean casDownload;
   private final String hash;
   private final OutputStream out;
+  private final boolean downloadContent;
 
-  protected DownloadCommand(URI uri, boolean casDownload, String hash, OutputStream out) {
+  protected DownloadCommand(
+      URI uri, boolean casDownload, String hash, OutputStream out, boolean downloadContent) {
     this.uri = Preconditions.checkNotNull(uri);
     this.casDownload = casDownload;
     this.hash = Preconditions.checkNotNull(hash);
     this.out = Preconditions.checkNotNull(out);
+    this.downloadContent = downloadContent;
   }
 
   public URI uri() {
@@ -47,5 +50,9 @@ final class DownloadCommand {
 
   public OutputStream out() {
     return out;
+  }
+
+  public boolean downloadContent() {
+    return downloadContent;
   }
 }

--- a/src/main/java/build/buildfarm/proxy/http/HttpDownloadHandler.java
+++ b/src/main/java/build/buildfarm/proxy/http/HttpDownloadHandler.java
@@ -135,7 +135,7 @@ final class HttpDownloadHandler extends AbstractHttpHandler<HttpObject> {
     HttpRequest httpRequest =
         new DefaultFullHttpRequest(
             HttpVersion.HTTP_1_1,
-            HttpMethod.GET,
+            request.downloadContent() ? HttpMethod.GET : HttpMethod.HEAD,
             constructPath(request.uri(), request.hash(), request.casDownload()));
     httpRequest.headers().set(HttpHeaderNames.HOST, constructHost(request.uri()));
     httpRequest.headers().set(HttpHeaderNames.CONNECTION, HttpHeaderValues.KEEP_ALIVE);

--- a/src/main/java/build/buildfarm/proxy/http/WriteStreamObserver.java
+++ b/src/main/java/build/buildfarm/proxy/http/WriteStreamObserver.java
@@ -57,8 +57,8 @@ class WriteStreamObserver implements StreamObserver<WriteRequest> {
         if (request.getFinishWrite()) {
           writeObserverSource.remove(request.getResourceName());
         }
-      } catch (Throwable t) {
-        onError(t);
+      } catch (Exception e) {
+        onError(e);
       }
     }
   }


### PR DESCRIPTION
Tested with bazel-remote. Writes now handle non-ascii data due to byte
sign extension. Errors encountered in stream are now handled nicely into
client, though too quietly. FindMissingBlobs is now supported through
http HEAD requests. Write completions now close a ring buffer properly
before attempting to join on their worker put.

Many of these changes are courtesy of #270, distilled. Thank you
@moroten for your contributions.