### PR TITLE
make actionCache an explicit object in backplane

### DIFF
--- a/src/main/java/build/buildfarm/common/redis/RedisMap.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisMap.java
@@ -83,6 +83,17 @@ public class RedisMap {
     p.sync();
   }
   ///
+  /// @brief   Get the value of the key.
+  /// @details If the key does not exist, null is returned.
+  /// @param   jedis Jedis cluster client.
+  /// @param   key   The name of the key.
+  /// @return  The value of the key. null if key does not exist.
+  /// @note    Suggested return identifier: value.
+  ///
+  public String get(JedisCluster jedis, String key) {
+    return jedis.get(createKeyName(key));
+  }
+  ///
   /// @brief   Create the key name used in redis.
   /// @details The key name is made more unique by leveraging the map's name.
   /// @param   keyName The name of the key.

--- a/src/main/java/build/buildfarm/common/redis/RedisMap.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisMap.java
@@ -1,0 +1,47 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.common.redis;
+
+
+///
+/// @class   RedisMap
+/// @brief   A redis map.
+/// @details A redis map is an implementation of a map data structure which
+///          internally uses redis to store and distribute the data. Its
+///          important to know that the lifetime of the map persists before
+///          and after the map data structure is created (since it exists in
+///          redis). Therefore, two redis maps with the same name, would in
+///          fact be the same underlying redis map.
+///
+public class RedisMap {
+
+  ///
+  /// @field   name
+  /// @brief   The unique name of the map.
+  /// @details The name is used by the redis cluster client to access the map
+  ///          data. If two maps had the same name, they would be instances of
+  ///          the same underlying redis map.
+  ///
+  private final String name;
+
+  ///
+  /// @brief   Constructor.
+  /// @details Construct a named redis map with an established redis cluster.
+  /// @param   name The global name of the map.
+  ///
+  public RedisMap(String name) {
+    this.name = name;
+  }
+}

--- a/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
@@ -811,7 +811,7 @@ public class RedisShardBackplane implements ShardBackplane {
   }
 
   private void removeActionResult(JedisCluster jedis, ActionKey actionKey) {
-    actionCache.remove(jedis,asDigestStr(actionKey));
+    actionCache.remove(jedis, asDigestStr(actionKey));
   }
 
   @Override

