### PR TITLE
Sanity value check for Filesystem CAS factory

### DIFF
--- a/src/main/java/build/buildfarm/cas/ContentAddressableStorages.java
+++ b/src/main/java/build/buildfarm/cas/ContentAddressableStorages.java
@@ -45,6 +45,7 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Paths;
 import java.util.Map;
 import java.util.UUID;
+import javax.naming.ConfigurationException;
 
 public final class ContentAddressableStorages {
   private static Channel createChannel(String target) {
@@ -63,12 +64,28 @@ public final class ContentAddressableStorages {
     return new GrpcCAS(config.getInstanceName(), channel, byteStreamUploader, onExpirations);
   }
 
-  public static ContentAddressableStorage createFilesystemCAS(FilesystemCASConfig config) {
+  public static ContentAddressableStorage createFilesystemCAS(FilesystemCASConfig config)
+      throws ConfigurationException {
+    String path = config.getPath();
+    if (path.isEmpty()) {
+      throw new ConfigurationException("filesystem cas path is empty");
+    }
+    long maxSizeBytes = config.getMaxSizeBytes();
+    long maxEntrySizeBytes = config.getMaxEntrySizeBytes();
+    if (maxSizeBytes <= 0) {
+      throw new ConfigurationException("filesystem cas max_size_bytes <= 0");
+    }
+    if (maxEntrySizeBytes <= 0) {
+      throw new ConfigurationException("filesystem cas max_entry_size_bytes <= 0");
+    }
+    if (maxEntrySizeBytes > maxSizeBytes) {
+      throw new ConfigurationException("filesystem cas max_entry_size_bytes > maxSizeBytes");
+    }
     CASFileCache cas =
         new CASFileCache(
-            Paths.get(config.getPath()),
-            config.getMaxSizeBytes(),
-            config.getMaxEntrySizeBytes(),
+            Paths.get(path),
+            maxSizeBytes,
+            maxEntrySizeBytes,
             DigestUtil.forHash("SHA256"),
             /* expireService=*/ newDirectExecutorService(),
             /* accessRecorder=*/ directExecutor()) {
@@ -85,7 +102,8 @@ public final class ContentAddressableStorages {
     return cas;
   }
 
-  public static ContentAddressableStorage create(ContentAddressableStorageConfig config) {
+  public static ContentAddressableStorage create(ContentAddressableStorageConfig config)
+      throws ConfigurationException {
     switch (config.getTypeCase()) {
       default:
       case FILESYSTEM:

--- a/src/main/java/build/buildfarm/instance/memory/MemoryInstance.java
+++ b/src/main/java/build/buildfarm/instance/memory/MemoryInstance.java
@@ -118,6 +118,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
+import javax.naming.ConfigurationException;
 
 public class MemoryInstance extends AbstractServerInstance {
   private static final Logger logger = Logger.getLogger(MemoryInstance.class.getName());
@@ -197,7 +198,8 @@ public class MemoryInstance extends AbstractServerInstance {
     }
   }
 
-  public MemoryInstance(String name, DigestUtil digestUtil, MemoryInstanceConfig config) {
+  public MemoryInstance(String name, DigestUtil digestUtil, MemoryInstanceConfig config)
+      throws ConfigurationException {
     this(
         name,
         digestUtil,


### PR DESCRIPTION
Throw a ConfigurationException if any of the path, max_size_bytes, or
max_entry_size_bytes fields are default/generally bad.