### PR TITLE
[WorkerGracefullyShutdown implementation] make worker support gracefully shutdown behavior

### DIFF
--- a/src/main/java/build/buildfarm/admin/Admin.java
+++ b/src/main/java/build/buildfarm/admin/Admin.java
@@ -29,4 +29,6 @@ public interface Admin {
       Integer maxHosts,
       Integer targetHosts,
       Integer targetReservedHostsPercent);
+
+  void disableHostProtection(String scaleGroupName, String hostId);
 }

--- a/src/main/java/build/buildfarm/admin/aws/AwsAdmin.java
+++ b/src/main/java/build/buildfarm/admin/aws/AwsAdmin.java
@@ -21,6 +21,8 @@ import com.amazonaws.services.autoscaling.AmazonAutoScaling;
 import com.amazonaws.services.autoscaling.AmazonAutoScalingClientBuilder;
 import com.amazonaws.services.autoscaling.model.InstancesDistribution;
 import com.amazonaws.services.autoscaling.model.MixedInstancesPolicy;
+import com.amazonaws.services.autoscaling.model.SetInstanceProtectionRequest;
+import com.amazonaws.services.autoscaling.model.SetInstanceProtectionResult;
 import com.amazonaws.services.autoscaling.model.UpdateAutoScalingGroupRequest;
 import com.amazonaws.services.ec2.AmazonEC2;
 import com.amazonaws.services.ec2.AmazonEC2ClientBuilder;
@@ -147,5 +149,20 @@ public class AwsAdmin implements Admin {
   private long getHostUptimeInMinutes(Date launchTime) {
     Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
     return (cal.getTime().getTime() - launchTime.getTime()) / 60000;
+  }
+
+  @Override
+  public void disableHostProtection(String scaleGroupName, String hostId) {
+    SetInstanceProtectionRequest disableRequest =
+        new SetInstanceProtectionRequest()
+            .withInstanceIds(hostId)
+            .withAutoScalingGroupName(scaleGroupName)
+            .withProtectedFromScaleIn(false);
+    SetInstanceProtectionResult response = scale.setInstanceProtection(disableRequest);
+    logger.log(
+        Level.INFO,
+        String.format(
+            "Disable protection of host: %s in AutoScalingGroup: %s and get result: %s",
+            hostId, scaleGroupName, response.toString()));
   }
 }

--- a/src/main/java/build/buildfarm/admin/gcp/GcpAdmin.java
+++ b/src/main/java/build/buildfarm/admin/gcp/GcpAdmin.java
@@ -42,4 +42,9 @@ public class GcpAdmin implements Admin {
       Integer targetReservedHostsPercent) {
     throw new UnsupportedOperationException("Not Implemented.");
   }
+
+  @Override
+  public void disableHostProtection(String scaleGroupName, String hostId) {
+    throw new UnsupportedOperationException("Not Implemented.");
+  }
 }

--- a/src/main/java/build/buildfarm/instance/AbstractServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/AbstractServerInstance.java
@@ -66,6 +66,7 @@ import build.buildfarm.common.Write;
 import build.buildfarm.operations.EnrichedOperation;
 import build.buildfarm.operations.FindOperationsResults;
 import build.buildfarm.v1test.CompletedOperationMetadata;
+import build.buildfarm.v1test.DrainWorkerPipelineResults;
 import build.buildfarm.v1test.ExecutingOperationMetadata;
 import build.buildfarm.v1test.GetClientStartTimeResult;
 import build.buildfarm.v1test.QueuedOperation;
