### PR TITLE
Kill members of cgroup on close, error op

### DIFF
--- a/src/main/java/build/buildfarm/BUILD
+++ b/src/main/java/build/buildfarm/BUILD
@@ -532,6 +532,7 @@ java_library(
     deps = [
         ":worker",
         "@maven//:com_google_code_findbugs_jsr305",
+        "@maven//:com_google_guava_guava",
     ],
 )
 

--- a/src/main/java/build/buildfarm/worker/Executor.java
+++ b/src/main/java/build/buildfarm/worker/Executor.java
@@ -24,6 +24,7 @@ import build.bazel.remote.execution.v2.ActionResult;
 import build.bazel.remote.execution.v2.Command;
 import build.bazel.remote.execution.v2.Command.EnvironmentVariable;
 import build.bazel.remote.execution.v2.ExecuteOperationMetadata;
+import build.bazel.remote.execution.v2.ExecuteResponse;
 import build.bazel.remote.execution.v2.ExecutionStage;
 import build.bazel.remote.execution.v2.Platform.Property;
 import build.buildfarm.common.Write;
@@ -189,7 +190,7 @@ class Executor {
     String operationName = operation.getName();
 
     ImmutableList.Builder<String> arguments = ImmutableList.builder();
-    final Code statusCode;
+    Code statusCode;
     try (IOResource resource =
         workerContext.limitExecution(operationName, arguments, operationContext.command)) {
       for (ExecutionPolicy policy : policies) {
@@ -210,6 +211,21 @@ class Executor {
               "", // executingMetadata.getStdoutStreamName(),
               "", // executingMetadata.getStderrStreamName(),
               resultBuilder);
+
+      if (resource.isReferenced()) {
+        // there should no longer be any references to the resource. Any references will be
+        // killed upon close, but we must error the operation due to improper execution
+        ExecuteResponse executeResponse = operationContext.executeResponse.build();
+        if (statusCode == Code.OK) {
+          // per the gRPC spec: 'The operation was attempted past the valid range.' Seems
+          // appropriate
+          statusCode = Code.OUT_OF_RANGE;
+          operationContext
+              .executeResponse
+              .getStatusBuilder()
+              .setMessage("command resources were referenced after execution completed");
+        }
+      }
     } catch (IOException e) {
       logger.log(Level.SEVERE, format("error executing operation %s", operationName), e);
       operationContext.poller.pause();

--- a/src/main/java/build/buildfarm/worker/WorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/WorkerContext.java
@@ -41,6 +41,8 @@ import java.util.Map;
 public interface WorkerContext {
   interface IOResource extends AutoCloseable {
     void close() throws IOException;
+
+    boolean isReferenced();
   }
 
   String getName();

--- a/src/main/java/build/buildfarm/worker/cgroup/Controller.java
+++ b/src/main/java/build/buildfarm/worker/cgroup/Controller.java
@@ -1,4 +1,20 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package build.buildfarm.worker.cgroup;
+
+import static com.google.common.base.Preconditions.checkState;
 
 import build.buildfarm.worker.WorkerContext.IOResource;
 import java.io.IOException;
@@ -31,17 +47,20 @@ abstract class Controller implements IOResource {
     }
   }
 
+  /**
+   * This method requires that all processes under the cgroup are no longer desirable and should be
+   * killed as a result
+   *
+   * <p>This requires a posix environment, as with cgroups, and will take reasonable action to
+   * attempt to end the process.
+   */
   @Override
   public void close() throws IOException {
+    checkState(opened, "controller was not opened");
     Path path = getPath();
     boolean exists = true;
     while (exists) {
-      try {
-        group.waitUntilEmpty(getName());
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-        throw new IOException(e);
-      }
+      group.killUntilEmpty(getName());
       try {
         Files.delete(path);
         exists = false;
@@ -53,6 +72,15 @@ abstract class Controller implements IOResource {
       }
     }
     opened = false;
+  }
+
+  @Override
+  public boolean isReferenced() {
+    try {
+      return !group.isEmpty(getName());
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   protected void writeInt(String propertyName, int value) throws IOException {

--- a/src/main/java/build/buildfarm/worker/cgroup/Cpu.java
+++ b/src/main/java/build/buildfarm/worker/cgroup/Cpu.java
@@ -1,3 +1,17 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package build.buildfarm.worker.cgroup;
 
 import java.io.IOException;

--- a/src/main/java/build/buildfarm/worker/cgroup/Group.java
+++ b/src/main/java/build/buildfarm/worker/cgroup/Group.java
@@ -1,11 +1,27 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package build.buildfarm.worker.cgroup;
 
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.stream.Collectors.joining;
 
+import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 import javax.annotation.Nullable;
 
 public class Group {
@@ -67,23 +83,39 @@ public class Group {
   }
 
   public int getProcCount(String controllerName) throws IOException {
-    Path procs = getPath(controllerName).resolve("cgroup.procs");
+    return getPids(controllerName).size();
+  }
+
+  /** Returns true if no processes exist under the controller path */
+  private boolean killAllProcs(String controllerName) throws IOException {
+    List<Integer> pids = getPids(controllerName);
+    if (!pids.isEmpty()) {
+      // TODO check arg limits, exit status, etc
+      Runtime.getRuntime()
+          .exec("kill -SIGKILL " + pids.stream().map(pid -> pid.toString()).collect(joining(" ")));
+      return false;
+    }
+    return true;
+  }
+
+  private List<Integer> getPids(String controllerName) throws IOException {
+    Path path = getPath(controllerName);
+    Path procs = path.resolve("cgroup.procs");
     try {
-      /* yes, pretty inefficient */
-      return Files.readAllLines(procs).size();
+      return Files.readAllLines(procs).stream()
+          .map(line -> Integer.parseInt(line))
+          .collect(ImmutableList.toImmutableList());
     } catch (IOException e) {
-      if (!Files.exists(getPath(controllerName))) {
-        return 0;
+      if (Files.exists(path)) {
+        throw e;
       }
-      throw e;
+      // nonexistent controller path means no processes
+      return ImmutableList.of();
     }
   }
 
-  public void waitUntilEmpty(String controllerName) throws IOException, InterruptedException {
-    while (!isEmpty(controllerName)) {
-      /* wait for event? */
-      MILLISECONDS.sleep(100);
-    }
+  public void killUntilEmpty(String controllerName) throws IOException {
+    while (!killAllProcs(controllerName)) ;
   }
 
   void create(String controllerName) throws IOException {

--- a/src/main/java/build/buildfarm/worker/operationqueue/Worker.java
+++ b/src/main/java/build/buildfarm/worker/operationqueue/Worker.java
@@ -684,6 +684,11 @@ public class Worker extends LoggingMain {
             return new IOResource() {
               @Override
               public void close() {}
+
+              @Override
+              public boolean isReferenced() {
+                return false;
+              }
             };
           }
 

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -873,6 +873,11 @@ class ShardWorkerContext implements WorkerContext {
     return new IOResource() {
       @Override
       public void close() {}
+
+      @Override
+      public boolean isReferenced() {
+        return false;
+      }
     };
   }
 
@@ -914,6 +919,12 @@ class ShardWorkerContext implements WorkerContext {
           new IOResource() {
             @Override
             public void close() {}
+
+            @Override
+            public boolean isReferenced() {
+              // no way to isolate references to this shared group
+              return false;
+            }
           };
     }
     if (limitGlobalExecution || group != operationsGroup) {


### PR DESCRIPTION
If an operation leaves references to the IOResource during its
execution, it is an operational failure and should be a source of
independent execution failure.