### PR TITLE
Configuration option for skipping CAS load

### DIFF
--- a/examples/shard-worker.config.example
+++ b/examples/shard-worker.config.example
@@ -62,7 +62,8 @@ cas: {
     # from CAS in the cache
     max_entry_size_bytes: 2147483648 # 2 * 1024 * 1024 * 1024
   }
-  
+  # whether the transient data on the worker should be loaded into the CAS on worker startup.
+  # It can be faster for worker startup to skip loading.
   skip_load: false
 }
 

--- a/examples/shard-worker.config.example
+++ b/examples/shard-worker.config.example
@@ -62,6 +62,8 @@ cas: {
     # from CAS in the cache
     max_entry_size_bytes: 2147483648 # 2 * 1024 * 1024 * 1024
   }
+  
+  skip_load: false
 }
 
 # another cas entry specification here will provide a fallback

--- a/src/main/java/build/buildfarm/worker/shard/CFCExecFileSystem.java
+++ b/src/main/java/build/buildfarm/worker/shard/CFCExecFileSystem.java
@@ -95,7 +95,8 @@ class CFCExecFileSystem implements ExecFileSystem {
   }
 
   @Override
-  public void start(Consumer<List<Digest>> onDigests) throws IOException, InterruptedException {
+  public void start(Consumer<List<Digest>> onDigests, boolean skipLoad)
+      throws IOException, InterruptedException {
     List<Dirent> dirents = null;
     try {
       dirents = readdir(root, /* followSymlinks= */ false);
@@ -115,7 +116,7 @@ class CFCExecFileSystem implements ExecFileSystem {
     }
 
     ImmutableList.Builder<Digest> blobDigests = ImmutableList.builder();
-    fileCache.start(blobDigests::add, removeDirectoryService, false);
+    fileCache.start(blobDigests::add, removeDirectoryService, skipLoad);
     onDigests.accept(blobDigests.build());
 
     getInterruptiblyOrIOException(allAsList(removeDirectoryFutures.build()));

--- a/src/main/java/build/buildfarm/worker/shard/ExecFileSystem.java
+++ b/src/main/java/build/buildfarm/worker/shard/ExecFileSystem.java
@@ -27,7 +27,8 @@ import java.util.Map;
 import java.util.function.Consumer;
 
 interface ExecFileSystem extends InputStreamFactory {
-  void start(Consumer<List<Digest>> onDigests) throws IOException, InterruptedException;
+  void start(Consumer<List<Digest>> onDigests, boolean skipLoad)
+      throws IOException, InterruptedException;
 
   void stop();
 

--- a/src/main/java/build/buildfarm/worker/shard/FuseExecFileSystem.java
+++ b/src/main/java/build/buildfarm/worker/shard/FuseExecFileSystem.java
@@ -39,7 +39,7 @@ class FuseExecFileSystem implements ExecFileSystem {
   }
 
   @Override
-  public void start(Consumer<List<Digest>> onDigests) {
+  public void start(Consumer<List<Digest>> onDigests, boolean skipLoad) {
     // onDigests.accept(storage.getAllDigests());
   }
 

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -811,10 +811,11 @@ public class Worker extends LoggingMain {
 
       removeWorker(config.getPublicName());
 
-      execFileSystem.start((digests) -> addBlobsLocation(digests, config.getPublicName()));
+      boolean skipLoad = config.getCasList().get(0).getSkipLoad();
+      execFileSystem.start(
+          (digests) -> addBlobsLocation(digests, config.getPublicName()), skipLoad);
 
       server.start();
-
       // Not all workers need to be registered and visible in the backplane.
       // For example, a GPU worker may wish to perform work that we do not want to cache locally for
       // other workers.

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -258,6 +258,9 @@ message ContentAddressableStorageConfig {
     FilesystemCASConfig filesystem = 3;
     FuseCASConfig fuse = 4;
   }
+  
+  // whether the transient data on the worker should be loaded into the CAS on worker startup
+  bool skip_load = 5;
 }
 
 message DelegateCASConfig {


### PR DESCRIPTION
The CasFileCache is capable of skipping the load phase when its started.
Now we make that configurable via the worker config.
The default will be current functionality; that is to NOT skip loading of the cas (proto bools are false by default)