@@ -1698,6 +1699,12 @@ public abstract class AbstractServerInstance implements Instance {
   public WorkerListMessage getWorkerList() {
     throw new UnsupportedOperationException(
         "AbstractServerInstance doesn't support getWorkerList() method.");
+  }
+
+  @Override
+  public DrainWorkerPipelineResults drainWorkerPipeline(String worker) {
+    throw new UnsupportedOperationException(
+        "AbstractServerInstance doesn't support drainWorkerPipeline() method.");
   }
 
   @Override

--- a/src/main/java/build/buildfarm/instance/Instance.java
+++ b/src/main/java/build/buildfarm/instance/Instance.java
@@ -30,6 +30,7 @@ import build.buildfarm.common.DigestUtil.ActionKey;
 import build.buildfarm.common.EntryLimitException;
 import build.buildfarm.common.Watcher;
 import build.buildfarm.common.Write;
+import build.buildfarm.v1test.DrainWorkerPipelineResults;
 import build.buildfarm.v1test.GetClientStartTimeResult;
 import build.buildfarm.v1test.OperationsStatus;
 import build.buildfarm.v1test.QueueEntry;
@@ -142,6 +143,8 @@ public interface Instance {
   WorkerProfileMessage getWorkerProfile();
 
   WorkerListMessage getWorkerList();
+
+  DrainWorkerPipelineResults drainWorkerPipeline(String worker);
 
   GetClientStartTimeResult getClientStartTime(String clientKey);
 

--- a/src/main/java/build/buildfarm/instance/stub/StubInstance.java
+++ b/src/main/java/build/buildfarm/instance/stub/StubInstance.java
@@ -71,6 +71,8 @@ import build.buildfarm.v1test.AdminGrpc;
 import build.buildfarm.v1test.AdminGrpc.AdminBlockingStub;
 import build.buildfarm.v1test.DeregisterWorkerRequest;
 import build.buildfarm.v1test.DeregisterWorkerRequestResults;
+import build.buildfarm.v1test.DrainWorkerPipelineRequest;
+import build.buildfarm.v1test.DrainWorkerPipelineResults;
 import build.buildfarm.v1test.GetClientStartTimeResult;
 import build.buildfarm.v1test.OperationQueueGrpc;
 import build.buildfarm.v1test.OperationQueueGrpc.OperationQueueBlockingStub;
@@ -80,6 +82,8 @@ import build.buildfarm.v1test.PollOperationRequest;
 import build.buildfarm.v1test.QueueEntry;
 import build.buildfarm.v1test.ReindexCasRequest;
 import build.buildfarm.v1test.ReindexCasRequestResults;
+import build.buildfarm.v1test.ShutDownWorkerGracefullyGrpc;
+import build.buildfarm.v1test.ShutDownWorkerGracefullyGrpc.ShutDownWorkerGracefullyBlockingStub;
 import build.buildfarm.v1test.TakeOperationRequest;
 import build.buildfarm.v1test.Tree;
 import build.buildfarm.v1test.WorkerListMessage;
@@ -294,6 +298,16 @@ public class StubInstance implements Instance {
               return WorkerProfileGrpc.newBlockingStub(channel);
             }
           });
+
+  private final Supplier<ShutDownWorkerGracefullyBlockingStub>
+      ShutDownWorkerGracefullyBlockingStub =
+          Suppliers.memoize(
+              new Supplier<ShutDownWorkerGracefullyBlockingStub>() {
+                @Override
+                public ShutDownWorkerGracefullyBlockingStub get() {
+                  return ShutDownWorkerGracefullyGrpc.newBlockingStub(channel);
+                }
+              });
 
   private <T extends AbstractStub<T>> T deadlined(Supplier<T> getter) {
     T stub = getter.get();
@@ -852,5 +866,12 @@ public class StubInstance implements Instance {
             .get()
             .deregisterWorker(
                 DeregisterWorkerRequest.newBuilder().setWorkerName(workerName).build());
+  }
+
+  @Override
+  public DrainWorkerPipelineResults drainWorkerPipeline(String worker) {
+    throwIfStopped();
+    return ShutDownWorkerGracefullyBlockingStub.get()
+        .drainWorkerPipeline(DrainWorkerPipelineRequest.newBuilder().build());
   }
 }

--- a/src/main/java/build/buildfarm/worker/Pipeline.java
+++ b/src/main/java/build/buildfarm/worker/Pipeline.java
@@ -60,6 +60,23 @@ public class Pipeline {
     join(true);
   }
 
