### PR TITLE
Allow individual env vars on exec_properties

### DIFF
--- a/src/main/java/build/buildfarm/worker/resources/ResourceDecider.java
+++ b/src/main/java/build/buildfarm/worker/resources/ResourceDecider.java
@@ -151,8 +151,8 @@ public class ResourceDecider {
             (property) -> {
               if (property.getName().startsWith(EXEC_PROPERTY_ENV_VAR)) {
                 String keyValue[] = property.getName().split(":", 2);
-                String key = keyValue[0];
-                String value = (keyValue.length > 1) ? keyValue[1] : "";
+                String key = keyValue[1];
+                String value = property.getValue();
                 limits.extraEnvironmentVariables.put(key, value);
               }
             });

--- a/src/main/java/build/buildfarm/worker/resources/ResourceDecider.java
+++ b/src/main/java/build/buildfarm/worker/resources/ResourceDecider.java
@@ -55,6 +55,14 @@ public class ResourceDecider {
   private static final String EXEC_PROPERTY_ENV_VARS = "env-vars";
 
   ///
+  /// @field   EXEC_PROPERTY_ENV_VAR
+  /// @brief   The exec_property and platform property prefix name for
+  ///          providing an additional environment variable.
+  /// @details This is decided between client and server.
+  ///
+  private static final String EXEC_PROPERTY_ENV_VAR = "env-var:";
+
+  ///
   /// @brief   Decide resource limitations for the given command.
   /// @details Platform properties from specified exec_properties are taken
   ///          into account as well as global buildfarm configuration.
@@ -117,6 +125,8 @@ public class ResourceDecider {
     } catch (ParseException pe) {
     }
 
+    addIndividualEnvVars(limits, command);
+
     // resolve any template values
     limits.extraEnvironmentVariables.replaceAll(
         (key, val) -> {
@@ -125,6 +135,27 @@ public class ResourceDecider {
           val = val.replace("{{limits.cpu.claimed}}", String.valueOf(limits.cpu.claimed));
           return val;
         });
+  }
+  ///
+  /// @brief   Extend env variables that were individual passed.
+  /// @details These are discovered by identifying execution property key
+  ///          names.
+  /// @param   limits  Current limits to apply changes to.
+  /// @param   command The command to decide resource limitations.
+  ///
+  private static void addIndividualEnvVars(ResourceLimits limits, Command command) {
+    command
+        .getPlatform()
+        .getPropertiesList()
+        .forEach(
+            (property) -> {
+              if (property.getName().startsWith(EXEC_PROPERTY_ENV_VAR)) {
+                String keyValue[] = property.getName().split(":", 2);
+                String key = keyValue[0];
+                String value = (keyValue.length > 1) ? keyValue[1] : "";
+                limits.extraEnvironmentVariables.put(key, value);
+              }
+            });
   }
   ///
   /// @brief   Get default resource limits.

--- a/src/test/java/build/buildfarm/worker/resources/ResourceDeciderTest.java
+++ b/src/test/java/build/buildfarm/worker/resources/ResourceDeciderTest.java
@@ -233,4 +233,85 @@ public class ResourceDeciderTest {
     assertThat(limits.extraEnvironmentVariables.containsKey("bar")).isTrue();
     assertThat(limits.extraEnvironmentVariables.get("bar")).isEqualTo("14");
   }
+
+  // Function under test: decideResourceLimitations
+  // Reason for testing: if the user passes an extra individual environment variable via platform
+  // properties they should be parsed into the map
+  // Failure explanation: the parsing was not done correctly and the variable was somehow ignored
+  @Test
+  public void decideResourceLimitationsTestIndividualEnvironmentVarParse() throws Exception {
+
+    // ARRANGE
+    Command command =
+        Command.newBuilder()
+            .setPlatform(
+                Platform.newBuilder()
+                    .addProperties(
+                        Platform.Property.newBuilder().setName("env-var:foo").setValue("bar")))
+            .build();
+
+    // ACT
+    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, true, 100);
+
+    // ASSERT
+    assertThat(limits.extraEnvironmentVariables.size()).isEqualTo(1);
+    assertThat(limits.extraEnvironmentVariables.containsKey("foo")).isTrue();
+    assertThat(limits.extraEnvironmentVariables.get("foo")).isEqualTo("bar");
+  }
+
+  // Function under test: decideResourceLimitations
+  // Reason for testing: if the user passes two extra individual environment variable via platform
+  // properties they should be parsed into the map
+  // Failure explanation: the parsing was not done correctly and the variables were ignored for some
+  // reason
+  @Test
+  public void decideResourceLimitationsTestTwoIndividualEnvironmentVarParse() throws Exception {
+
+    // ARRANGE
+    Command command =
+        Command.newBuilder()
+            .setPlatform(
+                Platform.newBuilder()
+                    .addProperties(
+                        Platform.Property.newBuilder().setName("env-var:foo").setValue("bar"))
+                    .addProperties(
+                        Platform.Property.newBuilder().setName("env-var:baz").setValue("qux")))
+            .build();
+
+    // ACT
+    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, true, 100);
+
+    // ASSERT
+    assertThat(limits.extraEnvironmentVariables.size()).isEqualTo(2);
+    assertThat(limits.extraEnvironmentVariables.containsKey("foo")).isTrue();
+    assertThat(limits.extraEnvironmentVariables.get("foo")).isEqualTo("bar");
+    assertThat(limits.extraEnvironmentVariables.containsKey("baz")).isTrue();
+    assertThat(limits.extraEnvironmentVariables.get("baz")).isEqualTo("qux");
+  }
+
+  // Function under test: decideResourceLimitations
+  // Reason for testing: if the user passes an extra individual environment var with no value, it
+  // should still be parsed into the map
+  // Failure explanation: the parsing was not done correctly and the variable was ignored or the
+  // value contents are wrong
+  @Test
+  public void decideResourceLimitationsTestEmptyEnvironmentVarParse() throws Exception {
+
+    // ARRANGE
+    Command command =
+        Command.newBuilder()
+            .setPlatform(
+                Platform.newBuilder()
+                    .addProperties(
+                        Platform.Property.newBuilder().setName("env-var:foo").setValue("")))
+            .build();
+
+    // ACT
+    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, true, 100);
+
+    // ASSERT
+    assertThat(limits.extraEnvironmentVariables.size()).isEqualTo(1);
+    assertThat(limits.extraEnvironmentVariables.containsKey("foo")).isTrue();
+    assertThat(limits.extraEnvironmentVariables.get("foo")).isEqualTo("");
+  }
 }