--- a/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
@@ -822,8 +822,8 @@ public class RedisShardBackplane implements ShardBackplane {
   @Override
   public void removeActionResults(Iterable<ActionKey> actionKeys) throws IOException {
 
+    // convert action keys to strings
     List<String> keyNames = new ArrayList<String>();
-
     actionKeys.forEach(
         key -> {
           keyNames.add(asDigestStr(key));

--- a/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
@@ -33,6 +33,7 @@ import build.buildfarm.common.WorkerIndexer;
 import build.buildfarm.common.function.InterruptingRunnable;
 import build.buildfarm.common.redis.BalancedRedisQueue;
 import build.buildfarm.common.redis.ProvisionedRedisQueue;
+import build.buildfarm.common.redis.RedisMap;
 import build.buildfarm.common.redis.RedisClient;
 import build.buildfarm.common.redis.RedisHashtags;
 import build.buildfarm.common.redis.RedisNodeHashes;

--- a/src/test/java/build/buildfarm/BUILD
+++ b/src/test/java/build/buildfarm/BUILD
@@ -473,6 +473,7 @@ java_test(
         "common/redis/ProvisionedRedisQueueTest.java",
         "common/redis/RedisNodeHashesMockTest.java",
         "common/redis/RedisQueueMockTest.java",
+        "common/redis/RedisMapMockTest.java",
         "common/redis/RedisSlotToHashTest.java",
     ],
     test_class = "build.buildfarm.AllTests",

--- a/src/test/java/build/buildfarm/common/redis/RedisMapMockTest.java
+++ b/src/test/java/build/buildfarm/common/redis/RedisMapMockTest.java
@@ -1,0 +1,43 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.common.redis;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+///
+/// @class   RedisMapMockTest
+/// @brief   tests A redis map.
+/// @details A redis map is an implementation of a map data structure which
+///          internally uses redis to store and distribute the data. Its
+///          important to know that the lifetime of the map persists before
+///          and after the map data structure is created (since it exists in
+///          redis). Therefore, two redis maps with the same name, would in
+///          fact be the same underlying redis map.
+///
+@RunWith(JUnit4.class)
+public class RedisMapMockTest {
+
+  // Function under test: redisMap
+  // Reason for testing: the map can be constructed with a valid cluster instance and name
+  // Failure explanation: the map is throwing an exception upon construction
+  @Test
+  public void redisMapConstructsWithoutError() throws Exception {
+
+    // ARRANGE
+    RedisMap map = new RedisMap("test");
+  }
+}

--- a/src/test/java/build/buildfarm/common/redis/RedisMapMockTest.java
+++ b/src/test/java/build/buildfarm/common/redis/RedisMapMockTest.java
@@ -14,9 +14,11 @@
 
 package build.buildfarm.common.redis;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -79,5 +81,25 @@ public class RedisMapMockTest {
 
     // ASSERT
     verify(redis, times(1)).del("test:key");
+  }
+
+  // Function under test: get
+  // Reason for testing: test how an element is looked up in a map
+  // Failure explanation: jedis was not called as expected
+  @Test
+  public void getGet() throws Exception {
+
+    // ARRANGE
+    JedisCluster redis = mock(JedisCluster.class);
+    when(redis.get("test:key")).thenReturn("value");
+    RedisMap map = new RedisMap("test");
+
+    // ACT
+    map.insert(redis, "key", "value", 60);
+    String value = map.get(redis, "key");
+
+    // ASSERT
+    verify(redis, times(1)).get("test:key");
+    assertThat(value).isEqualTo("value");
   }
 }

--- a/src/test/java/build/buildfarm/common/redis/RedisMapMockTest.java
+++ b/src/test/java/build/buildfarm/common/redis/RedisMapMockTest.java
@@ -14,9 +14,14 @@
 
 package build.buildfarm.common.redis;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import redis.clients.jedis.JedisCluster;
 
 ///
 /// @class   RedisMapMockTest
@@ -39,5 +44,40 @@ public class RedisMapMockTest {
 
     // ARRANGE
     RedisMap map = new RedisMap("test");
+  }
+
+  // Function under test: insert
+  // Reason for testing: test how an element is added to a map
+  // Failure explanation: jedis was not called as expected
+  @Test
+  public void insertInsert() throws Exception {
+
+    // ARRANGE
+    JedisCluster redis = mock(JedisCluster.class);
+    RedisMap map = new RedisMap("test");
+
+    // ACT
+    map.insert(redis, "key", "value", 60);
+
+    // ASSERT
+    verify(redis, times(1)).setex("test:key", 60, "value");
+  }
+
+  // Function under test: remove
+  // Reason for testing: test how an element is removed to a map
+  // Failure explanation: jedis was not called as expected
+  @Test
+  public void removeRemove() throws Exception {
+
+    // ARRANGE
+    JedisCluster redis = mock(JedisCluster.class);
+    RedisMap map = new RedisMap("test");
+
+    // ACT
+    map.insert(redis, "key", "value", 60);
+    map.remove(redis, "key");
+
+    // ASSERT
+    verify(redis, times(1)).del("test:key");
   }
 }


### PR DESCRIPTION
The prequeue/queue appear in the backplane as explicit containers.  This was done to make tracing code and extending the queue functionality easier.  We now want to do the same thing for the action cache.  

We create a map abstraction to represent the key/value format of the action cache and re-integrate it into the backplane.
This data structure will be later used for similar patterns found in the backplane.

**from internal convo:**
By "container", I mean the java class `RedisMap`.
By "object" I mean a named instantiation of this map: `RedisMap actionCache = newRedisMap("name");`