### PR TITLE
Store client uptime in Redis

### DIFF
--- a/src/main/java/build/buildfarm/common/ShardBackplane.java
+++ b/src/main/java/build/buildfarm/common/ShardBackplane.java
@@ -77,6 +77,10 @@ public interface ShardBackplane {
   @ThreadSafe
   boolean addWorker(ShardWorker shardWorker) throws IOException;
 
+  /** Records a worker start time. */
+  @ThreadSafe
+  void recordContainerStartTime(String keyName) throws IOException;
+
   /**
    * Removes a worker's name from the set of active workers.
    *

--- a/src/main/java/build/buildfarm/common/ShardBackplane.java
+++ b/src/main/java/build/buildfarm/common/ShardBackplane.java
@@ -59,7 +59,7 @@ public interface ShardBackplane {
 
   /** Start the backplane's operation */
   @ThreadSafe
-  void start() throws IOException;
+  void start(String publicClientName) throws IOException;
 
   /** Stop the backplane's operation */
   @ThreadSafe
@@ -76,10 +76,6 @@ public interface ShardBackplane {
    */
   @ThreadSafe
   boolean addWorker(ShardWorker shardWorker) throws IOException;
-
-  /** Records a worker start time. */
-  @ThreadSafe
-  void recordContainerStartTime(String keyName) throws IOException;
 
   /**
    * Removes a worker's name from the set of active workers.

--- a/src/main/java/build/buildfarm/instance/AbstractServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/AbstractServerInstance.java
@@ -193,7 +193,7 @@ public abstract class AbstractServerInstance implements Instance {
   }
 
   @Override
-  public void start() {}
+  public void start(String publicName) {}
 
   @Override
   public void stop() throws InterruptedException {}

--- a/src/main/java/build/buildfarm/instance/Instance.java
+++ b/src/main/java/build/buildfarm/instance/Instance.java
@@ -53,7 +53,7 @@ public interface Instance {
 
   DigestUtil getDigestUtil();
 
-  void start();
+  void start(String publicName);
 
   void stop() throws InterruptedException;
 

--- a/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
@@ -553,7 +553,7 @@ public class RedisShardBackplane implements ShardBackplane {
 
     // Record client start time
     client.call(
-      jedis -> jedis.set("uptime/" + clientPublicName, Long.toString(new Date().getTime())));
+        jedis -> jedis.set("uptime/" + clientPublicName, Long.toString(new Date().getTime())));
   }
 
   @Override

--- a/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
@@ -553,7 +553,7 @@ public class RedisShardBackplane implements ShardBackplane {
 
     // Record client start time
     client.call(
-        jedis -> jedis.set("uptime/" + clientPublicName, Long.toString(new Date().getTime())));
+        jedis -> jedis.set("startTime/" + clientPublicName, Long.toString(new Date().getTime())));
   }
 
   @Override

--- a/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
@@ -62,6 +62,7 @@ import com.google.longrunning.Operation;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.JsonFormat;
+import com.google.protobuf.util.Timestamps;
 import com.google.rpc.Code;
 import com.google.rpc.PreconditionFailure;
 import com.google.rpc.Status;
@@ -70,6 +71,7 @@ import java.time.Instant;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -616,6 +618,12 @@ public class RedisShardBackplane implements ShardBackplane {
           }
           return false;
         });
+  }
+
+  @Override
+  public void recordContainerStartTime(String keyName) throws IOException {
+    client.call(
+      jedis -> jedis.set(keyName, Long.toString(new Date().getTime())));
   }
 
   private boolean removeWorkerAndPublish(JedisCluster jedis, String name, String changeJson) {

--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -405,10 +405,11 @@ public class ShardInstance extends AbstractServerInstance {
   }
 
   @Override
-  public void start() {
+  public void start(String publicName) {
     stopped = false;
     try {
       backplane.start();
+      backplane.recordContainerStartTime(publicName);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -408,8 +408,7 @@ public class ShardInstance extends AbstractServerInstance {
   public void start(String publicName) {
     stopped = false;
     try {
-      backplane.start();
-      backplane.recordContainerStartTime(publicName);
+      backplane.start(publicName);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/src/main/java/build/buildfarm/instance/stub/StubInstance.java
+++ b/src/main/java/build/buildfarm/instance/stub/StubInstance.java
@@ -304,7 +304,7 @@ public class StubInstance implements Instance {
   }
 
   @Override
-  public void start() {}
+  public void start(String publicName) {}
 
   @Override
   public void stop() throws InterruptedException {

--- a/src/main/java/build/buildfarm/server/BuildFarmInstances.java
+++ b/src/main/java/build/buildfarm/server/BuildFarmInstances.java
@@ -144,9 +144,9 @@ public class BuildFarmInstances implements Instances {
   }
 
   @Override
-  public void start() {
+  public void start(String publicName) {
     for (Instance instance : instances.values()) {
-      instance.start();
+      instance.start(publicName);
     }
   }
 

--- a/src/main/java/build/buildfarm/server/BuildFarmServer.java
+++ b/src/main/java/build/buildfarm/server/BuildFarmServer.java
@@ -136,9 +136,9 @@ public class BuildFarmServer extends LoggingMain {
     }
   }
 
-  public void start() throws IOException {
+  public void start(String publicName) throws IOException {
     actionCacheRequestCounter.start();
-    instances.start();
+    instances.start(publicName);
     server.start();
     healthStatusManager.setStatus(
         HealthStatusManager.SERVICE_NAME_ALL_SERVICES, ServingStatus.SERVING);
@@ -223,7 +223,7 @@ public class BuildFarmServer extends LoggingMain {
           new BuildFarmServer(
               session, toBuildFarmServerConfig(new InputStreamReader(configInputStream), options));
       configInputStream.close();
-      server.start();
+      server.start(options.publicName);
       server.blockUntilShutdown();
       server.stop();
       return true;

--- a/src/main/java/build/buildfarm/server/Instances.java
+++ b/src/main/java/build/buildfarm/server/Instances.java
@@ -17,7 +17,7 @@ package build.buildfarm.server;
 import build.buildfarm.instance.Instance;
 
 public interface Instances {
-  void start();
+  void start(String publicName);
 
   void stop() throws InterruptedException;
 
@@ -69,7 +69,7 @@ public interface Instances {
       }
 
       @Override
-      public void start() {}
+      public void start(String publicName) {}
 
       @Override
       public void stop() {}

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -737,6 +737,14 @@ public class Worker extends LoggingMain {
     throw Status.UNAVAILABLE.withDescription("backplane was stopped").asRuntimeException();
   }
 
+  private void recordWorkerStartTime(String workerName) {
+    try {
+      backplane.recordContainerStartTime(workerName);
+    } catch (IOException e) {
+        logger.severe("Could not record worker start time for " + workerName);
+    }
+  }
+
   private void startFailsafeRegistration() {
     String endpoint = config.getPublicName();
     ShardWorker.Builder worker = ShardWorker.newBuilder().setEndpoint(endpoint);
@@ -802,6 +810,8 @@ public class Worker extends LoggingMain {
       } else {
         logger.log(INFO, "Skipping worker registration");
       }
+
+      recordWorkerStartTime(config.getPublicName());
 
     } catch (Exception e) {
       stop();

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -737,14 +737,6 @@ public class Worker extends LoggingMain {
     throw Status.UNAVAILABLE.withDescription("backplane was stopped").asRuntimeException();
   }
 
-  private void recordWorkerStartTime(String workerName) {
-    try {
-      backplane.recordContainerStartTime(workerName);
-    } catch (IOException e) {
-        logger.severe("Could not record worker start time for " + workerName);
-    }
-  }
-
   private void startFailsafeRegistration() {
     String endpoint = config.getPublicName();
     ShardWorker.Builder worker = ShardWorker.newBuilder().setEndpoint(endpoint);
@@ -794,7 +786,7 @@ public class Worker extends LoggingMain {
 
   public void start() throws InterruptedException {
     try {
-      backplane.start();
+      backplane.start(config.getPublicName());
 
       removeWorker(config.getPublicName());
 
@@ -810,9 +802,6 @@ public class Worker extends LoggingMain {
       } else {
         logger.log(INFO, "Skipping worker registration");
       }
-
-      recordWorkerStartTime(config.getPublicName());
-
     } catch (Exception e) {
       stop();
       logger.log(SEVERE, "error starting worker", e);

--- a/src/test/java/build/buildfarm/instance/shard/RedisShardBackplaneTest.java
+++ b/src/test/java/build/buildfarm/instance/shard/RedisShardBackplaneTest.java
@@ -75,7 +75,7 @@ public class RedisShardBackplaneTest {
             (o) -> false,
             (o) -> false,
             mockJedisClusterFactory);
-    backplane.start("test:0000");
+    backplane.start("startTime/test:0000");
 
     assertThat(backplane.getWorkers()).isEmpty();
     verify(jedisCluster, times(1)).hdel(config.getWorkersHashName(), "foo");
@@ -117,7 +117,7 @@ public class RedisShardBackplaneTest {
             (o) -> false,
             (o) -> false,
             mockJedisClusterFactory);
-    backplane.start("test:0000");
+    backplane.start("startTime/test:0000");
 
     final String opName = "op";
     ExecuteEntry executeEntry = ExecuteEntry.newBuilder().setOperationName(opName).build();
@@ -152,7 +152,7 @@ public class RedisShardBackplaneTest {
             (o) -> false,
             (o) -> false,
             mockJedisClusterFactory);
-    backplane.start("test:0000");
+    backplane.start("startTime/test:0000");
 
     final String opName = "op";
     backplane.queueing(opName);
@@ -180,7 +180,7 @@ public class RedisShardBackplaneTest {
             (o) -> false,
             (o) -> false,
             mockJedisClusterFactory);
-    backplane.start("test:0000");
+    backplane.start("startTime/test:0000");
 
     final String opName = "op";
     when(jedisCluster.hdel(config.getDispatchedOperationsHashName(), opName)).thenReturn(1l);
@@ -215,7 +215,7 @@ public class RedisShardBackplaneTest {
             (o) -> false,
             (o) -> false,
             mockJedisClusterFactory);
-    backplane.start("test:0000");
+    backplane.start("startTime/test:0000");
 
     final String opName = "op";
 
@@ -244,7 +244,7 @@ public class RedisShardBackplaneTest {
             (o) -> false,
             (o) -> false,
             mockJedisClusterFactory);
-    backplane.start("test:0000");
+    backplane.start("startTime/test:0000");
 
     final String opName = "op";
 
@@ -276,7 +276,7 @@ public class RedisShardBackplaneTest {
             o -> false,
             o -> false,
             mockJedisClusterFactory);
-    backplane.start("test:0000");
+    backplane.start("startTime/test:0000");
 
     final String opName = "op";
 

--- a/src/test/java/build/buildfarm/instance/shard/RedisShardBackplaneTest.java
+++ b/src/test/java/build/buildfarm/instance/shard/RedisShardBackplaneTest.java
@@ -75,7 +75,7 @@ public class RedisShardBackplaneTest {
             (o) -> false,
             (o) -> false,
             mockJedisClusterFactory);
-    backplane.start();
+    backplane.start("test:0000");
 
     assertThat(backplane.getWorkers()).isEmpty();
     verify(jedisCluster, times(1)).hdel(config.getWorkersHashName(), "foo");
@@ -117,7 +117,7 @@ public class RedisShardBackplaneTest {
             (o) -> false,
             (o) -> false,
             mockJedisClusterFactory);
-    backplane.start();
+    backplane.start("test:0000");
 
     final String opName = "op";
     ExecuteEntry executeEntry = ExecuteEntry.newBuilder().setOperationName(opName).build();
@@ -152,7 +152,7 @@ public class RedisShardBackplaneTest {
             (o) -> false,
             (o) -> false,
             mockJedisClusterFactory);
-    backplane.start();
+    backplane.start("test:0000");
 
     final String opName = "op";
     backplane.queueing(opName);
@@ -180,7 +180,7 @@ public class RedisShardBackplaneTest {
             (o) -> false,
             (o) -> false,
             mockJedisClusterFactory);
-    backplane.start();
+    backplane.start("test:0000");
 
     final String opName = "op";
     when(jedisCluster.hdel(config.getDispatchedOperationsHashName(), opName)).thenReturn(1l);
@@ -215,7 +215,7 @@ public class RedisShardBackplaneTest {
             (o) -> false,
             (o) -> false,
             mockJedisClusterFactory);
-    backplane.start();
+    backplane.start("test:0000");
 
     final String opName = "op";
 
@@ -244,7 +244,7 @@ public class RedisShardBackplaneTest {
             (o) -> false,
             (o) -> false,
             mockJedisClusterFactory);
-    backplane.start();
+    backplane.start("test:0000");
 
     final String opName = "op";
 
@@ -276,7 +276,7 @@ public class RedisShardBackplaneTest {
             o -> false,
             o -> false,
             mockJedisClusterFactory);
-    backplane.start();
+    backplane.start("test:0000");
 
     final String opName = "op";
 

--- a/src/test/java/build/buildfarm/instance/shard/ShardInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/shard/ShardInstanceTest.java
@@ -137,7 +137,7 @@ public class ShardInstanceTest {
             /* maxActionTimeout=*/ Duration.getDefaultInstance(),
             mockOnStop,
             CacheBuilder.newBuilder().build(mockInstanceLoader));
-    instance.start();
+    instance.start("test:0000");
   }
 
   @After

