### PR TITLE
Allow wildcard platform properties in action matching.

### DIFF
--- a/src/main/java/build/buildfarm/common/Actions.java
+++ b/src/main/java/build/buildfarm/common/Actions.java
@@ -116,7 +116,8 @@ public final class Actions {
     if (requirement.equals("max-cores")) {
       return true;
     }
-    return provisions.containsEntry(requirement, value);
+    return provisions.containsEntry(requirement, value)
+        || provisions.containsEntry(requirement, "*");
   }
 
   public static boolean satisfiesRequirements(


### PR DESCRIPTION
This change enables the use of wildcards in Platform matching. This
change is intended to allow actions to specify a set of execution
properties and have those properties met by an execution policy /
wrapper.

Specifically, we have the following as the shard worker config:

```
platform: {
  properties: {
    key: "container-image"
    value: "*"
  }
}
```

```
execution_policies: {
  name: ""
  wrapper: {
    path: "/app/tools/buildfarm/action-wrapper.binary"
    arguments: "--root=/build/worker/root"
    arguments: "--image"
    arguments: "<container-image>"
  }
}
```

and the following platform definition:
```
platform(
    name = "buildfarm",
    constraint_values = [
        "@bazel_tools//platforms:x86_64",
        "@bazel_tools//platforms:linux",
        "@bazel_tools//tools/cpp:clang",
        ":docker_exposed",
        "@io_bazel_rules_docker//platforms:run_in_container",
    ],
    remote_execution_properties = """
            properties: {
                name: "container-image"
                value: "our-super-cool-image"
            }
        """,
)
```

The action-wrapper utility takes the container image injected by
transforming the execution policy and executes any actions within the
given container.

Without this change, no shard worker matches the platform specified in
the action and nothing is executed.

There is a small chance this is not backwards compatible if a user has
a platform property value with both '*' and any other value being valid
as discrete configurations.