### PR TITLE
[refactor] Use Durations to simplify StubInstance

### DIFF
--- a/src/main/java/build/buildfarm/BUILD
+++ b/src/main/java/build/buildfarm/BUILD
@@ -236,6 +236,7 @@ java_library(
         "@maven//:io_grpc_grpc_protobuf",
         "@maven//:io_grpc_grpc_stub",
         "@remote_apis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
+        "@maven//:com_google_protobuf_protobuf_java_util",
     ],
 )
 
@@ -459,6 +460,7 @@ java_library(
         "@maven//:io_grpc_grpc_stub",
         "@remote_apis//:build_bazel_remote_execution_v2_remote_execution_java_grpc",
         "@remote_apis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
+        "@maven//:com_google_protobuf_protobuf_java_util",
     ],
 )
 
@@ -582,6 +584,7 @@ java_library(
         "@maven//:io_grpc_grpc_netty",
         "@maven//:io_grpc_grpc_protobuf",
         "@maven//:io_grpc_grpc_stub",
+        "@maven//:com_google_protobuf_protobuf_java_util",
     ],
 )
 

--- a/src/main/java/build/buildfarm/Cat.java
+++ b/src/main/java/build/buildfarm/Cat.java
@@ -758,7 +758,7 @@ class Cat {
       throws Exception {
     ManagedChannel channel = createChannel(host);
     Instance instance =
-        new StubInstance(instanceName, "bf-cat", digestUtil, channel, 10, TimeUnit.SECONDS);
+        new StubInstance(instanceName, "bf-cat", digestUtil, channel, Durations.fromSeconds(10));
     try {
       instanceMain(instance, type, args);
     } finally {

--- a/src/main/java/build/buildfarm/common/Time.java
+++ b/src/main/java/build/buildfarm/common/Time.java
@@ -28,22 +28,33 @@ public class Time {
 
   ///
   /// @brief   Convert a protobuf duration to a grpc deadline.
-  /// @details Deadline will be represented in seconds.
+  /// @details Deadline will have nanosecond precision.
   /// @param   duration A protobuf duration.
   /// @return  A converted grpc deadline.
   /// @note    Suggested return identifier: deadline.
   ///
   public static Deadline toDeadline(Duration duration) {
-    return Deadline.after(duration.getSeconds(), TimeUnit.SECONDS);
+    return Deadline.after(
+        secondsToNanoseconds(duration.getSeconds()) + duration.getNanos(), TimeUnit.NANOSECONDS);
   }
   ///
   /// @brief   Convert a grpc deadline to a protobuf duration.
-  /// @details Duration will be represented in seconds.
+  /// @details Duration will have nanosecond precision.
   /// @param   deadline A converted grpc deadline.
   /// @return  A protobuf duration.
   /// @note    Suggested return identifier: duration.
   ///
   public static Duration toDuration(Deadline deadline) {
-    return Durations.fromSeconds(deadline.timeRemaining(TimeUnit.SECONDS));
+    return Durations.fromNanos(deadline.timeRemaining(TimeUnit.NANOSECONDS));
+  }
+  ///
+  /// @brief   Seconds to nanoseconds.
+  /// @details Seconds to nanoseconds.
+  /// @param   seconds Seconds to convert.
+  /// @return  Nanoseconds converted from seconds.
+  /// @note    Suggested return identifier: nanoseconds.
+  ///
+  public static long secondsToNanoseconds(long seconds) {
+    return seconds * 1000000000;
   }
 }

--- a/src/main/java/build/buildfarm/common/Time.java
+++ b/src/main/java/build/buildfarm/common/Time.java
@@ -1,0 +1,49 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.common;
+
+import com.google.protobuf.Duration;
+import com.google.protobuf.util.Durations;
+import io.grpc.Deadline;
+import java.util.concurrent.TimeUnit;
+
+///
+/// @class   Time
+/// @brief   Utilities related to time, durations, deadlines, timeouts, etc.
+/// @details Contains converters between different time data types.
+///
+public class Time {
+
+  ///
+  /// @brief   Convert a protobuf duration to a grpc deadline.
+  /// @details Deadline will be represented in seconds.
+  /// @param   duration A protobuf duration.
+  /// @return  A converted grpc deadline.
+  /// @note    Suggested return identifier: deadline.
+  ///
+  public static Deadline toDeadline(Duration duration) {
+    return Deadline.after(duration.getSeconds(), TimeUnit.SECONDS);
+  }
+  ///
+  /// @brief   Convert a grpc deadline to a protobuf duration.
+  /// @details Duration will be represented in seconds.
+  /// @param   deadline A converted grpc deadline.
+  /// @return  A protobuf duration.
+  /// @note    Suggested return identifier: duration.
+  ///
+  public static Duration toDuration(Deadline deadline) {
+    return Durations.fromSeconds(deadline.timeRemaining(TimeUnit.SECONDS));
+  }
+}

--- a/src/main/java/build/buildfarm/instance/shard/WorkerStubs.java
+++ b/src/main/java/build/buildfarm/instance/shard/WorkerStubs.java
@@ -29,7 +29,6 @@ import com.google.common.cache.RemovalListener;
 import com.google.common.cache.RemovalNotification;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.protobuf.Duration;
-import com.google.protobuf.util.Durations;
 import io.grpc.ManagedChannel;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
@@ -63,8 +62,7 @@ public class WorkerStubs {
         worker,
         digestUtil,
         createChannel(worker),
-        Durations.toSeconds(timeout),
-        TimeUnit.SECONDS,
+        timeout,
         newStubRetrier(),
         newStubRetryService());
   }

--- a/src/main/java/build/buildfarm/instance/stub/StubInstance.java
+++ b/src/main/java/build/buildfarm/instance/stub/StubInstance.java
@@ -58,6 +58,7 @@ import build.bazel.remote.execution.v2.WaitExecutionRequest;
 import build.buildfarm.common.DigestUtil;
 import build.buildfarm.common.DigestUtil.ActionKey;
 import build.buildfarm.common.EntryLimitException;
+import build.buildfarm.common.Time;
 import build.buildfarm.common.Watcher;
 import build.buildfarm.common.Write;
 import build.buildfarm.common.grpc.ByteStreamHelper;
@@ -101,6 +102,8 @@ import com.google.longrunning.Operation;
 import com.google.longrunning.OperationsGrpc;
 import com.google.longrunning.OperationsGrpc.OperationsBlockingStub;
 import com.google.protobuf.ByteString;
+import com.google.protobuf.Duration;
+import com.google.protobuf.util.Durations;
 import com.google.rpc.Code;
 import io.grpc.Channel;
 import io.grpc.ManagedChannel;
@@ -134,20 +137,19 @@ public class StubInstance implements Instance {
   private final String identifier;
   private final DigestUtil digestUtil;
   private final ManagedChannel channel;
-  private final long deadlineAfter;
-  private final TimeUnit deadlineAfterUnits;
+  private final Duration grpcTimeout;
   private final Retrier retrier;
   private final @Nullable ListeningScheduledExecutorService retryService;
   private boolean isStopped = false;
   private final int maxBatchUpdateBlobsSize = 3 * 1024 * 1024;
 
   public StubInstance(String name, DigestUtil digestUtil, ManagedChannel channel) {
-    this(name, "no-identifier", digestUtil, channel, DEFAULT_DEADLINE_DAYS, TimeUnit.DAYS);
+    this(name, "no-identifier", digestUtil, channel, Durations.fromDays(DEFAULT_DEADLINE_DAYS));
   }
 
   public StubInstance(
       String name, String identifier, DigestUtil digestUtil, ManagedChannel channel) {
-    this(name, identifier, digestUtil, channel, DEFAULT_DEADLINE_DAYS, TimeUnit.DAYS);
+    this(name, identifier, digestUtil, channel, Durations.fromDays(DEFAULT_DEADLINE_DAYS));
   }
 
   public StubInstance(
@@ -155,17 +157,8 @@ public class StubInstance implements Instance {
       String identifier,
       DigestUtil digestUtil,
       ManagedChannel channel,
-      long deadlineAfter,
-      TimeUnit deadlineAfterUnits) {
-    this(
-        name,
-        identifier,
-        digestUtil,
-        channel,
-        deadlineAfter,
-        deadlineAfterUnits,
-        NO_RETRIES,
-        /* retryService=*/ null);
+      Duration grpcTimeout) {
+    this(name, identifier, digestUtil, channel, grpcTimeout, NO_RETRIES, /* retryService=*/ null);
   }
 
   public StubInstance(
@@ -173,16 +166,14 @@ public class StubInstance implements Instance {
       String identifier,
       DigestUtil digestUtil,
       ManagedChannel channel,
-      long deadlineAfter,
-      TimeUnit deadlineAfterUnits,
+      Duration grpcTimeout,
       Retrier retrier,
       @Nullable ListeningScheduledExecutorService retryService) {
     this.name = name;
     this.identifier = identifier;
     this.digestUtil = digestUtil;
     this.channel = channel;
-    this.deadlineAfter = deadlineAfter;
-    this.deadlineAfterUnits = deadlineAfterUnits;
+    this.grpcTimeout = grpcTimeout;
     this.retrier = retrier;
     this.retryService = retryService;
   }
@@ -288,8 +279,8 @@ public class StubInstance implements Instance {
 
   private <T extends AbstractStub<T>> T deadlined(Supplier<T> getter) {
     T stub = getter.get();
-    if (deadlineAfter > 0) {
-      stub = stub.withDeadlineAfter(deadlineAfter, deadlineAfterUnits);
+    if (grpcTimeout.getSeconds() > 0) {
+      stub = stub.withDeadline(Time.toDeadline(grpcTimeout));
     }
     return stub;
   }

--- a/src/main/java/build/buildfarm/worker/operationqueue/Worker.java
+++ b/src/main/java/build/buildfarm/worker/operationqueue/Worker.java
@@ -85,6 +85,7 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.Duration;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.TextFormat;
+import com.google.protobuf.util.Durations;
 import io.grpc.Channel;
 import io.grpc.Deadline;
 import io.grpc.ManagedChannel;
@@ -192,8 +193,7 @@ public class Worker extends LoggingMain {
         /* identifier=*/ "",
         digestUtil,
         channel,
-        deadlineAfterSeconds,
-        SECONDS,
+        Durations.fromSeconds(deadlineAfterSeconds),
         retrier,
         retryScheduler);
   }


### PR DESCRIPTION
### Problem:  
Buildfarm mixes `Duration` and `Deadline` types throughout the codebase.  
This is because timeouts are configured as a protobuf Duration, but later used to mean a grpc Deadline.  
In other places of the codebase, we pass around a value & a timepoint which eventually represents one of the more concrete types mentioned above.

### Refactor:  
 - we change StubInstance to expect Duration types instead of value + timepoints.
 - we provide utilities to easily convert between Duration/Deadline as needed.