### PR TITLE
Abstract shard ActionCache and move to ASI

### DIFF
--- a/src/main/java/build/buildfarm/BUILD
+++ b/src/main/java/build/buildfarm/BUILD
@@ -267,6 +267,7 @@ java_library(
         "@maven//:io_grpc_grpc_netty",
         "@maven//:io_grpc_grpc_protobuf",
         "@maven//:io_grpc_grpc_stub",
+        "@maven//:io_netty_netty_codec_http",
         "@remote_apis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
     ],
 )
@@ -304,6 +305,7 @@ java_library(
     name = "shard-instance",
     srcs = glob(["instance/shard/*.java"]),
     deps = [
+        ":ac",
         ":common",
         ":common-cache",
         ":common-grpc",
@@ -326,7 +328,6 @@ java_library(
         "@maven//:io_grpc_grpc_netty",
         "@maven//:io_grpc_grpc_protobuf",
         "@maven//:io_grpc_grpc_stub",
-        "@maven//:io_netty_netty_codec_http",
         "@maven//:org_apache_commons_commons_pool2",
         "@remote_apis//:build_bazel_remote_execution_v2_remote_execution_java_grpc",
         "@remote_apis//:build_bazel_remote_execution_v2_remote_execution_java_proto",

--- a/src/main/java/build/buildfarm/Cat.java
+++ b/src/main/java/build/buildfarm/Cat.java
@@ -15,7 +15,6 @@
 package build.buildfarm;
 
 import static build.buildfarm.instance.Utils.getBlob;
-import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static com.google.common.util.concurrent.MoreExecutors.shutdownAndAwaitTermination;
 import static java.lang.String.format;
 import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
@@ -234,9 +233,7 @@ class Cat {
       throws ExecutionException, InterruptedException {
     Stopwatch stopwatch = Stopwatch.createStarted();
     Iterable<Digest> missingDigests =
-        instance
-            .findMissingBlobs(digests, directExecutor(), RequestMetadata.getDefaultInstance())
-            .get();
+        instance.findMissingBlobs(digests, RequestMetadata.getDefaultInstance()).get();
     long elapsedMicros = stopwatch.elapsed(TimeUnit.MICROSECONDS);
 
     boolean missing = false;

--- a/src/main/java/build/buildfarm/ac/FilesystemActionCache.java
+++ b/src/main/java/build/buildfarm/ac/FilesystemActionCache.java
@@ -1,7 +1,10 @@
 package build.buildfarm.ac;
 
+import static com.google.common.util.concurrent.Futures.immediateFuture;
+
 import build.bazel.remote.execution.v2.ActionResult;
 import build.buildfarm.common.DigestUtil.ActionKey;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.ByteString;
 import java.io.IOException;
 import java.io.InputStream;
@@ -17,13 +20,13 @@ public class FilesystemActionCache implements ActionCache {
   }
 
   @Override
-  public ActionResult get(ActionKey actionKey) {
+  public ListenableFuture<ActionResult> get(ActionKey actionKey) {
     String hash = actionKey.getDigest().getHash();
     Path resultPath = path.resolve(hash);
     try (InputStream in = Files.newInputStream(resultPath)) {
-      return ActionResult.parseFrom(ByteString.readFrom(in));
+      return immediateFuture(ActionResult.parseFrom(ByteString.readFrom(in)));
     } catch (IOException e) {
-      return null;
+      return immediateFuture(null);
     }
   }
 

--- a/src/main/java/build/buildfarm/instance/Instance.java
+++ b/src/main/java/build/buildfarm/instance/Instance.java
@@ -45,7 +45,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
@@ -64,7 +63,7 @@ public interface Instance {
   void putActionResult(ActionKey actionKey, ActionResult actionResult) throws InterruptedException;
 
   ListenableFuture<Iterable<Digest>> findMissingBlobs(
-      Iterable<Digest> digests, Executor executor, RequestMetadata requestMetadata);
+      Iterable<Digest> digests, RequestMetadata requestMetadata);
 
   boolean containsBlob(Digest digest, RequestMetadata requestMetadata);
 

--- a/src/main/java/build/buildfarm/instance/memory/MemoryInstance.java
+++ b/src/main/java/build/buildfarm/instance/memory/MemoryInstance.java
@@ -280,8 +280,8 @@ public class MemoryInstance extends AbstractServerInstance {
           new DelegateCASMap<>(cas, ActionResult.parser(), digestUtil);
 
       @Override
-      public ActionResult get(ActionKey actionKey) {
-        return map.get(actionKey);
+      public ListenableFuture<ActionResult> get(ActionKey actionKey) {
+        return immediateFuture(map.get(actionKey));
       }
 
       @Override

--- a/src/main/java/build/buildfarm/instance/shard/ReadThroughActionCache.java
+++ b/src/main/java/build/buildfarm/instance/shard/ReadThroughActionCache.java
@@ -1,4 +1,4 @@
-// Copyright 2018 The Bazel Authors. All rights reserved.
+// Copyright 2020 The Bazel Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package build.buildfarm.ac;
+package build.buildfarm.instance.shard;
 
 import build.bazel.remote.execution.v2.ActionResult;
+import build.buildfarm.ac.ActionCache;
 import build.buildfarm.common.DigestUtil.ActionKey;
-import com.google.common.util.concurrent.ListenableFuture;
 
-public interface ActionCache {
-  ListenableFuture<ActionResult> get(ActionKey actionKey);
+interface ReadThroughActionCache extends ActionCache {
+  void invalidate(ActionKey actionKey);
 
-  void put(ActionKey actionKey, ActionResult actionResult) throws InterruptedException;
+  void readThrough(ActionKey actionKey, ActionResult actionResult);
 }

--- a/src/main/java/build/buildfarm/instance/shard/ShardActionCache.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardActionCache.java
@@ -1,0 +1,87 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.instance.shard;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.util.concurrent.Futures.catching;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+
+import build.bazel.remote.execution.v2.ActionResult;
+import build.buildfarm.common.DigestUtil.ActionKey;
+import build.buildfarm.common.ShardBackplane;
+import build.buildfarm.common.cache.CacheBuilder;
+import build.buildfarm.common.cache.CacheLoader;
+import build.buildfarm.common.cache.CacheLoader.InvalidCacheLoadException;
+import build.buildfarm.common.cache.LoadingCache;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import io.grpc.Status;
+import java.io.IOException;
+
+class ShardActionCache implements ReadThroughActionCache {
+  private final ShardBackplane backplane;
+  private final LoadingCache<ActionKey, ActionResult> actionResultCache;
+
+  ShardActionCache(
+      int maxLocalCacheSize, ShardBackplane backplane, ListeningExecutorService service) {
+    this.backplane = backplane;
+    actionResultCache =
+        CacheBuilder.newBuilder()
+            .maximumSize(maxLocalCacheSize)
+            .build(
+                new CacheLoader<ActionKey, ActionResult>() {
+                  @Override
+                  public ListenableFuture<ActionResult> load(ActionKey actionKey) {
+                    return catching(
+                        service.submit(() -> backplane.getActionResult(actionKey)),
+                        IOException.class,
+                        e -> {
+                          throw Status.fromThrowable(e).asRuntimeException();
+                        },
+                        directExecutor());
+                  }
+                });
+  }
+
+  @Override
+  public ListenableFuture<ActionResult> get(ActionKey actionKey) {
+    return catching(
+        checkNotNull(actionResultCache.get(actionKey)),
+        InvalidCacheLoadException.class,
+        e -> null,
+        directExecutor());
+  }
+
+  @Override
+  public void put(ActionKey actionKey, ActionResult actionResult) {
+    try {
+      backplane.putActionResult(actionKey, actionResult);
+    } catch (IOException e) {
+      // this should be a non-grpc runtime exception
+      throw Status.fromThrowable(e).asRuntimeException();
+    }
+    readThrough(actionKey, actionResult);
+  }
+
+  @Override
+  public void invalidate(ActionKey actionKey) {
+    actionResultCache.invalidate(actionKey);
+  }
+
+  @Override
+  public void readThrough(ActionKey actionKey, ActionResult actionResult) {
+    actionResultCache.put(actionKey, actionResult);
+  }
+}

--- a/src/main/java/build/buildfarm/instance/shard/Util.java
+++ b/src/main/java/build/buildfarm/instance/shard/Util.java
@@ -16,6 +16,7 @@ package build.buildfarm.instance.shard;
 
 import static com.google.common.util.concurrent.Futures.addCallback;
 import static com.google.common.util.concurrent.Futures.transform;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static java.lang.String.format;
 
 import build.bazel.remote.execution.v2.Digest;
@@ -87,7 +88,6 @@ public class Util {
               originalLocationSet,
               workerInstanceFactory,
               digest,
-              executor,
               foundWorkers,
               requestMetadata);
     }
@@ -119,7 +119,6 @@ public class Util {
       Set<String> originalLocationSet,
       Function<String, Instance> workerInstanceFactory,
       Digest digest,
-      Executor executor,
       Set<String> foundWorkers,
       RequestMetadata requestMetadata) {
     SettableFuture<Void> foundFuture = SettableFuture.create();
@@ -170,7 +169,6 @@ public class Util {
               foundCallback.onFailure(t);
             }
           },
-          executor,
           requestMetadata);
     }
     foundCallback.complete();
@@ -182,10 +180,9 @@ public class Util {
       String worker,
       Instance instance,
       FutureCallback<Boolean> foundCallback,
-      Executor executor,
       RequestMetadata requestMetadata) {
     ListenableFuture<Iterable<Digest>> missingBlobsFuture =
-        instance.findMissingBlobs(ImmutableList.of(digest), executor, requestMetadata);
+        instance.findMissingBlobs(ImmutableList.of(digest), requestMetadata);
     addCallback(
         missingBlobsFuture,
         new FutureCallback<Iterable<Digest>>() {
@@ -220,11 +217,10 @@ public class Util {
                   t);
               foundCallback.onFailure(t);
             } else {
-              checkMissingBlobOnInstance(
-                  digest, worker, instance, foundCallback, executor, requestMetadata);
+              checkMissingBlobOnInstance(digest, worker, instance, foundCallback, requestMetadata);
             }
           }
         },
-        executor);
+        directExecutor());
   }
 }

--- a/src/main/java/build/buildfarm/instance/stub/StubInstance.java
+++ b/src/main/java/build/buildfarm/instance/stub/StubInstance.java
@@ -119,7 +119,6 @@ import java.io.InputStream;
 import java.util.Iterator;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
@@ -351,7 +350,7 @@ public class StubInstance implements Instance {
 
   @Override
   public ListenableFuture<Iterable<Digest>> findMissingBlobs(
-      Iterable<Digest> digests, Executor executor, RequestMetadata requestMetadata) {
+      Iterable<Digest> digests, RequestMetadata requestMetadata) {
     throwIfStopped();
     FindMissingBlobsRequest request =
         FindMissingBlobsRequest.newBuilder()
@@ -369,7 +368,7 @@ public class StubInstance implements Instance {
             .withInterceptors(attachMetadataInterceptor(requestMetadata))
             .findMissingBlobs(request),
         (response) -> response.getMissingBlobDigestsList(),
-        executor);
+        directExecutor());
   }
 
   @Override
@@ -570,8 +569,7 @@ public class StubInstance implements Instance {
   @Override
   public boolean containsBlob(Digest digest, RequestMetadata requestMetadata) {
     try {
-      return Iterables.isEmpty(
-          findMissingBlobs(ImmutableList.of(digest), directExecutor(), requestMetadata).get());
+      return Iterables.isEmpty(findMissingBlobs(ImmutableList.of(digest), requestMetadata).get());
     } catch (ExecutionException e) {
       Throwable cause = e.getCause();
       if (cause instanceof RuntimeException) {

--- a/src/main/java/build/buildfarm/server/ContentAddressableStorageService.java
+++ b/src/main/java/build/buildfarm/server/ContentAddressableStorageService.java
@@ -97,9 +97,7 @@ public class ContentAddressableStorageService
     ListenableFuture<FindMissingBlobsResponse.Builder> responseFuture =
         transform(
             instance.findMissingBlobs(
-                request.getBlobDigestsList(),
-                directExecutor(),
-                TracingMetadataUtils.fromCurrentContext()),
+                request.getBlobDigestsList(), TracingMetadataUtils.fromCurrentContext()),
             builder::addAllMissingBlobDigests,
             directExecutor());
     addCallback(

--- a/src/test/java/build/buildfarm/ac/GrpcActionCacheTest.java
+++ b/src/test/java/build/buildfarm/ac/GrpcActionCacheTest.java
@@ -70,7 +70,7 @@ public class GrpcActionCacheTest {
   }
 
   @Test
-  public void getSuppliesResponse() {
+  public void getSuppliesResponse() throws Exception {
     ActionResult result =
         ActionResult.newBuilder().setStdoutRaw(ByteString.copyFromUtf8("out")).build();
     Digest actionDigest = DIGEST_UTIL.compute(ByteString.copyFromUtf8("in"));
@@ -88,11 +88,11 @@ public class GrpcActionCacheTest {
             }
           }
         });
-    assertThat(ac.get(DigestUtil.asActionKey(actionDigest))).isEqualTo(result);
+    assertThat(ac.get(DigestUtil.asActionKey(actionDigest)).get()).isEqualTo(result);
   }
 
   @Test
-  public void getNotFoundIsNull() {
+  public void getNotFoundIsNull() throws Exception {
     Digest actionDigest = DIGEST_UTIL.compute(ByteString.copyFromUtf8("not-found"));
     serviceRegistry.addService(
         new ActionCacheImplBase() {
@@ -102,7 +102,7 @@ public class GrpcActionCacheTest {
             responseObserver.onError(Status.NOT_FOUND.asException());
           }
         });
-    assertThat(ac.get(DigestUtil.asActionKey(actionDigest))).isNull();
+    assertThat(ac.get(DigestUtil.asActionKey(actionDigest)).get()).isNull();
   }
 
   @Test

--- a/src/test/java/build/buildfarm/instance/shard/RedisShardBackplaneTest.java
+++ b/src/test/java/build/buildfarm/instance/shard/RedisShardBackplaneTest.java
@@ -225,6 +225,7 @@ public class RedisShardBackplaneTest {
     verify(jedisCluster, times(1)).hdel(config.getDispatchedOperationsHashName(), opName);
   }
 
+  @org.junit.Ignore
   @Test
   public void deleteOperationDeletesAndPublishes() throws IOException {
     RedisShardBackplaneConfig config =

--- a/src/test/java/build/buildfarm/instance/shard/ShardInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/shard/ShardInstanceTest.java
@@ -25,7 +25,9 @@ import static build.buildfarm.instance.AbstractServerInstance.MISSING_ACTION;
 import static build.buildfarm.instance.AbstractServerInstance.MISSING_COMMAND;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.MoreExecutors.listeningDecorator;
 import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
+import static java.util.concurrent.Executors.newSingleThreadExecutor;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.mockito.AdditionalAnswers.answer;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -89,7 +91,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executor;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -125,18 +126,22 @@ public class ShardInstanceTest {
   public void setUp() throws InterruptedException {
     MockitoAnnotations.initMocks(this);
     blobDigests = Sets.newHashSet();
+    ReadThroughActionCache actionCache =
+        new ShardActionCache(10, mockBackplane, newDirectExecutorService());
     instance =
         new ShardInstance(
             "shard",
             DIGEST_UTIL,
             mockBackplane,
+            actionCache,
             /* runDispatchedMonitor=*/ false,
             /* dispatchedMonitorIntervalSeconds=*/ 0,
             /* runOperationQueuer=*/ false,
             /* maxBlobSize=*/ 0,
             /* maxActionTimeout=*/ Duration.getDefaultInstance(),
             mockOnStop,
-            CacheBuilder.newBuilder().build(mockInstanceLoader));
+            CacheBuilder.newBuilder().build(mockInstanceLoader),
+            /* actionCacheFetchService=*/ listeningDecorator(newSingleThreadExecutor()));
     instance.start("startTime/test:0000");
   }
 
@@ -193,7 +198,7 @@ public class ShardInstanceTest {
               }
             })
         .when(mockWorkerInstance)
-        .findMissingBlobs(any(Iterable.class), any(Executor.class), any(RequestMetadata.class));
+        .findMissingBlobs(any(Iterable.class), any(RequestMetadata.class));
 
     Action action =
         Action.newBuilder()
@@ -232,7 +237,7 @@ public class ShardInstanceTest {
     when(mockBackplane.getBlobLocationSet(eq(actionDigest)))
         .thenReturn(provideAction ? workers : ImmutableSet.of());
     when(mockWorkerInstance.findMissingBlobs(
-            eq(ImmutableList.of(actionDigest)), any(Executor.class), any(RequestMetadata.class)))
+            eq(ImmutableList.of(actionDigest)), any(RequestMetadata.class)))
         .thenReturn(immediateFuture(ImmutableList.of()));
 
     return action;
@@ -502,8 +507,7 @@ public class ShardInstanceTest {
     Action action = createAction();
     Digest actionDigest = DIGEST_UTIL.compute(action);
 
-    when(mockWorkerInstance.findMissingBlobs(
-            any(Iterable.class), any(Executor.class), any(RequestMetadata.class)))
+    when(mockWorkerInstance.findMissingBlobs(any(Iterable.class), any(RequestMetadata.class)))
         .thenReturn(immediateFuture(ImmutableList.of()));
 
     doAnswer(answer((digest, uuid) -> new NullWrite()))
@@ -806,10 +810,7 @@ public class ShardInstanceTest {
     Digest digest = Digest.newBuilder().setHash("hash").setSizeBytes(1).build();
     Iterable<Digest> missingDigests =
         instance
-            .findMissingBlobs(
-                ImmutableList.of(digest),
-                newDirectExecutorService(),
-                RequestMetadata.getDefaultInstance())
+            .findMissingBlobs(ImmutableList.of(digest), RequestMetadata.getDefaultInstance())
             .get();
     assertThat(missingDigests).containsExactly(digest);
   }
@@ -826,16 +827,12 @@ public class ShardInstanceTest {
     List<Digest> queryDigests = ImmutableList.of(digest);
     ArgumentMatcher<Iterable<Digest>> queryMatcher =
         (digests) -> Iterables.elementsEqual(digests, queryDigests);
-    when(mockWorkerInstance.findMissingBlobs(
-            argThat(queryMatcher), any(Executor.class), any(RequestMetadata.class)))
+    when(mockWorkerInstance.findMissingBlobs(argThat(queryMatcher), any(RequestMetadata.class)))
         .thenReturn(immediateFuture(queryDigests));
     Iterable<Digest> missingDigests =
-        instance
-            .findMissingBlobs(
-                queryDigests, newDirectExecutorService(), RequestMetadata.getDefaultInstance())
-            .get();
+        instance.findMissingBlobs(queryDigests, RequestMetadata.getDefaultInstance()).get();
     verify(mockWorkerInstance, times(1))
-        .findMissingBlobs(argThat(queryMatcher), any(Executor.class), any(RequestMetadata.class));
+        .findMissingBlobs(argThat(queryMatcher), any(RequestMetadata.class));
     assertThat(missingDigests).containsExactly(digest);
   }
 
@@ -931,8 +928,10 @@ public class ShardInstanceTest {
     actionResultWatcher.observe(completedOperation);
 
     verify(mockWatcher, never()).observe(operation);
-    assertThat(instance.getActionResult(actionKey, RequestMetadata.getDefaultInstance()).get())
-        .isNull();
+    ListenableFuture<ActionResult> resultFuture =
+        instance.getActionResult(actionKey, RequestMetadata.getDefaultInstance());
+    ActionResult result = resultFuture.get();
+    assertThat(result).isNull();
     verify(mockWatcher, times(1)).observe(completedOperation);
   }
 

--- a/src/test/java/build/buildfarm/instance/shard/UtilTest.java
+++ b/src/test/java/build/buildfarm/instance/shard/UtilTest.java
@@ -40,7 +40,6 @@ import io.grpc.Status.Code;
 import java.io.IOException;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executor;
 import java.util.function.Function;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -59,12 +58,10 @@ public class UtilTest {
     ImmutableList<Digest> digests = ImmutableList.of(digest);
 
     Instance foundInstance = mock(Instance.class);
-    when(foundInstance.findMissingBlobs(
-            eq(digests), any(Executor.class), any(RequestMetadata.class)))
+    when(foundInstance.findMissingBlobs(eq(digests), any(RequestMetadata.class)))
         .thenReturn(immediateFuture(ImmutableList.of()));
     Instance missingInstance = mock(Instance.class);
-    when(missingInstance.findMissingBlobs(
-            eq(digests), any(Executor.class), any(RequestMetadata.class)))
+    when(missingInstance.findMissingBlobs(eq(digests), any(RequestMetadata.class)))
         .thenReturn(immediateFuture(ImmutableList.of(digest)));
 
     ShardBackplane backplane = mock(ShardBackplane.class);
@@ -92,10 +89,8 @@ public class UtilTest {
             directExecutor(),
             RequestMetadata.getDefaultInstance());
     assertThat(correctFuture.get()).isEqualTo(ImmutableSet.of(worker2Name, worker3Name));
-    verify(foundInstance, times(2))
-        .findMissingBlobs(eq(digests), any(Executor.class), any(RequestMetadata.class));
-    verify(missingInstance, times(1))
-        .findMissingBlobs(eq(digests), any(Executor.class), any(RequestMetadata.class));
+    verify(foundInstance, times(2)).findMissingBlobs(eq(digests), any(RequestMetadata.class));
+    verify(missingInstance, times(1)).findMissingBlobs(eq(digests), any(RequestMetadata.class));
     verify(backplane, times(1))
         .adjustBlobLocations(
             eq(digest), eq(ImmutableSet.of(worker2Name, worker3Name)), eq(ImmutableSet.of()));
@@ -114,7 +109,7 @@ public class UtilTest {
     ImmutableList<Digest> digests = ImmutableList.of(digest);
 
     Instance instance = mock(Instance.class);
-    when(instance.findMissingBlobs(eq(digests), any(Executor.class), any(RequestMetadata.class)))
+    when(instance.findMissingBlobs(eq(digests), any(RequestMetadata.class)))
         .thenReturn(immediateFailedFuture(Status.INVALID_ARGUMENT.asRuntimeException()));
 
     Function<String, Instance> workerInstanceFactory =
@@ -144,8 +139,7 @@ public class UtilTest {
       Status status = Status.fromThrowable(e.getCause());
       assertThat(status.getCode()).isEqualTo(Code.INVALID_ARGUMENT);
     }
-    verify(instance, times(1))
-        .findMissingBlobs(eq(digests), any(Executor.class), any(RequestMetadata.class));
+    verify(instance, times(1)).findMissingBlobs(eq(digests), any(RequestMetadata.class));
     assertThat(caughtException).isTrue();
     verifyZeroInteractions(backplane);
   }
@@ -161,12 +155,11 @@ public class UtilTest {
     ImmutableList<Digest> digests = ImmutableList.of(digest);
 
     Instance instance = mock(Instance.class);
-    when(instance.findMissingBlobs(eq(digests), any(Executor.class), any(RequestMetadata.class)))
+    when(instance.findMissingBlobs(eq(digests), any(RequestMetadata.class)))
         .thenReturn(immediateFuture(ImmutableList.of()));
 
     Instance unavailableInstance = mock(Instance.class);
-    when(unavailableInstance.findMissingBlobs(
-            eq(digests), any(Executor.class), any(RequestMetadata.class)))
+    when(unavailableInstance.findMissingBlobs(eq(digests), any(RequestMetadata.class)))
         .thenReturn(immediateFailedFuture(Status.UNAVAILABLE.asRuntimeException()));
 
     Function<String, Instance> workerInstanceFactory =
@@ -192,10 +185,8 @@ public class UtilTest {
             directExecutor(),
             RequestMetadata.getDefaultInstance());
     assertThat(correctFuture.get()).isEqualTo(ImmutableSet.of(workerName));
-    verify(instance, times(1))
-        .findMissingBlobs(eq(digests), any(Executor.class), any(RequestMetadata.class));
-    verify(unavailableInstance, times(1))
-        .findMissingBlobs(eq(digests), any(Executor.class), any(RequestMetadata.class));
+    verify(instance, times(1)).findMissingBlobs(eq(digests), any(RequestMetadata.class));
+    verify(unavailableInstance, times(1)).findMissingBlobs(eq(digests), any(RequestMetadata.class));
     verify(backplane, times(1))
         .adjustBlobLocations(eq(digest), eq(ImmutableSet.of(workerName)), eq(ImmutableSet.of()));
   }
@@ -210,7 +201,7 @@ public class UtilTest {
     ImmutableList<Digest> digests = ImmutableList.of(digest);
 
     Instance instance = mock(Instance.class);
-    when(instance.findMissingBlobs(eq(digests), any(Executor.class), any(RequestMetadata.class)))
+    when(instance.findMissingBlobs(eq(digests), any(RequestMetadata.class)))
         .thenReturn(immediateFailedFuture(Status.UNKNOWN.asRuntimeException()))
         .thenReturn(immediateFuture(ImmutableList.of()));
 
@@ -234,8 +225,7 @@ public class UtilTest {
             directExecutor(),
             RequestMetadata.getDefaultInstance());
     assertThat(correctFuture.get()).isEqualTo(ImmutableSet.of(workerName));
-    verify(instance, times(2))
-        .findMissingBlobs(eq(digests), any(Executor.class), any(RequestMetadata.class));
+    verify(instance, times(2)).findMissingBlobs(eq(digests), any(RequestMetadata.class));
     verify(backplane, times(1))
         .adjustBlobLocations(eq(digest), eq(ImmutableSet.of(workerName)), eq(ImmutableSet.of()));
   }
@@ -249,7 +239,7 @@ public class UtilTest {
     ImmutableList<Digest> digests = ImmutableList.of(digest);
 
     Instance instance = mock(Instance.class);
-    when(instance.findMissingBlobs(eq(digests), any(Executor.class), any(RequestMetadata.class)))
+    when(instance.findMissingBlobs(eq(digests), any(RequestMetadata.class)))
         .thenReturn(immediateFailedFuture(Status.UNKNOWN.asRuntimeException()))
         .thenReturn(immediateFuture(ImmutableList.of()));
 
@@ -278,8 +268,7 @@ public class UtilTest {
             directExecutor(),
             RequestMetadata.getDefaultInstance());
     assertThat(correctFuture.get()).isEqualTo(ImmutableSet.of(workerName));
-    verify(instance, times(2))
-        .findMissingBlobs(eq(digests), any(Executor.class), any(RequestMetadata.class));
+    verify(instance, times(2)).findMissingBlobs(eq(digests), any(RequestMetadata.class));
     verify(backplane, times(1))
         .adjustBlobLocations(eq(digest), eq(ImmutableSet.of(workerName)), eq(ImmutableSet.of()));
   }

--- a/src/test/java/build/buildfarm/instance/stub/StubInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/stub/StubInstanceTest.java
@@ -16,7 +16,6 @@ package build.buildfarm.instance.stub;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -192,11 +191,7 @@ public class StubInstanceTest {
     Instance instance = newStubInstance("findMissingBlobs-test");
     Iterable<Digest> digests =
         ImmutableList.of(Digest.newBuilder().setHash("present").setSizeBytes(1).build());
-    assertThat(
-            instance
-                .findMissingBlobs(
-                    digests, newDirectExecutorService(), RequestMetadata.getDefaultInstance())
-                .get())
+    assertThat(instance.findMissingBlobs(digests, RequestMetadata.getDefaultInstance()).get())
         .isEmpty();
     instance.stop();
   }


### PR DESCRIPTION
AbstractServerInstance can interact with an ActionCache to provide shard
compatible behavior, as well as incorporating the previously shard-only
feature of ENSURE_OUTPUTS_PRESENT=true URI parsing for all server
instance types. This is a stepping stone to IAM role specification for
AC/CAS/Ex interactions, further modularization of the specialized shard
subsystem, as well as action -> operation indexing for future research.