### PR TITLE
Synchronize aggregate blobDigests on CFC start

### DIFF
--- a/src/main/java/build/buildfarm/worker/shard/CFCExecFileSystem.java
+++ b/src/main/java/build/buildfarm/worker/shard/CFCExecFileSystem.java
@@ -116,7 +116,14 @@ class CFCExecFileSystem implements ExecFileSystem {
     }
 
     ImmutableList.Builder<Digest> blobDigests = ImmutableList.builder();
-    fileCache.start(blobDigests::add, removeDirectoryService, skipLoad);
+    fileCache.start(
+        digest -> {
+          synchronized (blobDigests) {
+            blobDigests.add(digest);
+          }
+        },
+        removeDirectoryService,
+        skipLoad);
     onDigests.accept(blobDigests.build());
 
     getInterruptiblyOrIOException(allAsList(removeDirectoryFutures.build()));


### PR DESCRIPTION
Prevent thread safety issues when creating aggregated list of digests
for advertisement.

Fixes #567