### PR TITLE
Describe what to do when no eligible queues are found

### DIFF
--- a/src/main/java/build/buildfarm/instance/shard/OperationQueue.java
+++ b/src/main/java/build/buildfarm/instance/shard/OperationQueue.java
@@ -219,7 +219,9 @@ public class OperationQueue {
       }
     }
     throw new RuntimeException(
-        "there are no eligible queues for the provided execution requirements.  One solution to is to configure a provision queue with no requirements which would be eligible to all operations.");
+        "there are no eligible queues for the provided execution requirements."
+            + " One solution to is to configure a provision queue with no requirements which would be eligible to all operations."
+            + " See https://github.com/bazelbuild/bazel-buildfarm/wiki/Shard-Platform-Operation-Queue for details");
   }
   ///
   /// @brief   Convert proto provisions into java multimap.


### PR DESCRIPTION
Since the default shard-worker.example does not work out-of-the-box,
it is better to provide some documentation when the exception is thrown.