### PR TITLE
Extend worker match evaluation

### DIFF
--- a/src/main/java/build/buildfarm/BUILD
+++ b/src/main/java/build/buildfarm/BUILD
@@ -282,6 +282,7 @@ java_library(
         ":instance",
         ":server-instance",
         ":worker-queues",
+        ":worker",
         "//src/main/protobuf:build_buildfarm_v1test_buildfarm_java_proto",
         "@googleapis//:google_longrunning_operations_java_proto",
         "@googleapis//:google_rpc_code_java_proto",

--- a/src/main/java/build/buildfarm/common/Actions.java
+++ b/src/main/java/build/buildfarm/common/Actions.java
@@ -17,9 +17,6 @@ package build.buildfarm.common;
 import static java.lang.String.format;
 
 import build.bazel.remote.execution.v2.Digest;
-import build.bazel.remote.execution.v2.Platform;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.SetMultimap;
 import com.google.protobuf.Any;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.rpc.Code;
@@ -101,32 +98,5 @@ public final class Actions {
       }
     }
     return true; // if *all* > 0 violations have type MISSING
-  }
-
-  private static boolean satisfiesRequirement(
-      SetMultimap<String, String> provisions, String requirement, String value) {
-    if (requirement.equals("min-cores")) {
-      if (!provisions.containsKey("cores")) {
-        return false;
-      }
-      int mincores = Integer.parseInt(value);
-      int cores = Integer.parseInt(Iterables.getOnlyElement(provisions.get("cores")));
-      return cores >= mincores;
-    }
-    if (requirement.equals("max-cores")) {
-      return true;
-    }
-    return provisions.containsEntry(requirement, value)
-        || provisions.containsEntry(requirement, "*");
-  }
-
-  public static boolean satisfiesRequirements(
-      SetMultimap<String, String> provisions, Platform requirements) {
-    for (Platform.Property property : requirements.getPropertiesList()) {
-      if (!satisfiesRequirement(provisions, property.getName(), property.getValue())) {
-        return false;
-      }
-    }
-    return true;
   }
 }

--- a/src/main/java/build/buildfarm/instance/memory/MemoryInstance.java
+++ b/src/main/java/build/buildfarm/instance/memory/MemoryInstance.java
@@ -15,7 +15,6 @@
 package build.buildfarm.instance.memory;
 
 import static build.buildfarm.common.Actions.invalidActionVerboseMessage;
-import static build.buildfarm.common.Actions.satisfiesRequirements;
 import static build.buildfarm.common.Errors.VIOLATION_TYPE_INVALID;
 import static build.buildfarm.common.Errors.VIOLATION_TYPE_MISSING;
 import static build.buildfarm.instance.Utils.putBlob;
@@ -72,6 +71,8 @@ import build.buildfarm.v1test.OperationsStatus;
 import build.buildfarm.v1test.QueueEntry;
 import build.buildfarm.v1test.QueuedOperation;
 import build.buildfarm.v1test.Tree;
