### PR TITLE
expose worker graceful shutdown endpoint on server

### DIFF
--- a/src/main/java/build/buildfarm/instance/AbstractServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/AbstractServerInstance.java
@@ -69,9 +69,9 @@ import build.buildfarm.operations.FindOperationsResults;
 import build.buildfarm.v1test.CompletedOperationMetadata;
 import build.buildfarm.v1test.ExecutingOperationMetadata;
 import build.buildfarm.v1test.GetClientStartTimeResult;
+import build.buildfarm.v1test.PrepareWorkerForGracefulShutDownRequestResults;
 import build.buildfarm.v1test.QueuedOperation;
 import build.buildfarm.v1test.QueuedOperationMetadata;
-import build.buildfarm.v1test.ShutDownWorkerGracefullyResults;
 import build.buildfarm.v1test.Tree;
 import build.buildfarm.v1test.WorkerListMessage;
 import build.buildfarm.v1test.WorkerProfileMessage;
@@ -1731,7 +1731,7 @@ public abstract class AbstractServerInstance implements Instance {
   }
 
   @Override
-  public ShutDownWorkerGracefullyResults shutDownWorkerGracefully(String worker) {
+  public PrepareWorkerForGracefulShutDownRequestResults shutDownWorkerGracefully(String worker) {
     throw new UnsupportedOperationException(
         "AbstractServerInstance doesn't support drainWorkerPipeline() method.");
   }

--- a/src/main/java/build/buildfarm/instance/Instance.java
+++ b/src/main/java/build/buildfarm/instance/Instance.java
@@ -32,8 +32,8 @@ import build.buildfarm.common.Watcher;
 import build.buildfarm.common.Write;
 import build.buildfarm.v1test.GetClientStartTimeResult;
 import build.buildfarm.v1test.OperationsStatus;
+import build.buildfarm.v1test.PrepareWorkerForGracefulShutDownRequestResults;
 import build.buildfarm.v1test.QueueEntry;
-import build.buildfarm.v1test.ShutDownWorkerGracefullyResults;
 import build.buildfarm.v1test.Tree;
 import build.buildfarm.v1test.WorkerListMessage;
 import build.buildfarm.v1test.WorkerProfileMessage;
@@ -144,7 +144,7 @@ public interface Instance {
 
   WorkerListMessage getWorkerList();
 
-  ShutDownWorkerGracefullyResults shutDownWorkerGracefully(String worker);
+  PrepareWorkerForGracefulShutDownRequestResults shutDownWorkerGracefully(String worker);
 
   GetClientStartTimeResult getClientStartTime(String clientKey);
 

--- a/src/main/java/build/buildfarm/instance/stub/StubInstance.java
+++ b/src/main/java/build/buildfarm/instance/stub/StubInstance.java
@@ -69,19 +69,19 @@ import build.buildfarm.common.grpc.StubWriteOutputStream;
 import build.buildfarm.instance.Instance;
 import build.buildfarm.v1test.AdminGrpc;
 import build.buildfarm.v1test.AdminGrpc.AdminBlockingStub;
-import build.buildfarm.v1test.DeregisterWorkerRequest;
-import build.buildfarm.v1test.DeregisterWorkerRequestResults;
 import build.buildfarm.v1test.GetClientStartTimeResult;
 import build.buildfarm.v1test.OperationQueueGrpc;
 import build.buildfarm.v1test.OperationQueueGrpc.OperationQueueBlockingStub;
 import build.buildfarm.v1test.OperationsStatus;
 import build.buildfarm.v1test.OperationsStatusRequest;
 import build.buildfarm.v1test.PollOperationRequest;
+import build.buildfarm.v1test.PrepareWorkerForGracefulShutDownRequest;
+import build.buildfarm.v1test.PrepareWorkerForGracefulShutDownRequestResults;
 import build.buildfarm.v1test.QueueEntry;
 import build.buildfarm.v1test.ReindexCasRequest;
 import build.buildfarm.v1test.ReindexCasRequestResults;
 import build.buildfarm.v1test.ShutDownWorkerGracefullyRequest;
-import build.buildfarm.v1test.ShutDownWorkerGracefullyResults;
+import build.buildfarm.v1test.ShutDownWorkerGracefullyRequestResults;
 import build.buildfarm.v1test.ShutDownWorkerGrpc;
 import build.buildfarm.v1test.ShutDownWorkerGrpc.ShutDownWorkerBlockingStub;
 import build.buildfarm.v1test.TakeOperationRequest;
@@ -860,18 +860,19 @@ public class StubInstance implements Instance {
   @Override
   public void deregisterWorker(String workerName) {
     throwIfStopped();
-    DeregisterWorkerRequestResults proto =
+    ShutDownWorkerGracefullyRequestResults proto =
         adminBlockingStub
             .get()
-            .deregisterWorker(
-                DeregisterWorkerRequest.newBuilder().setWorkerName(workerName).build());
+            .shutDownWorkerGracefully(
+                ShutDownWorkerGracefullyRequest.newBuilder().setWorkerName(workerName).build());
   }
 
   @Override
-  public ShutDownWorkerGracefullyResults shutDownWorkerGracefully(String worker) {
+  public PrepareWorkerForGracefulShutDownRequestResults shutDownWorkerGracefully(String worker) {
     throwIfStopped();
     return shutDownWorkerBlockingStub
         .get()
-        .shutDownWorkerGracefully(ShutDownWorkerGracefullyRequest.newBuilder().build());
+        .prepareWorkerForGracefulShutdown(
+            PrepareWorkerForGracefulShutDownRequest.newBuilder().build());
   }
 }

--- a/src/main/java/build/buildfarm/server/AdminService.java
+++ b/src/main/java/build/buildfarm/server/AdminService.java
@@ -23,8 +23,6 @@ import build.buildfarm.common.CasIndexResults;
 import build.buildfarm.instance.Instance;
 import build.buildfarm.v1test.AdminConfig;
 import build.buildfarm.v1test.AdminGrpc;
-import build.buildfarm.v1test.DeregisterWorkerRequest;
-import build.buildfarm.v1test.DeregisterWorkerRequestResults;
 import build.buildfarm.v1test.DisableScaleInProtectionRequest;
 import build.buildfarm.v1test.DisableScaleInProtectionRequestResults;
 import build.buildfarm.v1test.GetClientStartTimeRequest;
@@ -34,6 +32,8 @@ import build.buildfarm.v1test.GetHostsResult;
 import build.buildfarm.v1test.ReindexCasRequest;
 import build.buildfarm.v1test.ReindexCasRequestResults;
 import build.buildfarm.v1test.ScaleClusterRequest;
+import build.buildfarm.v1test.ShutDownWorkerGracefullyRequest;
+import build.buildfarm.v1test.ShutDownWorkerGracefullyRequestResults;
 import build.buildfarm.v1test.StopContainerRequest;
 import build.buildfarm.v1test.TerminateHostRequest;
 import com.google.rpc.Code;
@@ -164,21 +164,20 @@ public class AdminService extends AdminGrpc.AdminImplBase {
   }
 
   @Override
-  public void deregisterWorker(
-      DeregisterWorkerRequest request,
-      StreamObserver<DeregisterWorkerRequestResults> responseObserver) {
-    Instance instance;
+  public void shutDownWorkerGracefully(
+      ShutDownWorkerGracefullyRequest request,
+      StreamObserver<ShutDownWorkerGracefullyRequestResults> responseObserver) {
     try {
-      instance = instances.get(request.getInstanceName());
-      instance.deregisterWorker(request.getWorkerName());
-      responseObserver.onNext(DeregisterWorkerRequestResults.newBuilder().build());
+      ShutDownWorker.informWorkerToPrepareForShutdown(request.getWorkerName());
+      responseObserver.onNext(ShutDownWorkerGracefullyRequestResults.newBuilder().build());
       responseObserver.onCompleted();
     } catch (Exception e) {
-      logger.log(
-          Level.SEVERE,
-          String.format("Could not deregister worker: %s", request.getWorkerName()),
-          e);
-      responseObserver.onError(io.grpc.Status.fromThrowable(e).asException());
+      String errorMessage =
+          String.format(
+              "Could not inform the worker %s to prepare for graceful shutdown with error %s.",
+              request.getWorkerName(), e.getMessage());
+      logger.log(Level.SEVERE, errorMessage);
+      responseObserver.onError(new Exception(errorMessage));
     }
   }
 

--- a/src/main/java/build/buildfarm/server/AdminService.java
+++ b/src/main/java/build/buildfarm/server/AdminService.java
@@ -163,6 +163,13 @@ public class AdminService extends AdminGrpc.AdminImplBase {
     }
   }
 
+  /**
+   * Server-side implementation of ShutDownWorkerGracefully. This will reroute the request to target
+   * worker.
+   *
+   * @param request ShutDownWorkerGracefullyRequest received through grpc
+   * @param responseObserver grpc response observer
+   */
   @Override
   public void shutDownWorkerGracefully(
       ShutDownWorkerGracefullyRequest request,
@@ -182,7 +189,7 @@ public class AdminService extends AdminGrpc.AdminImplBase {
   }
 
   /**
-   * Server-side implementation of disableScaleProtection.
+   * Server-side implementation of disableScaleInProtection.
    *
    * @param request grpc request
    * @param responseObserver grpc response observer

--- a/src/main/java/build/buildfarm/server/ShutDownWorker.java
+++ b/src/main/java/build/buildfarm/server/ShutDownWorker.java
@@ -1,0 +1,40 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.server;
+
+import build.buildfarm.v1test.PrepareWorkerForGracefulShutDownRequest;
+import build.buildfarm.v1test.ShutDownWorkerGrpc;
+import io.grpc.ManagedChannel;
+import io.grpc.netty.NegotiationType;
+import io.grpc.netty.NettyChannelBuilder;
+import java.util.logging.Logger;
+
+class ShutDownWorker {
+  private static final Logger logger = Logger.getLogger(ShutDownWorker.class.getName());
+
+  private static ManagedChannel createChannel(String target) {
+    NettyChannelBuilder builder =
+        NettyChannelBuilder.forTarget(target).negotiationType(NegotiationType.PLAINTEXT);
+    return builder.build();
+  }
+
+  public static void informWorkerToPrepareForShutdown(String host) {
+    ManagedChannel channel = createChannel(host);
+    ShutDownWorkerGrpc.ShutDownWorkerBlockingStub shutDownWorkerBlockingStub =
+        ShutDownWorkerGrpc.newBlockingStub(channel);
+    shutDownWorkerBlockingStub.prepareWorkerForGracefulShutdown(
+        PrepareWorkerForGracefulShutDownRequest.newBuilder().build());
+  }
+}

--- a/src/main/java/build/buildfarm/worker/shard/AdminServiceClient.java
+++ b/src/main/java/build/buildfarm/worker/shard/AdminServiceClient.java
@@ -16,8 +16,6 @@ package build.buildfarm.worker.shard;
 
 import build.buildfarm.v1test.AdminGrpc;
 import build.buildfarm.v1test.DisableScaleInProtectionRequest;
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import io.grpc.ManagedChannel;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
@@ -29,22 +27,10 @@ class AdminServiceClient {
     return builder.build();
   }
 
-  private static ManagedChannel channel;
-
-  private static final Supplier<AdminGrpc.AdminBlockingStub> adminBlockingStub =
-      Suppliers.memoize(
-          new Supplier<AdminGrpc.AdminBlockingStub>() {
-            @Override
-            public AdminGrpc.AdminBlockingStub get() {
-              return AdminGrpc.newBlockingStub(channel);
-            }
-          });
-
   public static void disableScaleInProtection(String host, String instanceIp) {
-    channel = createChannel(host);
-    adminBlockingStub
-        .get()
-        .disableScaleInProtection(
-            DisableScaleInProtectionRequest.newBuilder().setInstanceName(instanceIp).build());
+    ManagedChannel channel = createChannel(host);
+    AdminGrpc.AdminBlockingStub adminBlockingStub = AdminGrpc.newBlockingStub(channel);
+    adminBlockingStub.disableScaleInProtection(
+        DisableScaleInProtectionRequest.newBuilder().setInstanceName(instanceIp).build());
   }
 }

--- a/src/main/java/build/buildfarm/worker/shard/ShutDownWorkerGracefully.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShutDownWorkerGracefully.java
@@ -16,17 +16,15 @@ package build.buildfarm.worker.shard;
 
 import static java.util.logging.Level.WARNING;
 
+import build.buildfarm.v1test.PrepareWorkerForGracefulShutDownRequest;
+import build.buildfarm.v1test.PrepareWorkerForGracefulShutDownRequestResults;
 import build.buildfarm.v1test.ShardWorkerConfig;
-import build.buildfarm.v1test.ShutDownWorkerGracefullyRequest;
-import build.buildfarm.v1test.ShutDownWorkerGracefullyResults;
 import build.buildfarm.v1test.ShutDownWorkerGrpc;
 import io.grpc.stub.StreamObserver;
 import java.util.concurrent.CompletableFuture;
 import java.util.logging.Logger;
 
 public class ShutDownWorkerGracefully extends ShutDownWorkerGrpc.ShutDownWorkerImplBase {
-  private static final java.util.logging.Logger nettyLogger =
-      java.util.logging.Logger.getLogger("io.grpc.netty");
   private static final Logger logger = Logger.getLogger(ShutDownWorkerGracefully.class.getName());
   private final Worker worker;
   private final ShardWorkerConfig config;
@@ -43,9 +41,9 @@ public class ShutDownWorkerGracefully extends ShutDownWorkerGrpc.ShutDownWorkerI
    * @param responseObserver
    */
   @Override
-  public void shutDownWorkerGracefully(
-      ShutDownWorkerGracefullyRequest request,
-      StreamObserver<ShutDownWorkerGracefullyResults> responseObserver) {
+  public void prepareWorkerForGracefulShutdown(
+      PrepareWorkerForGracefulShutDownRequest request,
+      StreamObserver<PrepareWorkerForGracefulShutDownRequestResults> responseObserver) {
     String clusterId = config.getAdminConfig().getClusterId();
     if (clusterId == null
         || clusterId.equals("")
@@ -61,8 +59,8 @@ public class ShutDownWorkerGracefully extends ShutDownWorkerGrpc.ShutDownWorkerI
     }
 
     try {
-      CompletableFuture.runAsync(worker::shutDownWorkerGracefully);
-      responseObserver.onNext(ShutDownWorkerGracefullyResults.newBuilder().build());
+      CompletableFuture.runAsync(worker::prepareWorkerForGracefulShutdown);
+      responseObserver.onNext(PrepareWorkerForGracefulShutDownRequestResults.newBuilder().build());
       responseObserver.onCompleted();
     } catch (Exception e) {
       responseObserver.onError(e);

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -232,7 +232,7 @@ public class Worker extends LoggingMain {
    * scale in protection when the worker is ready. If unexpected errors happened, it will cancel the
    * graceful shutdown progress make the worker available again.
    */
-  public void shutDownWorkerGracefully() {
+  public void prepareWorkerForGracefulShutdown() {
     inGracefulShutdown = true;
     logger.log(Level.INFO, "The current worker is deregistered and should be shutdown gracefully!");
     int scanRate = 30; // check every 30 seconds

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -40,7 +40,7 @@ service Admin {
     option (google.api.http) = { get: "/v1test/admin:reindexCas" };
   }
   
-  rpc DeregisterWorker(DeregisterWorkerRequest) returns (DeregisterWorkerRequestResults) {
+  rpc ShutDownWorkerGracefully(ShutDownWorkerGracefullyRequest) returns (ShutDownWorkerGracefullyRequestResults) {
     option (google.api.http) = { get: "/v1test/admin:deregisterWorker" };
   }
 
@@ -49,13 +49,13 @@ service Admin {
   }
 }
 
-message DeregisterWorkerRequest {
+message ShutDownWorkerGracefullyRequest{
   string instance_name = 1;
   
   string worker_name = 2;
 }
 
-message DeregisterWorkerRequestResults {
+message ShutDownWorkerGracefullyRequestResults {
 }
 
 message DisableScaleInProtectionRequest{
@@ -1031,16 +1031,16 @@ service WorkerProfile {
   rpc GetWorkerList(WorkerListRequest) returns (WorkerListMessage) {}
 }
 
-message ShutDownWorkerGracefullyRequest {
+message PrepareWorkerForGracefulShutDownRequest{
   string instance_name = 1;
 
   string worker_name = 2;
 }
 
-message ShutDownWorkerGracefullyResults {
+message PrepareWorkerForGracefulShutDownRequestResults{
 }
 
 service ShutDownWorker {
-  rpc ShutDownWorkerGracefully(ShutDownWorkerGracefullyRequest) returns (ShutDownWorkerGracefullyResults) {}
+  rpc PrepareWorkerForGracefulShutdown(PrepareWorkerForGracefulShutDownRequest) returns (PrepareWorkerForGracefulShutDownRequestResults) {}
 }
 

--- a/src/test/java/build/buildfarm/instance/AbstractServerInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/AbstractServerInstanceTest.java
@@ -41,7 +41,7 @@ import build.buildfarm.common.Write;
 import build.buildfarm.operations.FindOperationsResults;
 import build.buildfarm.v1test.GetClientStartTimeResult;
 import build.buildfarm.v1test.OperationsStatus;
-import build.buildfarm.v1test.ShutDownWorkerGracefullyResults;
+import build.buildfarm.v1test.PrepareWorkerForGracefulShutDownRequestResults;
 import build.buildfarm.v1test.WorkerListMessage;
 import build.buildfarm.v1test.WorkerProfileMessage;
 import com.google.common.collect.ImmutableList;
@@ -196,7 +196,7 @@ public class AbstractServerInstanceTest {
     }
 
     @Override
-    public ShutDownWorkerGracefullyResults shutDownWorkerGracefully(String worker) {
+    public PrepareWorkerForGracefulShutDownRequestResults shutDownWorkerGracefully(String worker) {
       throw new UnsupportedOperationException();
     }
   }


### PR DESCRIPTION
Per discussion with @80degreeswest , the endpoint of worker graceful shutdown should be on the server-side. 

Three grpc calls are required in the whole processes: `ShutDownWorkerGracefully`, `PrepareWorkerForGracefulShutdown` and `DisableScaleInProtection`, as shown in the diagram below:

![Screen Shot 2021-01-06 at 2 23 03 PM](https://user-images.githubusercontent.com/54453872/103811554-16b97200-502b-11eb-97ee-4366dd916314.png)
