### PR TITLE
add tests to catch config errors

### DIFF
--- a/examples/BUILD
+++ b/examples/BUILD
@@ -1,0 +1,6 @@
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "example_configs",
+    srcs = glob(["*.example"])
+)

--- a/examples/shard-worker.config.example
+++ b/examples/shard-worker.config.example
@@ -64,7 +64,7 @@ cas: {
 
     # whether the file directories bidirectional mapping should be stored in memory (HashMap) or
     # in sqlite
-    file_directories_index_in_memory = false
+    file_directories_index_in_memory: false
   }
 
   # whether the transient data on the worker should be loaded into the CAS on worker startup.

--- a/src/test/java/build/buildfarm/BUILD
+++ b/src/test/java/build/buildfarm/BUILD
@@ -40,8 +40,37 @@ java_test(
         exclude = [
             "common/grpc/ByteStreamServiceWriter.java",
             "common/redis/*.java",
+            "common/ExampleConfigsTest.java",
         ],
     ) + ["common/redis/RedisClientTest.java"],
+    test_class = "build.buildfarm.AllTests",
+    deps = [
+        ":test_runner",
+        "//src/main/java/build/buildfarm:common",
+        "//src/main/java/build/buildfarm:common-grpc",
+        "//src/main/java/build/buildfarm:common-redis",
+        "//src/main/protobuf:build_buildfarm_v1test_buildfarm_java_proto",
+        "//third_party/jedis",
+        "@googleapis//:google_bytestream_bytestream_java_grpc",
+        "@googleapis//:google_bytestream_bytestream_java_proto",
+        "@googleapis//:google_rpc_error_details_java_proto",
+        "@maven//:com_google_guava_guava",
+        "@maven//:com_google_jimfs_jimfs",
+        "@maven//:com_google_protobuf_protobuf_java",
+        "@maven//:com_google_protobuf_protobuf_java_util",
+        "@maven//:com_google_truth_truth",
+        "@maven//:io_grpc_grpc_api",
+        "@maven//:io_grpc_grpc_core",
+        "@maven//:io_grpc_grpc_stub",
+        "@maven//:io_grpc_grpc_testing",
+        "@maven//:org_mockito_mockito_core",
+    ],
+)
+
+java_test(
+    name = "example-configs-tests",
+    size = "small",
+    srcs = ["common/ExampleConfigsTest.java"],
     test_class = "build.buildfarm.AllTests",
     data = ["//examples:example_configs"],
     deps = [

--- a/src/test/java/build/buildfarm/BUILD
+++ b/src/test/java/build/buildfarm/BUILD
@@ -43,6 +43,7 @@ java_test(
         ],
     ) + ["common/redis/RedisClientTest.java"],
     test_class = "build.buildfarm.AllTests",
+    data = ["//examples:example_configs"],
     deps = [
         ":test_runner",
         "//src/main/java/build/buildfarm:common",

--- a/src/test/java/build/buildfarm/common/ExampleConfigsTest.java
+++ b/src/test/java/build/buildfarm/common/ExampleConfigsTest.java
@@ -1,0 +1,82 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.common;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import build.bazel.remote.execution.v2.Digest;
+import build.bazel.remote.execution.v2.DigestFunction;
+import build.buildfarm.common.DigestUtil.HashFunction;
+import com.google.protobuf.ByteString;
+import java.io.IOException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import com.google.protobuf.TextFormat;
+import build.buildfarm.v1test.WorkerConfig;
+import build.buildfarm.v1test.ShardWorkerConfig;
+import build.buildfarm.v1test.BuildFarmServerConfig;
+
+// Test that example config files can load properly
+@RunWith(JUnit4.class)
+public class ExampleConfigsTest {
+
+  @Test
+  public void workerConfig() throws IOException {
+    
+    // parse text into protobuf
+    Path configPath = Paths.get("examples/worker.config.example");
+    try (InputStream configInputStream = Files.newInputStream(configPath)) {
+        WorkerConfig.Builder builder = WorkerConfig.newBuilder();
+        TextFormat.merge(new InputStreamReader(configInputStream), builder);
+        builder.build();
+    }
+  }
+  
+  @Test
+  public void serverConfig() throws IOException {
+    
+    // parse text into protobuf
+    Path configPath = Paths.get("examples/server.config.example");
+    try (InputStream configInputStream = Files.newInputStream(configPath)) {
+        BuildFarmServerConfig.Builder builder = BuildFarmServerConfig.newBuilder();
+        TextFormat.merge(new InputStreamReader(configInputStream), builder);
+        builder.build();
+    }
+  }
+  
+  @Test
+  public void shardWorkerConfig() throws IOException {
+    
+    // parse text into protobuf
+    Path configPath = Paths.get("examples/shard-worker.config.example");
+    try (InputStream configInputStream = Files.newInputStream(configPath)) {
+        ShardWorkerConfig.Builder builder = ShardWorkerConfig.newBuilder();
+        TextFormat.merge(new InputStreamReader(configInputStream), builder);
+        builder.build();
+    }
+  }
+  
+  
+}

--- a/src/test/java/build/buildfarm/common/ExampleConfigsTest.java
+++ b/src/test/java/build/buildfarm/common/ExampleConfigsTest.java
@@ -36,7 +36,7 @@ public class ExampleConfigsTest {
   public void workerConfig() throws IOException {
 
     // parse text into protobuf
-    Path configPath = Paths.get("examples/worker.config.example");
+    Path configPath = Paths.get("examples", "worker.config.example");
     try (InputStream configInputStream = Files.newInputStream(configPath)) {
       WorkerConfig.Builder builder = WorkerConfig.newBuilder();
       TextFormat.merge(new InputStreamReader(configInputStream), builder);
@@ -48,7 +48,7 @@ public class ExampleConfigsTest {
   public void serverConfig() throws IOException {
 
     // parse text into protobuf
-    Path configPath = Paths.get("examples/server.config.example");
+    Path configPath = Paths.get("examples", "server.config.example");
     try (InputStream configInputStream = Files.newInputStream(configPath)) {
       BuildFarmServerConfig.Builder builder = BuildFarmServerConfig.newBuilder();
       TextFormat.merge(new InputStreamReader(configInputStream), builder);
@@ -60,7 +60,7 @@ public class ExampleConfigsTest {
   public void shardWorkerConfig() throws IOException {
 
     // parse text into protobuf
-    Path configPath = Paths.get("examples/shard-worker.config.example");
+    Path configPath = Paths.get("examples", "shard-worker.config.example");
     try (InputStream configInputStream = Files.newInputStream(configPath)) {
       ShardWorkerConfig.Builder builder = ShardWorkerConfig.newBuilder();
       TextFormat.merge(new InputStreamReader(configInputStream), builder);
@@ -72,7 +72,7 @@ public class ExampleConfigsTest {
   public void shardServerConfig() throws IOException {
 
     // parse text into protobuf
-    Path configPath = Paths.get("examples/shard-server.config.example");
+    Path configPath = Paths.get("examples", "shard-server.config.example");
     try (InputStream configInputStream = Files.newInputStream(configPath)) {
       BuildFarmServerConfig.Builder builder = BuildFarmServerConfig.newBuilder();
       TextFormat.merge(new InputStreamReader(configInputStream), builder);

--- a/src/test/java/build/buildfarm/common/ExampleConfigsTest.java
+++ b/src/test/java/build/buildfarm/common/ExampleConfigsTest.java
@@ -14,29 +14,20 @@
 
 package build.buildfarm.common;
 
-import static com.google.common.truth.Truth.assertThat;
 
-import build.bazel.remote.execution.v2.Digest;
-import build.bazel.remote.execution.v2.DigestFunction;
-import build.buildfarm.common.DigestUtil.HashFunction;
-import com.google.protobuf.ByteString;
+import build.buildfarm.v1test.BuildFarmServerConfig;
+import build.buildfarm.v1test.ShardWorkerConfig;
+import build.buildfarm.v1test.WorkerConfig;
+import com.google.protobuf.TextFormat;
 import java.io.IOException;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.nio.file.FileSystem;
-import java.nio.file.FileSystems;
 import java.nio.file.Files;
-import com.google.protobuf.TextFormat;
-import build.buildfarm.v1test.WorkerConfig;
-import build.buildfarm.v1test.ShardWorkerConfig;
-import build.buildfarm.v1test.BuildFarmServerConfig;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 // Test that example config files can load properly
 @RunWith(JUnit4.class)
@@ -44,39 +35,49 @@ public class ExampleConfigsTest {
 
   @Test
   public void workerConfig() throws IOException {
-    
+
     // parse text into protobuf
     Path configPath = Paths.get("examples/worker.config.example");
     try (InputStream configInputStream = Files.newInputStream(configPath)) {
-        WorkerConfig.Builder builder = WorkerConfig.newBuilder();
-        TextFormat.merge(new InputStreamReader(configInputStream), builder);
-        builder.build();
+      WorkerConfig.Builder builder = WorkerConfig.newBuilder();
+      TextFormat.merge(new InputStreamReader(configInputStream), builder);
+      builder.build();
     }
   }
-  
+
   @Test
   public void serverConfig() throws IOException {
-    
+
     // parse text into protobuf
     Path configPath = Paths.get("examples/server.config.example");
     try (InputStream configInputStream = Files.newInputStream(configPath)) {
-        BuildFarmServerConfig.Builder builder = BuildFarmServerConfig.newBuilder();
-        TextFormat.merge(new InputStreamReader(configInputStream), builder);
-        builder.build();
+      BuildFarmServerConfig.Builder builder = BuildFarmServerConfig.newBuilder();
+      TextFormat.merge(new InputStreamReader(configInputStream), builder);
+      builder.build();
     }
   }
-  
+
   @Test
   public void shardWorkerConfig() throws IOException {
-    
+
     // parse text into protobuf
     Path configPath = Paths.get("examples/shard-worker.config.example");
     try (InputStream configInputStream = Files.newInputStream(configPath)) {
-        ShardWorkerConfig.Builder builder = ShardWorkerConfig.newBuilder();
-        TextFormat.merge(new InputStreamReader(configInputStream), builder);
-        builder.build();
+      ShardWorkerConfig.Builder builder = ShardWorkerConfig.newBuilder();
+      TextFormat.merge(new InputStreamReader(configInputStream), builder);
+      builder.build();
     }
   }
-  
-  
+
+  @Test
+  public void shardWorkerConfig() throws IOException {
+
+    // parse text into protobuf
+    Path configPath = Paths.get("examples/shard-server.config.example");
+    try (InputStream configInputStream = Files.newInputStream(configPath)) {
+      BuildFarmServerConfig.Builder builder = BuildFarmServerConfig.newBuilder();
+      TextFormat.merge(new InputStreamReader(configInputStream), builder);
+      builder.build();
+    }
+  }
 }

--- a/src/test/java/build/buildfarm/common/ExampleConfigsTest.java
+++ b/src/test/java/build/buildfarm/common/ExampleConfigsTest.java
@@ -24,6 +24,7 @@ import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -31,6 +32,11 @@ import org.junit.runners.JUnit4;
 // Test that example config files can load properly
 @RunWith(JUnit4.class)
 public class ExampleConfigsTest {
+
+  @Before
+  public void skipWindows() {
+    org.junit.Assume.assumeFalse(System.getProperty("os.name").contains("Win"));
+  }
 
   @Test
   public void workerConfig() throws IOException {

--- a/src/test/java/build/buildfarm/common/ExampleConfigsTest.java
+++ b/src/test/java/build/buildfarm/common/ExampleConfigsTest.java
@@ -14,7 +14,6 @@
 
 package build.buildfarm.common;
 
-
 import build.buildfarm.v1test.BuildFarmServerConfig;
 import build.buildfarm.v1test.ShardWorkerConfig;
 import build.buildfarm.v1test.WorkerConfig;

--- a/src/test/java/build/buildfarm/common/ExampleConfigsTest.java
+++ b/src/test/java/build/buildfarm/common/ExampleConfigsTest.java
@@ -70,7 +70,7 @@ public class ExampleConfigsTest {
   }
 
   @Test
-  public void shardWorkerConfig() throws IOException {
+  public void shardServerConfig() throws IOException {
 
     // parse text into protobuf
     Path configPath = Paths.get("examples/shard-server.config.example");


### PR DESCRIPTION
This will prevent our example config files from breaking the future.