### PR TITLE
add code coverage to CI

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -2,13 +2,15 @@
 buildifier: latest
 platforms:
   ubuntu1604:
-    shell_commands:
-    - ./.bazelci/format.sh --check
     build_targets:
     - "..."
     test_targets:
     - "..."
   ubuntu1804:
+    shell_commands:
+    - ./.bazelci/format.sh --check
+    - export BUILDFARM_SKIP_COVERAGE_HOST=true
+    - ./generate_coverage.sh
     build_targets:
     - "..."
     test_targets:

--- a/generate_coverage.sh
+++ b/generate_coverage.sh
@@ -1,25 +1,48 @@
 #!/bin/sh
-# Run on test targets
-# ex: ./generate_coverage.sh //src/test/...:all
+# Run on specifc test targets via: ./generate_coverage.sh <target>
+# Script can be run without <target> to get coverage on all tests.
 
+# This script recognizes the following environment variables:
+
+# BUILDFARM_SKIP_COVERAGE_HOST
+#     If BUILDFARM_SKIP_COVERAGE_HOST=true, the script will still
+#     generage coverage, but it will not convert results to html and start a server.
+#     This is useful for ensuring coverage works in CI without attempting to host it.
 set -e
+
+DEFAULT_TEST_TARGET="//src/test/...:all"
+DEFAULT_TEST_TAG_FILTERS="-redis"
+DEFAULT_BAZEL_WRAPPER=bazelw
+EXPECTED_TEST_LOGS=bazel-testlogs
 
 # store the targets to get test coverage on.
 # if no targets are specified we assume all tests.
 target=$@
 if [ -z "$target" ]
 then
-      target="//src/test/...:all"
+      target=$DEFAULT_TEST_TARGET
 fi
 
-bazel=bazelisk
-COVERAGE=bazel-testlogs/coverage
+# decide how to spawn bazel
+# we will use the script in the repo as apposed to bazelisk
+bazel=$DEFAULT_BAZEL_WRAPPER
+COVERAGE=$EXPECTED_TEST_LOGS/coverage
 
-"${bazel}" coverage $target --test_tag_filters="-redis"
+# Perform bazel coverage
+"${bazel}" coverage $target --test_tag_filters=$DEFAULT_TEST_TAG_FILTERS
 mkdir -p $COVERAGE
-traces=$(find bazel-testlogs/ -name coverage.dat | sed "s|^|$PWD/|")
+traces=$(find $EXPECTED_TEST_LOGS/ -name coverage.dat | sed "s|^|$PWD/|")
 rm -fr $COVERAGE/*
 ln -s $PWD/src $COVERAGE/src
 cd $COVERAGE
-genhtml -f $traces
-python -m http.server
+
+# After running coverage, convert the results to HTML and host it locally
+if [ "${BUILDFARM_SKIP_COVERAGE_HOST:-false}" = false ]; then
+    command -v genhtml >/dev/null 2>&1 || { echo >&2 'genhtml does not exist.  You may need to install lcov.'; exit 1; }
+    genhtml -f $traces
+
+    command -v python >/dev/null 2>&1 || { echo >&2 'python could not be found, so the coverage report cannot be locally hosted.'; exit 1; }
+    python -m http.server
+else
+    echo "Skipped coverage hosting."
+fi

--- a/generate_coverage.sh
+++ b/generate_coverage.sh
@@ -12,7 +12,7 @@ set -e
 
 DEFAULT_TEST_TARGET="//src/test/...:all"
 DEFAULT_TEST_TAG_FILTERS="-redis"
-DEFAULT_BAZEL_WRAPPER=bazelw
+DEFAULT_BAZEL_WRAPPER=./bazelw
 EXPECTED_TEST_LOGS=bazel-testlogs
 
 # store the targets to get test coverage on.


### PR DESCRIPTION
Code coverage worked for me, but it had some dependencies that may not be obvious to users.
 - bazelisk
 - genhtml (lcov)
 - python

I've refactored the script, and changed `bazelisk` into the `bazelw` script in the repo.  
Code coverage is now tested in the CI but skips the hosting logic which relies on genhtml/python.

Let me know if you still experience issues on your machine.