### PR TITLE
Gitignore more things

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,14 @@
 bazel-*
 .ijwb/
-.vscode/
 java_formatter.jar
+
+# Visual Studio Code
+/.vscode/
+
+# IntelliJ IDEA
+/.idea/
+*.iml
+
+# Eclipse
+/.project
+/.classpath


### PR DESCRIPTION
Tell Git to ignore IntelliJ IDEA and Eclipse files.

Having this change merged would make it nicer for us to work with the Buildfarm source code.