### PR TITLE
Use dispatch timeout configuration

### DIFF
--- a/examples/shard-server.config.example
+++ b/examples/shard-server.config.example
@@ -153,7 +153,7 @@ instances {
       # milliseconds after which the operation is considered lost.
       dispatching_prefix: "Dispatching"
 
-      # The delay in milliseconds used to populate dispathing operation
+      # The delay in milliseconds used to populate dispatching operation
       # entries
       dispatching_timeout_millis: 10000
 

--- a/examples/shard-server.config.example
+++ b/examples/shard-server.config.example
@@ -147,13 +147,6 @@ instances {
       # dispatching_list_name.
       queued_operations_list_name: "{Execution}:QueuedOperations"
 
-      # The redis key of a list used to ensure reliable processing of
-      # ready-to-run queue entries together with operation watch
-      # monitoring.
-      # The string contained within {} must match that of
-      # queued_operations_list_name.
-      dispatching_list_name: "{Execution}:DispatchingOperations"
-
       # A redis key prefix for operations which are being dequeued
       # from the ready-to-run queue. The key is suffixed with the
       # operation name and contains the expiration time in epoch

--- a/examples/shard-worker.config.example
+++ b/examples/shard-worker.config.example
@@ -191,13 +191,6 @@ redis_shard_backplane_config: {
   # dispatching_list_name.
   queued_operations_list_name: "{Execution}:QueuedOperations"
 
-  # The redis key of a list used to ensure reliable processing of
-  # ready-to-run queue entries together with operation watch
-  # monitoring.
-  # The string contained within {} must match that of
-  # queued_operations_list_name.
-  dispatching_list_name: "{Execution}:DispatchingOperations"
-
   # A redis key prefix for operations which are being dequeued
   # from the ready-to-run queue. The key is suffixed with the
   # operation name and contains the expiration time in epoch

--- a/examples/shard-worker.config.example
+++ b/examples/shard-worker.config.example
@@ -197,7 +197,7 @@ redis_shard_backplane_config: {
   # milliseconds after which the operation is considered lost.
   dispatching_prefix: "Dispatching"
 
-  # The delay in milliseconds used to populate dispathing operation
+  # The delay in milliseconds used to populate dispatching operation
   # entries
   dispatching_timeout_millis: 10000
 

--- a/src/main/java/build/buildfarm/instance/shard/DispatchedMonitor.java
+++ b/src/main/java/build/buildfarm/instance/shard/DispatchedMonitor.java
@@ -49,11 +49,8 @@ class DispatchedMonitor implements Runnable {
   private ListenableFuture<Void> requeueDispatchedOperation(DispatchedOperation o, long now) {
     QueueEntry queueEntry = o.getQueueEntry();
     String operationName = queueEntry.getExecuteEntry().getOperationName();
-    logger.log(
-        Level.INFO,
-        format(
-            "DispatchedMonitor: Testing %s because %d >= %d",
-            operationName, now, o.getRequeueAt()));
+
+    logOverdueOperation(o, now);
     ListenableFuture<Void> requeuedFuture = requeuer.apply(queueEntry);
     long startTime = System.nanoTime();
     requeuedFuture.addListener(
@@ -67,13 +64,26 @@ class DispatchedMonitor implements Runnable {
     return requeuedFuture;
   }
 
+  private void logOverdueOperation(DispatchedOperation o, long now) {
+
+    // log that the dispatched operation is overdue in order to indicate that it should be requeued.
+    String operationName = o.getQueueEntry().getExecuteEntry().getOperationName();
+    long overdue_amount = now - o.getRequeueAt();
+    StringBuilder message = new StringBuilder();
+    message.append(
+        String.format(
+            "DispatchedMonitor: Testing %s because %dms overdue (%d >= %d)",
+            operationName, overdue_amount, now, o.getRequeueAt()));
+    logger.log(Level.INFO, message.toString());
+  }
+
   private void testDispatchedOperations(
       long now,
       Iterable<DispatchedOperation> dispatchedOperations,
       ImmutableList.Builder<ListenableFuture<Void>> requeuedFutures) {
-    /* iterate over dispatched */
+
+    // requeue all operations that are over their dispatched duration time
     for (DispatchedOperation o : dispatchedOperations) {
-      /* if now > dispatchedOperation.getExpiresAt() */
       if (now >= o.getRequeueAt()) {
         requeuedFutures.add(requeueDispatchedOperation(o, now));
       }

--- a/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
@@ -1181,7 +1181,7 @@ public class RedisShardBackplane implements ShardBackplane {
     Operation operation = keepaliveOperation(operationName);
     publishReset(jedis, operation);
 
-    long requeueAt = System.currentTimeMillis() + 30 * 1000;
+    long requeueAt = System.currentTimeMillis() + config.getDispatchingTimeoutMillis();
     DispatchedOperation o =
         DispatchedOperation.newBuilder().setQueueEntry(queueEntry).setRequeueAt(requeueAt).build();
     boolean success = false;

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -431,9 +431,6 @@ message RedisShardBackplaneConfig {
   // the ready-to-run operation queue. Contains QueueEntry messages
   string queued_operations_list_name = 7;
 
-  // the atomic target list for reliable ready-to-run queue removal
-  string dispatching_list_name = 22;
-
   // the prefix of the dispatching list timeout monitor key
   string dispatching_prefix = 23;
 


### PR DESCRIPTION
**Configuration changes:**
`dispatching_list_name` is not being used anywhere in the code right now.  Let's remove it.
`dispatching_timeout_millis` is also not being used anywhere in the code.  Let's use it in place of the hard-coded value.

**For users:**
Existing configurations will need to remove `dispatching_list_name`, and set an appropriate `dispatching_timeout_millis`
(`dispatching_timeout_millis: 30000` can be used to restore the same behavior).