### PR TITLE
 initialize defaults for ResourceLimits to avoid NPE

### DIFF
--- a/src/main/java/build/buildfarm/worker/operationqueue/Worker.java
+++ b/src/main/java/build/buildfarm/worker/operationqueue/Worker.java
@@ -706,7 +706,7 @@ public class Worker extends LoggingMain {
 
           @Override
           public ResourceLimits commandExecutionSettings(Command command) {
-            return null;
+            return new ResourceLimits();
           }
         };
 

--- a/src/main/java/build/buildfarm/worker/resources/CpuLimits.java
+++ b/src/main/java/build/buildfarm/worker/resources/CpuLimits.java
@@ -39,26 +39,26 @@ public class CpuLimits {
   /// @details Depending on the server implementation, we may skip applying any
   ///          restrictions to core usage.
   ///
-  public boolean limit;
+  public boolean limit = true;
 
   ///
   /// @field   min
   /// @brief   The minimum CPU cores required.
   /// @details Client can suggest this though exec_properties.
   ///
-  public int min;
+  public int min = 1;
 
   ///
   /// @field   max
   /// @brief   The maximum CPU cores required.
   /// @details Client can suggest this though exec_properties.
   ///
-  public int max;
+  public int max = 1;
 
   ///
   /// @field   claimed
   /// @brief   The amount of cores actually claimed for the action.
   /// @details This will be in the range of (min,max) when limited.
   ///
-  public int claimed;
+  public int claimed = 1;
 }

--- a/src/main/java/build/buildfarm/worker/resources/ResourceLimits.java
+++ b/src/main/java/build/buildfarm/worker/resources/ResourceLimits.java
@@ -14,6 +14,7 @@
 
 package build.buildfarm.worker;
 
+import java.util.HashMap;
 import java.util.Map;
 
 ///
@@ -37,7 +38,7 @@ public class ResourceLimits {
   /// @details Decides specific CPU limitations and whether to apply them for a
   ///          given action.
   ///
-  public CpuLimits cpu;
+  public CpuLimits cpu = new CpuLimits();
 
   ///
   /// @field   extraEnvironmentVariables
@@ -46,5 +47,5 @@ public class ResourceLimits {
   /// @details These variables are added to the end of the existing environment
   ///          variables in the Command.
   ///
-  public Map<String, String> extraEnvironmentVariables;
+  public Map<String, String> extraEnvironmentVariables = new HashMap<String, String>();
 }


### PR DESCRIPTION
This is a bugfix for the memory instance introducing during https://github.com/bazelbuild/bazel-buildfarm/pull/595#issuecomment-739483991

Data members should be initialized before they are used.  Using data members without initializing them will result in a NPE.  This problem did not occur in the shard instance because we do initialize and construct all of the members.  This is also fixed and further improved in https://github.com/bazelbuild/bazel-buildfarm/pull/614.  

Reflecting on issue:  
I've been bitten by this a few times now.  Coming from C++ and other languages that default initialize your objects, I keep forgetting that in Java, initializing must be explicit in class definitions. I'll see about a linter for this, and the memory instance is clearly lacking unit tests that would have caught this, so we'll fix that too.