--- a/src/test/java/build/buildfarm/instance/shard/ShardInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/shard/ShardInstanceTest.java
@@ -137,7 +137,7 @@ public class ShardInstanceTest {
             /* maxActionTimeout=*/ Duration.getDefaultInstance(),
             mockOnStop,
             CacheBuilder.newBuilder().build(mockInstanceLoader));
-    instance.start("test:0000");
+    instance.start("startTime/test:0000");
   }
 
   @After

--- a/src/test/java/build/buildfarm/server/BuildFarmServerTest.java
+++ b/src/test/java/build/buildfarm/server/BuildFarmServerTest.java
@@ -135,7 +135,7 @@ public class BuildFarmServerTest {
             "test",
             InProcessServerBuilder.forName(uniqueServerName).directExecutor(),
             configBuilder.build());
-    server.start("test:0000");
+    server.start("startTime/test:0000");
     inProcessChannel = InProcessChannelBuilder.forName(uniqueServerName).directExecutor().build();
   }
 

--- a/src/test/java/build/buildfarm/server/BuildFarmServerTest.java
+++ b/src/test/java/build/buildfarm/server/BuildFarmServerTest.java
@@ -135,7 +135,7 @@ public class BuildFarmServerTest {
             "test",
             InProcessServerBuilder.forName(uniqueServerName).directExecutor(),
             configBuilder.build());
-    server.start();
+    server.start("test:0000");
     inProcessChannel = InProcessChannelBuilder.forName(uniqueServerName).directExecutor().build();
   }
 


### PR DESCRIPTION
The client (server/worker) uptime will be used for display purposes on the Buildfarm Admin dashboard.