### PR TITLE
Configurable grpc timeouts for stub instances

### DIFF
--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -204,7 +204,7 @@ public class ShardInstance extends AbstractServerInstance {
         config.getMaxBlobSize(),
         config.getMaximumActionTimeout(),
         onStop,
-        WorkerStubs.create(digestUtil));
+        WorkerStubs.create(digestUtil, config.getGrpcTimeout()));
   }
 
   private static ShardBackplane createBackplane(ShardInstanceConfig config, String identifier)

--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -40,6 +40,7 @@ import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.logging.Level.INFO;
 
 import build.bazel.remote.execution.v2.Action;
 import build.bazel.remote.execution.v2.ActionResult;
@@ -205,6 +206,25 @@ public class ShardInstance extends AbstractServerInstance {
         config.getMaximumActionTimeout(),
         onStop,
         WorkerStubs.create(digestUtil, config.getGrpcTimeout()));
+  }
+
+  private static Duration GetGrpcTimeout(ShardInstanceConfig config) {
+
+    // return the configured
+    if (config.hasGrpcTimeout()) {
+      Duration configured = config.getGrpcTimeout();
+      if (configured.getSeconds() > 0 || configured.getNanos() > 0) {
+        return configured;
+      }
+    }
+
+    // return a default
+    Duration defaultDuration = Durations.fromSeconds(120);
+    logger.log(
+        INFO,
+        String.format(
+            "grpc timeout not configured.  Setting to: " + defaultDuration.getSeconds() + "s"));
+    return defaultDuration;
   }
 
   private static ShardBackplane createBackplane(ShardInstanceConfig config, String identifier)

--- a/src/main/java/build/buildfarm/instance/shard/WorkerStubs.java
+++ b/src/main/java/build/buildfarm/instance/shard/WorkerStubs.java
@@ -28,16 +28,17 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.cache.RemovalListener;
 import com.google.common.cache.RemovalNotification;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+import com.google.protobuf.Duration;
+import com.google.protobuf.util.Durations;
 import io.grpc.ManagedChannel;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
-import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 public class WorkerStubs {
   private WorkerStubs() {}
 
-  public static LoadingCache create(DigestUtil digestUtil) {
+  public static LoadingCache create(DigestUtil digestUtil, Duration timeout) {
     return CacheBuilder.newBuilder()
         .expireAfterAccess(10, TimeUnit.MINUTES)
         .removalListener(
@@ -51,18 +52,18 @@ public class WorkerStubs {
             new CacheLoader<String, Instance>() {
               @Override
               public Instance load(String worker) {
-                return newStubInstance(worker, digestUtil);
+                return newStubInstance(worker, digestUtil, timeout);
               }
             });
   }
 
-  private static Instance newStubInstance(String worker, DigestUtil digestUtil) {
+  private static Instance newStubInstance(String worker, DigestUtil digestUtil, Duration timeout) {
     return new StubInstance(
         "",
         worker,
         digestUtil,
         createChannel(worker),
-        60 /* FIXME CONFIG */,
+        Durations.toSeconds(timeout),
         TimeUnit.SECONDS,
         newStubRetrier(),
         newStubRetryService());
@@ -77,8 +78,8 @@ public class WorkerStubs {
   private static Retrier newStubRetrier() {
     return new Retrier(
         Backoff.exponential(
-            Duration.ofMillis(/*options.experimentalRemoteRetryStartDelayMillis=*/ 100),
-            Duration.ofMillis(/*options.experimentalRemoteRetryMaxDelayMillis=*/ 5000),
+            java.time.Duration.ofMillis(/*options.experimentalRemoteRetryStartDelayMillis=*/ 100),
+            java.time.Duration.ofMillis(/*options.experimentalRemoteRetryMaxDelayMillis=*/ 5000),
             /*options.experimentalRemoteRetryMultiplier=*/ 2,
             /*options.experimentalRemoteRetryJitter=*/ 0.1,
             /*options.experimentalRemoteRetryMaxAttempts=*/ 5),

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -286,7 +286,8 @@ public class Worker extends LoggingMain {
         break;
     }
 
-    workerStubs = WorkerStubs.create(digestUtil);
+    workerStubs =
+        WorkerStubs.create(digestUtil, config.getShardWorkerInstanceConfig().getGrpcTimeout());
 
     ExecutorService removeDirectoryService =
         newFixedThreadPool(

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -71,7 +71,9 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.devtools.common.options.OptionsParser;
 import com.google.longrunning.Operation;
 import com.google.protobuf.ByteString;
+import com.google.protobuf.Duration;
 import com.google.protobuf.TextFormat;
+import com.google.protobuf.util.Durations;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.Status;
@@ -286,8 +288,7 @@ public class Worker extends LoggingMain {
         break;
     }
 
-    workerStubs =
-        WorkerStubs.create(digestUtil, config.getShardWorkerInstanceConfig().getGrpcTimeout());
+    workerStubs = WorkerStubs.create(digestUtil, GetGrpcTimeout(config));
 
     ExecutorService removeDirectoryService =
         newFixedThreadPool(
@@ -385,6 +386,25 @@ public class Worker extends LoggingMain {
 
   public static int KBtoBytes(int sizeKb) {
     return sizeKb * 1024;
+  }
+
+  private static Duration GetGrpcTimeout(ShardWorkerConfig config) {
+
+    // return the configured
+    if (config.getShardWorkerInstanceConfig().hasGrpcTimeout()) {
+      Duration configured = config.getShardWorkerInstanceConfig().getGrpcTimeout();
+      if (configured.getSeconds() > 0 || configured.getNanos() > 0) {
+        return configured;
+      }
+    }
+
+    // return a default
+    Duration defaultDuration = Durations.fromSeconds(120);
+    logger.log(
+        INFO,
+        String.format(
+            "grpc timeout not configured.  Setting to: " + defaultDuration.getSeconds() + "s"));
+    return defaultDuration;
   }
 
   private ListenableFuture<Long> streamIntoWriteFuture(InputStream in, Write write, Digest digest)

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -375,6 +375,9 @@ message ShardInstanceConfig {
   // a maximum threshold for an action's specified timeout,
   // beyond which an action will be rejected for execution
   google.protobuf.Duration maximum_action_timeout = 7;
+  
+  // default timeouts on grpc requests made by instances
+  google.protobuf.Duration grpc_timeout = 8;
 }
 
 message ShardWorkerInstanceConfig {
@@ -395,6 +398,9 @@ message ShardWorkerInstanceConfig {
 
   // page size for getTree request
   uint32 tree_page_size = 12;
+  
+  // default timeouts on grpc requests made by instances
+  google.protobuf.Duration grpc_timeout = 13;
 }
 
 message ShardWorkerConfig {


### PR DESCRIPTION
Stub instances have a hard-coded timeout of 1 minute.  
This may not be sufficient for `findMissingBlobs` depending on the size of the input.  
This diff is to ensure that the grpc timeout can be set from config.