### PR TITLE
Improve queue selection

### DIFF
--- a/src/main/java/build/buildfarm/common/redis/EligibilityResult.java
+++ b/src/main/java/build/buildfarm/common/redis/EligibilityResult.java
@@ -33,6 +33,13 @@ public class EligibilityResult {
   public String queueName;
 
   ///
+  /// @field   allowsUnmatched
+  /// @brief   Determines how unmatched properties effect eligibility.
+  /// @details If true, properties can remain unmatched yet still eligible.
+  ///
+  public boolean allowsUnmatched;
+
+  ///
   /// @field   isEligible
   /// @brief   Whether the properties were eligible for the queue.
   /// @details Determined the same way queues are selected.
@@ -45,6 +52,14 @@ public class EligibilityResult {
   /// @details Fully wildcard queues accept all properties.
   ///
   public boolean isFullyWildcard;
+
+  ///
+  /// @field   isSpecificallyChosen
+  /// @brief   Whether the queue was specifically chosen.
+  /// @details A special property was used to specifically match to the queue.
+  ///          This automatically makes it eligible.
+  ///
+  public boolean isSpecificallyChosen;
 
   ///
   /// @field   matched

--- a/src/test/java/build/buildfarm/common/redis/ProvisionedRedisQueueTest.java
+++ b/src/test/java/build/buildfarm/common/redis/ProvisionedRedisQueueTest.java
@@ -59,6 +59,16 @@ public class ProvisionedRedisQueueTest {
         new ProvisionedRedisQueue("name", ImmutableList.of(), HashMultimap.create());
   }
 
+  // Function under test: ProvisionedRedisQueue
+  // Reason for testing: the object can be constructed
+  // Failure explanation: the object cannot be constructed
+  @Test
+  public void provisionedRedisQueueCanConstructOverload() throws Exception {
+
+    ProvisionedRedisQueue queue =
+        new ProvisionedRedisQueue("name", ImmutableList.of(), HashMultimap.create(), true);
+  }
+
   // Function under test: explainEligibility
   // Reason for testing: the queue will accept the properties if no provisions are involved
   // Failure explanation: the queue is unable to accept the properties with no provisions or the
@@ -69,6 +79,30 @@ public class ProvisionedRedisQueueTest {
     // ARRANGE
     ProvisionedRedisQueue queue =
         new ProvisionedRedisQueue("foo", ImmutableList.of(), HashMultimap.create());
+
+    // ACT
+    String explanation = queue.explainEligibility(HashMultimap.create());
+    boolean isEligible = queue.isEligible(HashMultimap.create());
+
+    // ASSERT
+    String expected_explanation = "The properties are eligible for the foo queue.\n";
+    expected_explanation += "matched: {}\n";
+    expected_explanation += "unmatched: {}\n";
+    expected_explanation += "still required: {}\n";
+    assertThat(explanation).isEqualTo(expected_explanation);
+    assertThat(isEligible).isTrue();
+  }
+
+  // Function under test: explainEligibility
+  // Reason for testing: the queue will accept the properties if no provisions are involved
+  // Failure explanation: the queue is unable to accept the properties with no provisions or the
+  // explanation is wrong
+  @Test
+  public void explainEligibilityNoProvisionsAcceptedAllowUserUnmatched() throws Exception {
+
+    // ARRANGE
+    ProvisionedRedisQueue queue =
+        new ProvisionedRedisQueue("foo", ImmutableList.of(), HashMultimap.create(), true);
 
     // ACT
     String explanation = queue.explainEligibility(HashMultimap.create());
@@ -109,6 +143,31 @@ public class ProvisionedRedisQueueTest {
   }
 
   // Function under test: explainEligibility
+  // Reason for testing: the queue will accept the properties and show the provision was matched
+  // Failure explanation: the queue is unable to accept the properties or the explanation is wrong
+  @Test
+  public void explainEligibilitySingleProvisionMatchedAllowUserUnmatched() throws Exception {
+
+    // ARRANGE
+    SetMultimap<String, String> queueProperties = HashMultimap.create();
+    queueProperties.put("key", "value");
+    ProvisionedRedisQueue queue =
+        new ProvisionedRedisQueue("foo", ImmutableList.of(), queueProperties, true);
+
+    // ACT
+    String explanation = queue.explainEligibility(queueProperties);
+    boolean isEligible = queue.isEligible(queueProperties);
+
+    // ASSERT
+    String expected_explanation = "The properties are eligible for the foo queue.\n";
+    expected_explanation += "matched: {key=[value]}\n";
+    expected_explanation += "unmatched: {}\n";
+    expected_explanation += "still required: {}\n";
+    assertThat(explanation).isEqualTo(expected_explanation);
+    assertThat(isEligible).isTrue();
+  }
+
+  // Function under test: explainEligibility
   // Reason for testing: the queue will not accept properties and show the provision was not matched
   // Failure explanation: the queue is still accepting properties or the explanation is wrong
   @Test
@@ -131,6 +190,31 @@ public class ProvisionedRedisQueueTest {
     expected_explanation += "still required: {}\n";
     assertThat(explanation).isEqualTo(expected_explanation);
     assertThat(isEligible).isFalse();
+  }
+
+  // Function under test: explainEligibility
+  // Reason for testing: the queue will accept properties even though some were unmatched
+  // Failure explanation: the queue is not accepting properties or the explanation is wrong
+  @Test
+  public void explainEligibilitySingleProvisionAllowedToNotMatch() throws Exception {
+
+    // ARRANGE
+    SetMultimap<String, String> queueProperties = HashMultimap.create();
+    queueProperties.put("key", "value");
+    ProvisionedRedisQueue queue =
+        new ProvisionedRedisQueue("foo", ImmutableList.of(), HashMultimap.create(), true);
+
+    // ACT
+    String explanation = queue.explainEligibility(queueProperties);
+    boolean isEligible = queue.isEligible(queueProperties);
+
+    // ASSERT
+    String expected_explanation = "The properties are eligible for the foo queue.\n";
+    expected_explanation += "matched: {}\n";
+    expected_explanation += "unmatched: {key=[value]}\n";
+    expected_explanation += "still required: {}\n";
+    assertThat(explanation).isEqualTo(expected_explanation);
+    assertThat(isEligible).isTrue();
   }
 
   // Function under test: explainEligibility
@@ -160,6 +244,32 @@ public class ProvisionedRedisQueueTest {
   }
 
   // Function under test: explainEligibility
+  // Reason for testing: the queue will not accept properties and show the provision is still
+  // required
+  // Failure explanation: the queue is still accepting properties or the explanation is wrong
+  @Test
+  public void explainEligibilitySingleProvisionStillRequiredAllowUserUnmatched() throws Exception {
+
+    // ARRANGE
+    SetMultimap<String, String> queueProperties = HashMultimap.create();
+    queueProperties.put("key", "value");
+    ProvisionedRedisQueue queue =
+        new ProvisionedRedisQueue("foo", ImmutableList.of(), queueProperties, true);
+
+    // ACT
+    String explanation = queue.explainEligibility(HashMultimap.create());
+    boolean isEligible = queue.isEligible(HashMultimap.create());
+
+    // ASSERT
+    String expected_explanation = "The properties are not eligible for the foo queue.\n";
+    expected_explanation += "matched: {}\n";
+    expected_explanation += "unmatched: {}\n";
+    expected_explanation += "still required: {key=[value]}\n";
+    assertThat(explanation).isEqualTo(expected_explanation);
+    assertThat(isEligible).isFalse();
+  }
+
+  // Function under test: explainEligibility
   // Reason for testing: the queue will accept the properties because of wildcard
   // Failure explanation: the queue is unable to accept the properties or the explanation is wrong
   @Test
@@ -170,6 +280,29 @@ public class ProvisionedRedisQueueTest {
     queueProperties.put("*", "value");
     ProvisionedRedisQueue queue =
         new ProvisionedRedisQueue("foo", ImmutableList.of(), queueProperties);
+
+    // ACT
+    String explanation = queue.explainEligibility(HashMultimap.create());
+    boolean isEligible = queue.isEligible(HashMultimap.create());
+
+    // ASSERT
+    String expected_explanation = "The properties are eligible for the foo queue.\n";
+    expected_explanation += "The queue is fully wildcard.\n";
+    assertThat(explanation).isEqualTo(expected_explanation);
+    assertThat(isEligible).isTrue();
+  }
+
+  // Function under test: explainEligibility
+  // Reason for testing: the queue will accept the properties because of wildcard
+  // Failure explanation: the queue is unable to accept the properties or the explanation is wrong
+  @Test
+  public void explainEligibilityAcceptedDueToWildcardAllowUserUnmatched() throws Exception {
+
+    // ARRANGE
+    SetMultimap<String, String> queueProperties = HashMultimap.create();
+    queueProperties.put("*", "value");
+    ProvisionedRedisQueue queue =
+        new ProvisionedRedisQueue("foo", ImmutableList.of(), queueProperties, true);
 
     // ACT
     String explanation = queue.explainEligibility(HashMultimap.create());

--- a/src/test/java/build/buildfarm/common/redis/ProvisionedRedisQueueTest.java
+++ b/src/test/java/build/buildfarm/common/redis/ProvisionedRedisQueueTest.java
@@ -72,6 +72,7 @@ public class ProvisionedRedisQueueTest {
 
     // ACT
     String explanation = queue.explainEligibility(HashMultimap.create());
+    boolean isEligible = queue.isEligible(HashMultimap.create());
 
     // ASSERT
     String expected_explanation = "The properties are eligible for the foo queue.\n";
@@ -79,6 +80,7 @@ public class ProvisionedRedisQueueTest {
     expected_explanation += "unmatched: {}\n";
     expected_explanation += "still required: {}\n";
     assertThat(explanation).isEqualTo(expected_explanation);
+    assertThat(isEligible).isTrue();
   }
 
   // Function under test: explainEligibility
@@ -95,6 +97,7 @@ public class ProvisionedRedisQueueTest {
 
     // ACT
     String explanation = queue.explainEligibility(queueProperties);
+    boolean isEligible = queue.isEligible(queueProperties);
 
     // ASSERT
     String expected_explanation = "The properties are eligible for the foo queue.\n";
@@ -102,6 +105,7 @@ public class ProvisionedRedisQueueTest {
     expected_explanation += "unmatched: {}\n";
     expected_explanation += "still required: {}\n";
     assertThat(explanation).isEqualTo(expected_explanation);
+    assertThat(isEligible).isTrue();
   }
 
   // Function under test: explainEligibility
@@ -118,6 +122,7 @@ public class ProvisionedRedisQueueTest {
 
     // ACT
     String explanation = queue.explainEligibility(queueProperties);
+    boolean isEligible = queue.isEligible(queueProperties);
 
     // ASSERT
     String expected_explanation = "The properties are not eligible for the foo queue.\n";
@@ -125,6 +130,7 @@ public class ProvisionedRedisQueueTest {
     expected_explanation += "unmatched: {key=[value]}\n";
     expected_explanation += "still required: {}\n";
     assertThat(explanation).isEqualTo(expected_explanation);
+    assertThat(isEligible).isFalse();
   }
 
   // Function under test: explainEligibility
@@ -142,6 +148,7 @@ public class ProvisionedRedisQueueTest {
 
     // ACT
     String explanation = queue.explainEligibility(HashMultimap.create());
+    boolean isEligible = queue.isEligible(HashMultimap.create());
 
     // ASSERT
     String expected_explanation = "The properties are not eligible for the foo queue.\n";
@@ -149,6 +156,7 @@ public class ProvisionedRedisQueueTest {
     expected_explanation += "unmatched: {}\n";
     expected_explanation += "still required: {key=[value]}\n";
     assertThat(explanation).isEqualTo(expected_explanation);
+    assertThat(isEligible).isFalse();
   }
 
   // Function under test: explainEligibility
@@ -165,10 +173,12 @@ public class ProvisionedRedisQueueTest {
 
     // ACT
     String explanation = queue.explainEligibility(HashMultimap.create());
+    boolean isEligible = queue.isEligible(HashMultimap.create());
 
     // ASSERT
     String expected_explanation = "The properties are eligible for the foo queue.\n";
     expected_explanation += "The queue is fully wildcard.\n";
     assertThat(explanation).isEqualTo(expected_explanation);
+    assertThat(isEligible).isTrue();
   }
 }

--- a/src/test/java/build/buildfarm/common/redis/ProvisionedRedisQueueTest.java
+++ b/src/test/java/build/buildfarm/common/redis/ProvisionedRedisQueueTest.java
@@ -375,4 +375,52 @@ public class ProvisionedRedisQueueTest {
     assertThat(explanation).isEqualTo(expected_explanation);
     assertThat(isEligible).isTrue();
   }
+
+  // Function under test: explainEligibility
+  // Reason for testing: show that a queue can be specifically selected
+  // Failure explanation: the selection key is not properly being recognized
+  @Test
+  public void explainEligibilitySpecificallySelectQueue() throws Exception {
+
+    // ARRANGE
+    ProvisionedRedisQueue queue =
+        new ProvisionedRedisQueue("foo", ImmutableList.of(), HashMultimap.create());
+    SetMultimap<String, String> userGivenProperties = HashMultimap.create();
+    userGivenProperties.put("choose-queue", "foo");
+
+    // ACT
+    String explanation = queue.explainEligibility(userGivenProperties);
+    boolean isEligible = queue.isEligible(userGivenProperties);
+
+    // ASSERT
+    String expected_explanation = "The properties are eligible for the foo queue.\n";
+    expected_explanation += "The queue was specifically chosen.\n";
+    assertThat(explanation).isEqualTo(expected_explanation);
+    assertThat(isEligible).isTrue();
+  }
+
+  // Function under test: explainEligibility
+  // Reason for testing: show that trying to select the queue by the wrong name fails eligibility
+  // Failure explanation: the queue is incorrectly still being selected or the explanation is wrong
+  @Test
+  public void explainEligibilityFailToSpecificallySelectQueue() throws Exception {
+
+    // ARRANGE
+    ProvisionedRedisQueue queue =
+        new ProvisionedRedisQueue("foo", ImmutableList.of(), HashMultimap.create());
+    SetMultimap<String, String> userGivenProperties = HashMultimap.create();
+    userGivenProperties.put("choose-queue", "wrong");
+
+    // ACT
+    String explanation = queue.explainEligibility(userGivenProperties);
+    boolean isEligible = queue.isEligible(userGivenProperties);
+
+    // ASSERT
+    String expected_explanation = "The properties are not eligible for the foo queue.\n";
+    expected_explanation += "matched: {}\n";
+    expected_explanation += "unmatched: {choose-queue=[wrong]}\n";
+    expected_explanation += "still required: {}\n";
+    assertThat(explanation).isEqualTo(expected_explanation);
+    assertThat(isEligible).isFalse();
+  }
 }


### PR DESCRIPTION
## 1. Eligibility Problems:
### Problem:
User actions provide `execution_properties` (i.e. "platform properties") that must "perfectly match" a particular provision queue in order to be deemed eligible. This means that if a user provides a new execution property that is not known by any configured queue, the operation will be unable to match and will result in a failure (unless the queue was fully wildcard- we don't do this internally).

One solution to this is to ensure that all execution properties are accounted for when configuring provision queues and that they are all given the appropriate matching values.  However, due to "perfect matching" a user will then be forced to pass this execution property for all actions.

### Solution:
We want to support a middle ground.  We want to allow a users to pass a superset of execution_properties and still be elligible as long as they match all the properties specified by a queue.  This will allow users to optionally pass more `execution_properties` that will affect their execution but not affect their worker selection.  

See this [test case](https://github.com/bazelbuild/bazel-buildfarm/pull/593/files#diff-9cf93982989b1369b93034b7c244c9cd6fb8aea0da2949d022cd29be65f23e3fR323) for a motivating example (disregard the fact that the example is about env vars. eventhough `Commands` have separate proto data members for environment variables.  Using `--action_env` may not be our best use case).  The test case afterward shows how configuring the queue differently can achieve the eligibility we want.  Another use case worth mentioning, is that a repo might be attempting to support more than 1 remote execution product.  This will allow foreign execution properties to be handled gracefully by buildfarm. 

## 2. Choosing by Queue:
Other remote execution solutions have slightly different paradigms on deciding where actions go.  They leverage `execution_properties` for selecting a "pool" of machines to send the action.  We sort of have a pool of workers waiting on particular queues.  For parity with this concept, we support a new execution property called `choose-queue` which will take precedence in deciding eligibility.  See [test case](https://github.com/bazelbuild/bazel-buildfarm/pull/593/files#diff-9cf93982989b1369b93034b7c244c9cd6fb8aea0da2949d022cd29be65f23e3fR383) for example.

Neither of these features affect the current behavior of buildfarm, but will be configured on in the future.

## Documentation:
https://github.com/bazelbuild/bazel-buildfarm/wiki/Execution-Properties