### PR TITLE
configure max cpu for action validation

### DIFF
--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -497,6 +497,8 @@ message ShardInstanceConfig {
   }
 
   int64 max_blob_size = 5;
+  
+  int32 max_cpu = 9;
 
   // maximum selectable timeout
   // a maximum threshold for an action's specified timeout,

--- a/src/test/java/build/buildfarm/instance/shard/ShardInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/shard/ShardInstanceTest.java
@@ -137,6 +137,7 @@ public class ShardInstanceTest {
             /* dispatchedMonitorIntervalSeconds=*/ 0,
             /* runOperationQueuer=*/ false,
             /* maxBlobSize=*/ 0,
+            /* maxCpu=*/ 1,
             /* maxActionTimeout=*/ Duration.getDefaultInstance(),
             mockOnStop,
             CacheBuilder.newBuilder().build(mockInstanceLoader),


### PR DESCRIPTION
Users should set an appropriate value for `maxCpu`.
```
ShardInstanceConfig {
    max_cpu: 80
}