### PR TITLE
 make worker match settings configurable

### DIFF
--- a/examples/shard-worker.config.example
+++ b/examples/shard-worker.config.example
@@ -29,20 +29,24 @@ operation_poll_period: {
   nanos: 0
 }
 
-# key/value set of defining capabilities of this worker
-# all execute requests must match perfectly with workers which
-# provide capabilities
-# so an action with a required platform: { arch: "x86_64" } must
-# match with a worker with at least { arch: "x86_64" } here
-platform: {
-  # commented out here for illustrative purposes, a default empty
-  # 'platform' is a sufficient starting point without specifying
-  # any platform requirements on the actions' side
-  ###
-  # property: {
-  #   name: "key_name"
-  #   value: "value_string"
-  # }
+dequeue_match_settings: {
+
+  # key/value set of defining capabilities of this worker
+  # all execute requests must match perfectly with workers which
+  # provide capabilities
+  # so an action with a required platform: { arch: "x86_64" } must
+  # match with a worker with at least { arch: "x86_64" } here
+  platform: {
+    # commented out here for illustrative purposes, a default empty
+    # 'platform' is a sufficient starting point without specifying
+    # any platform requirements on the actions' side
+    ###
+    # property: {
+    #   name: "key_name"
+    #   value: "value_string"
+    # }
+  }
+
 }
 
 # the worker CAS configuration

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -105,6 +105,7 @@ class ShardWorkerContext implements WorkerContext {
 
   private final String name;
   private final Platform platform;
+  private final DequeueMatchSettings matchSettings;
   private final SetMultimap<String, String> matchProvisions;
   private final Duration operationPollPeriod;
   private final OperationPoller operationPoller;
@@ -142,6 +143,7 @@ class ShardWorkerContext implements WorkerContext {
 
   ShardWorkerContext(
       String name,
+      DequeueMatchSettings matchSettings,
       Platform platform,
       Duration operationPollPeriod,
       OperationPoller operationPoller,
@@ -163,6 +165,7 @@ class ShardWorkerContext implements WorkerContext {
       boolean errorOperationRemainingResources,
       Supplier<CasWriter> writer) {
     this.name = name;
+    this.matchSettings = matchSettings;
     this.platform = platform;
     this.matchProvisions = getMatchProvisions(platform, policies, executeStageWidth);
     this.operationPollPeriod = operationPollPeriod;
@@ -313,9 +316,7 @@ class ShardWorkerContext implements WorkerContext {
     }
     listener.onWaitEnd();
 
-    DequeueMatchSettings settings = new DequeueMatchSettings();
-    settings.allowUnmatched = true;
-    if (DequeueMatchEvaluator.shouldKeepOperation(settings, matchProvisions, queueEntry)) {
+    if (DequeueMatchEvaluator.shouldKeepOperation(matchSettings, matchProvisions, queueEntry)) {
       listener.onEntry(queueEntry);
     } else {
       backplane.rejectOperation(queueEntry);

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -51,6 +51,7 @@ import build.buildfarm.v1test.ContentAddressableStorageConfig;
 import build.buildfarm.v1test.FilesystemCASConfig;
 import build.buildfarm.v1test.ShardWorker;
 import build.buildfarm.v1test.ShardWorkerConfig;
+import build.buildfarm.worker.DequeueMatchSettings;
 import build.buildfarm.worker.ExecuteActionStage;
 import build.buildfarm.worker.FuseCAS;
 import build.buildfarm.worker.InputFetchStage;
@@ -332,10 +333,15 @@ public class Worker extends LoggingMain {
       writer = new LocalCasWriter();
     }
 
+    DequeueMatchSettings matchSettings = new DequeueMatchSettings();
+    matchSettings.acceptEverything = config.getDequeueMatchSettings().getAcceptEverything();
+    matchSettings.allowUnmatched = config.getDequeueMatchSettings().getAllowUnmatched();
+
     ShardWorkerContext context =
         new ShardWorkerContext(
             config.getPublicName(),
-            config.getPlatform(),
+            matchSettings,
+            config.getDequeueMatchSettings().getPlatform(),
             config.getOperationPollPeriod(),
             backplane::pollOperation,
             config.getInlineContentLimit(),

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -533,6 +533,18 @@ message ShardWorkerInstanceConfig {
   google.protobuf.Duration grpc_timeout = 13;
 }
 
+message DequeueMatchSettings {
+  
+  // whether a worker should accept everything it gets off the queue.
+  bool accept_everything = 1;
+
+  // whether a worker should accept platform properties that it does not match with.
+  bool allow_unmatched = 2;
+  
+  // worker platform used to match operations
+  build.bazel.remote.execution.v2.Platform platform = 3;
+}
+
 message ShardWorkerConfig {
   ShardWorkerInstanceConfig shard_worker_instance_config = 1;
 
@@ -549,11 +561,8 @@ message ShardWorkerConfig {
   // period of poll requests during execution
   google.protobuf.Duration operation_poll_period = 13;
 
-  // initial platform used to match operations
-  build.bazel.remote.execution.v2.Platform platform = 14;
-
-  // default platform to populate matched commands
-  build.bazel.remote.execution.v2.Platform default_platform = 28;
+  //settings used to match with operations
+  DequeueMatchSettings dequeue_match_settings = 35;
 
   // total size of the inline content for
   // action results

--- a/src/test/java/build/buildfarm/worker/shard/ShardWorkerContextTest.java
+++ b/src/test/java/build/buildfarm/worker/shard/ShardWorkerContextTest.java
@@ -33,6 +33,7 @@ import build.buildfarm.instance.Instance.MatchListener;
 import build.buildfarm.instance.shard.ShardBackplane;
 import build.buildfarm.v1test.ExecutionPolicy;
 import build.buildfarm.v1test.QueueEntry;
+import build.buildfarm.worker.DequeueMatchSettings;
 import build.buildfarm.worker.WorkerContext;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
@@ -79,8 +80,10 @@ public class ShardWorkerContextTest {
   }
 
   WorkerContext createTestContext(Platform platform, Iterable<ExecutionPolicy> policies) {
+    DequeueMatchSettings matchSettings = new DequeueMatchSettings();
     return new ShardWorkerContext(
         "test",
+        matchSettings,
         platform,
         /* operationPollPeriod=*/ Duration.getDefaultInstance(),
         /* operationPoller=*/ (queueEntry, stage, requeueAt) -> {


### PR DESCRIPTION
**Breaking config change**

**How to upgrade**:

You will need to wrap your `platform: {` in `dequeue_match_settings: {` to continue getting the same functionality
(see the config changes for example).  

Optionally, you may want to enable one of the new features:

```
dequeue_match_settings: {
    accept_everything: true
    allow_unmatched: true
    platform: { ... }
}
```

**Description**:
The worker performs two phases of matching.  It matches with the queue to decide which operation to get,  
and it matches against the dequeued operation to decide whether to put it back.
This diff allows further configuration when analyzing the dequeued operation.

**Reason for changing**:
The reason we wanted to configure this matching behavior is so that actions with foreign execution properties from different remote execution systems can still be accepted by buildfarm and so that users can pass env var properties are not known up-front to buildfarm.  Also, the worker is already matching with the queue.  So it can trust the operation that it receives (accept_everything: true).  However this may not always be desired depending on the kinds of workers you have sharing the same queue. 

See this discussion point:  
```
/// @details When a worker takes an entry off of the queue, should it decide
///          to keep that entry or reject and requeue it? In some sense, it
///          should keep all entries because they have already been vetted for
///          that particular worker. This is because the scheduler matches
///          operations to particular queues, and workers match themselves to
///          which queues they want to read from. But should the worker always
///          blindly take what it pops off? And can they trust the scheduler?
///          There may be situations where the worker chooses to give
///          operations back based on particular contexts not known to the
///          scheduler. For example, you might have a variety of workers with
///          different amounts of cpu cores all sharing the same queue. The
///          queue may accept N-core operations, because N-core workers exist
///          in the pool, but there are additionally some lower core workers
///          that would need to forfeit running the operation. All the reasons
///          a worker may decide it can't take on the operation and should
///          give it back are implemented here. The settings provided allow
///          varying amount of leniency when evaluating the platform
///          properties.
```