### PR TITLE
backplane: choosing workers for shutdown

### DIFF
--- a/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
@@ -716,10 +716,8 @@ public class RedisShardBackplane implements ShardBackplane {
   }
 
   // When performing a graceful scale down of workers, the backplane can provide worker names to the
-  // scale-down service.
-  // The algorithm in which the backplane chooses these workers can be made more sophisticated in
-  // the future.
-  // But for now, we'll give back n random workers.
+  // scale-down service. The algorithm in which the backplane chooses these workers can be made more
+  // sophisticated in the future. But for now, we'll give back n random workers.
   public List<String> SuggestedWorkersForShutdown(int amount) throws IOException {
 
     // get all workers

--- a/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
@@ -718,17 +718,17 @@ public class RedisShardBackplane implements ShardBackplane {
   // When performing a graceful scale down of workers, the backplane can provide worker names to the
   // scale-down service. The algorithm in which the backplane chooses these workers can be made more
   // sophisticated in the future. But for now, we'll give back n random workers.
-  public List<String> SuggestedWorkersForShutdown(int amount) throws IOException {
+  public List<String> suggestedWorkersToScaleDown(int numWorkers) throws IOException {
 
     // get all workers
     List<String> allWorkers = new ArrayList<String>();
     allWorkers.addAll(getWorkers());
 
     // ensure selection amount is in range [0 - size]
-    amount = Math.max(0, Math.min(amount, allWorkers.size()));
+    numWorkers = Math.max(0, Math.min(numWorkers, allWorkers.size()));
 
     // select n workers
-    return randomN(allWorkers, amount);
+    return randomN(allWorkers, numWorkers);
   }
 
   public static <T> List<T> randomN(List<T> list, int n) {


### PR DESCRIPTION
This is added for our "graceful worker shutdown" functionality.  A scale down service will decide how many workers it wants to shutdown and ask the backplane to provide those worker names.