### PR TITLE
Add admin grpc service

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -53,7 +53,9 @@ def buildfarm_init(name="buildfarm"):
     maven_install(
         artifacts = [
             "com.amazonaws:aws-java-sdk-core:1.11.729",
+            "com.amazonaws:aws-java-sdk-ec2:1.11.729",
             "com.amazonaws:aws-java-sdk-sns:1.11.729",
+            "com.amazonaws:aws-java-sdk-ssm:1.11.729",
             "com.github.jnr:jnr-constants:0.9.9",
             "com.github.jnr:jnr-ffi:2.1.7",
             "com.github.jnr:jffi:1.2.16",

--- a/src/main/java/build/buildfarm/BUILD
+++ b/src/main/java/build/buildfarm/BUILD
@@ -146,6 +146,60 @@ java_library(
 )
 
 java_library(
+    name = "common-admin",
+    srcs = glob([
+        "common/admin/Admin.java",
+    ]),
+    deps = [
+        "//src/main/protobuf:build_buildfarm_v1test_buildfarm_java_proto",
+        "@googleapis//:google_rpc_code_java_proto",
+        "@googleapis//:google_rpc_error_details_java_proto",
+        "@googleapis//:google_rpc_status_java_proto",
+        "@maven//:com_google_guava_guava",
+        "@maven//:com_google_protobuf_protobuf_java",
+        "@maven//:com_google_protobuf_protobuf_java_util",
+        "@remote_apis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
+    ],
+)
+
+java_library(
+    name = "aws-admin",
+    srcs = glob([
+        "common/admin/aws/*.java",
+    ]),
+    deps = [
+        ":common-admin",
+        "//src/main/protobuf:build_buildfarm_v1test_buildfarm_java_proto",
+        "@googleapis//:google_rpc_code_java_proto",
+        "@googleapis//:google_rpc_error_details_java_proto",
+        "@googleapis//:google_rpc_status_java_proto",
+        "@maven//:com_amazonaws_aws_java_sdk_core",
+        "@maven//:com_amazonaws_aws_java_sdk_ec2",
+        "@maven//:com_amazonaws_aws_java_sdk_ssm",
+        "@maven//:com_google_guava_guava",
+        "@maven//:com_google_protobuf_protobuf_java_util",
+        "@remote_apis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
+    ],
+)
+
+java_library(
+    name = "gcp-admin",
+    srcs = glob([
+        "common/admin/gcp/*.java",
+    ]),
+    deps = [
+        ":common-admin",
+        "//src/main/protobuf:build_buildfarm_v1test_buildfarm_java_proto",
+        "@googleapis//:google_rpc_code_java_proto",
+        "@googleapis//:google_rpc_error_details_java_proto",
+        "@googleapis//:google_rpc_status_java_proto",
+        "@maven//:com_google_guava_guava",
+        "@maven//:com_google_protobuf_protobuf_java_util",
+        "@remote_apis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
+    ],
+)
+
+java_library(
     name = "common-redis",
     srcs = glob([
         "common/redis/*.java",
@@ -307,11 +361,14 @@ java_library(
     srcs = glob(["server/**/*.java"]),
     visibility = ["//visibility:public"],
     deps = [
+        ":aws-admin",
         ":aws-metrics",
         ":cas",
         ":common",
         ":common-grpc",
+        ":common-admin",
         ":common-metrics",
+        ":gcp-admin",
         ":gcp-metrics",
         ":instance",
         ":log-metrics",

--- a/src/main/java/build/buildfarm/common/admin/Admin.java
+++ b/src/main/java/build/buildfarm/common/admin/Admin.java
@@ -1,0 +1,21 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.common.admin;
+
+public interface Admin {
+  void terminateHost(String hostId);
+
+  void stopContainer(String hostId, String containerName);
+}

--- a/src/main/java/build/buildfarm/common/admin/gcp/GcpAdmin.java
+++ b/src/main/java/build/buildfarm/common/admin/gcp/GcpAdmin.java
@@ -1,0 +1,29 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.common.admin.gcp;
+
+import build.buildfarm.common.admin.Admin;
+
+public class GcpAdmin implements Admin {
+  @Override
+  public void terminateHost(String hostId) {
+    throw new UnsupportedOperationException("Not Implemented.");
+  }
+
+  @Override
+  public void stopContainer(String hostId, String containerName) {
+    throw new UnsupportedOperationException("Not Implemented.");
+  }
+}

--- a/src/main/java/build/buildfarm/server/AdminService.java
+++ b/src/main/java/build/buildfarm/server/AdminService.java
@@ -1,0 +1,76 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.server;
+
+import build.buildfarm.common.admin.Admin;
+import build.buildfarm.common.admin.aws.AwsAdmin;
+import build.buildfarm.common.admin.gcp.GcpAdmin;
+import build.buildfarm.v1test.AdminConfig;
+import build.buildfarm.v1test.AdminGrpc;
+import build.buildfarm.v1test.StopContainerRequest;
+import build.buildfarm.v1test.TerminateHostRequest;
+import com.google.rpc.Code;
+import com.google.rpc.Status;
+import io.grpc.stub.StreamObserver;
+import java.util.logging.Logger;
+
+public class AdminService extends AdminGrpc.AdminImplBase {
+  private static final Logger logger = Logger.getLogger(AdminService.class.getName());
+
+  private final Admin adminController;
+
+  public AdminService(AdminConfig config) {
+    this.adminController = getAdminController(config);
+  }
+
+  @Override
+  public void terminateHost(TerminateHostRequest request, StreamObserver<Status> responseObserver) {
+    try {
+      if (adminController != null) {
+        adminController.terminateHost(request.getHostId());
+      }
+      responseObserver.onNext(Status.newBuilder().setCode(Code.OK_VALUE).build());
+      responseObserver.onCompleted();
+    } catch (Exception e) {
+      logger.severe("Could not terminate host." + e);
+      responseObserver.onError(io.grpc.Status.fromThrowable(e).asException());
+    }
+  }
+
+  @Override
+  public void stopContainer(StopContainerRequest request, StreamObserver<Status> responseObserver) {
+    try {
+      if (adminController != null) {
+        adminController.stopContainer(request.getHostId(), request.getContainerName());
+      }
+      responseObserver.onNext(Status.newBuilder().setCode(Code.OK_VALUE).build());
+      responseObserver.onCompleted();
+    } catch (Exception e) {
+      logger.severe("Could not stop container." + e);
+      responseObserver.onError(io.grpc.Status.fromThrowable(e).asException());
+    }
+  }
+
+  private static Admin getAdminController(AdminConfig config) {
+    switch (config.getDeploymentEnvironment()) {
+      default:
+        return null;
+      case "aws":
+        return new AwsAdmin(config.getAwsAdminConfig().getRegion());
+      case "gcp":
+        return new GcpAdmin();
+    }
+  }
+}

--- a/src/main/java/build/buildfarm/server/BuildFarmServer.java
+++ b/src/main/java/build/buildfarm/server/BuildFarmServer.java
@@ -107,6 +107,7 @@ public class BuildFarmServer extends LoggingMain {
                     getMetricsPublisher(config.getMetricsConfig())))
             .addService(new OperationQueueService(instances))
             .addService(new OperationsService(instances))
+            .addService(new AdminService(config.getAdminConfig()))
             .intercept(TransmitStatusRuntimeExceptionInterceptor.instance())
             .intercept(headersInterceptor)
             .build();

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -14,6 +14,31 @@ option java_package = "build.buildfarm.v1test";
 option java_multiple_files = true;
 option java_outer_classname = "OperationQueueProto";
 
+// The Admin API is used to perform administrative functions on Buildfarm infrastructure
+service Admin {
+  rpc TerminateHost(TerminateHostRequest) returns (google.rpc.Status) {
+    option (google.api.http) = { get: "/v1test/admin:terminateHost" };
+  }
+
+  rpc StopContainer(StopContainerRequest) returns (google.rpc.Status) {
+    option (google.api.http) = { get: "/v1test/admin:stopContainer" };
+  }
+}
+
+message TerminateHostRequest {
+  string instance_name = 1;
+
+  string host_id = 2;
+}
+
+message StopContainerRequest {
+  string instance_name = 1;
+
+  string host_id = 2;
+
+  string container_name = 3;
+}
+
 // The OperationQueue API is used internally to communicate with Workers
 service OperationQueue {
   rpc Take(TakeOperationRequest) returns (QueueEntry) {
@@ -70,6 +95,8 @@ message BuildFarmServerConfig {
   int32 execute_keepalive_after_seconds = 4;
 
   MetricsConfig metrics_config = 5;
+
+  AdminConfig admin_config = 6;
 }
 
 message MetricsConfig {
@@ -102,6 +129,22 @@ message GcpMetricsConfig {
 
 message LogMetricsConfig {
   string log_level = 1;
+}
+
+message AdminConfig {
+  string deployment_environment = 1;
+
+  oneof type {
+    AwsAdminConfig aws_admin_config = 2;
+    GcpAdminConfig gcp_admin_config = 3;
+  }
+}
+
+message AwsAdminConfig {
+  string region = 1;
+}
+
+message GcpAdminConfig {
 }
 
 message MemoryCASConfig {


### PR DESCRIPTION
Add an admin grpc service to perform various buildfarm management tasks, such as terminate hosts, reboot instances, etc.