### PR TITLE
Allow custom connection timeout and connection attempts for jedis cluster

### DIFF
--- a/src/main/java/build/buildfarm/instance/shard/JedisClusterFactory.java
+++ b/src/main/java/build/buildfarm/instance/shard/JedisClusterFactory.java
@@ -47,7 +47,11 @@ public class JedisClusterFactory {
   ///
   public static Supplier<JedisCluster> create(RedisShardBackplaneConfig config)
       throws ConfigurationException {
-    return createJedisClusterFactory(parseUri(config.getRedisUri()), createJedisPoolConfig(config));
+    return createJedisClusterFactory(
+        parseUri(config.getRedisUri()),
+        config.getTimeout(),
+        config.getMaxAttempts(),
+        createJedisPoolConfig(config));
   }
   ///
   /// @brief   Create a test jedis cluster instance.
@@ -134,6 +138,26 @@ public class JedisClusterFactory {
       URI redisUri, JedisPoolConfig poolConfig) {
     return () ->
         new JedisCluster(new HostAndPort(redisUri.getHost(), redisUri.getPort()), poolConfig);
+  }
+  ///
+  /// @brief   Create a jedis cluster instance with connection settings.
+  /// @details Use the URI, pool and connection information to connect to a redis cluster
+  ///          server and provide a jedis client.
+  /// @param   redisUri   A valid uri to a redis instance.
+  /// @param   timeout Connection timeout
+  /// @param   maxAttempts Number of connection attempts
+  /// @param   poolConfig Configuration related to redis pools.
+  /// @return  An established jedis client used to operate on the redis cluster.
+  /// @note    Suggested return identifier: jedis.
+  ///
+  private static Supplier<JedisCluster> createJedisClusterFactory(
+      URI redisUri, int timeout, int maxAttempts, JedisPoolConfig poolConfig) {
+    return () ->
+        new JedisCluster(
+            new HostAndPort(redisUri.getHost(), redisUri.getPort()),
+            Integer.max(2000, timeout),
+            Integer.max(5, maxAttempts),
+            poolConfig);
   }
   ///
   /// @brief   Create a jedis pool config.

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -244,6 +244,8 @@ message RedisShardBackplaneConfig {
   int32 max_queue_depth = 16;
   int32 max_pre_queue_depth = 17;
   ProvisionedQueuesConfig provisioned_queues = 31;
+  int32 timeout = 32;
+  int32 max_attempts = 33;
 }
 
 message ShardInstanceConfig {


### PR DESCRIPTION
Addresses https://github.com/bazelbuild/bazel-buildfarm/issues/484

The default connection timeout is 2000ms and the max number of attempts is 5. When network hiccups occur, the max number of connections gets exhausted and the container shuts down. This change will give us the ability to increase the thresholds so that we can better control connection to Redis.