### PR TITLE
Fix server hanging during startup on Redis error

### DIFF
--- a/src/main/java/build/buildfarm/server/BuildFarmServer.java
+++ b/src/main/java/build/buildfarm/server/BuildFarmServer.java
@@ -136,7 +136,11 @@ public class BuildFarmServer extends LoggingMain {
     }
   }
 
-  public void start(String publicName) throws IOException {
+  public synchronized void start(String publicName) throws IOException {
+    if (stopping) {
+      logger.log(Level.WARNING, "already stopping, skipping start");
+      return;
+    }
     actionCacheRequestCounter.start();
     instances.start(publicName);
     server.start();

--- a/src/main/java/build/buildfarm/server/BuildFarmServer.java
+++ b/src/main/java/build/buildfarm/server/BuildFarmServer.java
@@ -15,6 +15,7 @@
 package build.buildfarm.server;
 
 import static build.buildfarm.common.io.Utils.formatIOError;
+import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.util.concurrent.MoreExecutors.shutdownAndAwaitTermination;
 import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
 import static java.util.logging.Level.SEVERE;
@@ -137,10 +138,7 @@ public class BuildFarmServer extends LoggingMain {
   }
 
   public synchronized void start(String publicName) throws IOException {
-    if (stopping) {
-      logger.log(Level.WARNING, "already stopping, skipping start");
-      return;
-    }
+    checkState(!stopping, "must not call start after stop");
     actionCacheRequestCounter.start();
     instances.start(publicName);
     server.start();


### PR DESCRIPTION
Fixes #623.

---

There is a race condition in BuildFarmServer.start(): if redis fails
before BuildFarmServer.start() has finished, a callback will end up
triggering BuildFarmServer.stop(), causing the server to hang.

In BuildFarmServer.start(), [instances.start()][1] starts a new thread.

If [RedisShardSubscription.iterate()][2] throws an IOException, the
[onUnsubscribe callback][3] will trigger. In the end, this calls
[BuildFarmServer.stop()][4]. If stop() is called before start() has
finished, the server hangs.

A fix is to make start() synchronized.

[1]: https://github.com/bazelbuild/bazel-buildfarm/blob/4104ed9c97e9cea0b1e5125e3511146de00fc038/src/main/java/build/buildfarm/server/BuildFarmServer.java#L141
[2]: https://github.com/bazelbuild/bazel-buildfarm/blob/4104ed9c97e9cea0b1e5125e3511146de00fc038/src/main/java/build/buildfarm/instance/shard/RedisShardSubscription.java#L69-L84
[3]: https://github.com/bazelbuild/bazel-buildfarm/blob/4104ed9c97e9cea0b1e5125e3511146de00fc038/src/main/java/build/buildfarm/instance/shard/RedisShardSubscription.java#L110
[4]: https://github.com/bazelbuild/bazel-buildfarm/blob/4104ed9c97e9cea0b1e5125e3511146de00fc038/src/main/java/build/buildfarm/server/BuildFarmServer.java#L80-L81