### PR TITLE
allow skipping the CASFileCache load

### DIFF
--- a/src/main/java/build/buildfarm/CASTest.java
+++ b/src/main/java/build/buildfarm/CASTest.java
@@ -19,6 +19,7 @@ import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorS
 
 import build.bazel.remote.execution.v2.Digest;
 import build.buildfarm.cas.CASFileCache;
+import build.buildfarm.cas.CASFileCache.StartupCacheResults;
 import build.buildfarm.common.DigestUtil;
 import build.buildfarm.common.DigestUtil.HashFunction;
 import java.io.IOException;
@@ -71,12 +72,21 @@ class CASTest {
             /* accessRecorder=*/ directExecutor());
 
     // Start cache and measure startup time (reported internally).
-    fileCache.start(newDirectExecutorService());
+    StartupCacheResults results = fileCache.start(newDirectExecutorService(), true);
 
     // Report information on started cache.
     System.out.println("CAS Started.");
+    System.out.println("Start Time: " + results.startupTime.getSeconds() + "s");
+
+    // Load Information
+    System.out.println("Loaded Cache: " + !results.load.loadSkipped);
+
+    // Entry Information
     System.out.println("Total Entry Count: " + fileCache.entryCount());
     System.out.println("Unreferenced Entry Count: " + fileCache.unreferencedEntryCount());
+
+    // File Information
+    System.out.println("Cache Root: " + results.cacheDirectory);
     System.out.println("Directory Count: " + fileCache.directoryStorageCount());
     System.out.println("Current Size: " + BytestoGB(fileCache.size()) + "GB");
   }

--- a/src/main/java/build/buildfarm/cas/CASFileCache.java
+++ b/src/main/java/build/buildfarm/cas/CASFileCache.java
@@ -91,6 +91,7 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -214,15 +215,15 @@ public abstract class CASFileCache implements ContentAddressableStorage {
   }
 
   public class CacheScanResults {
-    public List<Path> computeDirs;
-    public List<Path> deleteFiles;
-    public Map<Object, Entry> fileKeys;
+    public List<Path> computeDirs = Collections.emptyList();
+    public List<Path> deleteFiles = Collections.emptyList();
+    public Map<Object, Entry> fileKeys = Collections.emptyMap();
   }
 
   public class CacheLoadResults {
     public boolean loadSkipped;
-    public CacheScanResults scan;
-    public List<Path> invalidDirectories;
+    public CacheScanResults scan = new CacheScanResults();
+    public List<Path> invalidDirectories = Collections.emptyList();
   }
 
   public class StartupCacheResults {

--- a/src/main/java/build/buildfarm/cas/ContentAddressableStorages.java
+++ b/src/main/java/build/buildfarm/cas/ContentAddressableStorages.java
@@ -95,7 +95,7 @@ public final class ContentAddressableStorages {
           }
         };
     try {
-      cas.start();
+      cas.start(false);
     } catch (IOException | InterruptedException e) {
       throw new RuntimeException("error starting filesystem cas", e);
     }

