### PR TITLE
Coerce io into Interrupt on destroyExecDir

### DIFF
--- a/src/main/java/build/buildfarm/cas/DirectoriesIndex.java
+++ b/src/main/java/build/buildfarm/cas/DirectoriesIndex.java
@@ -15,6 +15,7 @@
 package build.buildfarm.cas;
 
 import build.bazel.remote.execution.v2.Digest;
+import java.io.IOException;
 import java.util.Set;
 
 /**
@@ -25,13 +26,13 @@ import java.util.Set;
 interface DirectoriesIndex {
   void close();
 
-  Set<Digest> removeEntry(String entry);
+  Set<Digest> removeEntry(String entry) throws IOException;
 
-  Iterable<String> directoryEntries(Digest directory);
+  Iterable<String> directoryEntries(Digest directory) throws IOException;
 
-  void put(Digest directory, Iterable<String> entries);
+  void put(Digest directory, Iterable<String> entries) throws IOException;
 
-  void remove(Digest directory);
+  void remove(Digest directory) throws IOException;
 
   void start();
 }

--- a/src/main/java/build/buildfarm/cas/FileDirectoriesIndex.java
+++ b/src/main/java/build/buildfarm/cas/FileDirectoriesIndex.java
@@ -148,30 +148,24 @@ class FileDirectoriesIndex implements DirectoriesIndex {
   }
 
   @Override
-  public synchronized Set<Digest> removeEntry(String entry) {
+  public synchronized Set<Digest> removeEntry(String entry) throws IOException {
     Set<Digest> directories = removeEntryDirectories(entry);
-    try {
-      for (Digest directory : directories) {
-        try {
-          Files.delete(path(directory));
-        } catch (NoSuchFileException e) {
-          // ignore
-        }
+    for (Digest directory : directories) {
+      try {
+        Files.delete(path(directory));
+      } catch (NoSuchFileException e) {
+        // ignore
       }
-    } catch (IOException e) {
-      throw new RuntimeException(e);
     }
     return directories;
   }
 
   @Override
-  public Iterable<String> directoryEntries(Digest directory) {
+  public Iterable<String> directoryEntries(Digest directory) throws IOException {
     try {
       return asCharSource(path(directory), UTF_8).readLines();
     } catch (NoSuchFileException e) {
       return ImmutableList.of();
-    } catch (IOException e) {
-      throw new RuntimeException(e);
     }
   }
 
@@ -195,12 +189,8 @@ class FileDirectoriesIndex implements DirectoriesIndex {
   }
 
   @Override
-  public void put(Digest directory, Iterable<String> entries) {
-    try {
-      asCharSink(path(directory), UTF_8).writeLines(entries);
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
+  public void put(Digest directory, Iterable<String> entries) throws IOException {
+    asCharSink(path(directory), UTF_8).writeLines(entries);
     addEntriesDirectory(ImmutableSet.copyOf(entries), directory);
   }
 
@@ -219,13 +209,11 @@ class FileDirectoriesIndex implements DirectoriesIndex {
   }
 
   @Override
-  public synchronized void remove(Digest directory) {
+  public synchronized void remove(Digest directory) throws IOException {
     try {
       Files.delete(path(directory));
     } catch (NoSuchFileException e) {
       // ignore
-    } catch (IOException e) {
-      throw new RuntimeException(e);
     }
     removeEntriesDirectory(directory);
   }

--- a/src/main/java/build/buildfarm/worker/operationqueue/Worker.java
+++ b/src/main/java/build/buildfarm/worker/operationqueue/Worker.java
@@ -613,7 +613,7 @@ public class Worker extends LoggingMain {
           }
 
           @Override
-          public void destroyExecDir(Path execDir) throws IOException {
+          public void destroyExecDir(Path execDir) throws IOException, InterruptedException {
             Iterable<String> inputFiles = rootInputFiles.remove(execDir);
             Iterable<Digest> inputDirectories = rootInputDirectories.remove(execDir);
 

--- a/src/test/java/build/buildfarm/cas/CASFileCacheTest.java
+++ b/src/test/java/build/buildfarm/cas/CASFileCacheTest.java
@@ -621,7 +621,7 @@ class CASFileCacheTest {
         .getWrite(eq(expiringDigest), any(UUID.class), any(RequestMetadata.class));
   }
 
-  void decrementReference(Path path) {
+  void decrementReference(Path path) throws IOException, InterruptedException {
     fileCache.decrementReferences(
         ImmutableList.of(path.getFileName().toString()), ImmutableList.of());
   }


### PR DESCRIPTION
Interpret ClosedByInterruptException at the CAS layer as an
InterruptedException when interacting with the DirectoriesIndex.
Avoid wrapping IOExceptions in RuntimeExceptions (SQLExceptions are to
be dealt with separately).