### PR TITLE
Remove checkState for Controller opened

### DIFF
--- a/src/main/java/build/buildfarm/worker/cgroup/Controller.java
+++ b/src/main/java/build/buildfarm/worker/cgroup/Controller.java
@@ -14,7 +14,6 @@
 
 package build.buildfarm.worker.cgroup;
 
-import static com.google.common.base.Preconditions.checkState;
 
 import build.buildfarm.worker.WorkerContext.IOResource;
 import java.io.IOException;
@@ -56,7 +55,6 @@ abstract class Controller implements IOResource {
    */
   @Override
   public void close() throws IOException {
-    checkState(opened, "controller was not opened");
     Path path = getPath();
     boolean exists = true;
     while (exists) {


### PR DESCRIPTION
This close is used (somewhat inappropriately) to handle a non-resource
based initialization from a clean slate.