### PR TITLE
change tool name for CasFileCache

### DIFF
--- a/src/main/java/build/buildfarm/BUILD
+++ b/src/main/java/build/buildfarm/BUILD
@@ -683,12 +683,12 @@ java_binary(
 )
 
 java_binary(
-    name = "bf-cas",
-    srcs = ["CASTest.java"],
+    name = "bf-cache-load",
+    srcs = ["CacheLoad.java"],
     classpath_resources = [
         ":configs",
     ],
-    main_class = "build.buildfarm.CASTest",
+    main_class = "build.buildfarm.CacheLoad",
     visibility = ["//visibility:public"],
     deps = [
         ":cas",

--- a/src/main/java/build/buildfarm/CacheLoad.java
+++ b/src/main/java/build/buildfarm/CacheLoad.java
@@ -29,7 +29,9 @@ import java.nio.file.Paths;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 
-class CASTest {
+// This tool is helpful for testing the startup of the CasFileCache.
+// Give an existing file cache, and the tool will load and print startup information about it.
+class CacheLoad {
   private static class LocalCASFileCache extends CASFileCache {
     LocalCASFileCache(
         Path root,

--- a/src/main/java/build/buildfarm/CacheLoad.java
+++ b/src/main/java/build/buildfarm/CacheLoad.java
@@ -30,7 +30,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 
 // This tool is helpful for testing the startup of the CasFileCache.
-// Give an existing file cache, and the tool will load and print startup information about it.
+// Give an existing file path, and the tool will load and print startup information about it.
 class CacheLoad {
   private static class LocalCASFileCache extends CASFileCache {
     LocalCASFileCache(


### PR DESCRIPTION
We have an existing tool to load the CasFileCache and print it's startup information.  The name of the tool is too vague and I'd like to make other CAS-related tools for debugging.  We can rename it.