### PR TITLE
build containers in CI

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -20,6 +20,6 @@ platforms:
     - "..."
   windows:
     build_targets:
-    - "..."
+    - "... --test_tag_filters=-container"
     test_targets:
     - "..."

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -20,7 +20,7 @@ platforms:
     - "..."
   windows:
     build_flags:
-    - "--test_tag_filters=-container"
+    - "--build_tag_filters=-container"
     build_targets:
     - "..."
     test_targets:

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -19,7 +19,9 @@ platforms:
     test_targets:
     - "..."
   windows:
+    build_flags:
+    - "--test_tag_filters=-container"
     build_targets:
-    - "... --test_tag_filters=-container"
+    - "..."
     test_targets:
     - "..."

--- a/src/main/java/build/buildfarm/BUILD
+++ b/src/main/java/build/buildfarm/BUILD
@@ -431,7 +431,6 @@ container_image(
     files = [
         ":buildfarm-server_deploy.jar",
     ],
-    tags = ["manual"],
     visibility = ["//visibility:public"],
 )
 
@@ -520,7 +519,6 @@ container_image(
     files = [
         ":buildfarm-shard-worker_deploy.jar",
     ],
-    tags = ["manual"],
     visibility = ["//visibility:public"],
 )
 
@@ -654,7 +652,6 @@ container_image(
     files = [
         ":buildfarm-operationqueue-worker_deploy.jar",
     ],
-    tags = ["manual"],
     visibility = ["//visibility:public"],
 )
 

--- a/src/main/java/build/buildfarm/BUILD
+++ b/src/main/java/build/buildfarm/BUILD
@@ -431,6 +431,7 @@ container_image(
     files = [
         ":buildfarm-server_deploy.jar",
     ],
+    tags = ["container"],
     visibility = ["//visibility:public"],
 )
 
@@ -519,6 +520,7 @@ container_image(
     files = [
         ":buildfarm-shard-worker_deploy.jar",
     ],
+    tags = ["container"],
     visibility = ["//visibility:public"],
 )
 
@@ -652,6 +654,7 @@ container_image(
     files = [
         ":buildfarm-operationqueue-worker_deploy.jar",
     ],
+    tags = ["container"],
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
We broke a user by not testing that container targets build. (https://github.com/bazelbuild/bazel-buildfarm/issues/532)
They don't seem too expensive to build.  We could start building them in CI.  
They fail to build in windows though, so I'm skipping them for windows CI.