### PR TITLE
Implement AdminService::DeregisterWorker

### DIFF
--- a/src/main/java/build/buildfarm/common/ShardBackplane.java
+++ b/src/main/java/build/buildfarm/common/ShardBackplane.java
@@ -87,7 +87,7 @@ public interface ShardBackplane {
   boolean removeWorker(String workerName, String reason) throws IOException;
 
   @ThreadSafe
-  CasIndexResults reindexCas(String hostName) throws IOException;
+  CasIndexResults reindexCas(String workerName) throws IOException;
 
   @ThreadSafe
   void deregisterWorker(String hostName) throws IOException;

--- a/src/main/java/build/buildfarm/common/ShardBackplane.java
+++ b/src/main/java/build/buildfarm/common/ShardBackplane.java
@@ -87,7 +87,10 @@ public interface ShardBackplane {
   boolean removeWorker(String workerName, String reason) throws IOException;
 
   @ThreadSafe
-  public CasIndexResults reindexCas(String hostName) throws IOException;
+  CasIndexResults reindexCas(String hostName) throws IOException;
+
+  @ThreadSafe
+  void deregisterWorker(String hostName) throws IOException;
 
   /** Returns a set of the names of all active workers. */
   @ThreadSafe

--- a/src/main/java/build/buildfarm/instance/AbstractServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/AbstractServerInstance.java
@@ -1700,7 +1700,7 @@ public abstract class AbstractServerInstance implements Instance {
   public abstract CasIndexResults reindexCas(String hostName);
 
   @Override
-  public abstract void deregisterWorker(String hostName);
+  public abstract void deregisterWorker(String workerName);
 
   protected abstract Logger getLogger();
 }

--- a/src/main/java/build/buildfarm/instance/AbstractServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/AbstractServerInstance.java
@@ -1699,5 +1699,8 @@ public abstract class AbstractServerInstance implements Instance {
   @Override
   public abstract CasIndexResults reindexCas(String hostName);
 
+  @Override
+  public abstract void deregisterWorker(String hostName);
+
   protected abstract Logger getLogger();
 }

--- a/src/main/java/build/buildfarm/instance/Instance.java
+++ b/src/main/java/build/buildfarm/instance/Instance.java
@@ -144,7 +144,7 @@ public interface Instance {
 
   CasIndexResults reindexCas(String hostName);
 
-  void deregisterWorker(String hostName);
+  void deregisterWorker(String workerName);
 
   interface MatchListener {
     // start/end pair called for each wait period

--- a/src/main/java/build/buildfarm/instance/Instance.java
+++ b/src/main/java/build/buildfarm/instance/Instance.java
@@ -144,6 +144,8 @@ public interface Instance {
 
   CasIndexResults reindexCas(String hostName);
 
+  void deregisterWorker(String hostName);
+
   interface MatchListener {
     // start/end pair called for each wait period
     void onWaitStart();

--- a/src/main/java/build/buildfarm/instance/memory/MemoryInstance.java
+++ b/src/main/java/build/buildfarm/instance/memory/MemoryInstance.java
@@ -1024,4 +1024,9 @@ public class MemoryInstance extends AbstractServerInstance {
   public CasIndexResults reindexCas(String hostName) {
     throw new UnsupportedOperationException();
   }
+
+  @Override
+  public void deregisterWorker(String hostName) {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/src/main/java/build/buildfarm/instance/memory/MemoryInstance.java
+++ b/src/main/java/build/buildfarm/instance/memory/MemoryInstance.java
@@ -1026,7 +1026,7 @@ public class MemoryInstance extends AbstractServerInstance {
   }
 
   @Override
-  public void deregisterWorker(String hostName) {
+  public void deregisterWorker(String workerName) {
     throw new UnsupportedOperationException();
   }
 }

--- a/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
@@ -678,6 +678,11 @@ public class RedisShardBackplane implements ShardBackplane {
   }
 
   @Override
+  public void deregisterWorker(String hostName) throws IOException {
+    removeWorker(hostName, "Requested shutdown");
+  }
+
+  @Override
   public synchronized Set<String> getWorkers() throws IOException {
     long now = System.currentTimeMillis();
     if (now < workerSetExpiresAt) {

--- a/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
@@ -678,8 +678,8 @@ public class RedisShardBackplane implements ShardBackplane {
   }
 
   @Override
-  public void deregisterWorker(String hostName) throws IOException {
-    removeWorker(hostName, "Requested shutdown");
+  public void deregisterWorker(String workerName) throws IOException {
+    removeWorker(workerName, "Requested shutdown");
   }
 
   @Override

--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -2338,4 +2338,13 @@ public class ShardInstance extends AbstractServerInstance {
       throw Status.fromThrowable(e).asRuntimeException();
     }
   }
+
+  @Override
+  public void deregisterWorker(String hostName) {
+    try {
+      backplane.deregisterWorker(hostName);
+    } catch (IOException e) {
+      throw Status.fromThrowable(e).asRuntimeException();
+    }
+  }
 }

--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -2340,9 +2340,9 @@ public class ShardInstance extends AbstractServerInstance {
   }
 
   @Override
-  public void deregisterWorker(String hostName) {
+  public void deregisterWorker(String workerName) {
     try {
-      backplane.deregisterWorker(hostName);
+      backplane.deregisterWorker(workerName);
     } catch (IOException e) {
       throw Status.fromThrowable(e).asRuntimeException();
     }

--- a/src/main/java/build/buildfarm/instance/stub/StubInstance.java
+++ b/src/main/java/build/buildfarm/instance/stub/StubInstance.java
@@ -838,11 +838,12 @@ public class StubInstance implements Instance {
   }
 
   @Override
-  public void deregisterWorker(String hostName) {
+  public void deregisterWorker(String workerName) {
     throwIfStopped();
     DeregisterWorkerRequestResults proto =
         adminBlockingStub
             .get()
-            .deregisterWorker(DeregisterWorkerRequest.newBuilder().setHostId(hostName).build());
+            .deregisterWorker(
+                DeregisterWorkerRequest.newBuilder().setWorkerName(workerName).build());
   }
 }

--- a/src/main/java/build/buildfarm/instance/stub/StubInstance.java
+++ b/src/main/java/build/buildfarm/instance/stub/StubInstance.java
@@ -69,6 +69,8 @@ import build.buildfarm.common.grpc.StubWriteOutputStream;
 import build.buildfarm.instance.Instance;
 import build.buildfarm.v1test.AdminGrpc;
 import build.buildfarm.v1test.AdminGrpc.AdminBlockingStub;
+import build.buildfarm.v1test.DeregisterWorkerRequest;
+import build.buildfarm.v1test.DeregisterWorkerRequestResults;
 import build.buildfarm.v1test.GetClientStartTimeResult;
 import build.buildfarm.v1test.OperationQueueGrpc;
 import build.buildfarm.v1test.OperationQueueGrpc.OperationQueueBlockingStub;
@@ -833,5 +835,14 @@ public class StubInstance implements Instance {
     results.removedKeys = proto.getRemovedKeys();
     results.totalKeys = proto.getTotalKeys();
     return results;
+  }
+
+  @Override
+  public void deregisterWorker(String hostName) {
+    throwIfStopped();
+    DeregisterWorkerRequestResults proto =
+        adminBlockingStub
+            .get()
+            .deregisterWorker(DeregisterWorkerRequest.newBuilder().setHostId(hostName).build());
   }
 }

--- a/src/main/java/build/buildfarm/server/AdminService.java
+++ b/src/main/java/build/buildfarm/server/AdminService.java
@@ -168,12 +168,14 @@ public class AdminService extends AdminGrpc.AdminImplBase {
     Instance instance;
     try {
       instance = instances.get(request.getInstanceName());
-      instance.deregisterWorker(request.getHostId());
+      instance.deregisterWorker(request.getWorkerName());
       responseObserver.onNext(DeregisterWorkerRequestResults.newBuilder().build());
       responseObserver.onCompleted();
     } catch (Exception e) {
       logger.log(
-          Level.SEVERE, String.format("Could not deregister worker: %s", request.getHostId()), e);
+          Level.SEVERE,
+          String.format("Could not deregister worker: %s", request.getWorkerName()),
+          e);
       responseObserver.onError(io.grpc.Status.fromThrowable(e).asException());
     }
   }

--- a/src/main/java/build/buildfarm/server/AdminService.java
+++ b/src/main/java/build/buildfarm/server/AdminService.java
@@ -23,6 +23,8 @@ import build.buildfarm.common.CasIndexResults;
 import build.buildfarm.instance.Instance;
 import build.buildfarm.v1test.AdminConfig;
 import build.buildfarm.v1test.AdminGrpc;
+import build.buildfarm.v1test.DeregisterWorkerRequest;
+import build.buildfarm.v1test.DeregisterWorkerRequestResults;
 import build.buildfarm.v1test.GetClientStartTimeRequest;
 import build.buildfarm.v1test.GetClientStartTimeResult;
 import build.buildfarm.v1test.GetHostsRequest;
@@ -155,6 +157,23 @@ public class AdminService extends AdminGrpc.AdminImplBase {
       responseObserver.onCompleted();
     } catch (Exception e) {
       logger.log(Level.SEVERE, "Could not reindex CAS.", e);
+      responseObserver.onError(io.grpc.Status.fromThrowable(e).asException());
+    }
+  }
+
+  @Override
+  public void deregisterWorker(
+      DeregisterWorkerRequest request,
+      StreamObserver<DeregisterWorkerRequestResults> responseObserver) {
+    Instance instance;
+    try {
+      instance = instances.get(request.getInstanceName());
+      instance.deregisterWorker(request.getHostId());
+      responseObserver.onNext(DeregisterWorkerRequestResults.newBuilder().build());
+      responseObserver.onCompleted();
+    } catch (Exception e) {
+      logger.log(
+          Level.SEVERE, String.format("Could not deregister worker: %s", request.getHostId()), e);
       responseObserver.onError(io.grpc.Status.fromThrowable(e).asException());
     }
   }

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerInstance.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerInstance.java
@@ -387,4 +387,13 @@ public class ShardWorkerInstance extends AbstractServerInstance {
       throw Status.fromThrowable(e).asRuntimeException();
     }
   }
+
+  @Override
+  public void deregisterWorker(String hostName) {
+    try {
+      backplane.deregisterWorker(hostName);
+    } catch (IOException e) {
+      throw Status.fromThrowable(e).asRuntimeException();
+    }
+  }
 }

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerInstance.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerInstance.java
@@ -389,9 +389,9 @@ public class ShardWorkerInstance extends AbstractServerInstance {
   }
 
   @Override
-  public void deregisterWorker(String hostName) {
+  public void deregisterWorker(String workerName) {
     try {
-      backplane.deregisterWorker(hostName);
+      backplane.deregisterWorker(workerName);
     } catch (IOException e) {
       throw Status.fromThrowable(e).asRuntimeException();
     }

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -39,6 +39,20 @@ service Admin {
   rpc ReindexCas(ReindexCasRequest) returns (ReindexCasRequestResults) {
     option (google.api.http) = { get: "/v1test/admin:reindexCas" };
   }
+  
+  rpc DeregisterWorker(DeregisterWorkerRequest) returns (DeregisterWorkerRequestResults) {
+    option (google.api.http) = { get: "/v1test/admin:deregisterWorker" };
+  }
+}
+
+message DeregisterWorkerRequest {
+  string instance_name = 1;
+  
+  // format: ip:port
+  string host_id = 2;
+}
+
+message DeregisterWorkerRequestResults {
 }
 
 message ReindexCasRequest {

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -48,8 +48,7 @@ service Admin {
 message DeregisterWorkerRequest {
   string instance_name = 1;
   
-  // format: ip:port
-  string host_id = 2;
+  string worker_name = 2;
 }
 
 message DeregisterWorkerRequestResults {

--- a/src/test/java/build/buildfarm/instance/AbstractServerInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/AbstractServerInstanceTest.java
@@ -172,7 +172,7 @@ public class AbstractServerInstanceTest {
     }
 
     @Override
-    public void deregisterWorker(String hostName) {
+    public void deregisterWorker(String workerName) {
       throw new UnsupportedOperationException();
     }
   }

--- a/src/test/java/build/buildfarm/instance/AbstractServerInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/AbstractServerInstanceTest.java
@@ -170,6 +170,11 @@ public class AbstractServerInstanceTest {
     public CasIndexResults reindexCas(String hostName) {
       throw new UnsupportedOperationException();
     }
+
+    @Override
+    public void deregisterWorker(String hostName) {
+      throw new UnsupportedOperationException();
+    }
   }
 
   @Test


### PR DESCRIPTION
This provides an API for the Admin Service to deregister a worker from the shard.  
It implements the "Deregister from Redis" box:
![Buildfarm Worker Shutdowns](https://user-images.githubusercontent.com/1312081/101128864-82dd2c00-35ce-11eb-864e-763b478c66e7.png)