--- a/src/main/java/build/buildfarm/worker/operationqueue/Worker.java
+++ b/src/main/java/build/buildfarm/worker/operationqueue/Worker.java
@@ -383,7 +383,7 @@ public class Worker extends LoggingMain {
   public void start() throws InterruptedException {
     try {
       Files.createDirectories(root);
-      fileCache.start();
+      fileCache.start(false);
     } catch (IOException e) {
       logger.log(SEVERE, "error starting file cache", e);
       return;

--- a/src/main/java/build/buildfarm/worker/shard/CFCExecFileSystem.java
+++ b/src/main/java/build/buildfarm/worker/shard/CFCExecFileSystem.java
@@ -115,7 +115,7 @@ class CFCExecFileSystem implements ExecFileSystem {
     }
 
     ImmutableList.Builder<Digest> blobDigests = ImmutableList.builder();
-    fileCache.start(blobDigests::add, removeDirectoryService);
+    fileCache.start(blobDigests::add, removeDirectoryService, false);
     onDigests.accept(blobDigests.build());
 
     getInterruptiblyOrIOException(allAsList(removeDirectoryFutures.build()));

--- a/src/test/java/build/buildfarm/cas/CASFileCacheTest.java
+++ b/src/test/java/build/buildfarm/cas/CASFileCacheTest.java
@@ -329,7 +329,7 @@ class CASFileCacheTest {
     assertThat(fileCache.put(blobDigest, false).equals(path)).isTrue();
     assertThat(fileCache.put(blobDigest, true).equals(execPath)).isTrue();
   }
-  
+
   @Test
   public void startSkipsLoadingExistingBlob() throws IOException, InterruptedException {
     ByteString blob = ByteString.copyFromUtf8("blob");

--- a/src/test/java/build/buildfarm/cas/CASFileCacheTest.java
+++ b/src/test/java/build/buildfarm/cas/CASFileCacheTest.java
@@ -349,12 +349,6 @@ class CASFileCacheTest {
     assertThat(results.load.scan.deleteFiles.size()).isEqualTo(0);
     assertThat(results.load.scan.fileKeys.size()).isEqualTo(0);
     assertThat(results.load.invalidDirectories.size()).isEqualTo(0);
-
-    // explicitly not providing blob via blobs, this would throw if fetched from factory
-    //
-    // FIXME https://github.com/google/truth/issues/285 assertThat(Path) is ambiguous
-    assertThat(fileCache.put(blobDigest, false).equals(path)).isTrue();
-    assertThat(fileCache.put(blobDigest, true).equals(execPath)).isTrue();
   }
 
   @Test

--- a/src/test/java/build/buildfarm/cas/CASFileCacheTest.java
+++ b/src/test/java/build/buildfarm/cas/CASFileCacheTest.java
@@ -273,13 +273,14 @@ class CASFileCacheTest {
 
     // start the file cache with no files.
     // the cache should start without any initial files in the cache.
-    StartupCacheResults results = fileCache.start();
+    StartupCacheResults results = fileCache.start(false);
 
     // check the startuo results to ensure no files were processed
-    assertThat(results.scan.computeDirs.size()).isEqualTo(0);
-    assertThat(results.scan.deleteFiles.size()).isEqualTo(0);
-    assertThat(results.scan.fileKeys.size()).isEqualTo(0);
-    assertThat(results.invalidDirectories.size()).isEqualTo(0);
+    assertThat(results.load.loadSkipped).isFalse();
+    assertThat(results.load.scan.computeDirs.size()).isEqualTo(0);
+    assertThat(results.load.scan.deleteFiles.size()).isEqualTo(0);
+    assertThat(results.load.scan.fileKeys.size()).isEqualTo(0);
+    assertThat(results.load.invalidDirectories.size()).isEqualTo(0);
   }
 
   @Test
@@ -292,13 +293,14 @@ class CASFileCacheTest {
 
     // start the CAS with a file whose name indicates its a directory
     // the cache should start and consider it a compute directory
-    StartupCacheResults results = fileCache.start();
+    StartupCacheResults results = fileCache.start(false);
 
     // check the startup results to ensure no files were processed
-    assertThat(results.scan.computeDirs.size()).isEqualTo(0);
-    assertThat(results.scan.deleteFiles.size()).isEqualTo(1);
-    assertThat(results.scan.fileKeys.size()).isEqualTo(0);
-    assertThat(results.invalidDirectories.size()).isEqualTo(0);
+    assertThat(results.load.loadSkipped).isFalse();
+    assertThat(results.load.scan.computeDirs.size()).isEqualTo(0);
+    assertThat(results.load.scan.deleteFiles.size()).isEqualTo(1);
+    assertThat(results.load.scan.fileKeys.size()).isEqualTo(0);
+    assertThat(results.load.invalidDirectories.size()).isEqualTo(0);
   }
 
   @Test
@@ -312,13 +314,41 @@ class CASFileCacheTest {
     Files.write(execPath, blob.toByteArray());
     EvenMoreFiles.setReadOnlyPerms(execPath, true);
 
-    StartupCacheResults results = fileCache.start();
+    StartupCacheResults results = fileCache.start(false);
 
     // check the startup results to ensure our two files were processed
-    assertThat(results.scan.computeDirs.size()).isEqualTo(0);
-    assertThat(results.scan.deleteFiles.size()).isEqualTo(0);
-    assertThat(results.scan.fileKeys.size()).isEqualTo(2);
-    assertThat(results.invalidDirectories.size()).isEqualTo(0);
+    assertThat(results.load.loadSkipped).isFalse();
+    assertThat(results.load.scan.computeDirs.size()).isEqualTo(0);
+    assertThat(results.load.scan.deleteFiles.size()).isEqualTo(0);
+    assertThat(results.load.scan.fileKeys.size()).isEqualTo(2);
+    assertThat(results.load.invalidDirectories.size()).isEqualTo(0);
+
+    // explicitly not providing blob via blobs, this would throw if fetched from factory
+    //
+    // FIXME https://github.com/google/truth/issues/285 assertThat(Path) is ambiguous
+    assertThat(fileCache.put(blobDigest, false).equals(path)).isTrue();
+    assertThat(fileCache.put(blobDigest, true).equals(execPath)).isTrue();
+  }
+  
+  @Test
+  public void startSkipsLoadingExistingBlob() throws IOException, InterruptedException {
+    ByteString blob = ByteString.copyFromUtf8("blob");
+    Digest blobDigest = DIGEST_UTIL.compute(blob);
+    Path path = root.resolve(fileCache.getKey(blobDigest, false));
+    Path execPath = root.resolve(fileCache.getKey(blobDigest, true));
+    Files.write(path, blob.toByteArray());
+    EvenMoreFiles.setReadOnlyPerms(path, false);
+    Files.write(execPath, blob.toByteArray());
+    EvenMoreFiles.setReadOnlyPerms(execPath, true);
+
+    StartupCacheResults results = fileCache.start(true);
+
+    // check the startup results to ensure our two files were processed
+    assertThat(results.load.loadSkipped).isTrue();
+    assertThat(results.load.scan.computeDirs.size()).isEqualTo(0);
+    assertThat(results.load.scan.deleteFiles.size()).isEqualTo(0);
+    assertThat(results.load.scan.fileKeys.size()).isEqualTo(0);
+    assertThat(results.load.invalidDirectories.size()).isEqualTo(0);
 
     // explicitly not providing blob via blobs, this would throw if fetched from factory
     //
@@ -350,7 +380,7 @@ class CASFileCacheTest {
     Files.write(
         invalidExec, validBlob.toByteArray()); // content would match but for invalid exec field
 
-    fileCache.start();
+    fileCache.start(false);
 
     assertThat(!Files.exists(tooFewComponents)).isTrue();
     assertThat(!Files.exists(tooManyComponents)).isTrue();


### PR DESCRIPTION
### Goal:
We want to experiment with the idea of starting workers without an initial cache.  
Loading the cache can be slow- upwards of 20 minutes depending on its size.
The faster a worker starts, the sooner it can take on work.  
We have issues currently where we can't scale to meet demands because of the slow startup time.
In the future, buildfarm-admin may tell workers to skip loading their cache based on the context of existing scaling issues.
^ we'll see based on experiments of having this functionality available

### Diff:
For starters, we customize the CASFileCache to allow skipping the load phase. 
If loading the cache is skipped, we instead delete those files.

### Test:
 - Added a test that shows load skipping.  
 - Edited the unit tests to report if loading occured or not.  