+import build.buildfarm.worker.DequeueMatchEvaluator;
+import build.buildfarm.worker.DequeueMatchSettings;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
@@ -713,10 +714,12 @@ public class MemoryInstance extends AbstractServerInstance {
     boolean dispatched = false;
     WorkerQueue queue =
         queuedOperations.MatchEligibleQueue(createProvisions(command.getPlatform()));
+
+    DequeueMatchSettings settings = new DequeueMatchSettings();
     synchronized (queue.workers) {
       while (!dispatched && !queue.workers.isEmpty()) {
         Worker worker = queue.workers.remove(0);
-        if (!satisfiesRequirements(worker.getProvisions(), command.getPlatform())) {
+        if (!DequeueMatchEvaluator.shouldKeepOperation(settings, worker.getProvisions(), command)) {
           rejectedWorkers.add(worker);
         } else {
           QueueEntry queueEntry =
@@ -800,9 +803,11 @@ public class MemoryInstance extends AbstractServerInstance {
       Preconditions.checkState(command != null, "command not found");
 
       String operationName = operation.getName();
+
+      DequeueMatchSettings settings = new DequeueMatchSettings();
       if (command == null) {
         cancelOperation(operationName);
-      } else if (satisfiesRequirements(provisions, command.getPlatform())) {
+      } else if (DequeueMatchEvaluator.shouldKeepOperation(settings, provisions, command)) {
         QueuedOperation queuedOperation =
             QueuedOperation.newBuilder()
                 .setAction(action)

--- a/src/main/java/build/buildfarm/worker/DequeueMatchEvaluator.java
+++ b/src/main/java/build/buildfarm/worker/DequeueMatchEvaluator.java
@@ -36,7 +36,7 @@ import com.google.common.collect.SetMultimap;
 ///          scheduler. For example, you might have a variety of workers with
 ///          different amounts of cpu cores all sharing the same queue. The
 ///          queue may accept N-core operations, because N-core workers exist
-///          in the pool,. But there are additionally some lower core workers
+///          in the pool, but there are additionally some lower core workers
 ///          that would need to forfeit running the operation. All the reasons
 ///          a worker may decide it can't take on the operation and should
 ///          give it back are implemented here. The settings provided allow

--- a/src/main/java/build/buildfarm/worker/DequeueMatchEvaluator.java
+++ b/src/main/java/build/buildfarm/worker/DequeueMatchEvaluator.java
@@ -1,0 +1,162 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.worker;
+
+import build.bazel.remote.execution.v2.Platform;
+import build.buildfarm.v1test.QueueEntry;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.SetMultimap;
+
+///
+/// @class   DequeueMatchEvaluator
+/// @brief   Algorithm for deciding whether a worker should keep a dequeued
+///          operation.
+/// @details When a worker takes an entry off of the queue, should it decide
+///          to keep that entry or reject and requeue it? In some sense, it
+///          should keep all entries because they have already been vetted for
+///          that particular worker. This is because the scheduler matches
+///          operations to particular queues, and workers match themselves to
+///          which queues they want to read from. But should the worker always
+///          blindly take what it pops off? And can they trust the scheduler?
+///          There may be situations where the worker chooses to give
+///          operations back based on particular contexts not known to the
+///          scheduler. For example, you might have a variety of workers with
+///          different amounts of cpu cores all sharing the same queue. The
+///          queue may accept N-core operations, because N-core workers exist
+///          in the pool,. But there are additionally some lower core workers
+///          that would need to forfeit running the operation. All the reasons
+///          a worker may decide it can't take on the operation and should
+///          give it back are implemented here. The settings provided allow
+///          varying amount of leniency when evaluating the platform
+///          properties.
+///
+public class DequeueMatchEvaluator {
+
+  ///
+  /// @field   EXEC_PROPERTY_MIN_CORES
+  /// @brief   The exec_property and platform property name for setting min
+  ///          cores.
+  /// @details This is decided between client and server.
+  ///
+  private static final String EXEC_PROPERTY_MIN_CORES = "min-cores";
+
+  ///
+  /// @field   EXEC_PROPERTY_MAX_CORES
+  /// @brief   The exec_property and platform property name for setting max
+  ///          cores.
+  /// @details This is decided between client and server.
+  ///
+  private static final String EXEC_PROPERTY_MAX_CORES = "max-cores";
+
+  ///
+  /// @field   WORKER_PLATFORM_CORES_PROPERTY
+  /// @brief   A platform property decided and assigned to a worker.
+  /// @details This often correlates to execute width of the workers (the max
+  ///          amount of cores it is willing to give an operation).
+  ///
+  private static final String WORKER_PLATFORM_CORES_PROPERTY = "cores";
+
+  ///
+  /// @brief   Decide whether the worker should keep the operation or put it
+  ///          back on the queue.
+  /// @details Compares the platform properties of the worker to the platform
+  ///          properties.
+  /// @param   matchSettings    The provisions of the worker.
+  /// @param   workerProvisions The provisions of the worker.
+  /// @param   queueEntry       An entry recently removed from the queue.
+  /// @return  Whether or not the worker should accept or reject the queue entry.
+  /// @note    Suggested return identifier: shouldKeepOperation.
+  ///
+  public static boolean shouldKeepOperation(
+      DequeueMatchSettings matchSettings,
+      SetMultimap<String, String> workerProvisions,
+      QueueEntry queueEntry) {
+    // attempt to execute everything it gets off the queue.
+    if (matchSettings.acceptEverything) {
+      return true;
+    }
+
+    // if the queue entry was not actually dequeued, we should still accept it?
+    // TODO(luxe): find out why its currently like this, and if that still makes sense.
+    if (queueEntry == null) {
+      return true;
+    }
+
+    return satisfiesProperties(matchSettings, workerProvisions, queueEntry);
+  }
+  ///
+  /// @brief   Decide whether the worker should keep the operation by comparing
+  ///          its platform properties with the queue entry.
+  /// @details Compares the platform properties of the worker to the platform
+  ///          properties.
+  /// @param   matchSettings    The provisions of the worker.
+  /// @param   workerProvisions The provisions of the worker.
+  /// @param   queueEntry       An entry recently removed from the queue.
+  /// @return  Whether or not the worker should accept or reject the queue entry.
+  /// @note    Suggested return identifier: shouldKeepOperation.
+  ///
+  private static boolean satisfiesProperties(
+      DequeueMatchSettings matchSettings,
+      SetMultimap<String, String> workerProvisions,
+      QueueEntry queueEntry) {
+    for (Platform.Property property : queueEntry.getPlatform().getPropertiesList()) {
+      if (!satisfiesProperty(matchSettings, workerProvisions, property)) {
+        return false;
+      }
+    }
+    return true;
+  }
+  ///
+  /// @brief   Decide whether the worker should keep the operation by comparing
+  ///          its platform properties with a queue entry property.
+  /// @details Checks for certain exact matches on key/values.
+  /// @param   matchSettings    The provisions of the worker.
+  /// @param   workerProvisions The provisions of the worker.
+  /// @param   property         A property of the queued entry.
+  /// @return  Whether or not the worker should accept or reject the queue entry.
+  /// @note    Suggested return identifier: shouldKeepOperation.
+  ///
+  private static boolean satisfiesProperty(
+      DequeueMatchSettings matchSettings,
+      SetMultimap<String, String> workerProvisions,
+      Platform.Property property) {
+    // validate min cores
+    if (property.getName().equals(EXEC_PROPERTY_MIN_CORES)) {
+      if (!workerProvisions.containsKey(WORKER_PLATFORM_CORES_PROPERTY)) {
+        return false;
+      }
+
+      int coresRequested = Integer.parseInt(property.getValue());
+      int possibleCores =
+          Integer.parseInt(
+              Iterables.getOnlyElement(workerProvisions.get(WORKER_PLATFORM_CORES_PROPERTY)));
+      return possibleCores >= coresRequested;
+    }
+
+    // validate max cores
+    if (property.getName().equals(EXEC_PROPERTY_MAX_CORES)) {
+      return true;
+    }
+
+    // accept other properties not specified on the worker
+    if (matchSettings.allowUnmatched) {
+      return true;
+    }
+
+    // ensure exact matches
+    return workerProvisions.containsEntry(property.getName(), property.getValue())
+        || workerProvisions.containsEntry(property.getName(), "*");
+  }
+}

--- a/src/main/java/build/buildfarm/worker/DequeueMatchSettings.java
+++ b/src/main/java/build/buildfarm/worker/DequeueMatchSettings.java
@@ -14,7 +14,6 @@
 
 package build.buildfarm.worker;
 
-
 ///
 /// @class   DequeueMatchSettings
 /// @brief   Settings used by a worker to determine whether they should keep

--- a/src/main/java/build/buildfarm/worker/DequeueMatchSettings.java
+++ b/src/main/java/build/buildfarm/worker/DequeueMatchSettings.java
@@ -1,0 +1,44 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.worker;
+
+
+///
+/// @class   DequeueMatchSettings
+/// @brief   Settings used by a worker to determine whether they should keep
+///          dequeued operations.
+/// @details This determines whether workers keep operations or decide to
+///          requeue them for a different worker.
+///
+public class DequeueMatchSettings {
+
+  ///
+  /// @field   acceptEverything
+  /// @brief   Whether or not the worker should accept everything it gets off
+  ///          the queue.
+  /// @details This will assume the worker can always execute operations from
+  ///          the queue it matches with.
+  ///
+  public boolean acceptEverything;
+
+  ///
+  /// @field   allowUnmatched
+  /// @brief   Whether or not the worker should accept platform properties that
+  ///          it does not match with.
+  /// @details This is often necessary if the queue is also configured to allow
+  ///          unmatched properties.
+  ///
+  public boolean allowUnmatched;
+}

--- a/src/main/java/build/buildfarm/worker/DequeueMatchSettings.java
+++ b/src/main/java/build/buildfarm/worker/DequeueMatchSettings.java
@@ -31,7 +31,7 @@ public class DequeueMatchSettings {
   /// @details This will assume the worker can always execute operations from
   ///          the queue it matches with.
   ///
-  public boolean acceptEverything;
+  public boolean acceptEverything = false;
 
   ///
   /// @field   allowUnmatched
@@ -40,5 +40,5 @@ public class DequeueMatchSettings {
   /// @details This is often necessary if the queue is also configured to allow
   ///          unmatched properties.
   ///
-  public boolean allowUnmatched;
+  public boolean allowUnmatched = false;
 }

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -50,6 +50,8 @@ import build.buildfarm.v1test.ExecutionPolicy;
 import build.buildfarm.v1test.QueueEntry;
 import build.buildfarm.v1test.QueuedOperation;
 import build.buildfarm.v1test.QueuedOperationMetadata;
+import build.buildfarm.worker.DequeueMatchEvaluator;
+import build.buildfarm.worker.DequeueMatchSettings;
 import build.buildfarm.worker.ExecutionPolicies;
 import build.buildfarm.worker.ResourceDecider;
 import build.buildfarm.worker.ResourceLimits;
@@ -95,8 +97,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import build.buildfarm.worker.DequeueMatchEvaluator;
-import build.buildfarm.worker.DequeueMatchSettings;
 
 class ShardWorkerContext implements WorkerContext {
   private static final Logger logger = Logger.getLogger(ShardWorkerContext.class.getName());

--- a/src/test/java/build/buildfarm/worker/DequeueMatchEvaluatorTest.java
+++ b/src/test/java/build/buildfarm/worker/DequeueMatchEvaluatorTest.java
@@ -1,0 +1,300 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.worker;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import build.bazel.remote.execution.v2.Platform;
+import build.buildfarm.v1test.QueueEntry;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.SetMultimap;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+///
+/// @class   DequeueMatchEvaluatorTest
+/// @brief   tests Algorithm for deciding whether a worker should keep a dequeued
+///          operation.
+/// @details When a worker takes an entry off of the queue, should it decide
+///          to keep that entry or reject and requeue it? In some sense, it
+///          should keep all entries because they have already been vetted for
+///          that particular worker. This is because the scheduler matches
+///          operations to particular queues, and workers match themselves to
+///          which queues they want to read from. But should the worker always
+///          blindly take what it pops off? And can they trust the scheduler?
+///          There may be situations where the worker chooses to give
+///          operations back based on particular contexts not known to the
+///          scheduler. For example, you might have a variety of workers with
+///          different amounts of cpu cores all sharing the same queue. The
+///          queue may accept N-core operations, because N-core workers exist
+///          in the pool, but there are additionally some lower core workers
+///          that would need to forfeit running the operation. All the reasons
+///          a worker may decide it can't take on the operation and should
+///          give it back are implemented here. The settings provided allow
+///          varying amount of leniency when evaluating the platform
+///          properties.
+///
+@RunWith(JUnit4.class)
+public class DequeueMatchEvaluatorTest {
+
+  // Function under test: shouldKeepOperation
+  // Reason for testing: null queue entries should be kept
+  // Failure explanation: this decision has changed
+  @Test
+  public void shouldKeepOperationKeepNullQueueEntry() throws Exception {
+
+    // ARRANGE
+    DequeueMatchSettings settings = new DequeueMatchSettings();
+    SetMultimap<String, String> workerProvisions = HashMultimap.create();
+    QueueEntry entry = null;
+
+    // ACT
+    boolean shouldKeep =
+        DequeueMatchEvaluator.shouldKeepOperation(settings, workerProvisions, entry);
+
+    // ASSERT
+    assertThat(shouldKeep).isTrue();
+  }
+
+  // Function under test: shouldKeepOperation
+  // Reason for testing: empty plaform queue entries should be kept
+  // Failure explanation: properties are being evaluated differently now
+  @Test
+  public void shouldKeepOperationKeepEmptyQueueEntry() throws Exception {
+
+    // ARRANGE
+    DequeueMatchSettings settings = new DequeueMatchSettings();
+    SetMultimap<String, String> workerProvisions = HashMultimap.create();
+    QueueEntry entry = QueueEntry.newBuilder().setPlatform(Platform.newBuilder()).build();
+
+    // ACT
+    boolean shouldKeep =
+        DequeueMatchEvaluator.shouldKeepOperation(settings, workerProvisions, entry);
+
+    // ASSERT
+    assertThat(shouldKeep).isTrue();
+  }
+
+  // Function under test: shouldKeepOperation
+  // Reason for testing: the entry should be kept because the min cores are valid for the worker
+  // properties
+  // Failure explanation: either the property names changed or we evaluate these properties
+  // differently
+  @Test
+  public void shouldKeepOperationValidMinCoresQueueEntry() throws Exception {
+
+    // ARRANGE
+    DequeueMatchSettings settings = new DequeueMatchSettings();
+
+    SetMultimap<String, String> workerProvisions = HashMultimap.create();
+    workerProvisions.put("cores", "11");
+
+    QueueEntry entry =
+        QueueEntry.newBuilder()
+            .setPlatform(
+                Platform.newBuilder()
+                    .addProperties(
+                        Platform.Property.newBuilder().setName("min-cores").setValue("10")))
+            .build();
+
+    // ACT
+    boolean shouldKeep =
+        DequeueMatchEvaluator.shouldKeepOperation(settings, workerProvisions, entry);
+
+    // ASSERT
+    // the worker accepts because it has more cores than the min-cores requested
+    assertThat(shouldKeep).isTrue();
+  }
+
+  // Function under test: shouldKeepOperation
+  // Reason for testing: the entry should be kept because the min cores are valid for the worker
+  // properties
+  // Failure explanation: either the property names changed or we evaluate these properties
+  // differently
+  @Test
+  public void shouldKeepOperationValidEqualMinCoresQueueEntry() throws Exception {
+
+    // ARRANGE
+    DequeueMatchSettings settings = new DequeueMatchSettings();
+
+    SetMultimap<String, String> workerProvisions = HashMultimap.create();
+    workerProvisions.put("cores", "10");
+
+    QueueEntry entry =
+        QueueEntry.newBuilder()
+            .setPlatform(
+                Platform.newBuilder()
+                    .addProperties(
+                        Platform.Property.newBuilder().setName("min-cores").setValue("10")))
+            .build();
+
+    // ACT
+    boolean shouldKeep =
+        DequeueMatchEvaluator.shouldKeepOperation(settings, workerProvisions, entry);
+
+    // ASSERT
+    // the worker accepts because it has the same cores as the min-cores requested
+    assertThat(shouldKeep).isTrue();
+  }
+
+  // Function under test: shouldKeepOperation
+  // Reason for testing: the entry should not be kept because the min cores are invalid for the
+  // worker properties
+  // Failure explanation: either the property names changed or we evaluate these properties
+  // differently
+  @Test
+  public void shouldKeepOperationInvalidMinCoresQueueEntry() throws Exception {
+
+    // ARRANGE
+    DequeueMatchSettings settings = new DequeueMatchSettings();
+
+    SetMultimap<String, String> workerProvisions = HashMultimap.create();
+    workerProvisions.put("cores", "10");
+
+    QueueEntry entry =
+        QueueEntry.newBuilder()
+            .setPlatform(
+                Platform.newBuilder()
+                    .addProperties(
+                        Platform.Property.newBuilder().setName("min-cores").setValue("11")))
+            .build();
+
+    // ACT
+    boolean shouldKeep =
+        DequeueMatchEvaluator.shouldKeepOperation(settings, workerProvisions, entry);
+
+    // ASSERT
+    // the worker rejects because it has less cores than the min-cores requested
+    assertThat(shouldKeep).isFalse();
+  }
+
+  // Function under test: shouldKeepOperation
+  // Reason for testing: a higher max-core than what the worker has does not result in rejection
+  // Failure explanation: either the property names changed or max-cores is evaluated differently
+  @Test
+  public void shouldKeepOperationMaxCoresDoNotInfluenceAcceptance() throws Exception {
+
+    // ARRANGE
+    DequeueMatchSettings settings = new DequeueMatchSettings();
+
+    SetMultimap<String, String> workerProvisions = HashMultimap.create();
+    workerProvisions.put("cores", "10");
+
+    QueueEntry entry =
+        QueueEntry.newBuilder()
+            .setPlatform(
+                Platform.newBuilder()
+                    .addProperties(
+                        Platform.Property.newBuilder().setName("min-cores").setValue("10"))
+                    .addProperties(
+                        Platform.Property.newBuilder().setName("max-cores").setValue("20")))
+            .build();
+
+    // ACT
+    boolean shouldKeep =
+        DequeueMatchEvaluator.shouldKeepOperation(settings, workerProvisions, entry);
+
+    // ASSERT
+    // the worker accepts because it has the same cores as the min-cores requested
+    assertThat(shouldKeep).isTrue();
+  }
+
+  // Function under test: shouldKeepOperation
+  // Reason for testing: the worker should reject a property if it is not provided in the worker
+  // platform
+  // Failure explanation: ensuring exact property matches is not behaving correctly by default
+  @Test
+  public void shouldKeepOperationUnmatchedPropertiesCauseRejection() throws Exception {
+
+    // ARRANGE
+    DequeueMatchSettings settings = new DequeueMatchSettings();
+
+    SetMultimap<String, String> workerProvisions = HashMultimap.create();
+
+    QueueEntry entry =
+        QueueEntry.newBuilder()
+            .setPlatform(
+                Platform.newBuilder()
+                    .addProperties(
+                        Platform.Property.newBuilder().setName("foo-key").setValue("foo-value")))
+            .build();
+
+    // ACT
+    boolean shouldKeep =
+        DequeueMatchEvaluator.shouldKeepOperation(settings, workerProvisions, entry);
+
+    // ASSERT
+    assertThat(shouldKeep).isFalse();
+  }
+
+  // Function under test: shouldKeepOperation
+  // Reason for testing: the worker usually rejects a property if it is not provided in the worker
+  // platform, but we can choose to accept all entries regardless
+  // Failure explanation: this overwriting decision is not being respected
+  @Test
+  public void shouldKeepOperationUnmatchedPropertiesForceAcceptance() throws Exception {
+
+    // ARRANGE
+    DequeueMatchSettings settings = new DequeueMatchSettings();
+    settings.acceptEverything = true;
+
+    SetMultimap<String, String> workerProvisions = HashMultimap.create();
+
+    QueueEntry entry =
+        QueueEntry.newBuilder()
+            .setPlatform(
+                Platform.newBuilder()
+                    .addProperties(
+                        Platform.Property.newBuilder().setName("foo-key").setValue("foo-value")))
+            .build();
+
+    // ACT
+    boolean shouldKeep =
+        DequeueMatchEvaluator.shouldKeepOperation(settings, workerProvisions, entry);
+
+    // ASSERT
+    assertThat(shouldKeep).isTrue();
+  }
+
+  // Function under test: shouldKeepOperation
+  // Reason for testing: the worker usually rejects a property if it is not provided in the worker
+  // platform, but we can choose to allow unmatched properties
+  // Failure explanation: this matching decision is not being respected
+  @Test
+  public void shouldKeepOperationUnmatchedPropertiesAllowUnmatched() throws Exception {
+
+    // ARRANGE
+    DequeueMatchSettings settings = new DequeueMatchSettings();
+    settings.allowUnmatched = true;
+
+    SetMultimap<String, String> workerProvisions = HashMultimap.create();
+
+    QueueEntry entry =
+        QueueEntry.newBuilder()
+            .setPlatform(
+                Platform.newBuilder()
+                    .addProperties(
+                        Platform.Property.newBuilder().setName("foo-key").setValue("foo-value")))
+            .build();
+
+    // ACT
+    boolean shouldKeep =
+        DequeueMatchEvaluator.shouldKeepOperation(settings, workerProvisions, entry);
+
+    // ASSERT
+    assertThat(shouldKeep).isTrue();
+  }
+}

--- a/src/test/java/build/buildfarm/worker/DequeueMatchEvaluatorTest.java
+++ b/src/test/java/build/buildfarm/worker/DequeueMatchEvaluatorTest.java
@@ -120,37 +120,6 @@ public class DequeueMatchEvaluatorTest {
   }
 
   // Function under test: shouldKeepOperation
-  // Reason for testing: the entry should be kept because the min cores are valid for the worker
-  // properties
-  // Failure explanation: either the property names changed or we evaluate these properties
-  // differently
-  @Test
-  public void shouldKeepOperationValidEqualMinCoresQueueEntry() throws Exception {
-
-    // ARRANGE
-    DequeueMatchSettings settings = new DequeueMatchSettings();
-
-    SetMultimap<String, String> workerProvisions = HashMultimap.create();
-    workerProvisions.put("cores", "10");
-
-    QueueEntry entry =
-        QueueEntry.newBuilder()
-            .setPlatform(
-                Platform.newBuilder()
-                    .addProperties(
-                        Platform.Property.newBuilder().setName("min-cores").setValue("10")))
-            .build();
-
-    // ACT
-    boolean shouldKeep =
-        DequeueMatchEvaluator.shouldKeepOperation(settings, workerProvisions, entry);
-
-    // ASSERT
-    // the worker accepts because it has the same cores as the min-cores requested
-    assertThat(shouldKeep).isTrue();
-  }
-
-  // Function under test: shouldKeepOperation
   // Reason for testing: the entry should not be kept because the min cores are invalid for the
   // worker properties
   // Failure explanation: either the property names changed or we evaluate these properties
@@ -217,7 +186,7 @@ public class DequeueMatchEvaluatorTest {
   // platform
   // Failure explanation: ensuring exact property matches is not behaving correctly by default
   @Test
-  public void shouldKeepOperationUnmatchedPropertiesCauseRejection() throws Exception {
+  public void shouldKeepOperationUnmatchedPropertiesRejectionAcceptance() throws Exception {
 
     // ARRANGE
     DequeueMatchSettings settings = new DequeueMatchSettings();
@@ -238,61 +207,21 @@ public class DequeueMatchEvaluatorTest {
 
     // ASSERT
     assertThat(shouldKeep).isFalse();
-  }
-
-  // Function under test: shouldKeepOperation
-  // Reason for testing: the worker usually rejects a property if it is not provided in the worker
-  // platform, but we can choose to accept all entries regardless
-  // Failure explanation: this overwriting decision is not being respected
-  @Test
-  public void shouldKeepOperationUnmatchedPropertiesForceAcceptance() throws Exception {
 
     // ARRANGE
-    DequeueMatchSettings settings = new DequeueMatchSettings();
     settings.acceptEverything = true;
 
-    SetMultimap<String, String> workerProvisions = HashMultimap.create();
-
-    QueueEntry entry =
-        QueueEntry.newBuilder()
-            .setPlatform(
-                Platform.newBuilder()
-                    .addProperties(
-                        Platform.Property.newBuilder().setName("foo-key").setValue("foo-value")))
-            .build();
-
     // ACT
-    boolean shouldKeep =
-        DequeueMatchEvaluator.shouldKeepOperation(settings, workerProvisions, entry);
+    shouldKeep = DequeueMatchEvaluator.shouldKeepOperation(settings, workerProvisions, entry);
 
     // ASSERT
     assertThat(shouldKeep).isTrue();
-  }
-
-  // Function under test: shouldKeepOperation
-  // Reason for testing: the worker usually rejects a property if it is not provided in the worker
-  // platform, but we can choose to allow unmatched properties
-  // Failure explanation: this matching decision is not being respected
-  @Test
-  public void shouldKeepOperationUnmatchedPropertiesAllowUnmatched() throws Exception {
 
     // ARRANGE
-    DequeueMatchSettings settings = new DequeueMatchSettings();
     settings.allowUnmatched = true;
 
-    SetMultimap<String, String> workerProvisions = HashMultimap.create();
-
-    QueueEntry entry =
-        QueueEntry.newBuilder()
-            .setPlatform(
-                Platform.newBuilder()
-                    .addProperties(
-                        Platform.Property.newBuilder().setName("foo-key").setValue("foo-value")))
-            .build();
-
     // ACT
-    boolean shouldKeep =
-        DequeueMatchEvaluator.shouldKeepOperation(settings, workerProvisions, entry);
+    shouldKeep = DequeueMatchEvaluator.shouldKeepOperation(settings, workerProvisions, entry);
 
     // ASSERT
     assertThat(shouldKeep).isTrue();


### PR DESCRIPTION
### Worker re-queuing 
When a worker gets an operation they must make a decision as to whether they should keep that operation or put it back on the queue.  We wish to customize this decision process and add testing where there previously was not any.  

### Feature request
There is a subtle issue that we are trying to address.
Since the `OperationQueue` has been extended to allow a superset of `execution_properties`, so too must the workers be able to accept a superset of properties on a `queueEntry`.  If a user were to craft an invalid execution property it may make it onto the queue but be constantly rejected by all the workers and never actually execute.  A similar flag to the queue's `allowUnmatched` has been added.  This can be made configurable  in the future.

### Superset rationale
One might wonder why we allow these supersets at all, and the reason is to better accommodate other remote execution solutions who are specifying their own execution_properties in the same repository.  Whether you want to allow supersets or not is something that should be fully customizable so we are not enforcing any kind of paradigm.  If users want to lock down a strict set of allowed execution properties, this is still possible via queue configuration.