### PR TITLE
Reduce lock contention

### DIFF
--- a/src/main/java/build/buildfarm/cas/CASFileCache.java
+++ b/src/main/java/build/buildfarm/cas/CASFileCache.java
@@ -1479,8 +1479,9 @@ public abstract class CASFileCache implements ContentAddressableStorage {
             // populate key it is not currently stored.
             String key = fileEntryKey.getKey();
             Entry e = new Entry(key, size, Deadline.after(10, SECONDS));
+            Object fileKey = getFileKey(root.resolve(key), stat);
             synchronized (fileKeys) {
-              fileKeys.put(getFileKey(root.resolve(key), stat), e);
+              fileKeys.put(fileKey, e);
             }
             storage.put(e.key, e);
             onPut.accept(fileEntryKey.getDigest());


### PR DESCRIPTION
We did a 2-minutes profile of startup time and 38 seconds were spent waiting for this lock.

We believe that it is safe to read file metadata without holding this lock.

I have talked to Spotify Legal, and they say that we have a company wide signature of the Google CLA, and that we should not be signing the CLA individually.