### PR DESCRIPTION
### problem:
Currently buildfarm allows specifying environment variables through `exec_properties`.   
We made this available because `--action_env` was limited in bazel.  
Given this existing feature there are still some rough edges on the client side.  

### discussion:
See this discussion point about existing functionality and the suggested alternative:
> I can see that this is constrained by exec_properties needing to be a dictionary that maps a string key to a string value. A downside of the current approach is that it does not permit using --remote_default_exec_properties to build up a set of environment variables one at a time. Nor does it facilitate the aggregation of the set of the environment variables from a variety of sources, since the most recent value of env-vars overrides any previous value. Adding a new environment variable to a previous setting would be a bit awkward, as you'd first have to convert the string to a dictionary, then update the dictionary with the new environment variable name and value, and then render the dictionary back into a string. This is possible within Starlark, but not from the command line. And even within Starlark, the code would not have access to a default setting of env-vars provided by --remote_default_exec_properties.
> 
> Another way to do this would be to have exec_properties keys indicate the environment variable names. For instance:
> 
> validated_exec_properties["env-var:MKL_NUM_THREADS"] = "{{limits.cpu.claimed}}"
> validated_exec_properties["env-var:OMP_NUM_THREADS"] = "{{limits.cpu.claimed}}"
> In this format, we could specify the equivalent on the command line:
> 
> --remote_default_exec_properties=env-var:MKL_NUM_THREADS={{limits.cpu.claimed}}
> --remote_default_exec_properties=env-var:OMP_NUM_THREADS={{limits.cpu.claimed}}
> without these being overwritten by the setting of any other environment variables elsewhere.
> This approach, via .bazelrc, would also have the same scope as the default setting of max-cores=1. Specifying the environment variables via the atg wrappers, as in this PR, only covers the code that uses these wrappers, so it will be a subset of all the places that currently get the max-cores=1 setting. I think it would be better to ensure that every place that sees max-cores=1 also gets these environment variable settings.
> 
> This approach would, of course, require buildfarm to scan all the exec_properties keys in order to identify all the environment variables to set. This approach would also eliminate a possible failure mode of supplying a value that did not happen to be a correctly formatted string representing a dictionary.

### solution:
We add this alternative strategy for specifying environment variables.
We will consider removing the other strategy afterward.