### PR TITLE
Speed up startup time by batching Redis calls

### DIFF
--- a/src/main/java/build/buildfarm/worker/shard/ShardCASFileCache.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardCASFileCache.java
@@ -40,6 +40,7 @@ class ShardCASFileCache extends CASFileCache {
       ExecutorService expireService,
       Executor accessRecorder,
       Consumer<Digest> onPut,
+      Consumer<Iterable<Digest>> onPutAll,
       Consumer<Iterable<Digest>> onExpire,
       ContentAddressableStorage delegate) {
     super(
@@ -53,6 +54,7 @@ class ShardCASFileCache extends CASFileCache {
         /* storage=*/ Maps.newConcurrentMap(),
         DEFAULT_DIRECTORIES_INDEX_NAME,
         onPut,
+        onPutAll,
         onExpire,
         delegate);
     this.inputStreamFactory =

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -605,6 +605,7 @@ public class Worker extends LoggingMain {
             removeDirectoryService,
             accessRecorder,
             this::onStoragePut,
+            this::onStoragePutAll,
             delegate == null ? this::onStorageExpire : (digests) -> {},
             delegate);
     }
@@ -702,6 +703,19 @@ public class Worker extends LoggingMain {
       throw Status.fromThrowable(e).asRuntimeException();
     }
   }
+
+  private void onStoragePutAll(Iterable<Digest> digests) {
+    try {
+
+      // if the worker is a CAS member, it can send/modify blobs in the backplane.
+      if (isCasShard) {
+        backplane.addBlobsLocation(digests, config.getPublicName());
+      }
+    } catch (IOException e) {
+      throw Status.fromThrowable(e).asRuntimeException();
+    }
+  }
+
 
   private void onStorageExpire(Iterable<Digest> digests) {
     if (isCasShard) {

--- a/src/test/java/build/buildfarm/cas/CASFileCacheTest.java
+++ b/src/test/java/build/buildfarm/cas/CASFileCacheTest.java
@@ -98,6 +98,8 @@ class CASFileCacheTest {
 
   @Mock private Consumer<Digest> onPut;
 
+  @Mock private Consumer<Iterable<Digest>> onPutAll;
+
   @Mock private Consumer<Iterable<Digest>> onExpire;
 
   @Mock private ContentAddressableStorage delegate;
@@ -136,6 +138,7 @@ class CASFileCacheTest {
             storage,
             /* directoriesIndexDbName=*/ ":memory:",
             onPut,
+            onPutAll,
             onExpire,
             delegate) {
           @Override


### PR DESCRIPTION
The following changes will reduce the amount of calls to Redis and can accelerate the startup time by a factor of two.

Before this change, one call per cache entry was made to Redis.

With this change in place, we collect a list of all the cache entires during cache scanning, and then make one call with all of them at the end.