+  public boolean isEmpty() {
+    for (PipelineStage stage : stageClosePriorities.keySet()) {
+      if (stage instanceof SuperscalarPipelineStage) {
+        if (stage.isClaimed()) {
+          logger.log(Level.INFO, "SuperScalarPipelineStage is not empty yet!");
+          return false;
+        }
+      } else { // not SuperScalar
+        if (stage.claimed) {
+          logger.log(Level.INFO, "NonSuperScalarPipelineStage is not empty yet!");
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
   public void join() throws InterruptedException {
     synchronized (this) {
       joiningThread = Thread.currentThread();

--- a/src/main/java/build/buildfarm/worker/shard/ShutDownWorkerGracefully.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShutDownWorkerGracefully.java
@@ -1,0 +1,44 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.worker.shard;
+
+import build.buildfarm.v1test.DrainWorkerPipelineRequest;
+import build.buildfarm.v1test.DrainWorkerPipelineResults;
+import build.buildfarm.v1test.ShutDownWorkerGracefullyGrpc;
+import io.grpc.stub.StreamObserver;
+
+public class ShutDownWorkerGracefully
+    extends ShutDownWorkerGracefullyGrpc.ShutDownWorkerGracefullyImplBase {
+  private final Worker worker;
+
+  public ShutDownWorkerGracefully(Worker worker) {
+    this.worker = worker;
+  }
+
+  @Override
+  public void drainWorkerPipeline(
+      DrainWorkerPipelineRequest request,
+      StreamObserver<DrainWorkerPipelineResults> responseObserver) {
+    try {
+      responseObserver.onNext(
+          DrainWorkerPipelineResults.newBuilder()
+              .setIsPipelineEmpty(worker.shutDownWorkerGracefully())
+              .build());
+      responseObserver.onCompleted();
+    } catch (Exception e) {
+      responseObserver.onError(e);
+    }
+  }
+}

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -239,7 +239,6 @@ public class Worker extends LoggingMain {
       return false;
     }
     logger.log(Level.INFO, "The worker Pipeline is empty now!");
-    // turn off auto scaling protection here
     return true;
   }
 

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -112,6 +112,8 @@ public class Worker extends LoggingMain {
   private static final int shutdownWaitTimeInSeconds = 10;
   private final boolean isCasShard;
 
+  private boolean isDeregistered = false;
+
   private final ShardWorkerConfig config;
   private final ShardWorkerInstance instance;
   private final HealthStatusManager healthStatusManager;
@@ -222,6 +224,23 @@ public class Worker extends LoggingMain {
 
   public Worker(String session, ShardWorkerConfig config) throws ConfigurationException {
     this(session, ServerBuilder.forPort(config.getPort()), config);
+  }
+
+  public boolean shutDownWorkerGracefully() {
+    isDeregistered = true;
+    logger.log(Level.INFO, "The current worker is deregistered and should be shutdown gracefully!");
+
+    try {
+      while (!pipeline.isEmpty()) {
+        SECONDS.sleep(10);
+      }
+    } catch (InterruptedException e) {
+      logger.log(Level.SEVERE, "The worker gracefully shutdown is interrupted: " + e.getMessage());
+      return false;
+    }
+    logger.log(Level.INFO, "The worker Pipeline is empty now!");
+    // turn off auto scaling protection here
+    return true;
   }
 
   private static Path getValidRoot(ShardWorkerConfig config) throws ConfigurationException {
@@ -391,6 +410,7 @@ public class Worker extends LoggingMain {
                     context,
                     completeStage,
                     backplane))
+            .addService(new ShutDownWorkerGracefully(this))
             .build();
 
     logger.log(INFO, String.format("%s initialized", identifier));
@@ -790,7 +810,7 @@ public class Worker extends LoggingMain {
 
               void registerIfExpired() {
                 long now = System.currentTimeMillis();
-                if (now >= workerRegistrationExpiresAt) {
+                if (now >= workerRegistrationExpiresAt && !isDeregistered) {
                   // worker must be registered to match
                   addWorker(nextRegistration(now));
                   // update every 10 seconds

--- a/src/main/java/build/buildfarm/worker/shard/WorkerProfileService.java
+++ b/src/main/java/build/buildfarm/worker/shard/WorkerProfileService.java
@@ -16,7 +16,7 @@ package build.buildfarm.worker.shard;
 
 import build.buildfarm.cas.ContentAddressableStorage;
 import build.buildfarm.cas.cfc.CASFileCache;
-import build.buildfarm.common.ShardBackplane;
+import build.buildfarm.instance.shard.ShardBackplane;
 import build.buildfarm.v1test.OperationTimesBetweenStages;
 import build.buildfarm.v1test.StageInformation;
 import build.buildfarm.v1test.WorkerListMessage;

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -1016,3 +1016,18 @@ service WorkerProfile {
 
   rpc GetWorkerList(WorkerListRequest) returns (WorkerListMessage) {}
 }
+
+message DrainWorkerPipelineRequest {
+  string instance_name = 1;
+
+  string worker_name = 2;
+}
+
+message DrainWorkerPipelineResults {
+  bool is_pipeline_empty = 1;
+}
+
+
+service ShutDownWorkerGracefully {
+  rpc DrainWorkerPipeline(DrainWorkerPipelineRequest) returns (DrainWorkerPipelineResults) {}
+}

--- a/src/test/java/build/buildfarm/instance/AbstractServerInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/AbstractServerInstanceTest.java
@@ -39,8 +39,11 @@ import build.buildfarm.common.TreeIterator.DirectoryEntry;
 import build.buildfarm.common.Watcher;
 import build.buildfarm.common.Write;
 import build.buildfarm.operations.FindOperationsResults;
+import build.buildfarm.v1test.DrainWorkerPipelineResults;
 import build.buildfarm.v1test.GetClientStartTimeResult;
 import build.buildfarm.v1test.OperationsStatus;
+import build.buildfarm.v1test.WorkerListMessage;
+import build.buildfarm.v1test.WorkerProfileMessage;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -179,6 +182,21 @@ public class AbstractServerInstanceTest {
 
     @Override
     public void deregisterWorker(String workerName) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public WorkerProfileMessage getWorkerProfile() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public WorkerListMessage getWorkerList() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public DrainWorkerPipelineResults drainWorkerPipeline(String worker) {
       throw new UnsupportedOperationException();
     }
   }


### PR DESCRIPTION
The pr implements another piece of worker gracefully shutdown, which corresponds to `Finish Executions` and `Disable EC2 Scale Protection`. 

Worker Gracefully Shutdown essentially means that an on-demand worker should finish all of its ongoing actions, including actions on any stages, before it gets scaled in. To achieve that, all worker instances/hosts will have the scale in protection when they are started. When a worker host/instnce is chosen to be scaled in, its protection will be disabled when it's confirmed the worker's pipeline is empty.

![workergracefullyshutdown](https://user-images.githubusercontent.com/54453872/101796481-f30c1600-3ad6-11eb-91ed-e70442706e1c.png)
