### PR TITLE
add allowUnmatched proto option for ProvisionQueues

### DIFF
--- a/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
@@ -546,7 +546,8 @@ public class RedisShardBackplane implements ShardBackplane {
           new ProvisionedRedisQueue(
               queueConfig.getName(),
               getQueueHashes(client, queueConfig.getName()),
-              toMultimap(queueConfig.getPlatform().getPropertiesList()));
+              toMultimap(queueConfig.getPlatform().getPropertiesList()),
+              queueConfig.getAllowUnmatched());
       provisionedQueues.add(provisionedQueue);
     }
     // If there is no configuration for provisioned queues, we might consider that an error.

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -349,6 +349,8 @@ message MemoryInstanceConfig {
 message ProvisionedQueue {
   string name = 1;
   
+  bool allow_unmatched = 3;
+  
   build.bazel.remote.execution.v2.Platform platform = 2;
 }
 


### PR DESCRIPTION
Allow configuring queues to accept a superset of execution_properties.