### PR TITLE
Unify documentation comment style

### DIFF
--- a/src/main/java/build/buildfarm/common/CasIndexResults.java
+++ b/src/main/java/build/buildfarm/common/CasIndexResults.java
@@ -14,43 +14,43 @@
 
 package build.buildfarm.common;
 
-///
-/// @class   CasIndexResults
-/// @brief   The result of a worker de-registering itself from CAS entries.
-/// @details This will remove the worker from CAS indexes, and in some cases,
-///          remove the CAS key.
-///
+/**
+ * @class   CasIndexResults
+ * @brief   The result of a worker de-registering itself from CAS entries.
+ * @details This will remove the worker from CAS indexes, and in some cases,
+ *          remove the CAS key.
+ */
 public class CasIndexResults {
 
-  ///
-  /// @field   removedHosts
-  /// @brief   The number of CAS entries the worker was removed from.
-  /// @details This indicates how much CAS data the shard new the worker had.
-  ///
+  /**
+   * @field   removedHosts
+   * @brief   The number of CAS entries the worker was removed from.
+   * @details This indicates how much CAS data the shard new the worker had.
+   */
   public int removedHosts = 0;
 
-  ///
-  /// @field   removedKeys
-  /// @brief   The number of CAS entries removed due to loss of worker.
-  /// @details This indicates how many CAS entries were held only by the
-  ///          removed worker.
-  ///
+  /**
+   * @field   removedKeys
+   * @brief   The number of CAS entries removed due to loss of worker.
+   * @details This indicates how many CAS entries were held only by the
+   *          removed worker.
+   */
   public int removedKeys = 0;
 
-  ///
-  /// @field   totalKeys
-  /// @brief   The total number of keys processed.
-  /// @details A fraction can be made with removed keys to see the total
-  ///          percentage of CAS lost.
-  ///
+  /**
+   * @field   totalKeys
+   * @brief   The total number of keys processed.
+   * @details A fraction can be made with removed keys to see the total
+   *          percentage of CAS lost.
+   */
   public int totalKeys = 0;
 
-  ///
-  /// @brief   Get a string message from performing worker indexing on the CAS.
-  /// @details This message is useful for logging.
-  /// @return  A message representation of the CasIndexResults.
-  /// @note    Suggested return identifier: message.
-  ///
+  /**
+   * @brief   Get a string message from performing worker indexing on the CAS.
+   * @details This message is useful for logging.
+   * @return  A message representation of the CasIndexResults.
+   * @note    Suggested return identifier: message.
+   */
   public String toMessage() {
     StringBuilder message = new StringBuilder();
     message.append(String.format("Total keys re-indexed: %d. ", totalKeys));

--- a/src/main/java/build/buildfarm/common/CasIndexResults.java
+++ b/src/main/java/build/buildfarm/common/CasIndexResults.java
@@ -15,41 +15,38 @@
 package build.buildfarm.common;
 
 /**
- * @class   CasIndexResults
- * @brief   The result of a worker de-registering itself from CAS entries.
- * @details This will remove the worker from CAS indexes, and in some cases,
- *          remove the CAS key.
+ * @class CasIndexResults
+ * @brief The result of a worker de-registering itself from CAS entries.
+ * @details This will remove the worker from CAS indexes, and in some cases, remove the CAS key.
  */
 public class CasIndexResults {
 
   /**
-   * @field   removedHosts
-   * @brief   The number of CAS entries the worker was removed from.
+   * @field removedHosts
+   * @brief The number of CAS entries the worker was removed from.
    * @details This indicates how much CAS data the shard new the worker had.
    */
   public int removedHosts = 0;
 
   /**
-   * @field   removedKeys
-   * @brief   The number of CAS entries removed due to loss of worker.
-   * @details This indicates how many CAS entries were held only by the
-   *          removed worker.
+   * @field removedKeys
+   * @brief The number of CAS entries removed due to loss of worker.
+   * @details This indicates how many CAS entries were held only by the removed worker.
    */
   public int removedKeys = 0;
 
   /**
-   * @field   totalKeys
-   * @brief   The total number of keys processed.
-   * @details A fraction can be made with removed keys to see the total
-   *          percentage of CAS lost.
+   * @field totalKeys
+   * @brief The total number of keys processed.
+   * @details A fraction can be made with removed keys to see the total percentage of CAS lost.
    */
   public int totalKeys = 0;
 
   /**
-   * @brief   Get a string message from performing worker indexing on the CAS.
+   * @brief Get a string message from performing worker indexing on the CAS.
    * @details This message is useful for logging.
-   * @return  A message representation of the CasIndexResults.
-   * @note    Suggested return identifier: message.
+   * @return A message representation of the CasIndexResults.
+   * @note Suggested return identifier: message.
    */
   public String toMessage() {
     StringBuilder message = new StringBuilder();

--- a/src/main/java/build/buildfarm/common/CasIndexSettings.java
+++ b/src/main/java/build/buildfarm/common/CasIndexSettings.java
@@ -14,34 +14,34 @@
 
 package build.buildfarm.common;
 
-///
-/// @class   CasIndexSettings
-/// @brief   Settings used to determine how to index CAS entries and remove
-///          worker entries.
-/// @details These are used for reindexing when a worker is leaving the
-///          cluster.
-///
+/**
+ * @class   CasIndexSettings
+ * @brief   Settings used to determine how to index CAS entries and remove
+ *          worker entries.
+ * @details These are used for reindexing when a worker is leaving the
+ *          cluster.
+ */
 public class CasIndexSettings {
 
-  ///
-  /// @field   hostName
-  /// @brief   The name of the worker.
-  /// @details This correlates the the worker that needs removed from CAS
-  ///          entries.
-  ///
+  /**
+   * @field   hostName
+   * @brief   The name of the worker.
+   * @details This correlates the the worker that needs removed from CAS
+   *          entries.
+   */
   public String hostName;
 
-  ///
-  /// @field   scanAmount
-  /// @brief   The number of redis entries to scan at a time.
-  /// @details Larger amounts will be faster but require more memory.
-  ///
+  /**
+   * @field   scanAmount
+   * @brief   The number of redis entries to scan at a time.
+   * @details Larger amounts will be faster but require more memory.
+   */
   public int scanAmount;
 
-  ///
-  /// @field   casQuery
-  /// @brief   How to query all of the CAS entries in redis.
-  /// @details The cas key is a global buildfarm config.
-  ///
+  /**
+   * @field   casQuery
+   * @brief   How to query all of the CAS entries in redis.
+   * @details The cas key is a global buildfarm config.
+   */
   public String casQuery;
 }

--- a/src/main/java/build/buildfarm/common/CasIndexSettings.java
+++ b/src/main/java/build/buildfarm/common/CasIndexSettings.java
@@ -15,32 +15,29 @@
 package build.buildfarm.common;
 
 /**
- * @class   CasIndexSettings
- * @brief   Settings used to determine how to index CAS entries and remove
- *          worker entries.
- * @details These are used for reindexing when a worker is leaving the
- *          cluster.
+ * @class CasIndexSettings
+ * @brief Settings used to determine how to index CAS entries and remove worker entries.
+ * @details These are used for reindexing when a worker is leaving the cluster.
  */
 public class CasIndexSettings {
 
   /**
-   * @field   hostName
-   * @brief   The name of the worker.
-   * @details This correlates the the worker that needs removed from CAS
-   *          entries.
+   * @field hostName
+   * @brief The name of the worker.
+   * @details This correlates the the worker that needs removed from CAS entries.
    */
   public String hostName;
 
   /**
-   * @field   scanAmount
-   * @brief   The number of redis entries to scan at a time.
+   * @field scanAmount
+   * @brief The number of redis entries to scan at a time.
    * @details Larger amounts will be faster but require more memory.
    */
   public int scanAmount;
 
   /**
-   * @field   casQuery
-   * @brief   How to query all of the CAS entries in redis.
+   * @field casQuery
+   * @brief How to query all of the CAS entries in redis.
    * @details The cas key is a global buildfarm config.
    */
   public String casQuery;

--- a/src/main/java/build/buildfarm/common/Size.java
+++ b/src/main/java/build/buildfarm/common/Size.java
@@ -14,70 +14,75 @@
 
 package build.buildfarm.common;
 
-///
-/// @class   Size
-/// @brief   Utilities related to file sizes.
-/// @details Contains converters between different time units.
-///
+/**
+ * @class   Size
+ * @brief   Utilities related to file sizes.
+ * @details Contains converters between different time units.
+ */
 public class Size {
 
-  ///
-  /// @brief   Kb to bytes.
-  /// @details Kb to bytes.
-  /// @param   sizeKb Size in KB to convert.
-  /// @return  The number of bytes converted from KB.
-  /// @note    Suggested return identifier: bytes.
-  ///
+  /**
+   * @brief   Kb to bytes.
+   * @details Kb to bytes.
+   * @param   sizeKb Size in KB to convert.
+   * @return  The number of bytes converted from KB.
+   * @note    Suggested return identifier: bytes.
+   */
   public static long kbToBytes(long sizeKb) {
     return sizeKb * 1024;
   }
-  ///
-  /// @brief   Bytes to kb.
-  /// @details Bytes to kb.
-  /// @param   bytes Size in bytes to convert.
-  /// @return  Size in KB converted from bytes.
-  /// @note    Suggested return identifier: sizeKb.
-  ///
+
+  /**
+   * @brief   Bytes to kb.
+   * @details Bytes to kb.
+   * @param   bytes Size in bytes to convert.
+   * @return  Size in KB converted from bytes.
+   * @note    Suggested return identifier: sizeKb.
+   */
   public static long bytesToKb(long bytes) {
     return bytes / 1024;
   }
-  ///
-  /// @brief   Mb to bytes.
-  /// @details Mb to bytes.
-  /// @param   sizeMb Size in MB to convert.
-  /// @return  The number of bytes converted from MB.
-  /// @note    Suggested return identifier: bytes.
-  ///
+
+  /**
+   * @brief   Mb to bytes.
+   * @details Mb to bytes.
+   * @param   sizeMb Size in MB to convert.
+   * @return  The number of bytes converted from MB.
+   * @note    Suggested return identifier: bytes.
+   */
   public static long mbToBytes(long sizeMb) {
     return sizeMb * 1024 * 1024;
   }
-  ///
-  /// @brief   Bytes to mb.
-  /// @details Bytes to mb.
-  /// @param   bytes Size in bytes to convert.
-  /// @return  Size in MB converted from bytes.
-  /// @note    Suggested return identifier: sizeMb.
-  ///
+
+  /**
+   * @brief   Bytes to mb.
+   * @details Bytes to mb.
+   * @param   bytes Size in bytes to convert.
+   * @return  Size in MB converted from bytes.
+   * @note    Suggested return identifier: sizeMb.
+   */
   public static long bytesToMb(long bytes) {
     return bytes / 1024 / 1024;
   }
-  ///
-  /// @brief   Gb to bytes.
-  /// @details Gb to bytes.
-  /// @param   sizeGb Size in GB to convert.
-  /// @return  The number of bytes converted from GB.
-  /// @note    Suggested return identifier: bytes.
-  ///
+
+  /**
+   * @brief   Gb to bytes.
+   * @details Gb to bytes.
+   * @param   sizeGb Size in GB to convert.
+   * @return  The number of bytes converted from GB.
+   * @note    Suggested return identifier: bytes.
+   */
   public static long gbToBytes(long sizeGb) {
     return sizeGb * 1024 * 1024 * 1024;
   }
-  ///
-  /// @brief   Bytes to gb.
-  /// @details Bytes to gb.
-  /// @param   bytes Size in bytes to convert.
-  /// @return  Size in GB converted from bytes.
-  /// @note    Suggested return identifier: sizeGb.
-  ///
+
+  /**
+   * @brief   Bytes to gb.
+   * @details Bytes to gb.
+   * @param   bytes Size in bytes to convert.
+   * @return  Size in GB converted from bytes.
+   * @note    Suggested return identifier: sizeGb.
+   */
   public static long bytesToGb(long bytes) {
     return bytes / 1024 / 1024 / 1024;
   }

--- a/src/main/java/build/buildfarm/common/Size.java
+++ b/src/main/java/build/buildfarm/common/Size.java
@@ -15,73 +15,73 @@
 package build.buildfarm.common;
 
 /**
- * @class   Size
- * @brief   Utilities related to file sizes.
+ * @class Size
+ * @brief Utilities related to file sizes.
  * @details Contains converters between different time units.
  */
 public class Size {
 
   /**
-   * @brief   Kb to bytes.
+   * @brief Kb to bytes.
    * @details Kb to bytes.
-   * @param   sizeKb Size in KB to convert.
-   * @return  The number of bytes converted from KB.
-   * @note    Suggested return identifier: bytes.
+   * @param sizeKb Size in KB to convert.
+   * @return The number of bytes converted from KB.
+   * @note Suggested return identifier: bytes.
    */
   public static long kbToBytes(long sizeKb) {
     return sizeKb * 1024;
   }
 
   /**
-   * @brief   Bytes to kb.
+   * @brief Bytes to kb.
    * @details Bytes to kb.
-   * @param   bytes Size in bytes to convert.
-   * @return  Size in KB converted from bytes.
-   * @note    Suggested return identifier: sizeKb.
+   * @param bytes Size in bytes to convert.
+   * @return Size in KB converted from bytes.
+   * @note Suggested return identifier: sizeKb.
    */
   public static long bytesToKb(long bytes) {
     return bytes / 1024;
   }
 
   /**
-   * @brief   Mb to bytes.
+   * @brief Mb to bytes.
    * @details Mb to bytes.
-   * @param   sizeMb Size in MB to convert.
-   * @return  The number of bytes converted from MB.
-   * @note    Suggested return identifier: bytes.
+   * @param sizeMb Size in MB to convert.
+   * @return The number of bytes converted from MB.
+   * @note Suggested return identifier: bytes.
    */
   public static long mbToBytes(long sizeMb) {
     return sizeMb * 1024 * 1024;
   }
 
   /**
-   * @brief   Bytes to mb.
+   * @brief Bytes to mb.
    * @details Bytes to mb.
-   * @param   bytes Size in bytes to convert.
-   * @return  Size in MB converted from bytes.
-   * @note    Suggested return identifier: sizeMb.
+   * @param bytes Size in bytes to convert.
+   * @return Size in MB converted from bytes.
+   * @note Suggested return identifier: sizeMb.
    */
   public static long bytesToMb(long bytes) {
     return bytes / 1024 / 1024;
   }
 
   /**
-   * @brief   Gb to bytes.
+   * @brief Gb to bytes.
    * @details Gb to bytes.
-   * @param   sizeGb Size in GB to convert.
-   * @return  The number of bytes converted from GB.
-   * @note    Suggested return identifier: bytes.
+   * @param sizeGb Size in GB to convert.
+   * @return The number of bytes converted from GB.
+   * @note Suggested return identifier: bytes.
    */
   public static long gbToBytes(long sizeGb) {
     return sizeGb * 1024 * 1024 * 1024;
   }
 
   /**
-   * @brief   Bytes to gb.
+   * @brief Bytes to gb.
    * @details Bytes to gb.
-   * @param   bytes Size in bytes to convert.
-   * @return  Size in GB converted from bytes.
-   * @note    Suggested return identifier: sizeGb.
+   * @param bytes Size in bytes to convert.
+   * @return Size in GB converted from bytes.
+   * @note Suggested return identifier: sizeGb.
    */
   public static long bytesToGb(long bytes) {
     return bytes / 1024 / 1024 / 1024;

--- a/src/main/java/build/buildfarm/common/StringVisitor.java
+++ b/src/main/java/build/buildfarm/common/StringVisitor.java
@@ -15,16 +15,16 @@
 package build.buildfarm.common;
 
 /**
- * @class   StringVisitor
- * @brief   A string visitor.
+ * @class StringVisitor
+ * @brief A string visitor.
  * @details Used to visit strings in a generic context.
  */
 public abstract class StringVisitor {
 
   /**
-   * @brief   The visit interface to be implemented.
+   * @brief The visit interface to be implemented.
    * @details Inherited classes but implement visit.
-   * @param   str The visited string.
+   * @param str The visited string.
    */
   public abstract void visit(String str);
 }

--- a/src/main/java/build/buildfarm/common/StringVisitor.java
+++ b/src/main/java/build/buildfarm/common/StringVisitor.java
@@ -14,17 +14,17 @@
 
 package build.buildfarm.common;
 
-///
-/// @class   StringVisitor
-/// @brief   A string visitor.
-/// @details Used to visit strings in a generic context.
-///
+/**
+ * @class   StringVisitor
+ * @brief   A string visitor.
+ * @details Used to visit strings in a generic context.
+ */
 public abstract class StringVisitor {
 
-  ///
-  /// @brief   The visit interface to be implemented.
-  /// @details Inherited classes but implement visit.
-  /// @param   str The visited string.
-  ///
+  /**
+   * @brief   The visit interface to be implemented.
+   * @details Inherited classes but implement visit.
+   * @param   str The visited string.
+   */
   public abstract void visit(String str);
 }

--- a/src/main/java/build/buildfarm/common/Time.java
+++ b/src/main/java/build/buildfarm/common/Time.java
@@ -19,41 +19,43 @@ import com.google.protobuf.util.Durations;
 import io.grpc.Deadline;
 import java.util.concurrent.TimeUnit;
 
-///
-/// @class   Time
-/// @brief   Utilities related to time, durations, deadlines, timeouts, etc.
-/// @details Contains converters between different time data types.
-///
+/**
+ * @class   Time
+ * @brief   Utilities related to time, durations, deadlines, timeouts, etc.
+ * @details Contains converters between different time data types.
+ */
 public class Time {
 
-  ///
-  /// @brief   Convert a protobuf duration to a grpc deadline.
-  /// @details Deadline will have nanosecond precision.
-  /// @param   duration A protobuf duration.
-  /// @return  A converted grpc deadline.
-  /// @note    Suggested return identifier: deadline.
-  ///
+  /**
+   * @brief   Convert a protobuf duration to a grpc deadline.
+   * @details Deadline will have nanosecond precision.
+   * @param   duration A protobuf duration.
+   * @return  A converted grpc deadline.
+   * @note    Suggested return identifier: deadline.
+   */
   public static Deadline toDeadline(Duration duration) {
     return Deadline.after(
         secondsToNanoseconds(duration.getSeconds()) + duration.getNanos(), TimeUnit.NANOSECONDS);
   }
-  ///
-  /// @brief   Convert a grpc deadline to a protobuf duration.
-  /// @details Duration will have nanosecond precision.
-  /// @param   deadline A converted grpc deadline.
-  /// @return  A protobuf duration.
-  /// @note    Suggested return identifier: duration.
-  ///
+
+  /**
+   * @brief   Convert a grpc deadline to a protobuf duration.
+   * @details Duration will have nanosecond precision.
+   * @param   deadline A converted grpc deadline.
+   * @return  A protobuf duration.
+   * @note    Suggested return identifier: duration.
+   */
   public static Duration toDuration(Deadline deadline) {
     return Durations.fromNanos(deadline.timeRemaining(TimeUnit.NANOSECONDS));
   }
-  ///
-  /// @brief   Seconds to nanoseconds.
-  /// @details Seconds to nanoseconds.
-  /// @param   seconds Seconds to convert.
-  /// @return  Nanoseconds converted from seconds.
-  /// @note    Suggested return identifier: nanoseconds.
-  ///
+
+  /**
+   * @brief   Seconds to nanoseconds.
+   * @details Seconds to nanoseconds.
+   * @param   seconds Seconds to convert.
+   * @return  Nanoseconds converted from seconds.
+   * @note    Suggested return identifier: nanoseconds.
+   */
   public static long secondsToNanoseconds(long seconds) {
     return seconds * 1000000000;
   }

--- a/src/main/java/build/buildfarm/common/Time.java
+++ b/src/main/java/build/buildfarm/common/Time.java
@@ -20,18 +20,18 @@ import io.grpc.Deadline;
 import java.util.concurrent.TimeUnit;
 
 /**
- * @class   Time
- * @brief   Utilities related to time, durations, deadlines, timeouts, etc.
+ * @class Time
+ * @brief Utilities related to time, durations, deadlines, timeouts, etc.
  * @details Contains converters between different time data types.
  */
 public class Time {
 
   /**
-   * @brief   Convert a protobuf duration to a grpc deadline.
+   * @brief Convert a protobuf duration to a grpc deadline.
    * @details Deadline will have nanosecond precision.
-   * @param   duration A protobuf duration.
-   * @return  A converted grpc deadline.
-   * @note    Suggested return identifier: deadline.
+   * @param duration A protobuf duration.
+   * @return A converted grpc deadline.
+   * @note Suggested return identifier: deadline.
    */
   public static Deadline toDeadline(Duration duration) {
     return Deadline.after(
@@ -39,22 +39,22 @@ public class Time {
   }
 
   /**
-   * @brief   Convert a grpc deadline to a protobuf duration.
+   * @brief Convert a grpc deadline to a protobuf duration.
    * @details Duration will have nanosecond precision.
-   * @param   deadline A converted grpc deadline.
-   * @return  A protobuf duration.
-   * @note    Suggested return identifier: duration.
+   * @param deadline A converted grpc deadline.
+   * @return A protobuf duration.
+   * @note Suggested return identifier: duration.
    */
   public static Duration toDuration(Deadline deadline) {
     return Durations.fromNanos(deadline.timeRemaining(TimeUnit.NANOSECONDS));
   }
 
   /**
-   * @brief   Seconds to nanoseconds.
+   * @brief Seconds to nanoseconds.
    * @details Seconds to nanoseconds.
-   * @param   seconds Seconds to convert.
-   * @return  Nanoseconds converted from seconds.
-   * @note    Suggested return identifier: nanoseconds.
+   * @param seconds Seconds to convert.
+   * @return Nanoseconds converted from seconds.
+   * @note Suggested return identifier: nanoseconds.
    */
   public static long secondsToNanoseconds(long seconds) {
     return seconds * 1000000000;

--- a/src/main/java/build/buildfarm/common/WorkerIndexer.java
+++ b/src/main/java/build/buildfarm/common/WorkerIndexer.java
@@ -21,26 +21,26 @@ import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.ScanParams;
 import redis.clients.jedis.ScanResult;
 
-///
-/// @class   WorkerIndexer
-/// @brief   Handle the reindexing the CAS entries based on a departing
-///          worker.
-/// @details When workers leave the cluster, the CAS keys must be updated to
-///          inform other workers that they can no longer obtain CAS data from
-///          the missing worker.
-///
+/**
+ * @class   WorkerIndexer
+ * @brief   Handle the reindexing the CAS entries based on a departing
+ *          worker.
+ * @details When workers leave the cluster, the CAS keys must be updated to
+ *          inform other workers that they can no longer obtain CAS data from
+ *          the missing worker.
+ */
 public class WorkerIndexer {
 
-  ///
-  /// @brief   Handle the reindexing the CAS entries based on a departing
-  ///          worker.
-  /// @details This is intended to be called by a service endpoint as part of
-  ///          gracefully shutting down a worker.
-  /// @param   cluster  An established redis cluster.
-  /// @param   settings Settings on how to traverse the CAS and which worker to remove.
-  /// @return  Results from re-indexing the worker in the CAS.
-  /// @note    Suggested return identifier: indexResults.
-  ///
+  /**
+   * @brief   Handle the reindexing the CAS entries based on a departing
+   *          worker.
+   * @details This is intended to be called by a service endpoint as part of
+   *          gracefully shutting down a worker.
+   * @param   cluster  An established redis cluster.
+   * @param   settings Settings on how to traverse the CAS and which worker to remove.
+   * @return  Results from re-indexing the worker in the CAS.
+   * @note    Suggested return identifier: indexResults.
+   */
   public static CasIndexResults removeWorkerIndexesFromCas(
       JedisCluster cluster, CasIndexSettings settings) {
     CasIndexResults results = new CasIndexResults();
@@ -58,15 +58,16 @@ public class WorkerIndexer {
 
     return results;
   }
-  ///
-  /// @brief   Scan all CAS entires on existing Jedis node and remove
-  ///          particular worker indices.
-  /// @details Results are accumulated onto.
-  /// @param   cluster  An established redis cluster.
-  /// @param   node     A node of the cluster.
-  /// @param   settings Settings on how to traverse the CAS and which worker to remove.
-  /// @param   results  Accumulating results from performing reindexing.
-  ///
+
+  /**
+   * @brief   Scan all CAS entires on existing Jedis node and remove
+   *          particular worker indices.
+   * @details Results are accumulated onto.
+   * @param   cluster  An established redis cluster.
+   * @param   node     A node of the cluster.
+   * @param   settings Settings on how to traverse the CAS and which worker to remove.
+   * @param   results  Accumulating results from performing reindexing.
+   */
   private static void reindexNode(
       JedisCluster cluster, Jedis node, CasIndexSettings settings, CasIndexResults results) {
     // iterate over all CAS entries via scanning
@@ -78,15 +79,16 @@ public class WorkerIndexer {
 
     } while (!cursor.equals("0"));
   }
-  ///
-  /// @brief   Scan the cas to obtain CAS keys.
-  /// @details Scanning is done incrementally via a cursor.
-  /// @param   node     A node of the cluster.
-  /// @param   cursor   Scan cursor.
-  /// @param   settings Settings on how to traverse the CAS.
-  /// @return  Resulting CAS keys from scanning.
-  /// @note    Suggested return identifier: casKeys.
-  ///
+
+  /**
+   * @brief   Scan the cas to obtain CAS keys.
+   * @details Scanning is done incrementally via a cursor.
+   * @param   node     A node of the cluster.
+   * @param   cursor   Scan cursor.
+   * @param   settings Settings on how to traverse the CAS.
+   * @return  Resulting CAS keys from scanning.
+   * @note    Suggested return identifier: casKeys.
+   */
   private static List<String> scanCas(Jedis node, String cursor, CasIndexSettings settings) {
     // construct CAS query
     ScanParams params = new ScanParams();
@@ -101,14 +103,15 @@ public class WorkerIndexer {
     }
     return new ArrayList<>();
   }
-  ///
-  /// @brief   Delete the worker index from the given cas keys.
-  /// @details Accumulates results about the deletion.
-  /// @param   cluster    An established redis cluster.
-  /// @param   casKeys    Keys to remove worker index from.
-  /// @param   workerName Index to remove.
-  /// @param   results    Accumulating results from performing reindexing.
-  ///
+
+  /**
+   * @brief   Delete the worker index from the given cas keys.
+   * @details Accumulates results about the deletion.
+   * @param   cluster    An established redis cluster.
+   * @param   casKeys    Keys to remove worker index from.
+   * @param   workerName Index to remove.
+   * @param   results    Accumulating results from performing reindexing.
+   */
   private static void removeWorkerFromCasKeys(
       JedisCluster cluster, List<String> casKeys, String workerName, CasIndexResults results) {
     for (String casKey : casKeys) {

--- a/src/main/java/build/buildfarm/common/WorkerIndexer.java
+++ b/src/main/java/build/buildfarm/common/WorkerIndexer.java
@@ -22,24 +22,21 @@ import redis.clients.jedis.ScanParams;
 import redis.clients.jedis.ScanResult;
 
 /**
- * @class   WorkerIndexer
- * @brief   Handle the reindexing the CAS entries based on a departing
- *          worker.
- * @details When workers leave the cluster, the CAS keys must be updated to
- *          inform other workers that they can no longer obtain CAS data from
- *          the missing worker.
+ * @class WorkerIndexer
+ * @brief Handle the reindexing the CAS entries based on a departing worker.
+ * @details When workers leave the cluster, the CAS keys must be updated to inform other workers
+ *     that they can no longer obtain CAS data from the missing worker.
  */
 public class WorkerIndexer {
 
   /**
-   * @brief   Handle the reindexing the CAS entries based on a departing
-   *          worker.
-   * @details This is intended to be called by a service endpoint as part of
-   *          gracefully shutting down a worker.
-   * @param   cluster  An established redis cluster.
-   * @param   settings Settings on how to traverse the CAS and which worker to remove.
-   * @return  Results from re-indexing the worker in the CAS.
-   * @note    Suggested return identifier: indexResults.
+   * @brief Handle the reindexing the CAS entries based on a departing worker.
+   * @details This is intended to be called by a service endpoint as part of gracefully shutting
+   *     down a worker.
+   * @param cluster An established redis cluster.
+   * @param settings Settings on how to traverse the CAS and which worker to remove.
+   * @return Results from re-indexing the worker in the CAS.
+   * @note Suggested return identifier: indexResults.
    */
   public static CasIndexResults removeWorkerIndexesFromCas(
       JedisCluster cluster, CasIndexSettings settings) {
@@ -60,13 +57,12 @@ public class WorkerIndexer {
   }
 
   /**
-   * @brief   Scan all CAS entires on existing Jedis node and remove
-   *          particular worker indices.
+   * @brief Scan all CAS entires on existing Jedis node and remove particular worker indices.
    * @details Results are accumulated onto.
-   * @param   cluster  An established redis cluster.
-   * @param   node     A node of the cluster.
-   * @param   settings Settings on how to traverse the CAS and which worker to remove.
-   * @param   results  Accumulating results from performing reindexing.
+   * @param cluster An established redis cluster.
+   * @param node A node of the cluster.
+   * @param settings Settings on how to traverse the CAS and which worker to remove.
+   * @param results Accumulating results from performing reindexing.
    */
   private static void reindexNode(
       JedisCluster cluster, Jedis node, CasIndexSettings settings, CasIndexResults results) {
@@ -81,13 +77,13 @@ public class WorkerIndexer {
   }
 
   /**
-   * @brief   Scan the cas to obtain CAS keys.
+   * @brief Scan the cas to obtain CAS keys.
    * @details Scanning is done incrementally via a cursor.
-   * @param   node     A node of the cluster.
-   * @param   cursor   Scan cursor.
-   * @param   settings Settings on how to traverse the CAS.
-   * @return  Resulting CAS keys from scanning.
-   * @note    Suggested return identifier: casKeys.
+   * @param node A node of the cluster.
+   * @param cursor Scan cursor.
+   * @param settings Settings on how to traverse the CAS.
+   * @return Resulting CAS keys from scanning.
+   * @note Suggested return identifier: casKeys.
    */
   private static List<String> scanCas(Jedis node, String cursor, CasIndexSettings settings) {
     // construct CAS query
@@ -105,12 +101,12 @@ public class WorkerIndexer {
   }
 
   /**
-   * @brief   Delete the worker index from the given cas keys.
+   * @brief Delete the worker index from the given cas keys.
    * @details Accumulates results about the deletion.
-   * @param   cluster    An established redis cluster.
-   * @param   casKeys    Keys to remove worker index from.
-   * @param   workerName Index to remove.
-   * @param   results    Accumulating results from performing reindexing.
+   * @param cluster An established redis cluster.
+   * @param casKeys Keys to remove worker index from.
+   * @param workerName Index to remove.
+   * @param results Accumulating results from performing reindexing.
    */
   private static void removeWorkerFromCasKeys(
       JedisCluster cluster, List<String> casKeys, String workerName, CasIndexResults results) {

--- a/src/main/java/build/buildfarm/common/redis/BalancedRedisQueue.java
+++ b/src/main/java/build/buildfarm/common/redis/BalancedRedisQueue.java
@@ -22,15 +22,13 @@ import java.util.List;
 import redis.clients.jedis.JedisCluster;
 
 /**
- * @class   BalancedRedisQueue
- * @brief   A balanced redis queue.
- * @details A balanced redis queue is an implementation of a queue data
- *          structure which internally uses multiple redis nodes to
- *          distribute the data across the cluster. Its important to know
- *          that the lifetime of the queue persists before and after the
- *          queue data structure is created (since it exists in redis).
- *          Therefore, two redis queues with the same name, would in fact be
- *          the same underlying redis queues.
+ * @class BalancedRedisQueue
+ * @brief A balanced redis queue.
+ * @details A balanced redis queue is an implementation of a queue data structure which internally
+ *     uses multiple redis nodes to distribute the data across the cluster. Its important to know
+ *     that the lifetime of the queue persists before and after the queue data structure is created
+ *     (since it exists in redis). Therefore, two redis queues with the same name, would in fact be
+ *     the same underlying redis queues.
  */
 public class BalancedRedisQueue {
 
@@ -39,58 +37,55 @@ public class BalancedRedisQueue {
   private static final int MAX_TIMEOUT_SECONDS = 8;
 
   /**
-   * @field   name
-   * @brief   The unique name of the queue.
-   * @details The name is used as a template for the internal queues
-   *          distributed across nodes. Hashtags are added to this base name.
-   *          This name will not contain a redis hashtag.
+   * @field name
+   * @brief The unique name of the queue.
+   * @details The name is used as a template for the internal queues distributed across nodes.
+   *     Hashtags are added to this base name. This name will not contain a redis hashtag.
    */
   private final String name;
 
   /**
-   * @field   originalHashtag
-   * @brief   The original hashtag of the name provided to the queue.
-   * @details If the balanced queue is named with a hashtag, we store it, but
-   *          will not be able to use it for the internal balanced queues. They
-   *          will need to have their own hashes that correlate to particular
-   *          nodes. However, if the balanced queue is unable to derive
-   *          hashtags it will fallback to a single queue. And rely on the
-   *          original hashtag it was given. If an original hashtag is not
-   *          given, this will be empty.
+   * @field originalHashtag
+   * @brief The original hashtag of the name provided to the queue.
+   * @details If the balanced queue is named with a hashtag, we store it, but will not be able to
+   *     use it for the internal balanced queues. They will need to have their own hashes that
+   *     correlate to particular nodes. However, if the balanced queue is unable to derive hashtags
+   *     it will fallback to a single queue. And rely on the original hashtag it was given. If an
+   *     original hashtag is not given, this will be empty.
    */
   private final String originalHashtag;
 
   /**
-   * @field   queues
-   * @brief   Internal queues used to distribute data across redis nodes.
-   * @details Although these are multiple queues, the balanced redis queue
-   *          treats them as one in its interface.
+   * @field queues
+   * @brief Internal queues used to distribute data across redis nodes.
+   * @details Although these are multiple queues, the balanced redis queue treats them as one in its
+   *     interface.
    */
   private List<RedisQueue> queues = new ArrayList<RedisQueue>();
 
   /**
-   * @field   currentPushQueue
-   * @brief   The current queue to act push on.
-   * @details Used in a round-robin fashion to ensure an even distribution of
-   *          pushes and appropriate ordering of pops.
+   * @field currentPushQueue
+   * @brief The current queue to act push on.
+   * @details Used in a round-robin fashion to ensure an even distribution of pushes and appropriate
+   *     ordering of pops.
    */
   private int currentPushQueue = 0;
 
   /**
-   * @field   currentPopQueue
-   * @brief   The current queue to act pop on.
-   * @details Used in a round-robin fashion to ensure an even distribution of
-   *          pushes and appropriate ordering of pops.
+   * @field currentPopQueue
+   * @brief The current queue to act pop on.
+   * @details Used in a round-robin fashion to ensure an even distribution of pushes and appropriate
+   *     ordering of pops.
    */
   private int currentPopQueue = 0;
 
   /**
-   * @brief   Constructor.
+   * @brief Constructor.
    * @details Construct a named redis queue with an established redis cluster.
-   * @param   client   An established redis client.
-   * @param   name     The global name of the queue.
-   * @param   hashtags Hashtags to distribute queue data.
-   * @note    Overloaded.
+   * @param client An established redis client.
+   * @param name The global name of the queue.
+   * @param hashtags Hashtags to distribute queue data.
+   * @note Overloaded.
    */
   public BalancedRedisQueue(String name, List<String> hashtags) {
     this.originalHashtag = RedisHashtags.existingHash(name);
@@ -99,21 +94,20 @@ public class BalancedRedisQueue {
   }
 
   /**
-   * @brief   Push a value onto the queue.
+   * @brief Push a value onto the queue.
    * @details Adds the value into one of the internal backend redis queues.
-   * @param   val The value to push onto the queue.
+   * @param val The value to push onto the queue.
    */
   public void push(JedisCluster jedis, String val) {
     queues.get(roundRobinPushIndex()).push(jedis, val);
   }
 
   /**
-   * @brief   Remove element from dequeue.
-   * @details Removes an element from the dequeue and specifies whether it was
-   *          removed.
-   * @param   val The value to remove.
-   * @return  Whether or not the value was removed.
-   * @note    Suggested return identifier: wasRemoved.
+   * @brief Remove element from dequeue.
+   * @details Removes an element from the dequeue and specifies whether it was removed.
+   * @param val The value to remove.
+   * @return Whether or not the value was removed.
+   * @note Suggested return identifier: wasRemoved.
    */
   public boolean removeFromDequeue(JedisCluster jedis, String val) {
     for (RedisQueue queue : partialIterationQueueOrder()) {
@@ -125,12 +119,12 @@ public class BalancedRedisQueue {
   }
 
   /**
-   * @brief   Pop element into internal dequeue and return value.
-   * @details This pops the element from one queue atomically into an internal
-   *          list called the dequeue. It will perform an exponential backoff.
-   *          Null is returned if the overall backoff times out.
-   * @return  The value of the transfered element. null if the thread was interrupted.
-   * @note    Suggested return identifier: val.
+   * @brief Pop element into internal dequeue and return value.
+   * @details This pops the element from one queue atomically into an internal list called the
+   *     dequeue. It will perform an exponential backoff. Null is returned if the overall backoff
+   *     times out.
+   * @return The value of the transfered element. null if the thread was interrupted.
+   * @note Suggested return identifier: val.
    */
   public String dequeue(JedisCluster jedis) throws InterruptedException {
     // The conditions of this algorithm are as followed:
@@ -181,65 +175,63 @@ public class BalancedRedisQueue {
   }
 
   /**
-   * @brief   Get the current pop queue.
+   * @brief Get the current pop queue.
    * @details Get the queue that the balanced queue intends to pop from next.
-   * @return  The queue that the balanced queue intends to pop from next.
-   * @note    Suggested return identifier: currentPopQueue.
+   * @return The queue that the balanced queue intends to pop from next.
+   * @note Suggested return identifier: currentPopQueue.
    */
   public RedisQueue getCurrentPopQueue() {
     return queues.get(currentPopQueue);
   }
 
   /**
-   * @brief   Get the current pop queue index.
-   * @details Get the index of the queue that the balanced queue intends to
-   *          pop from next.
-   * @return  The index of the queue that the balanced queue intends to pop from next.
-   * @note    Suggested return identifier: currentPopQueueIndex.
+   * @brief Get the current pop queue index.
+   * @details Get the index of the queue that the balanced queue intends to pop from next.
+   * @return The index of the queue that the balanced queue intends to pop from next.
+   * @note Suggested return identifier: currentPopQueueIndex.
    */
   public int getCurrentPopQueueIndex() {
     return currentPopQueue;
   }
 
   /**
-   * @brief   Get queue at index.
+   * @brief Get queue at index.
    * @details Get the internal queue at the specified index.
-   * @param   index The index to the internal queue (must be in bounds).
-   * @return  The internal queue found at that index.
-   * @note    Suggested return identifier: internalQueue.
+   * @param index The index to the internal queue (must be in bounds).
+   * @return The internal queue found at that index.
+   * @note Suggested return identifier: internalQueue.
    */
   public RedisQueue getInternalQueue(int index) {
     return queues.get(index);
   }
 
   /**
-   * @brief   Get dequeue name.
-   * @details Get the name of the internal dequeue used by the queue. since
-   *          each internal queue has their own dequeue, this name is generic
-   *          without the hashtag.
-   * @return  The name of the queue.
-   * @note    Suggested return identifier: name.
+   * @brief Get dequeue name.
+   * @details Get the name of the internal dequeue used by the queue. since each internal queue has
+   *     their own dequeue, this name is generic without the hashtag.
+   * @return The name of the queue.
+   * @note Suggested return identifier: name.
    */
   public String getDequeueName() {
     return name + "_dequeue";
   }
 
   /**
-   * @brief   Get name.
-   * @details Get the name of the queue. this is the redis key used as base
-   *          name for internal queues.
-   * @return  The base name of the queue.
-   * @note    Suggested return identifier: name.
+   * @brief Get name.
+   * @details Get the name of the queue. this is the redis key used as base name for internal
+   *     queues.
+   * @return The base name of the queue.
+   * @note Suggested return identifier: name.
    */
   public String getName() {
     return name;
   }
 
   /**
-   * @brief   Get size.
+   * @brief Get size.
    * @details Checks the current length of the queue.
-   * @return  The current length of the queue.
-   * @note    Suggested return identifier: length.
+   * @return The current length of the queue.
+   * @note Suggested return identifier: length.
    */
   public long size(JedisCluster jedis) {
     // the accumulated size of all of the queues
@@ -251,11 +243,10 @@ public class BalancedRedisQueue {
   }
 
   /**
-   * @brief   Get status information about the queue.
-   * @details Helpful for understanding the current load on the queue and how
-   *          elements are balanced.
-   * @return  The current status of the queue.
-   * @note    Suggested return identifier: status.
+   * @brief Get status information about the queue.
+   * @details Helpful for understanding the current load on the queue and how elements are balanced.
+   * @return The current status of the queue.
+   * @note Suggested return identifier: status.
    */
   public QueueStatus status(JedisCluster jedis) {
     // get properties
@@ -272,9 +263,9 @@ public class BalancedRedisQueue {
   }
 
   /**
-   * @brief   Visit each element in the queue.
+   * @brief Visit each element in the queue.
    * @details Enacts a visitor over each element in the queue.
-   * @param   visitor A visitor for each visited element in the queue.
+   * @param visitor A visitor for each visited element in the queue.
    */
   public void visit(JedisCluster jedis, StringVisitor visitor) {
     for (RedisQueue queue : fullIterationQueueOrder()) {
@@ -283,9 +274,9 @@ public class BalancedRedisQueue {
   }
 
   /**
-   * @brief   Visit each element in the dequeue.
+   * @brief Visit each element in the dequeue.
    * @details Enacts a visitor over each element in the dequeue.
-   * @param   visitor A visitor for each visited element in the queue.
+   * @param visitor A visitor for each visited element in the queue.
    */
   public void visitDequeue(JedisCluster jedis, StringVisitor visitor) {
     for (RedisQueue queue : fullIterationQueueOrder()) {
@@ -294,14 +285,12 @@ public class BalancedRedisQueue {
   }
 
   /**
-   * @brief   Check that the internal queues have evenly distributed the
-   *          values.
-   * @details We are checking that the size of all the internal queues are the
-   *          same. This means, the balanced queue will be evenly distributed
-   *          on every n elements pushed, where n is the number of internal
-   *          queues.
-   * @return  Whether or not the queues values are evenly distributed by internal queues.
-   * @note    Suggested return identifier: isEvenlyDistributed.
+   * @brief Check that the internal queues have evenly distributed the values.
+   * @details We are checking that the size of all the internal queues are the same. This means, the
+   *     balanced queue will be evenly distributed on every n elements pushed, where n is the number
+   *     of internal queues.
+   * @return Whether or not the queues values are evenly distributed by internal queues.
+   * @note Suggested return identifier: isEvenlyDistributed.
    */
   public boolean isEvenlyDistributed(JedisCluster jedis) {
     long size = queues.get(0).size(jedis);
@@ -314,12 +303,11 @@ public class BalancedRedisQueue {
   }
 
   /**
-   * @brief   Create multiple queues for each of the hashes given.
-   * @details Create the multiple queues that will act as a single balanced
-   *          queue.
-   * @param   client   An established redis client.
-   * @param   name     The global name of the queue.
-   * @param   hashtags Hashtags to distribute queue data.
+   * @brief Create multiple queues for each of the hashes given.
+   * @details Create the multiple queues that will act as a single balanced queue.
+   * @param client An established redis client.
+   * @param name The global name of the queue.
+   * @param hashtags Hashtags to distribute queue data.
    */
   private void createHashedQueues(String name, List<String> hashtags) {
     // create an internal queue for each of the provided hashtags
@@ -345,10 +333,10 @@ public class BalancedRedisQueue {
   }
 
   /**
-   * @brief   Get the current queue index for round-robin pushing.
+   * @brief Get the current queue index for round-robin pushing.
    * @details Adjusts the round-robin index for next call.
-   * @return  The current round-robin index.
-   * @note    Suggested return identifier: queueIndex.
+   * @return The current round-robin index.
+   * @note Suggested return identifier: queueIndex.
    */
   private int roundRobinPushIndex() {
     int currentIndex = currentPushQueue;
@@ -357,10 +345,10 @@ public class BalancedRedisQueue {
   }
 
   /**
-   * @brief   Get the current queue index for round-robin popping.
+   * @brief Get the current queue index for round-robin popping.
    * @details Adjusts the round-robin index for next call.
-   * @return  The current round-robin index.
-   * @note    Suggested return identifier: queueIndex.
+   * @return The current round-robin index.
+   * @note Suggested return identifier: queueIndex.
    */
   private int roundRobinPopIndex() {
     int currentIndex = currentPopQueue;
@@ -369,12 +357,11 @@ public class BalancedRedisQueue {
   }
 
   /**
-   * @brief   Get the next queue in the round robin.
-   * @details If we are currently on the last queue it becomes the first
-   *          queue.
-   * @param   index Current queue index.
-   * @return  And adjusted val based on the current queue index.
-   * @note    Suggested return identifier: adjustedCurrentQueue.
+   * @brief Get the next queue in the round robin.
+   * @details If we are currently on the last queue it becomes the first queue.
+   * @param index Current queue index.
+   * @return And adjusted val based on the current queue index.
+   * @note Suggested return identifier: adjustedCurrentQueue.
    */
   private int nextQueueInRoundRobin(int index) {
     if (index >= queues.size() - 1) {
@@ -384,12 +371,11 @@ public class BalancedRedisQueue {
   }
 
   /**
-   * @brief   Get the previous queue in the round robin.
-   * @details If we are currently on the first queue it becomes the last
-   *          queue.
-   * @param   index Current queue index.
-   * @return  And adjusted val based on the current queue index.
-   * @note    Suggested return identifier: adjustedCurrentQueue.
+   * @brief Get the previous queue in the round robin.
+   * @details If we are currently on the first queue it becomes the last queue.
+   * @param index Current queue index.
+   * @return And adjusted val based on the current queue index.
+   * @note Suggested return identifier: adjustedCurrentQueue.
    */
   private int previousQueueInRoundRobin(int index) {
     if (index == 0) {
@@ -399,14 +385,12 @@ public class BalancedRedisQueue {
   }
 
   /**
-   * @brief   List of queues in a particular order for full iteration over all
-   *          of the queues.
-   * @details An ordered list of queues for operations that assume to traverse
-   *          over all of the queues. Some operations like clear() / size()
-   *          require calling methods on all of the internal queues. For those
-   *          cases, this function represents the desired order of the queues.
-   * @return  An ordered list of queues.
-   * @note    Suggested return identifier: queues.
+   * @brief List of queues in a particular order for full iteration over all of the queues.
+   * @details An ordered list of queues for operations that assume to traverse over all of the
+   *     queues. Some operations like clear() / size() require calling methods on all of the
+   *     internal queues. For those cases, this function represents the desired order of the queues.
+   * @return An ordered list of queues.
+   * @note Suggested return identifier: queues.
    */
   private List<RedisQueue> fullIterationQueueOrder() {
     // if we are going to iterate over all of the queues
@@ -415,15 +399,14 @@ public class BalancedRedisQueue {
   }
 
   /**
-   * @brief   List of queues in a particular order for a possibly partial
-   *          iteration over all of the queues.
-   * @details An ordered list of queues for operations that may end early
-   *          without needing to perform the operation on all of the internal
-   *          queues. Some operations like exists() / remove() can return early
-   *          without processing over all of the internal queues. For those
-   *          cases, this function represents the desired order of the queues.
-   * @return  An ordered list of queues.
-   * @note    Suggested return identifier: queues.
+   * @brief List of queues in a particular order for a possibly partial iteration over all of the
+   *     queues.
+   * @details An ordered list of queues for operations that may end early without needing to perform
+   *     the operation on all of the internal queues. Some operations like exists() / remove() can
+   *     return early without processing over all of the internal queues. For those cases, this
+   *     function represents the desired order of the queues.
+   * @return An ordered list of queues.
+   * @note Suggested return identifier: queues.
    */
   private List<RedisQueue> partialIterationQueueOrder() {
     // to improve cpu utilization, we can try randomizing

--- a/src/main/java/build/buildfarm/common/redis/BalancedRedisQueue.java
+++ b/src/main/java/build/buildfarm/common/redis/BalancedRedisQueue.java
@@ -21,100 +21,100 @@ import java.util.Collections;
 import java.util.List;
 import redis.clients.jedis.JedisCluster;
 
-///
-/// @class   BalancedRedisQueue
-/// @brief   A balanced redis queue.
-/// @details A balanced redis queue is an implementation of a queue data
-///          structure which internally uses multiple redis nodes to
-///          distribute the data across the cluster. Its important to know
-///          that the lifetime of the queue persists before and after the
-///          queue data structure is created (since it exists in redis).
-///          Therefore, two redis queues with the same name, would in fact be
-///          the same underlying redis queues.
-///
+/**
+ * @class   BalancedRedisQueue
+ * @brief   A balanced redis queue.
+ * @details A balanced redis queue is an implementation of a queue data
+ *          structure which internally uses multiple redis nodes to
+ *          distribute the data across the cluster. Its important to know
+ *          that the lifetime of the queue persists before and after the
+ *          queue data structure is created (since it exists in redis).
+ *          Therefore, two redis queues with the same name, would in fact be
+ *          the same underlying redis queues.
+ */
 public class BalancedRedisQueue {
 
   private static final int START_TIMEOUT_SECONDS = 1;
 
   private static final int MAX_TIMEOUT_SECONDS = 8;
 
-  ///
-  /// @field   name
-  /// @brief   The unique name of the queue.
-  /// @details The name is used as a template for the internal queues
-  ///          distributed across nodes. Hashtags are added to this base name.
-  ///          This name will not contain a redis hashtag.
-  ///
+  /**
+   * @field   name
+   * @brief   The unique name of the queue.
+   * @details The name is used as a template for the internal queues
+   *          distributed across nodes. Hashtags are added to this base name.
+   *          This name will not contain a redis hashtag.
+   */
   private final String name;
 
-  ///
-  /// @field   originalHashtag
-  /// @brief   The original hashtag of the name provided to the queue.
-  /// @details If the balanced queue is named with a hashtag, we store it, but
-  ///          will not be able to use it for the internal balanced queues. They
-  ///          will need to have their own hashes that correlate to particular
-  ///          nodes. However, if the balanced queue is unable to derive
-  ///          hashtags it will fallback to a single queue. And rely on the
-  ///          original hashtag it was given. If an original hashtag is not
-  ///          given, this will be empty.
-  ///
+  /**
+   * @field   originalHashtag
+   * @brief   The original hashtag of the name provided to the queue.
+   * @details If the balanced queue is named with a hashtag, we store it, but
+   *          will not be able to use it for the internal balanced queues. They
+   *          will need to have their own hashes that correlate to particular
+   *          nodes. However, if the balanced queue is unable to derive
+   *          hashtags it will fallback to a single queue. And rely on the
+   *          original hashtag it was given. If an original hashtag is not
+   *          given, this will be empty.
+   */
   private final String originalHashtag;
 
-  ///
-  /// @field   queues
-  /// @brief   Internal queues used to distribute data across redis nodes.
-  /// @details Although these are multiple queues, the balanced redis queue
-  ///          treats them as one in its interface.
-  ///
+  /**
+   * @field   queues
+   * @brief   Internal queues used to distribute data across redis nodes.
+   * @details Although these are multiple queues, the balanced redis queue
+   *          treats them as one in its interface.
+   */
   private List<RedisQueue> queues = new ArrayList<RedisQueue>();
 
-  ///
-  /// @field   currentPushQueue
-  /// @brief   The current queue to act push on.
-  /// @details Used in a round-robin fashion to ensure an even distribution of
-  ///          pushes and appropriate ordering of pops.
-  ///
+  /**
+   * @field   currentPushQueue
+   * @brief   The current queue to act push on.
+   * @details Used in a round-robin fashion to ensure an even distribution of
+   *          pushes and appropriate ordering of pops.
+   */
   private int currentPushQueue = 0;
 
-  ///
-  /// @field   currentPopQueue
-  /// @brief   The current queue to act pop on.
-  /// @details Used in a round-robin fashion to ensure an even distribution of
-  ///          pushes and appropriate ordering of pops.
-  ///
+  /**
+   * @field   currentPopQueue
+   * @brief   The current queue to act pop on.
+   * @details Used in a round-robin fashion to ensure an even distribution of
+   *          pushes and appropriate ordering of pops.
+   */
   private int currentPopQueue = 0;
 
-  ///
-  /// @brief   Constructor.
-  /// @details Construct a named redis queue with an established redis cluster.
-  /// @param   client   An established redis client.
-  /// @param   name     The global name of the queue.
-  /// @param   hashtags Hashtags to distribute queue data.
-  /// @note    Overloaded.
-  ///
+  /**
+   * @brief   Constructor.
+   * @details Construct a named redis queue with an established redis cluster.
+   * @param   client   An established redis client.
+   * @param   name     The global name of the queue.
+   * @param   hashtags Hashtags to distribute queue data.
+   * @note    Overloaded.
+   */
   public BalancedRedisQueue(String name, List<String> hashtags) {
     this.originalHashtag = RedisHashtags.existingHash(name);
     this.name = RedisHashtags.unhashedName(name);
     createHashedQueues(this.name, hashtags);
   }
 
-  ///
-  /// @brief   Push a value onto the queue.
-  /// @details Adds the value into one of the internal backend redis queues.
-  /// @param   val The value to push onto the queue.
-  ///
+  /**
+   * @brief   Push a value onto the queue.
+   * @details Adds the value into one of the internal backend redis queues.
+   * @param   val The value to push onto the queue.
+   */
   public void push(JedisCluster jedis, String val) {
     queues.get(roundRobinPushIndex()).push(jedis, val);
   }
 
-  ///
-  /// @brief   Remove element from dequeue.
-  /// @details Removes an element from the dequeue and specifies whether it was
-  ///          removed.
-  /// @param   val The value to remove.
-  /// @return  Whether or not the value was removed.
-  /// @note    Suggested return identifier: wasRemoved.
-  ///
+  /**
+   * @brief   Remove element from dequeue.
+   * @details Removes an element from the dequeue and specifies whether it was
+   *          removed.
+   * @param   val The value to remove.
+   * @return  Whether or not the value was removed.
+   * @note    Suggested return identifier: wasRemoved.
+   */
   public boolean removeFromDequeue(JedisCluster jedis, String val) {
     for (RedisQueue queue : partialIterationQueueOrder()) {
       if (queue.removeFromDequeue(jedis, val)) {
@@ -124,14 +124,14 @@ public class BalancedRedisQueue {
     return false;
   }
 
-  ///
-  /// @brief   Pop element into internal dequeue and return value.
-  /// @details This pops the element from one queue atomically into an internal
-  ///          list called the dequeue. It will perform an exponential backoff.
-  ///          Null is returned if the overall backoff times out.
-  /// @return  The value of the transfered element. null if the thread was interrupted.
-  /// @note    Suggested return identifier: val.
-  ///
+  /**
+   * @brief   Pop element into internal dequeue and return value.
+   * @details This pops the element from one queue atomically into an internal
+   *          list called the dequeue. It will perform an exponential backoff.
+   *          Null is returned if the overall backoff times out.
+   * @return  The value of the transfered element. null if the thread was interrupted.
+   * @note    Suggested return identifier: val.
+   */
   public String dequeue(JedisCluster jedis) throws InterruptedException {
     // The conditions of this algorithm are as followed:
     // - from a client's perspective we want to block indefinitely.
@@ -180,67 +180,67 @@ public class BalancedRedisQueue {
     }
   }
 
-  ///
-  /// @brief   Get the current pop queue.
-  /// @details Get the queue that the balanced queue intends to pop from next.
-  /// @return  The queue that the balanced queue intends to pop from next.
-  /// @note    Suggested return identifier: currentPopQueue.
-  ///
+  /**
+   * @brief   Get the current pop queue.
+   * @details Get the queue that the balanced queue intends to pop from next.
+   * @return  The queue that the balanced queue intends to pop from next.
+   * @note    Suggested return identifier: currentPopQueue.
+   */
   public RedisQueue getCurrentPopQueue() {
     return queues.get(currentPopQueue);
   }
 
-  ///
-  /// @brief   Get the current pop queue index.
-  /// @details Get the index of the queue that the balanced queue intends to
-  ///          pop from next.
-  /// @return  The index of the queue that the balanced queue intends to pop from next.
-  /// @note    Suggested return identifier: currentPopQueueIndex.
-  ///
+  /**
+   * @brief   Get the current pop queue index.
+   * @details Get the index of the queue that the balanced queue intends to
+   *          pop from next.
+   * @return  The index of the queue that the balanced queue intends to pop from next.
+   * @note    Suggested return identifier: currentPopQueueIndex.
+   */
   public int getCurrentPopQueueIndex() {
     return currentPopQueue;
   }
 
-  ///
-  /// @brief   Get queue at index.
-  /// @details Get the internal queue at the specified index.
-  /// @param   index The index to the internal queue (must be in bounds).
-  /// @return  The internal queue found at that index.
-  /// @note    Suggested return identifier: internalQueue.
-  ///
+  /**
+   * @brief   Get queue at index.
+   * @details Get the internal queue at the specified index.
+   * @param   index The index to the internal queue (must be in bounds).
+   * @return  The internal queue found at that index.
+   * @note    Suggested return identifier: internalQueue.
+   */
   public RedisQueue getInternalQueue(int index) {
     return queues.get(index);
   }
 
-  ///
-  /// @brief   Get dequeue name.
-  /// @details Get the name of the internal dequeue used by the queue. since
-  ///          each internal queue has their own dequeue, this name is generic
-  ///          without the hashtag.
-  /// @return  The name of the queue.
-  /// @note    Suggested return identifier: name.
-  ///
+  /**
+   * @brief   Get dequeue name.
+   * @details Get the name of the internal dequeue used by the queue. since
+   *          each internal queue has their own dequeue, this name is generic
+   *          without the hashtag.
+   * @return  The name of the queue.
+   * @note    Suggested return identifier: name.
+   */
   public String getDequeueName() {
     return name + "_dequeue";
   }
 
-  ///
-  /// @brief   Get name.
-  /// @details Get the name of the queue. this is the redis key used as base
-  ///          name for internal queues.
-  /// @return  The base name of the queue.
-  /// @note    Suggested return identifier: name.
-  ///
+  /**
+   * @brief   Get name.
+   * @details Get the name of the queue. this is the redis key used as base
+   *          name for internal queues.
+   * @return  The base name of the queue.
+   * @note    Suggested return identifier: name.
+   */
   public String getName() {
     return name;
   }
 
-  ///
-  /// @brief   Get size.
-  /// @details Checks the current length of the queue.
-  /// @return  The current length of the queue.
-  /// @note    Suggested return identifier: length.
-  ///
+  /**
+   * @brief   Get size.
+   * @details Checks the current length of the queue.
+   * @return  The current length of the queue.
+   * @note    Suggested return identifier: length.
+   */
   public long size(JedisCluster jedis) {
     // the accumulated size of all of the queues
     long size = 0;
@@ -250,13 +250,13 @@ public class BalancedRedisQueue {
     return size;
   }
 
-  ///
-  /// @brief   Get status information about the queue.
-  /// @details Helpful for understanding the current load on the queue and how
-  ///          elements are balanced.
-  /// @return  The current status of the queue.
-  /// @note    Suggested return identifier: status.
-  ///
+  /**
+   * @brief   Get status information about the queue.
+   * @details Helpful for understanding the current load on the queue and how
+   *          elements are balanced.
+   * @return  The current status of the queue.
+   * @note    Suggested return identifier: status.
+   */
   public QueueStatus status(JedisCluster jedis) {
     // get properties
     long size = size(jedis);
@@ -271,38 +271,38 @@ public class BalancedRedisQueue {
     return status;
   }
 
-  ///
-  /// @brief   Visit each element in the queue.
-  /// @details Enacts a visitor over each element in the queue.
-  /// @param   visitor A visitor for each visited element in the queue.
-  ///
+  /**
+   * @brief   Visit each element in the queue.
+   * @details Enacts a visitor over each element in the queue.
+   * @param   visitor A visitor for each visited element in the queue.
+   */
   public void visit(JedisCluster jedis, StringVisitor visitor) {
     for (RedisQueue queue : fullIterationQueueOrder()) {
       queue.visit(jedis, visitor);
     }
   }
 
-  ///
-  /// @brief   Visit each element in the dequeue.
-  /// @details Enacts a visitor over each element in the dequeue.
-  /// @param   visitor A visitor for each visited element in the queue.
-  ///
+  /**
+   * @brief   Visit each element in the dequeue.
+   * @details Enacts a visitor over each element in the dequeue.
+   * @param   visitor A visitor for each visited element in the queue.
+   */
   public void visitDequeue(JedisCluster jedis, StringVisitor visitor) {
     for (RedisQueue queue : fullIterationQueueOrder()) {
       queue.visitDequeue(jedis, visitor);
     }
   }
 
-  ///
-  /// @brief   Check that the internal queues have evenly distributed the
-  ///          values.
-  /// @details We are checking that the size of all the internal queues are the
-  ///          same. This means, the balanced queue will be evenly distributed
-  ///          on every n elements pushed, where n is the number of internal
-  ///          queues.
-  /// @return  Whether or not the queues values are evenly distributed by internal queues.
-  /// @note    Suggested return identifier: isEvenlyDistributed.
-  ///
+  /**
+   * @brief   Check that the internal queues have evenly distributed the
+   *          values.
+   * @details We are checking that the size of all the internal queues are the
+   *          same. This means, the balanced queue will be evenly distributed
+   *          on every n elements pushed, where n is the number of internal
+   *          queues.
+   * @return  Whether or not the queues values are evenly distributed by internal queues.
+   * @note    Suggested return identifier: isEvenlyDistributed.
+   */
   public boolean isEvenlyDistributed(JedisCluster jedis) {
     long size = queues.get(0).size(jedis);
     for (RedisQueue queue : partialIterationQueueOrder()) {
@@ -313,14 +313,14 @@ public class BalancedRedisQueue {
     return true;
   }
 
-  ///
-  /// @brief   Create multiple queues for each of the hashes given.
-  /// @details Create the multiple queues that will act as a single balanced
-  ///          queue.
-  /// @param   client   An established redis client.
-  /// @param   name     The global name of the queue.
-  /// @param   hashtags Hashtags to distribute queue data.
-  ///
+  /**
+   * @brief   Create multiple queues for each of the hashes given.
+   * @details Create the multiple queues that will act as a single balanced
+   *          queue.
+   * @param   client   An established redis client.
+   * @param   name     The global name of the queue.
+   * @param   hashtags Hashtags to distribute queue data.
+   */
   private void createHashedQueues(String name, List<String> hashtags) {
     // create an internal queue for each of the provided hashtags
     for (String hashtag : hashtags) {
@@ -344,38 +344,38 @@ public class BalancedRedisQueue {
     }
   }
 
-  ///
-  /// @brief   Get the current queue index for round-robin pushing.
-  /// @details Adjusts the round-robin index for next call.
-  /// @return  The current round-robin index.
-  /// @note    Suggested return identifier: queueIndex.
-  ///
+  /**
+   * @brief   Get the current queue index for round-robin pushing.
+   * @details Adjusts the round-robin index for next call.
+   * @return  The current round-robin index.
+   * @note    Suggested return identifier: queueIndex.
+   */
   private int roundRobinPushIndex() {
     int currentIndex = currentPushQueue;
     currentPushQueue = nextQueueInRoundRobin(currentPushQueue);
     return currentIndex;
   }
 
-  ///
-  /// @brief   Get the current queue index for round-robin popping.
-  /// @details Adjusts the round-robin index for next call.
-  /// @return  The current round-robin index.
-  /// @note    Suggested return identifier: queueIndex.
-  ///
+  /**
+   * @brief   Get the current queue index for round-robin popping.
+   * @details Adjusts the round-robin index for next call.
+   * @return  The current round-robin index.
+   * @note    Suggested return identifier: queueIndex.
+   */
   private int roundRobinPopIndex() {
     int currentIndex = currentPopQueue;
     currentPopQueue = nextQueueInRoundRobin(currentPopQueue);
     return currentIndex;
   }
 
-  ///
-  /// @brief   Get the next queue in the round robin.
-  /// @details If we are currently on the last queue it becomes the first
-  ///          queue.
-  /// @param   index Current queue index.
-  /// @return  And adjusted val based on the current queue index.
-  /// @note    Suggested return identifier: adjustedCurrentQueue.
-  ///
+  /**
+   * @brief   Get the next queue in the round robin.
+   * @details If we are currently on the last queue it becomes the first
+   *          queue.
+   * @param   index Current queue index.
+   * @return  And adjusted val based on the current queue index.
+   * @note    Suggested return identifier: adjustedCurrentQueue.
+   */
   private int nextQueueInRoundRobin(int index) {
     if (index >= queues.size() - 1) {
       return 0;
@@ -383,14 +383,14 @@ public class BalancedRedisQueue {
     return index + 1;
   }
 
-  ///
-  /// @brief   Get the previous queue in the round robin.
-  /// @details If we are currently on the first queue it becomes the last
-  ///          queue.
-  /// @param   index Current queue index.
-  /// @return  And adjusted val based on the current queue index.
-  /// @note    Suggested return identifier: adjustedCurrentQueue.
-  ///
+  /**
+   * @brief   Get the previous queue in the round robin.
+   * @details If we are currently on the first queue it becomes the last
+   *          queue.
+   * @param   index Current queue index.
+   * @return  And adjusted val based on the current queue index.
+   * @note    Suggested return identifier: adjustedCurrentQueue.
+   */
   private int previousQueueInRoundRobin(int index) {
     if (index == 0) {
       return queues.size() - 1;
@@ -398,33 +398,33 @@ public class BalancedRedisQueue {
     return index - 1;
   }
 
-  ///
-  /// @brief   List of queues in a particular order for full iteration over all
-  ///          of the queues.
-  /// @details An ordered list of queues for operations that assume to traverse
-  ///          over all of the queues. Some operations like clear() / size()
-  ///          require calling methods on all of the internal queues. For those
-  ///          cases, this function represents the desired order of the queues.
-  /// @return  An ordered list of queues.
-  /// @note    Suggested return identifier: queues.
-  ///
+  /**
+   * @brief   List of queues in a particular order for full iteration over all
+   *          of the queues.
+   * @details An ordered list of queues for operations that assume to traverse
+   *          over all of the queues. Some operations like clear() / size()
+   *          require calling methods on all of the internal queues. For those
+   *          cases, this function represents the desired order of the queues.
+   * @return  An ordered list of queues.
+   * @note    Suggested return identifier: queues.
+   */
   private List<RedisQueue> fullIterationQueueOrder() {
     // if we are going to iterate over all of the queues
     // there will be no noticeable side effects from the order
     return queues;
   }
 
-  ///
-  /// @brief   List of queues in a particular order for a possibly partial
-  ///          iteration over all of the queues.
-  /// @details An ordered list of queues for operations that may end early
-  ///          without needing to perform the operation on all of the internal
-  ///          queues. Some operations like exists() / remove() can return early
-  ///          without processing over all of the internal queues. For those
-  ///          cases, this function represents the desired order of the queues.
-  /// @return  An ordered list of queues.
-  /// @note    Suggested return identifier: queues.
-  ///
+  /**
+   * @brief   List of queues in a particular order for a possibly partial
+   *          iteration over all of the queues.
+   * @details An ordered list of queues for operations that may end early
+   *          without needing to perform the operation on all of the internal
+   *          queues. Some operations like exists() / remove() can return early
+   *          without processing over all of the internal queues. For those
+   *          cases, this function represents the desired order of the queues.
+   * @return  An ordered list of queues.
+   * @note    Suggested return identifier: queues.
+   */
   private List<RedisQueue> partialIterationQueueOrder() {
     // to improve cpu utilization, we can try randomizing
     // the order we traverse the internal queues for operations

--- a/src/main/java/build/buildfarm/common/redis/EligibilityResult.java
+++ b/src/main/java/build/buildfarm/common/redis/EligibilityResult.java
@@ -16,69 +16,69 @@ package build.buildfarm.common.redis;
 
 import com.google.common.collect.SetMultimap;
 
-///
-/// @class   EligibilityResult
-/// @brief   Detailed results from checking eligibility of properties on a
-///          provisioned redis queue.
-/// @details Useful for visibility and debugging into the queue selection
-///          algorithm.
-///
+/**
+ * @class   EligibilityResult
+ * @brief   Detailed results from checking eligibility of properties on a
+ *          provisioned redis queue.
+ * @details Useful for visibility and debugging into the queue selection
+ *          algorithm.
+ */
 public class EligibilityResult {
 
-  ///
-  /// @field   queueName
-  /// @brief   The name of the queue the eligibility was tested on.
-  /// @details The name of the provisioned redis queue.
-  ///
+  /**
+   * @field   queueName
+   * @brief   The name of the queue the eligibility was tested on.
+   * @details The name of the provisioned redis queue.
+   */
   public String queueName;
 
-  ///
-  /// @field   allowsUnmatched
-  /// @brief   Determines how unmatched properties effect eligibility.
-  /// @details If true, properties can remain unmatched yet still eligible.
-  ///
+  /**
+   * @field   allowsUnmatched
+   * @brief   Determines how unmatched properties effect eligibility.
+   * @details If true, properties can remain unmatched yet still eligible.
+   */
   public boolean allowsUnmatched;
 
-  ///
-  /// @field   isEligible
-  /// @brief   Whether the properties were eligible for the queue.
-  /// @details Determined the same way queues are selected.
-  ///
+  /**
+   * @field   isEligible
+   * @brief   Whether the properties were eligible for the queue.
+   * @details Determined the same way queues are selected.
+   */
   public boolean isEligible;
 
-  ///
-  /// @field   isFullyWildcard
-  /// @brief   Whether the queue is fully wildcard.
-  /// @details Fully wildcard queues accept all properties.
-  ///
+  /**
+   * @field   isFullyWildcard
+   * @brief   Whether the queue is fully wildcard.
+   * @details Fully wildcard queues accept all properties.
+   */
   public boolean isFullyWildcard;
 
-  ///
-  /// @field   isSpecificallyChosen
-  /// @brief   Whether the queue was specifically chosen.
-  /// @details A special property was used to specifically match to the queue.
-  ///          This automatically makes it eligible.
-  ///
+  /**
+   * @field   isSpecificallyChosen
+   * @brief   Whether the queue was specifically chosen.
+   * @details A special property was used to specifically match to the queue.
+   *          This automatically makes it eligible.
+   */
   public boolean isSpecificallyChosen;
 
-  ///
-  /// @field   matched
-  /// @brief   Properties that were correctly matched for the queue.
-  /// @details Contribute to successful eligibility.
-  ///
+  /**
+   * @field   matched
+   * @brief   Properties that were correctly matched for the queue.
+   * @details Contribute to successful eligibility.
+   */
   public SetMultimap<String, String> matched;
 
-  ///
-  /// @field   unmatched
-  /// @brief   Properties that were not correctly matched for the queue.
-  /// @details Contribute to failure of eligibility.
-  ///
+  /**
+   * @field   unmatched
+   * @brief   Properties that were not correctly matched for the queue.
+   * @details Contribute to failure of eligibility.
+   */
   public SetMultimap<String, String> unmatched;
 
-  ///
-  /// @field   stillRequired
-  /// @brief   Properties that are still required for the queue.
-  /// @details Contribute to failure of eligibility.
-  ///
+  /**
+   * @field   stillRequired
+   * @brief   Properties that are still required for the queue.
+   * @details Contribute to failure of eligibility.
+   */
   public SetMultimap<String, String> stillRequired;
 }

--- a/src/main/java/build/buildfarm/common/redis/EligibilityResult.java
+++ b/src/main/java/build/buildfarm/common/redis/EligibilityResult.java
@@ -17,67 +17,65 @@ package build.buildfarm.common.redis;
 import com.google.common.collect.SetMultimap;
 
 /**
- * @class   EligibilityResult
- * @brief   Detailed results from checking eligibility of properties on a
- *          provisioned redis queue.
- * @details Useful for visibility and debugging into the queue selection
- *          algorithm.
+ * @class EligibilityResult
+ * @brief Detailed results from checking eligibility of properties on a provisioned redis queue.
+ * @details Useful for visibility and debugging into the queue selection algorithm.
  */
 public class EligibilityResult {
 
   /**
-   * @field   queueName
-   * @brief   The name of the queue the eligibility was tested on.
+   * @field queueName
+   * @brief The name of the queue the eligibility was tested on.
    * @details The name of the provisioned redis queue.
    */
   public String queueName;
 
   /**
-   * @field   allowsUnmatched
-   * @brief   Determines how unmatched properties effect eligibility.
+   * @field allowsUnmatched
+   * @brief Determines how unmatched properties effect eligibility.
    * @details If true, properties can remain unmatched yet still eligible.
    */
   public boolean allowsUnmatched;
 
   /**
-   * @field   isEligible
-   * @brief   Whether the properties were eligible for the queue.
+   * @field isEligible
+   * @brief Whether the properties were eligible for the queue.
    * @details Determined the same way queues are selected.
    */
   public boolean isEligible;
 
   /**
-   * @field   isFullyWildcard
-   * @brief   Whether the queue is fully wildcard.
+   * @field isFullyWildcard
+   * @brief Whether the queue is fully wildcard.
    * @details Fully wildcard queues accept all properties.
    */
   public boolean isFullyWildcard;
 
   /**
-   * @field   isSpecificallyChosen
-   * @brief   Whether the queue was specifically chosen.
-   * @details A special property was used to specifically match to the queue.
-   *          This automatically makes it eligible.
+   * @field isSpecificallyChosen
+   * @brief Whether the queue was specifically chosen.
+   * @details A special property was used to specifically match to the queue. This automatically
+   *     makes it eligible.
    */
   public boolean isSpecificallyChosen;
 
   /**
-   * @field   matched
-   * @brief   Properties that were correctly matched for the queue.
+   * @field matched
+   * @brief Properties that were correctly matched for the queue.
    * @details Contribute to successful eligibility.
    */
   public SetMultimap<String, String> matched;
 
   /**
-   * @field   unmatched
-   * @brief   Properties that were not correctly matched for the queue.
+   * @field unmatched
+   * @brief Properties that were not correctly matched for the queue.
    * @details Contribute to failure of eligibility.
    */
   public SetMultimap<String, String> unmatched;
 
   /**
-   * @field   stillRequired
-   * @brief   Properties that are still required for the queue.
+   * @field stillRequired
+   * @brief Properties that are still required for the queue.
    * @details Contribute to failure of eligibility.
    */
   public SetMultimap<String, String> stillRequired;

--- a/src/main/java/build/buildfarm/common/redis/FilteredProvisions.java
+++ b/src/main/java/build/buildfarm/common/redis/FilteredProvisions.java
@@ -17,27 +17,27 @@ package build.buildfarm.common.redis;
 import java.util.Map;
 import java.util.Set;
 
-///
-/// @class   FilteredProvisions
-/// @brief   Provisions of a provisioned redis queue.
-/// @details These provisions are filtered by wildcards and used by the
-///          provisioned redis queue.
-///
+/**
+ * @class   FilteredProvisions
+ * @brief   Provisions of a provisioned redis queue.
+ * @details These provisions are filtered by wildcards and used by the
+ *          provisioned redis queue.
+ */
 public class FilteredProvisions {
 
-  ///
-  /// @field   wildcard
-  /// @brief   The wildcard provisions of the queue.
-  /// @details A filtered set of all provisions that use wildcards.
-  ///
+  /**
+   * @field   wildcard
+   * @brief   The wildcard provisions of the queue.
+   * @details A filtered set of all provisions that use wildcards.
+   */
   public Set<String> wildcard;
 
-  ///
-  /// @field   required
-  /// @brief   The required provisions of the queue.
-  /// @details The required provisions to allow workers and operations to be
-  ///          added to the queue. These often match the remote api's command
-  ///          platform properties.
-  ///
+  /**
+   * @field   required
+   * @brief   The required provisions of the queue.
+   * @details The required provisions to allow workers and operations to be
+   *          added to the queue. These often match the remote api's command
+   *          platform properties.
+   */
   public Set<Map.Entry<String, String>> required;
 }

--- a/src/main/java/build/buildfarm/common/redis/FilteredProvisions.java
+++ b/src/main/java/build/buildfarm/common/redis/FilteredProvisions.java
@@ -18,26 +18,24 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * @class   FilteredProvisions
- * @brief   Provisions of a provisioned redis queue.
- * @details These provisions are filtered by wildcards and used by the
- *          provisioned redis queue.
+ * @class FilteredProvisions
+ * @brief Provisions of a provisioned redis queue.
+ * @details These provisions are filtered by wildcards and used by the provisioned redis queue.
  */
 public class FilteredProvisions {
 
   /**
-   * @field   wildcard
-   * @brief   The wildcard provisions of the queue.
+   * @field wildcard
+   * @brief The wildcard provisions of the queue.
    * @details A filtered set of all provisions that use wildcards.
    */
   public Set<String> wildcard;
 
   /**
-   * @field   required
-   * @brief   The required provisions of the queue.
-   * @details The required provisions to allow workers and operations to be
-   *          added to the queue. These often match the remote api's command
-   *          platform properties.
+   * @field required
+   * @brief The required provisions of the queue.
+   * @details The required provisions to allow workers and operations to be added to the queue.
+   *     These often match the remote api's command platform properties.
    */
   public Set<Map.Entry<String, String>> required;
 }

--- a/src/main/java/build/buildfarm/common/redis/ProvisionedRedisQueue.java
+++ b/src/main/java/build/buildfarm/common/redis/ProvisionedRedisQueue.java
@@ -23,91 +23,91 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-///
-/// @class   ProvisionedRedisQueue
-/// @brief   A queue that is designed to hold particularly provisioned
-///          elements.
-/// @details A provisioned redis queue is an implementation of a queue data
-///          structure which internally uses a redis cluster to distribute the
-///          data across shards. Its important to know that the lifetime of
-///          the queue persists before and after the queue data structure is
-///          created (since it exists in redis). Therefore, two redis queues
-///          with the same name, would in fact be the same underlying redis
-///          queue. This redis queue comes with a list of required provisions.
-///          If the queue element does not meet the required provisions, it
-///          should not be stored in the queue. Provision queues are intended
-///          to represent particular operations that should only be processed
-///          by particular workers. An example use case for this would be to
-///          have two dedicated provision queues for CPU and GPU operations.
-///          CPU/GPU requirements would be determined through the remote api's
-///          command platform properties. We designate provision queues to
-///          have a set of "required provisions" (which match the platform
-///          properties). This allows the scheduler to distribute operations
-///          by their properties and allows workers to dequeue from particular
-///          queues.
-///
+/**
+ * @class   ProvisionedRedisQueue
+ * @brief   A queue that is designed to hold particularly provisioned
+ *          elements.
+ * @details A provisioned redis queue is an implementation of a queue data
+ *          structure which internally uses a redis cluster to distribute the
+ *          data across shards. Its important to know that the lifetime of
+ *          the queue persists before and after the queue data structure is
+ *          created (since it exists in redis). Therefore, two redis queues
+ *          with the same name, would in fact be the same underlying redis
+ *          queue. This redis queue comes with a list of required provisions.
+ *          If the queue element does not meet the required provisions, it
+ *          should not be stored in the queue. Provision queues are intended
+ *          to represent particular operations that should only be processed
+ *          by particular workers. An example use case for this would be to
+ *          have two dedicated provision queues for CPU and GPU operations.
+ *          CPU/GPU requirements would be determined through the remote api's
+ *          command platform properties. We designate provision queues to
+ *          have a set of "required provisions" (which match the platform
+ *          properties). This allows the scheduler to distribute operations
+ *          by their properties and allows workers to dequeue from particular
+ *          queues.
+ */
 public class ProvisionedRedisQueue {
 
-  ///
-  /// @field   WILDCARD_VALUE
-  /// @brief   Wildcard value.
-  /// @details Symbol for identifying wildcard in both key/value of provisions.
-  ///
+  /**
+   * @field   WILDCARD_VALUE
+   * @brief   Wildcard value.
+   * @details Symbol for identifying wildcard in both key/value of provisions.
+   */
   public static final String WILDCARD_VALUE = "*";
 
-  ///
-  /// @field   CHOOSE_QUEUE_KEY
-  /// @brief   Special key to allow directly matching with a queue.
-  /// @details This is to support another paradigm where actions want to
-  ///          specifically request the queue to be placed in. Its less generic
-  ///          than having buildfarm choose the queue for you, and it leaks
-  ///          implementation details about how buildfarm is queuing your work.
-  ///          However, its desirable to match similar remote execution
-  ///          solutions that use exec_properties to choose which "pool" they
-  ///          want to run in.
-  ///
+  /**
+   * @field   CHOOSE_QUEUE_KEY
+   * @brief   Special key to allow directly matching with a queue.
+   * @details This is to support another paradigm where actions want to
+   *          specifically request the queue to be placed in. Its less generic
+   *          than having buildfarm choose the queue for you, and it leaks
+   *          implementation details about how buildfarm is queuing your work.
+   *          However, its desirable to match similar remote execution
+   *          solutions that use exec_properties to choose which "pool" they
+   *          want to run in.
+   */
   public static final String CHOOSE_QUEUE_KEY = "choose-queue";
 
-  ///
-  /// @field   isFullyWildcard
-  /// @brief   If the queue will deem any set of properties eligible.
-  /// @details If any of the provision keys has a wildcard, we consider
-  ///          anything for the queue to be eligible.
-  ///
+  /**
+   * @field   isFullyWildcard
+   * @brief   If the queue will deem any set of properties eligible.
+   * @details If any of the provision keys has a wildcard, we consider
+   *          anything for the queue to be eligible.
+   */
   private final boolean isFullyWildcard;
 
-  ///
-  /// @field   allowUserUnmatched
-  /// @brief   Can the user provide extra platform properties that are not a
-  ///          part of the queue and still be matched with it?
-  /// @details If true, the user can provide a superset of platform properties
-  ///          and still be matched with the queue.
-  ///
+  /**
+   * @field   allowUserUnmatched
+   * @brief   Can the user provide extra platform properties that are not a
+   *          part of the queue and still be matched with it?
+   * @details If true, the user can provide a superset of platform properties
+   *          and still be matched with the queue.
+   */
   private final boolean allowUserUnmatched;
 
-  ///
-  /// @field   provisions
-  /// @brief   Provisions enforced by the queue.
-  /// @details The provisions are filtered by wildcard.
-  ///
+  /**
+   * @field   provisions
+   * @brief   Provisions enforced by the queue.
+   * @details The provisions are filtered by wildcard.
+   */
   private final FilteredProvisions provisions;
 
-  ///
-  /// @field   queue
-  /// @brief   The queue itself.
-  /// @details A balanced redis queue designed to hold particularly provisioned
-  ///          elements.
-  ///
+  /**
+   * @field   queue
+   * @brief   The queue itself.
+   * @details A balanced redis queue designed to hold particularly provisioned
+   *          elements.
+   */
   private final BalancedRedisQueue queue;
 
-  ///
-  /// @brief   Constructor.
-  /// @details Construct the provision queue.
-  /// @param   name             The global name of the queue.
-  /// @param   hashtags         Hashtags to distribute queue data.
-  /// @param   filterProvisions The filtered provisions of the queue.
-  /// @note    Overloaded.
-  ///
+  /**
+   * @brief   Constructor.
+   * @details Construct the provision queue.
+   * @param   name             The global name of the queue.
+   * @param   hashtags         Hashtags to distribute queue data.
+   * @param   filterProvisions The filtered provisions of the queue.
+   * @note    Overloaded.
+   */
   public ProvisionedRedisQueue(
       String name, List<String> hashtags, SetMultimap<String, String> filterProvisions) {
     this.queue = new BalancedRedisQueue(name, hashtags);
@@ -115,16 +115,17 @@ public class ProvisionedRedisQueue {
     provisions = filterProvisionsByWildcard(filterProvisions, isFullyWildcard, WILDCARD_VALUE);
     allowUserUnmatched = false;
   }
-  ///
-  /// @brief   Constructor.
-  /// @details Construct the provision queue.
-  /// @param   name               The global name of the queue.
-  /// @param   hashtags           Hashtags to distribute queue data.
-  /// @param   filterProvisions   The filtered provisions of the queue.
-  /// @param   allowUserUnmatched Whether the user can provide extra platform properties and still
-  // match the queue.
-  /// @note    Overloaded.
-  ///
+
+  /**
+   * @brief   Constructor.
+   * @details Construct the provision queue.
+   * @param   name               The global name of the queue.
+   * @param   hashtags           Hashtags to distribute queue data.
+   * @param   filterProvisions   The filtered provisions of the queue.
+   * @param   allowUserUnmatched Whether the user can provide extra platform properties and still
+   *match the queue.
+   * @note    Overloaded.
+   */
   public ProvisionedRedisQueue(
       String name,
       List<String> hashtags,
@@ -135,14 +136,15 @@ public class ProvisionedRedisQueue {
     provisions = filterProvisionsByWildcard(filterProvisions, isFullyWildcard, WILDCARD_VALUE);
     this.allowUserUnmatched = allowUserUnmatched;
   }
-  ///
-  /// @brief   Checks required properties.
-  /// @details Checks whether the properties given fulfill all of the required
-  ///          provisions of the queue.
-  /// @param   properties Properties to check that requirements are met.
-  /// @return  Whether the queue is eligible based on the properties given.
-  /// @note    Suggested return identifier: isEligible.
-  ///
+
+  /**
+   * @brief   Checks required properties.
+   * @details Checks whether the properties given fulfill all of the required
+   *          provisions of the queue.
+   * @param   properties Properties to check that requirements are met.
+   * @return  Whether the queue is eligible based on the properties given.
+   * @note    Suggested return identifier: isEligible.
+   */
   public boolean isEligible(SetMultimap<String, String> properties) {
     // check if a property is specifically requesting to match with the queue
     // any attempt to specifically match will not evaluate other properties
@@ -167,37 +169,40 @@ public class ProvisionedRedisQueue {
     }
     return requirements.isEmpty();
   }
-  ///
-  /// @brief   Explain eligibility.
-  /// @details Returns an explanation as to why the properties provided are
-  ///          eligible / ineligible to be placed on the queue.
-  /// @param   properties Properties to get an eligibility explanation of.
-  /// @return  An explanation on the eligibility of the provided properties.
-  /// @note    Suggested return identifier: explanation.
-  ///
+
+  /**
+   * @brief   Explain eligibility.
+   * @details Returns an explanation as to why the properties provided are
+   *          eligible / ineligible to be placed on the queue.
+   * @param   properties Properties to get an eligibility explanation of.
+   * @return  An explanation on the eligibility of the provided properties.
+   * @note    Suggested return identifier: explanation.
+   */
   public String explainEligibility(SetMultimap<String, String> properties) {
     EligibilityResult result = getEligibilityResult(properties);
     return toString(result);
   }
-  ///
-  /// @brief   Get queue.
-  /// @details Obtain the internal queue.
-  /// @return  The internal queue.
-  /// @note    Suggested return identifier: queue.
-  ///
+
+  /**
+   * @brief   Get queue.
+   * @details Obtain the internal queue.
+   * @return  The internal queue.
+   * @note    Suggested return identifier: queue.
+   */
   public BalancedRedisQueue queue() {
     return queue;
   }
-  ///
-  /// @brief   Filter the provisions into separate sets by checking for the
-  ///          existence of wildcards.
-  /// @details This will organize the incoming provisions into separate sets.
-  /// @param   filterProvisions The filtered provisions of the queue.
-  /// @param   isFullyWildcard  If the queue will deem any set of properties eligible.
-  /// @param   wildcardValue    Symbol for identifying wildcard in both key/value of provisions.
-  /// @return  Provisions filtered by wildcard.
-  /// @note    Suggested return identifier: filteredProvisions.
-  ///
+
+  /**
+   * @brief   Filter the provisions into separate sets by checking for the
+   *          existence of wildcards.
+   * @details This will organize the incoming provisions into separate sets.
+   * @param   filterProvisions The filtered provisions of the queue.
+   * @param   isFullyWildcard  If the queue will deem any set of properties eligible.
+   * @param   wildcardValue    Symbol for identifying wildcard in both key/value of provisions.
+   * @return  Provisions filtered by wildcard.
+   * @note    Suggested return identifier: filteredProvisions.
+   */
   private static FilteredProvisions filterProvisionsByWildcard(
       SetMultimap<String, String> filterProvisions, boolean isFullyWildcard, String wildcardValue) {
     FilteredProvisions provisions = new FilteredProvisions();
@@ -216,14 +221,15 @@ public class ProvisionedRedisQueue {
                 .collect(ImmutableSet.toImmutableSet());
     return provisions;
   }
-  ///
-  /// @brief   Get eligibility result.
-  /// @details Perform eligibility check with detailed information on
-  ///          evaluation.
-  /// @param   properties Properties to get an eligibility explanation of.
-  /// @return  Detailed results on the evaluation of an eligibility check.
-  /// @note    Suggested return identifier: eligibilityResult.
-  ///
+
+  /**
+   * @brief   Get eligibility result.
+   * @details Perform eligibility check with detailed information on
+   *          evaluation.
+   * @param   properties Properties to get an eligibility explanation of.
+   * @return  Detailed results on the evaluation of an eligibility check.
+   * @note    Suggested return identifier: eligibilityResult.
+   */
   private EligibilityResult getEligibilityResult(SetMultimap<String, String> properties) {
     EligibilityResult result = new EligibilityResult();
     result.queueName = queue.getName();
@@ -259,14 +265,15 @@ public class ProvisionedRedisQueue {
 
     return result;
   }
-  ///
-  /// @brief   Convert map to printable string.
-  /// @details Uses streams.
-  /// @param   map Map to convert to string.
-  /// @return  String representation of map.
-  /// @note    Overloaded.
-  /// @note    Suggested return identifier: str.
-  ///
+
+  /**
+   * @brief   Convert map to printable string.
+   * @details Uses streams.
+   * @param   map Map to convert to string.
+   * @return  String representation of map.
+   * @note    Overloaded.
+   * @note    Suggested return identifier: str.
+   */
   private static String toString(Map<String, ?> map) {
     String mapAsString =
         map.keySet().stream()
@@ -274,14 +281,15 @@ public class ProvisionedRedisQueue {
             .collect(Collectors.joining(", ", "{", "}"));
     return mapAsString;
   }
-  ///
-  /// @brief   Convert eligibility result to printable string.
-  /// @details Used for visibility / debugging.
-  /// @param   result Detailed results on the evaluation of an eligibility check.
-  /// @return  An explanation on the eligibility of the provided properties.
-  /// @note    Overloaded.
-  /// @note    Suggested return identifier: explanation.
-  ///
+
+  /**
+   * @brief   Convert eligibility result to printable string.
+   * @details Used for visibility / debugging.
+   * @param   result Detailed results on the evaluation of an eligibility check.
+   * @return  An explanation on the eligibility of the provided properties.
+   * @note    Overloaded.
+   * @note    Suggested return identifier: explanation.
+   */
   private static String toString(EligibilityResult result) {
     String explanation = new String();
     if (result.isEligible) {

--- a/src/main/java/build/buildfarm/common/redis/ProvisionedRedisQueue.java
+++ b/src/main/java/build/buildfarm/common/redis/ProvisionedRedisQueue.java
@@ -24,89 +24,80 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * @class   ProvisionedRedisQueue
- * @brief   A queue that is designed to hold particularly provisioned
- *          elements.
- * @details A provisioned redis queue is an implementation of a queue data
- *          structure which internally uses a redis cluster to distribute the
- *          data across shards. Its important to know that the lifetime of
- *          the queue persists before and after the queue data structure is
- *          created (since it exists in redis). Therefore, two redis queues
- *          with the same name, would in fact be the same underlying redis
- *          queue. This redis queue comes with a list of required provisions.
- *          If the queue element does not meet the required provisions, it
- *          should not be stored in the queue. Provision queues are intended
- *          to represent particular operations that should only be processed
- *          by particular workers. An example use case for this would be to
- *          have two dedicated provision queues for CPU and GPU operations.
- *          CPU/GPU requirements would be determined through the remote api's
- *          command platform properties. We designate provision queues to
- *          have a set of "required provisions" (which match the platform
- *          properties). This allows the scheduler to distribute operations
- *          by their properties and allows workers to dequeue from particular
- *          queues.
+ * @class ProvisionedRedisQueue
+ * @brief A queue that is designed to hold particularly provisioned elements.
+ * @details A provisioned redis queue is an implementation of a queue data structure which
+ *     internally uses a redis cluster to distribute the data across shards. Its important to know
+ *     that the lifetime of the queue persists before and after the queue data structure is created
+ *     (since it exists in redis). Therefore, two redis queues with the same name, would in fact be
+ *     the same underlying redis queue. This redis queue comes with a list of required provisions.
+ *     If the queue element does not meet the required provisions, it should not be stored in the
+ *     queue. Provision queues are intended to represent particular operations that should only be
+ *     processed by particular workers. An example use case for this would be to have two dedicated
+ *     provision queues for CPU and GPU operations. CPU/GPU requirements would be determined through
+ *     the remote api's command platform properties. We designate provision queues to have a set of
+ *     "required provisions" (which match the platform properties). This allows the scheduler to
+ *     distribute operations by their properties and allows workers to dequeue from particular
+ *     queues.
  */
 public class ProvisionedRedisQueue {
 
   /**
-   * @field   WILDCARD_VALUE
-   * @brief   Wildcard value.
+   * @field WILDCARD_VALUE
+   * @brief Wildcard value.
    * @details Symbol for identifying wildcard in both key/value of provisions.
    */
   public static final String WILDCARD_VALUE = "*";
 
   /**
-   * @field   CHOOSE_QUEUE_KEY
-   * @brief   Special key to allow directly matching with a queue.
-   * @details This is to support another paradigm where actions want to
-   *          specifically request the queue to be placed in. Its less generic
-   *          than having buildfarm choose the queue for you, and it leaks
-   *          implementation details about how buildfarm is queuing your work.
-   *          However, its desirable to match similar remote execution
-   *          solutions that use exec_properties to choose which "pool" they
-   *          want to run in.
+   * @field CHOOSE_QUEUE_KEY
+   * @brief Special key to allow directly matching with a queue.
+   * @details This is to support another paradigm where actions want to specifically request the
+   *     queue to be placed in. Its less generic than having buildfarm choose the queue for you, and
+   *     it leaks implementation details about how buildfarm is queuing your work. However, its
+   *     desirable to match similar remote execution solutions that use exec_properties to choose
+   *     which "pool" they want to run in.
    */
   public static final String CHOOSE_QUEUE_KEY = "choose-queue";
 
   /**
-   * @field   isFullyWildcard
-   * @brief   If the queue will deem any set of properties eligible.
-   * @details If any of the provision keys has a wildcard, we consider
-   *          anything for the queue to be eligible.
+   * @field isFullyWildcard
+   * @brief If the queue will deem any set of properties eligible.
+   * @details If any of the provision keys has a wildcard, we consider anything for the queue to be
+   *     eligible.
    */
   private final boolean isFullyWildcard;
 
   /**
-   * @field   allowUserUnmatched
-   * @brief   Can the user provide extra platform properties that are not a
-   *          part of the queue and still be matched with it?
-   * @details If true, the user can provide a superset of platform properties
-   *          and still be matched with the queue.
+   * @field allowUserUnmatched
+   * @brief Can the user provide extra platform properties that are not a part of the queue and
+   *     still be matched with it?
+   * @details If true, the user can provide a superset of platform properties and still be matched
+   *     with the queue.
    */
   private final boolean allowUserUnmatched;
 
   /**
-   * @field   provisions
-   * @brief   Provisions enforced by the queue.
+   * @field provisions
+   * @brief Provisions enforced by the queue.
    * @details The provisions are filtered by wildcard.
    */
   private final FilteredProvisions provisions;
 
   /**
-   * @field   queue
-   * @brief   The queue itself.
-   * @details A balanced redis queue designed to hold particularly provisioned
-   *          elements.
+   * @field queue
+   * @brief The queue itself.
+   * @details A balanced redis queue designed to hold particularly provisioned elements.
    */
   private final BalancedRedisQueue queue;
 
   /**
-   * @brief   Constructor.
+   * @brief Constructor.
    * @details Construct the provision queue.
-   * @param   name             The global name of the queue.
-   * @param   hashtags         Hashtags to distribute queue data.
-   * @param   filterProvisions The filtered provisions of the queue.
-   * @note    Overloaded.
+   * @param name The global name of the queue.
+   * @param hashtags Hashtags to distribute queue data.
+   * @param filterProvisions The filtered provisions of the queue.
+   * @note Overloaded.
    */
   public ProvisionedRedisQueue(
       String name, List<String> hashtags, SetMultimap<String, String> filterProvisions) {
@@ -117,14 +108,14 @@ public class ProvisionedRedisQueue {
   }
 
   /**
-   * @brief   Constructor.
+   * @brief Constructor.
    * @details Construct the provision queue.
-   * @param   name               The global name of the queue.
-   * @param   hashtags           Hashtags to distribute queue data.
-   * @param   filterProvisions   The filtered provisions of the queue.
-   * @param   allowUserUnmatched Whether the user can provide extra platform properties and still
-   *match the queue.
-   * @note    Overloaded.
+   * @param name The global name of the queue.
+   * @param hashtags Hashtags to distribute queue data.
+   * @param filterProvisions The filtered provisions of the queue.
+   * @param allowUserUnmatched Whether the user can provide extra platform properties and still
+   *     match the queue.
+   * @note Overloaded.
    */
   public ProvisionedRedisQueue(
       String name,
@@ -138,12 +129,12 @@ public class ProvisionedRedisQueue {
   }
 
   /**
-   * @brief   Checks required properties.
-   * @details Checks whether the properties given fulfill all of the required
-   *          provisions of the queue.
-   * @param   properties Properties to check that requirements are met.
-   * @return  Whether the queue is eligible based on the properties given.
-   * @note    Suggested return identifier: isEligible.
+   * @brief Checks required properties.
+   * @details Checks whether the properties given fulfill all of the required provisions of the
+   *     queue.
+   * @param properties Properties to check that requirements are met.
+   * @return Whether the queue is eligible based on the properties given.
+   * @note Suggested return identifier: isEligible.
    */
   public boolean isEligible(SetMultimap<String, String> properties) {
     // check if a property is specifically requesting to match with the queue
@@ -171,12 +162,12 @@ public class ProvisionedRedisQueue {
   }
 
   /**
-   * @brief   Explain eligibility.
-   * @details Returns an explanation as to why the properties provided are
-   *          eligible / ineligible to be placed on the queue.
-   * @param   properties Properties to get an eligibility explanation of.
-   * @return  An explanation on the eligibility of the provided properties.
-   * @note    Suggested return identifier: explanation.
+   * @brief Explain eligibility.
+   * @details Returns an explanation as to why the properties provided are eligible / ineligible to
+   *     be placed on the queue.
+   * @param properties Properties to get an eligibility explanation of.
+   * @return An explanation on the eligibility of the provided properties.
+   * @note Suggested return identifier: explanation.
    */
   public String explainEligibility(SetMultimap<String, String> properties) {
     EligibilityResult result = getEligibilityResult(properties);
@@ -184,24 +175,23 @@ public class ProvisionedRedisQueue {
   }
 
   /**
-   * @brief   Get queue.
+   * @brief Get queue.
    * @details Obtain the internal queue.
-   * @return  The internal queue.
-   * @note    Suggested return identifier: queue.
+   * @return The internal queue.
+   * @note Suggested return identifier: queue.
    */
   public BalancedRedisQueue queue() {
     return queue;
   }
 
   /**
-   * @brief   Filter the provisions into separate sets by checking for the
-   *          existence of wildcards.
+   * @brief Filter the provisions into separate sets by checking for the existence of wildcards.
    * @details This will organize the incoming provisions into separate sets.
-   * @param   filterProvisions The filtered provisions of the queue.
-   * @param   isFullyWildcard  If the queue will deem any set of properties eligible.
-   * @param   wildcardValue    Symbol for identifying wildcard in both key/value of provisions.
-   * @return  Provisions filtered by wildcard.
-   * @note    Suggested return identifier: filteredProvisions.
+   * @param filterProvisions The filtered provisions of the queue.
+   * @param isFullyWildcard If the queue will deem any set of properties eligible.
+   * @param wildcardValue Symbol for identifying wildcard in both key/value of provisions.
+   * @return Provisions filtered by wildcard.
+   * @note Suggested return identifier: filteredProvisions.
    */
   private static FilteredProvisions filterProvisionsByWildcard(
       SetMultimap<String, String> filterProvisions, boolean isFullyWildcard, String wildcardValue) {
@@ -223,12 +213,11 @@ public class ProvisionedRedisQueue {
   }
 
   /**
-   * @brief   Get eligibility result.
-   * @details Perform eligibility check with detailed information on
-   *          evaluation.
-   * @param   properties Properties to get an eligibility explanation of.
-   * @return  Detailed results on the evaluation of an eligibility check.
-   * @note    Suggested return identifier: eligibilityResult.
+   * @brief Get eligibility result.
+   * @details Perform eligibility check with detailed information on evaluation.
+   * @param properties Properties to get an eligibility explanation of.
+   * @return Detailed results on the evaluation of an eligibility check.
+   * @note Suggested return identifier: eligibilityResult.
    */
   private EligibilityResult getEligibilityResult(SetMultimap<String, String> properties) {
     EligibilityResult result = new EligibilityResult();
@@ -267,12 +256,12 @@ public class ProvisionedRedisQueue {
   }
 
   /**
-   * @brief   Convert map to printable string.
+   * @brief Convert map to printable string.
    * @details Uses streams.
-   * @param   map Map to convert to string.
-   * @return  String representation of map.
-   * @note    Overloaded.
-   * @note    Suggested return identifier: str.
+   * @param map Map to convert to string.
+   * @return String representation of map.
+   * @note Overloaded.
+   * @note Suggested return identifier: str.
    */
   private static String toString(Map<String, ?> map) {
     String mapAsString =
@@ -283,12 +272,12 @@ public class ProvisionedRedisQueue {
   }
 
   /**
-   * @brief   Convert eligibility result to printable string.
+   * @brief Convert eligibility result to printable string.
    * @details Used for visibility / debugging.
-   * @param   result Detailed results on the evaluation of an eligibility check.
-   * @return  An explanation on the eligibility of the provided properties.
-   * @note    Overloaded.
-   * @note    Suggested return identifier: explanation.
+   * @param result Detailed results on the evaluation of an eligibility check.
+   * @return An explanation on the eligibility of the provided properties.
+   * @note Overloaded.
+   * @note Suggested return identifier: explanation.
    */
   private static String toString(EligibilityResult result) {
     String explanation = new String();

--- a/src/main/java/build/buildfarm/common/redis/RedisHashtags.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisHashtags.java
@@ -18,44 +18,42 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * @class   RedisHashtags
- * @brief   String utilities when dealing with key names that involve
- *          hashtags.
- * @details Simple parsers for extracting out / adding hashtags to redis
- *          keys.
+ * @class RedisHashtags
+ * @brief String utilities when dealing with key names that involve hashtags.
+ * @details Simple parsers for extracting out / adding hashtags to redis keys.
  */
 public class RedisHashtags {
 
   /**
-   * @brief   Append the hashtag value to the base queue name.
+   * @brief Append the hashtag value to the base queue name.
    * @details Creates a valid queue name for one of the entire queues.
-   * @param   name    The global name of the queue.
-   * @param   hashtag A hashtag for an individual internal queue.
-   * @return  A valid queue name for one of the internal queues.
-   * @note    Suggested return identifier: queueName.
+   * @param name The global name of the queue.
+   * @param hashtag A hashtag for an individual internal queue.
+   * @return A valid queue name for one of the internal queues.
+   * @note Suggested return identifier: queueName.
    */
   public static String hashedName(String name, String hashtag) {
     return "{" + hashtag + "}" + name;
   }
 
   /**
-   * @brief   Remove any existing redis hashtag from the key name.
+   * @brief Remove any existing redis hashtag from the key name.
    * @details Creates a valid key name with any existing hashtags removed.
-   * @param   name The global name of the queue.
-   * @return  A valid keyname without hashtags.
-   * @note    Suggested return identifier: queueName.
+   * @param name The global name of the queue.
+   * @return A valid keyname without hashtags.
+   * @note Suggested return identifier: queueName.
    */
   public static String unhashedName(String name) {
     return name.replaceAll("\\{.*?\\}", "");
   }
 
   /**
-   * @brief   Get the existing hashtag of the name.
-   * @details Parses out the first redis hashtag found. If no hashtags are
-   *          found, an empty string is returned.
-   * @param   name The global name of the queue.
-   * @return  The existing hashtag name found in the string (brackets are removed).
-   * @note    Suggested return identifier: hashtag.
+   * @brief Get the existing hashtag of the name.
+   * @details Parses out the first redis hashtag found. If no hashtags are found, an empty string is
+   *     returned.
+   * @param name The global name of the queue.
+   * @return The existing hashtag name found in the string (brackets are removed).
+   * @note Suggested return identifier: hashtag.
    */
   public static String existingHash(String name) {
     String regex = "\\{.*?\\}";

--- a/src/main/java/build/buildfarm/common/redis/RedisHashtags.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisHashtags.java
@@ -17,44 +17,46 @@ package build.buildfarm.common.redis;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-///
-/// @class   RedisHashtags
-/// @brief   String utilities when dealing with key names that involve
-///          hashtags.
-/// @details Simple parsers for extracting out / adding hashtags to redis
-///          keys.
-///
+/**
+ * @class   RedisHashtags
+ * @brief   String utilities when dealing with key names that involve
+ *          hashtags.
+ * @details Simple parsers for extracting out / adding hashtags to redis
+ *          keys.
+ */
 public class RedisHashtags {
 
-  ///
-  /// @brief   Append the hashtag value to the base queue name.
-  /// @details Creates a valid queue name for one of the entire queues.
-  /// @param   name    The global name of the queue.
-  /// @param   hashtag A hashtag for an individual internal queue.
-  /// @return  A valid queue name for one of the internal queues.
-  /// @note    Suggested return identifier: queueName.
-  ///
+  /**
+   * @brief   Append the hashtag value to the base queue name.
+   * @details Creates a valid queue name for one of the entire queues.
+   * @param   name    The global name of the queue.
+   * @param   hashtag A hashtag for an individual internal queue.
+   * @return  A valid queue name for one of the internal queues.
+   * @note    Suggested return identifier: queueName.
+   */
   public static String hashedName(String name, String hashtag) {
     return "{" + hashtag + "}" + name;
   }
-  ///
-  /// @brief   Remove any existing redis hashtag from the key name.
-  /// @details Creates a valid key name with any existing hashtags removed.
-  /// @param   name The global name of the queue.
-  /// @return  A valid keyname without hashtags.
-  /// @note    Suggested return identifier: queueName.
-  ///
+
+  /**
+   * @brief   Remove any existing redis hashtag from the key name.
+   * @details Creates a valid key name with any existing hashtags removed.
+   * @param   name The global name of the queue.
+   * @return  A valid keyname without hashtags.
+   * @note    Suggested return identifier: queueName.
+   */
   public static String unhashedName(String name) {
     return name.replaceAll("\\{.*?\\}", "");
   }
-  ///
-  /// @brief   Get the existing hashtag of the name.
-  /// @details Parses out the first redis hashtag found. If no hashtags are
-  ///          found, an empty string is returned.
-  /// @param   name The global name of the queue.
-  /// @return  The existing hashtag name found in the string (brackets are removed).
-  /// @note    Suggested return identifier: hashtag.
-  ///
+
+  /**
+   * @brief   Get the existing hashtag of the name.
+   * @details Parses out the first redis hashtag found. If no hashtags are
+   *          found, an empty string is returned.
+   * @param   name The global name of the queue.
+   * @return  The existing hashtag name found in the string (brackets are removed).
+   * @note    Suggested return identifier: hashtag.
+   */
   public static String existingHash(String name) {
     String regex = "\\{.*?\\}";
     Pattern pattern = Pattern.compile(regex);

--- a/src/main/java/build/buildfarm/common/redis/RedisMap.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisMap.java
@@ -18,65 +18,61 @@ import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.JedisClusterPipeline;
 
 /**
- * @class   RedisMap
- * @brief   A redis map.
- * @details A redis map is an implementation of a map data structure which
- *          internally uses redis to store and distribute the data. Its
- *          important to know that the lifetime of the map persists before
- *          and after the map data structure is created (since it exists in
- *          redis). Therefore, two redis maps with the same name, would in
- *          fact be the same underlying redis map.
+ * @class RedisMap
+ * @brief A redis map.
+ * @details A redis map is an implementation of a map data structure which internally uses redis to
+ *     store and distribute the data. Its important to know that the lifetime of the map persists
+ *     before and after the map data structure is created (since it exists in redis). Therefore, two
+ *     redis maps with the same name, would in fact be the same underlying redis map.
  */
 public class RedisMap {
 
   /**
-   * @field   name
-   * @brief   The unique name of the map.
-   * @details The name is used by the redis cluster client to access the map
-   *          data. If two maps had the same name, they would be instances of
-   *          the same underlying redis map.
+   * @field name
+   * @brief The unique name of the map.
+   * @details The name is used by the redis cluster client to access the map data. If two maps had
+   *     the same name, they would be instances of the same underlying redis map.
    */
   private final String name;
 
   /**
-   * @brief   Constructor.
+   * @brief Constructor.
    * @details Construct a named redis map with an established redis cluster.
-   * @param   name The global name of the map.
+   * @param name The global name of the map.
    */
   public RedisMap(String name) {
     this.name = name;
   }
 
   /**
-   * @brief   Set key to hold the string value and set key to timeout after a
-   *          given number of seconds.
+   * @brief Set key to hold the string value and set key to timeout after a given number of seconds.
    * @details If the key already exists, then the value is replaced.
-   * @param   jedis     Jedis cluster client.
-   * @param   key       The name of the key.
-   * @param   value     The value for the key.
-   * @param   timeout_s Timeout to expire the entry. (units: seconds (s))
+   * @param jedis Jedis cluster client.
+   * @param key The name of the key.
+   * @param value The value for the key.
+   * @param timeout_s Timeout to expire the entry. (units: seconds (s))
    */
   public void insert(JedisCluster jedis, String key, String value, int timeout_s) {
     jedis.setex(createKeyName(key), timeout_s, value);
   }
 
   /**
-   * @brief   Remove a key from the map.
+   * @brief Remove a key from the map.
    * @details Deletes the key/value pair.
-   * @param   jedis Jedis cluster client.
-   * @param   key   The name of the key.
-   * @note    Overloaded.
+   * @param jedis Jedis cluster client.
+   * @param key The name of the key.
+   * @note Overloaded.
    */
   public void remove(JedisCluster jedis, String key) {
     jedis.del(createKeyName(key));
   }
 
   /**
-   * @brief   Remove multiple keys from the map.
+   * @brief Remove multiple keys from the map.
    * @details Done via pipeline.
-   * @param   jedis Jedis cluster client.
-   * @param   keys  The name of the keys.
-   * @note    Overloaded.
+   * @param jedis Jedis cluster client.
+   * @param keys The name of the keys.
+   * @note Overloaded.
    */
   public void remove(JedisCluster jedis, Iterable<String> keys) {
     JedisClusterPipeline p = jedis.pipelined();
@@ -87,23 +83,23 @@ public class RedisMap {
   }
 
   /**
-   * @brief   Get the value of the key.
+   * @brief Get the value of the key.
    * @details If the key does not exist, null is returned.
-   * @param   jedis Jedis cluster client.
-   * @param   key   The name of the key.
-   * @return  The value of the key. null if key does not exist.
-   * @note    Suggested return identifier: value.
+   * @param jedis Jedis cluster client.
+   * @param key The name of the key.
+   * @return The value of the key. null if key does not exist.
+   * @note Suggested return identifier: value.
    */
   public String get(JedisCluster jedis, String key) {
     return jedis.get(createKeyName(key));
   }
 
   /**
-   * @brief   Create the key name used in redis.
+   * @brief Create the key name used in redis.
    * @details The key name is made more unique by leveraging the map's name.
-   * @param   keyName The name of the key.
-   * @return  The key name to use in redis.
-   * @note    Suggested return identifier: redisKeyName.
+   * @param keyName The name of the key.
+   * @return The key name to use in redis.
+   * @note Suggested return identifier: redisKeyName.
    */
   private String createKeyName(String keyName) {
     return name + ":" + keyName;

--- a/src/main/java/build/buildfarm/common/redis/RedisMap.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisMap.java
@@ -17,64 +17,67 @@ package build.buildfarm.common.redis;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.JedisClusterPipeline;
 
-///
-/// @class   RedisMap
-/// @brief   A redis map.
-/// @details A redis map is an implementation of a map data structure which
-///          internally uses redis to store and distribute the data. Its
-///          important to know that the lifetime of the map persists before
-///          and after the map data structure is created (since it exists in
-///          redis). Therefore, two redis maps with the same name, would in
-///          fact be the same underlying redis map.
-///
+/**
+ * @class   RedisMap
+ * @brief   A redis map.
+ * @details A redis map is an implementation of a map data structure which
+ *          internally uses redis to store and distribute the data. Its
+ *          important to know that the lifetime of the map persists before
+ *          and after the map data structure is created (since it exists in
+ *          redis). Therefore, two redis maps with the same name, would in
+ *          fact be the same underlying redis map.
+ */
 public class RedisMap {
 
-  ///
-  /// @field   name
-  /// @brief   The unique name of the map.
-  /// @details The name is used by the redis cluster client to access the map
-  ///          data. If two maps had the same name, they would be instances of
-  ///          the same underlying redis map.
-  ///
+  /**
+   * @field   name
+   * @brief   The unique name of the map.
+   * @details The name is used by the redis cluster client to access the map
+   *          data. If two maps had the same name, they would be instances of
+   *          the same underlying redis map.
+   */
   private final String name;
 
-  ///
-  /// @brief   Constructor.
-  /// @details Construct a named redis map with an established redis cluster.
-  /// @param   name The global name of the map.
-  ///
+  /**
+   * @brief   Constructor.
+   * @details Construct a named redis map with an established redis cluster.
+   * @param   name The global name of the map.
+   */
   public RedisMap(String name) {
     this.name = name;
   }
-  ///
-  /// @brief   Set key to hold the string value and set key to timeout after a
-  ///          given number of seconds.
-  /// @details If the key already exists, then the value is replaced.
-  /// @param   jedis     Jedis cluster client.
-  /// @param   key       The name of the key.
-  /// @param   value     The value for the key.
-  /// @param   timeout_s Timeout to expire the entry. (units: seconds (s))
-  ///
+
+  /**
+   * @brief   Set key to hold the string value and set key to timeout after a
+   *          given number of seconds.
+   * @details If the key already exists, then the value is replaced.
+   * @param   jedis     Jedis cluster client.
+   * @param   key       The name of the key.
+   * @param   value     The value for the key.
+   * @param   timeout_s Timeout to expire the entry. (units: seconds (s))
+   */
   public void insert(JedisCluster jedis, String key, String value, int timeout_s) {
     jedis.setex(createKeyName(key), timeout_s, value);
   }
-  ///
-  /// @brief   Remove a key from the map.
-  /// @details Deletes the key/value pair.
-  /// @param   jedis Jedis cluster client.
-  /// @param   key   The name of the key.
-  /// @note    Overloaded.
-  ///
+
+  /**
+   * @brief   Remove a key from the map.
+   * @details Deletes the key/value pair.
+   * @param   jedis Jedis cluster client.
+   * @param   key   The name of the key.
+   * @note    Overloaded.
+   */
   public void remove(JedisCluster jedis, String key) {
     jedis.del(createKeyName(key));
   }
-  ///
-  /// @brief   Remove multiple keys from the map.
-  /// @details Done via pipeline.
-  /// @param   jedis Jedis cluster client.
-  /// @param   keys  The name of the keys.
-  /// @note    Overloaded.
-  ///
+
+  /**
+   * @brief   Remove multiple keys from the map.
+   * @details Done via pipeline.
+   * @param   jedis Jedis cluster client.
+   * @param   keys  The name of the keys.
+   * @note    Overloaded.
+   */
   public void remove(JedisCluster jedis, Iterable<String> keys) {
     JedisClusterPipeline p = jedis.pipelined();
     for (String key : keys) {
@@ -82,24 +85,26 @@ public class RedisMap {
     }
     p.sync();
   }
-  ///
-  /// @brief   Get the value of the key.
-  /// @details If the key does not exist, null is returned.
-  /// @param   jedis Jedis cluster client.
-  /// @param   key   The name of the key.
-  /// @return  The value of the key. null if key does not exist.
-  /// @note    Suggested return identifier: value.
-  ///
+
+  /**
+   * @brief   Get the value of the key.
+   * @details If the key does not exist, null is returned.
+   * @param   jedis Jedis cluster client.
+   * @param   key   The name of the key.
+   * @return  The value of the key. null if key does not exist.
+   * @note    Suggested return identifier: value.
+   */
   public String get(JedisCluster jedis, String key) {
     return jedis.get(createKeyName(key));
   }
-  ///
-  /// @brief   Create the key name used in redis.
-  /// @details The key name is made more unique by leveraging the map's name.
-  /// @param   keyName The name of the key.
-  /// @return  The key name to use in redis.
-  /// @note    Suggested return identifier: redisKeyName.
-  ///
+
+  /**
+   * @brief   Create the key name used in redis.
+   * @details The key name is made more unique by leveraging the map's name.
+   * @param   keyName The name of the key.
+   * @return  The key name to use in redis.
+   * @note    Suggested return identifier: redisKeyName.
+   */
   private String createKeyName(String keyName) {
     return name + ":" + keyName;
   }

--- a/src/main/java/build/buildfarm/common/redis/RedisNodeHashes.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisNodeHashes.java
@@ -23,25 +23,25 @@ import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.exceptions.JedisException;
 import redis.clients.jedis.exceptions.JedisNoReachableClusterNodeException;
 
-///
-/// @class   RedisNodeHashes
-/// @brief   A list of redis hashtags that each map to different nodes in the
-///          cluster.
-/// @details When looking to evenly distribute keys across nodes, specific
-///          hashtags need obtained in which each hashtag hashes to a
-///          particular slot owned by a particular worker. This class is used
-///          to obtain the hashtags needed to hit every node in the cluster.
-///
+/**
+ * @class   RedisNodeHashes
+ * @brief   A list of redis hashtags that each map to different nodes in the
+ *          cluster.
+ * @details When looking to evenly distribute keys across nodes, specific
+ *          hashtags need obtained in which each hashtag hashes to a
+ *          particular slot owned by a particular worker. This class is used
+ *          to obtain the hashtags needed to hit every node in the cluster.
+ */
 public class RedisNodeHashes {
 
-  ///
-  /// @brief   Get a list of evenly distributing hashtags for the provided
-  ///          redis cluster.
-  /// @details Each hashtag will map to a slot on a different node.
-  /// @param   jedis An established jedis client.
-  /// @return  Hashtags that will each has to a slot on a different node.
-  /// @note    Suggested return identifier: hashtags.
-  ///
+  /**
+   * @brief   Get a list of evenly distributing hashtags for the provided
+   *          redis cluster.
+   * @details Each hashtag will map to a slot on a different node.
+   * @param   jedis An established jedis client.
+   * @return  Hashtags that will each has to a slot on a different node.
+   * @note    Suggested return identifier: hashtags.
+   */
   public static List<String> getEvenlyDistributedHashes(JedisCluster jedis) {
     try {
       List<List<Long>> slotRanges = getSlotRanges(jedis);
@@ -57,15 +57,16 @@ public class RedisNodeHashes {
       return ImmutableList.of();
     }
   }
-  ///
-  /// @brief   Get a list of evenly distributing hashtags for the provided
-  ///          redis cluster.
-  /// @details Each hashtag will map to a slot on a different node.
-  /// @param   jedis  An established jedis client.
-  /// @param   prefix The prefix to include as part of hashtags.
-  /// @return  Hashtags that will each has to a slot on a different node.
-  /// @note    Suggested return identifier: hashtags.
-  ///
+
+  /**
+   * @brief   Get a list of evenly distributing hashtags for the provided
+   *          redis cluster.
+   * @details Each hashtag will map to a slot on a different node.
+   * @param   jedis  An established jedis client.
+   * @param   prefix The prefix to include as part of hashtags.
+   * @return  Hashtags that will each has to a slot on a different node.
+   * @note    Suggested return identifier: hashtags.
+   */
   public static List<String> getEvenlyDistributedHashesWithPrefix(
       JedisCluster jedis, String prefix) {
     try {
@@ -83,14 +84,15 @@ public class RedisNodeHashes {
       return ImmutableList.of();
     }
   }
-  ///
-  /// @brief   Get a list of slot ranges for each of the nodes in the cluster.
-  /// @details This information can be found from any of the redis nodes in the
-  ///          cluster.
-  /// @param   jedis An established jedis client.
-  /// @return  Slot ranges for all of the nodes in the cluster.
-  /// @note    Suggested return identifier: slotRanges.
-  ///
+
+  /**
+   * @brief   Get a list of slot ranges for each of the nodes in the cluster.
+   * @details This information can be found from any of the redis nodes in the
+   *          cluster.
+   * @param   jedis An established jedis client.
+   * @return  Slot ranges for all of the nodes in the cluster.
+   * @note    Suggested return identifier: slotRanges.
+   */
   private static List<List<Long>> getSlotRanges(JedisCluster jedis) {
     // get slot information for each node
     List<Object> slots = getClusterSlots(jedis);
@@ -105,24 +107,26 @@ public class RedisNodeHashes {
 
     return slotRanges.build();
   }
-  ///
-  /// @brief   Convert a jedis slotInfo object to a range or slot numbers.
-  /// @details Every redis node has a range of slots represented as integers.
-  /// @param   slotInfo Slot info objects from a redis node.
-  /// @return  The slot number range for the particular redis node.
-  /// @note    Suggested return identifier: slotRange.
-  ///
+
+  /**
+   * @brief   Convert a jedis slotInfo object to a range or slot numbers.
+   * @details Every redis node has a range of slots represented as integers.
+   * @param   slotInfo Slot info objects from a redis node.
+   * @return  The slot number range for the particular redis node.
+   * @note    Suggested return identifier: slotRange.
+   */
   private static List<Long> slotInfoToSlotRange(List<Object> slotInfo) {
     return ImmutableList.of((Long) slotInfo.get(0), (Long) slotInfo.get(1));
   }
-  ///
-  /// @brief   Query slot information for each redis node.
-  /// @details Obtains cluster information for understanding slot ranges for
-  ///          balancing.
-  /// @param   jedis An established jedis client.
-  /// @return  Cluster slot information.
-  /// @note    Suggested return identifier: clusterSlots.
-  ///
+
+  /**
+   * @brief   Query slot information for each redis node.
+   * @details Obtains cluster information for understanding slot ranges for
+   *          balancing.
+   * @param   jedis An established jedis client.
+   * @return  Cluster slot information.
+   * @note    Suggested return identifier: clusterSlots.
+   */
   private static List<Object> getClusterSlots(JedisCluster jedis) {
     JedisException nodeException = null;
     for (Map.Entry<String, JedisPool> node : jedis.getClusterNodes().entrySet()) {

--- a/src/main/java/build/buildfarm/common/redis/RedisNodeHashes.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisNodeHashes.java
@@ -24,23 +24,20 @@ import redis.clients.jedis.exceptions.JedisException;
 import redis.clients.jedis.exceptions.JedisNoReachableClusterNodeException;
 
 /**
- * @class   RedisNodeHashes
- * @brief   A list of redis hashtags that each map to different nodes in the
- *          cluster.
- * @details When looking to evenly distribute keys across nodes, specific
- *          hashtags need obtained in which each hashtag hashes to a
- *          particular slot owned by a particular worker. This class is used
- *          to obtain the hashtags needed to hit every node in the cluster.
+ * @class RedisNodeHashes
+ * @brief A list of redis hashtags that each map to different nodes in the cluster.
+ * @details When looking to evenly distribute keys across nodes, specific hashtags need obtained in
+ *     which each hashtag hashes to a particular slot owned by a particular worker. This class is
+ *     used to obtain the hashtags needed to hit every node in the cluster.
  */
 public class RedisNodeHashes {
 
   /**
-   * @brief   Get a list of evenly distributing hashtags for the provided
-   *          redis cluster.
+   * @brief Get a list of evenly distributing hashtags for the provided redis cluster.
    * @details Each hashtag will map to a slot on a different node.
-   * @param   jedis An established jedis client.
-   * @return  Hashtags that will each has to a slot on a different node.
-   * @note    Suggested return identifier: hashtags.
+   * @param jedis An established jedis client.
+   * @return Hashtags that will each has to a slot on a different node.
+   * @note Suggested return identifier: hashtags.
    */
   public static List<String> getEvenlyDistributedHashes(JedisCluster jedis) {
     try {
@@ -59,13 +56,12 @@ public class RedisNodeHashes {
   }
 
   /**
-   * @brief   Get a list of evenly distributing hashtags for the provided
-   *          redis cluster.
+   * @brief Get a list of evenly distributing hashtags for the provided redis cluster.
    * @details Each hashtag will map to a slot on a different node.
-   * @param   jedis  An established jedis client.
-   * @param   prefix The prefix to include as part of hashtags.
-   * @return  Hashtags that will each has to a slot on a different node.
-   * @note    Suggested return identifier: hashtags.
+   * @param jedis An established jedis client.
+   * @param prefix The prefix to include as part of hashtags.
+   * @return Hashtags that will each has to a slot on a different node.
+   * @note Suggested return identifier: hashtags.
    */
   public static List<String> getEvenlyDistributedHashesWithPrefix(
       JedisCluster jedis, String prefix) {
@@ -86,12 +82,11 @@ public class RedisNodeHashes {
   }
 
   /**
-   * @brief   Get a list of slot ranges for each of the nodes in the cluster.
-   * @details This information can be found from any of the redis nodes in the
-   *          cluster.
-   * @param   jedis An established jedis client.
-   * @return  Slot ranges for all of the nodes in the cluster.
-   * @note    Suggested return identifier: slotRanges.
+   * @brief Get a list of slot ranges for each of the nodes in the cluster.
+   * @details This information can be found from any of the redis nodes in the cluster.
+   * @param jedis An established jedis client.
+   * @return Slot ranges for all of the nodes in the cluster.
+   * @note Suggested return identifier: slotRanges.
    */
   private static List<List<Long>> getSlotRanges(JedisCluster jedis) {
     // get slot information for each node
@@ -109,23 +104,22 @@ public class RedisNodeHashes {
   }
 
   /**
-   * @brief   Convert a jedis slotInfo object to a range or slot numbers.
+   * @brief Convert a jedis slotInfo object to a range or slot numbers.
    * @details Every redis node has a range of slots represented as integers.
-   * @param   slotInfo Slot info objects from a redis node.
-   * @return  The slot number range for the particular redis node.
-   * @note    Suggested return identifier: slotRange.
+   * @param slotInfo Slot info objects from a redis node.
+   * @return The slot number range for the particular redis node.
+   * @note Suggested return identifier: slotRange.
    */
   private static List<Long> slotInfoToSlotRange(List<Object> slotInfo) {
     return ImmutableList.of((Long) slotInfo.get(0), (Long) slotInfo.get(1));
   }
 
   /**
-   * @brief   Query slot information for each redis node.
-   * @details Obtains cluster information for understanding slot ranges for
-   *          balancing.
-   * @param   jedis An established jedis client.
-   * @return  Cluster slot information.
-   * @note    Suggested return identifier: clusterSlots.
+   * @brief Query slot information for each redis node.
+   * @details Obtains cluster information for understanding slot ranges for balancing.
+   * @param jedis An established jedis client.
+   * @return Cluster slot information.
+   * @note Suggested return identifier: clusterSlots.
    */
   private static List<Object> getClusterSlots(JedisCluster jedis) {
     JedisException nodeException = null;

--- a/src/main/java/build/buildfarm/common/redis/RedisQueue.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisQueue.java
@@ -19,77 +19,73 @@ import java.util.List;
 import redis.clients.jedis.JedisCluster;
 
 /**
- * @class   RedisQueue
- * @brief   A redis queue.
- * @details A redis queue is an implementation of a queue data structure
- *          which internally uses redis to store and distribute the data. Its
- *          important to know that the lifetime of the queue persists before
- *          and after the queue data structure is created (since it exists in
- *          redis). Therefore, two redis queues with the same name, would in
- *          fact be the same underlying redis queue.
+ * @class RedisQueue
+ * @brief A redis queue.
+ * @details A redis queue is an implementation of a queue data structure which internally uses redis
+ *     to store and distribute the data. Its important to know that the lifetime of the queue
+ *     persists before and after the queue data structure is created (since it exists in redis).
+ *     Therefore, two redis queues with the same name, would in fact be the same underlying redis
+ *     queue.
  */
 public class RedisQueue {
 
   /**
-   * @field   name
-   * @brief   The unique name of the queue.
-   * @details The name is used by the redis cluster client to access the queue
-   *          data. If two queues had the same name, they would be instances of
-   *          the same underlying redis queue.
+   * @field name
+   * @brief The unique name of the queue.
+   * @details The name is used by the redis cluster client to access the queue data. If two queues
+   *     had the same name, they would be instances of the same underlying redis queue.
    */
   private final String name;
 
   /**
-   * @brief   Constructor.
+   * @brief Constructor.
    * @details Construct a named redis queue with an established redis cluster.
-   * @param   name   The global name of the queue.
+   * @param name The global name of the queue.
    */
   public RedisQueue(String name) {
     this.name = name;
   }
 
   /**
-   * @brief   Push a value onto the queue.
+   * @brief Push a value onto the queue.
    * @details Adds the value into the backend redis queue.
-   * @param   val The value to push onto the queue.
+   * @param val The value to push onto the queue.
    */
   public void push(JedisCluster jedis, String val) {
     jedis.lpush(name, val);
   }
 
   /**
-   * @brief   Remove element from dequeue.
-   * @details Removes an element from the dequeue and specifies whether it was
-   *          removed.
-   * @param   val The value to remove.
-   * @return  Whether or not the value was removed.
-   * @note    Suggested return identifier: wasRemoved.
+   * @brief Remove element from dequeue.
+   * @details Removes an element from the dequeue and specifies whether it was removed.
+   * @param val The value to remove.
+   * @return Whether or not the value was removed.
+   * @note Suggested return identifier: wasRemoved.
    */
   public boolean removeFromDequeue(JedisCluster jedis, String val) {
     return jedis.lrem(getDequeueName(), -1, val) != 0;
   }
 
   /**
-   * @brief   Remove all elements that match from queue.
-   * @details Removes all matching elements from the queue and specifies
-   *          whether it was removed.
-   * @param   val The value to remove.
-   * @return  Whether or not the value was removed.
-   * @note    Suggested return identifier: wasRemoved.
+   * @brief Remove all elements that match from queue.
+   * @details Removes all matching elements from the queue and specifies whether it was removed.
+   * @param val The value to remove.
+   * @return Whether or not the value was removed.
+   * @note Suggested return identifier: wasRemoved.
    */
   public boolean removeAll(JedisCluster jedis, String val) {
     return jedis.lrem(name, 0, val) != 0;
   }
 
   /**
-   * @brief   Pop element into internal dequeue and return value.
-   * @details This pops the element from one queue atomically into an internal
-   *          list called the dequeue. It will wait until the timeout has
-   *          expired. Null is returned if the timeout has expired.
-   * @param   timeout_s Timeout to wait if there is no item to dequeue. (units: seconds (s))
-   * @return  The value of the transfered element. null if the thread was interrupted.
-   * @note    Overloaded.
-   * @note    Suggested return identifier: val.
+   * @brief Pop element into internal dequeue and return value.
+   * @details This pops the element from one queue atomically into an internal list called the
+   *     dequeue. It will wait until the timeout has expired. Null is returned if the timeout has
+   *     expired.
+   * @param timeout_s Timeout to wait if there is no item to dequeue. (units: seconds (s))
+   * @return The value of the transfered element. null if the thread was interrupted.
+   * @note Overloaded.
+   * @note Suggested return identifier: val.
    */
   public String dequeue(JedisCluster jedis, int timeout_s) throws InterruptedException {
     String val = null;
@@ -103,12 +99,11 @@ public class RedisQueue {
   }
 
   /**
-   * @brief   Pop element into internal dequeue and return value.
-   * @details This pops the element from one queue atomically into an internal
-   *          list called the dequeue. It does not block and null is returned
-   *          if there is nothing to dequeue.
-   * @return  The value of the transfered element. null if nothing was dequeued.
-   * @note    Suggested return identifier: val.
+   * @brief Pop element into internal dequeue and return value.
+   * @details This pops the element from one queue atomically into an internal list called the
+   *     dequeue. It does not block and null is returned if there is nothing to dequeue.
+   * @return The value of the transfered element. null if nothing was dequeued.
+   * @note Suggested return identifier: val.
    */
   public String nonBlockingDequeue(JedisCluster jedis) throws InterruptedException {
     String val = jedis.rpoplpush(name, getDequeueName());
@@ -122,62 +117,61 @@ public class RedisQueue {
   }
 
   /**
-   * @brief   Get name.
-   * @details Get the name of the queue. this is the redis key used for the
-   *          list.
-   * @return  The name of the queue.
-   * @note    Suggested return identifier: name.
+   * @brief Get name.
+   * @details Get the name of the queue. this is the redis key used for the list.
+   * @return The name of the queue.
+   * @note Suggested return identifier: name.
    */
   public String getName() {
     return name;
   }
 
   /**
-   * @brief   Get dequeue name.
-   * @details Get the name of the internal dequeue used by the queue. this is
-   *          the redis key used for the list.
-   * @return  The name of the queue.
-   * @note    Suggested return identifier: name.
+   * @brief Get dequeue name.
+   * @details Get the name of the internal dequeue used by the queue. this is the redis key used for
+   *     the list.
+   * @return The name of the queue.
+   * @note Suggested return identifier: name.
    */
   public String getDequeueName() {
     return name + "_dequeue";
   }
 
   /**
-   * @brief   Get size.
+   * @brief Get size.
    * @details Checks the current length of the queue.
-   * @return  The current length of the queue.
-   * @note    Suggested return identifier: length.
+   * @return The current length of the queue.
+   * @note Suggested return identifier: length.
    */
   public long size(JedisCluster jedis) {
     return jedis.llen(name);
   }
 
   /**
-   * @brief   Visit each element in the queue.
+   * @brief Visit each element in the queue.
    * @details Enacts a visitor over each element in the queue.
-   * @param   visitor A visitor for each visited element in the queue.
-   * @note    Overloaded.
+   * @param visitor A visitor for each visited element in the queue.
+   * @note Overloaded.
    */
   public void visit(JedisCluster jedis, StringVisitor visitor) {
     visit(jedis, name, visitor);
   }
 
   /**
-   * @brief   Visit each element in the dequeue.
+   * @brief Visit each element in the dequeue.
    * @details Enacts a visitor over each element in the dequeue.
-   * @param   visitor A visitor for each visited element in the queue.
+   * @param visitor A visitor for each visited element in the queue.
    */
   public void visitDequeue(JedisCluster jedis, StringVisitor visitor) {
     visit(jedis, getDequeueName(), visitor);
   }
 
   /**
-   * @brief   Visit each element in the queue via queue name.
+   * @brief Visit each element in the queue via queue name.
    * @details Enacts a visitor over each element in the queue.
-   * @param   queueName The name of the queue to visit.
-   * @param   visitor   A visitor for each visited element in the queue.
-   * @note    Overloaded.
+   * @param queueName The name of the queue to visit.
+   * @param visitor A visitor for each visited element in the queue.
+   * @note Overloaded.
    */
   private void visit(JedisCluster jedis, String queueName, StringVisitor visitor) {
     int listPageSize = 10000;

--- a/src/main/java/build/buildfarm/common/redis/RedisQueue.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisQueue.java
@@ -18,80 +18,79 @@ import build.buildfarm.common.StringVisitor;
 import java.util.List;
 import redis.clients.jedis.JedisCluster;
 
-///
-/// @class   RedisQueue
-/// @brief   A redis queue.
-/// @details A redis queue is an implementation of a queue data structure
-///          which internally uses redis to store and distribute the data. Its
-///          important to know that the lifetime of the queue persists before
-///          and after the queue data structure is created (since it exists in
-///          redis). Therefore, two redis queues with the same name, would in
-///          fact be the same underlying redis queue.
-///
+/**
+ * @class   RedisQueue
+ * @brief   A redis queue.
+ * @details A redis queue is an implementation of a queue data structure
+ *          which internally uses redis to store and distribute the data. Its
+ *          important to know that the lifetime of the queue persists before
+ *          and after the queue data structure is created (since it exists in
+ *          redis). Therefore, two redis queues with the same name, would in
+ *          fact be the same underlying redis queue.
+ */
 public class RedisQueue {
 
-  ///
-  /// @field   name
-  /// @brief   The unique name of the queue.
-  /// @details The name is used by the redis cluster client to access the queue
-  ///          data. If two queues had the same name, they would be instances of
-  ///          the same underlying redis queue.
-  ///
+  /**
+   * @field   name
+   * @brief   The unique name of the queue.
+   * @details The name is used by the redis cluster client to access the queue
+   *          data. If two queues had the same name, they would be instances of
+   *          the same underlying redis queue.
+   */
   private final String name;
 
-  ///
-  /// @brief   Constructor.
-  /// @details Construct a named redis queue with an established redis cluster.
-  /// @param   client An established redis client.
-  /// @param   name   The global name of the queue.
-  ///
+  /**
+   * @brief   Constructor.
+   * @details Construct a named redis queue with an established redis cluster.
+   * @param   name   The global name of the queue.
+   */
   public RedisQueue(String name) {
     this.name = name;
   }
 
-  ///
-  /// @brief   Push a value onto the queue.
-  /// @details Adds the value into the backend redis queue.
-  /// @param   val The value to push onto the queue.
-  ///
+  /**
+   * @brief   Push a value onto the queue.
+   * @details Adds the value into the backend redis queue.
+   * @param   val The value to push onto the queue.
+   */
   public void push(JedisCluster jedis, String val) {
     jedis.lpush(name, val);
   }
 
-  ///
-  /// @brief   Remove element from dequeue.
-  /// @details Removes an element from the dequeue and specifies whether it was
-  ///          removed.
-  /// @param   val The value to remove.
-  /// @return  Whether or not the value was removed.
-  /// @note    Suggested return identifier: wasRemoved.
-  ///
+  /**
+   * @brief   Remove element from dequeue.
+   * @details Removes an element from the dequeue and specifies whether it was
+   *          removed.
+   * @param   val The value to remove.
+   * @return  Whether or not the value was removed.
+   * @note    Suggested return identifier: wasRemoved.
+   */
   public boolean removeFromDequeue(JedisCluster jedis, String val) {
     return jedis.lrem(getDequeueName(), -1, val) != 0;
   }
 
-  ///
-  /// @brief   Remove all elements that match from queue.
-  /// @details Removes all matching elements from the queue and specifies
-  ///          whether it was removed.
-  /// @param   val The value to remove.
-  /// @return  Whether or not the value was removed.
-  /// @note    Suggested return identifier: wasRemoved.
-  ///
+  /**
+   * @brief   Remove all elements that match from queue.
+   * @details Removes all matching elements from the queue and specifies
+   *          whether it was removed.
+   * @param   val The value to remove.
+   * @return  Whether or not the value was removed.
+   * @note    Suggested return identifier: wasRemoved.
+   */
   public boolean removeAll(JedisCluster jedis, String val) {
     return jedis.lrem(name, 0, val) != 0;
   }
 
-  ///
-  /// @brief   Pop element into internal dequeue and return value.
-  /// @details This pops the element from one queue atomically into an internal
-  ///          list called the dequeue. It will wait until the timeout has
-  ///          expired. Null is returned if the timeout has expired.
-  /// @param   timeout_s Timeout to wait if there is no item to dequeue. (units: seconds (s))
-  /// @return  The value of the transfered element. null if the thread was interrupted.
-  /// @note    Overloaded.
-  /// @note    Suggested return identifier: val.
-  ///
+  /**
+   * @brief   Pop element into internal dequeue and return value.
+   * @details This pops the element from one queue atomically into an internal
+   *          list called the dequeue. It will wait until the timeout has
+   *          expired. Null is returned if the timeout has expired.
+   * @param   timeout_s Timeout to wait if there is no item to dequeue. (units: seconds (s))
+   * @return  The value of the transfered element. null if the thread was interrupted.
+   * @note    Overloaded.
+   * @note    Suggested return identifier: val.
+   */
   public String dequeue(JedisCluster jedis, int timeout_s) throws InterruptedException {
     String val = null;
     for (int i = 0; i < timeout_s; ++i) {
@@ -103,14 +102,14 @@ public class RedisQueue {
     return null;
   }
 
-  ///
-  /// @brief   Pop element into internal dequeue and return value.
-  /// @details This pops the element from one queue atomically into an internal
-  ///          list called the dequeue. It does not block and null is returned
-  ///          if there is nothing to dequeue.
-  /// @return  The value of the transfered element. null if nothing was dequeued.
-  /// @note    Suggested return identifier: val.
-  ///
+  /**
+   * @brief   Pop element into internal dequeue and return value.
+   * @details This pops the element from one queue atomically into an internal
+   *          list called the dequeue. It does not block and null is returned
+   *          if there is nothing to dequeue.
+   * @return  The value of the transfered element. null if nothing was dequeued.
+   * @note    Suggested return identifier: val.
+   */
   public String nonBlockingDequeue(JedisCluster jedis) throws InterruptedException {
     String val = jedis.rpoplpush(name, getDequeueName());
     if (val != null) {
@@ -122,64 +121,64 @@ public class RedisQueue {
     return null;
   }
 
-  ///
-  /// @brief   Get name.
-  /// @details Get the name of the queue. this is the redis key used for the
-  ///          list.
-  /// @return  The name of the queue.
-  /// @note    Suggested return identifier: name.
-  ///
+  /**
+   * @brief   Get name.
+   * @details Get the name of the queue. this is the redis key used for the
+   *          list.
+   * @return  The name of the queue.
+   * @note    Suggested return identifier: name.
+   */
   public String getName() {
     return name;
   }
 
-  ///
-  /// @brief   Get dequeue name.
-  /// @details Get the name of the internal dequeue used by the queue. this is
-  ///          the redis key used for the list.
-  /// @return  The name of the queue.
-  /// @note    Suggested return identifier: name.
-  ///
+  /**
+   * @brief   Get dequeue name.
+   * @details Get the name of the internal dequeue used by the queue. this is
+   *          the redis key used for the list.
+   * @return  The name of the queue.
+   * @note    Suggested return identifier: name.
+   */
   public String getDequeueName() {
     return name + "_dequeue";
   }
 
-  ///
-  /// @brief   Get size.
-  /// @details Checks the current length of the queue.
-  /// @return  The current length of the queue.
-  /// @note    Suggested return identifier: length.
-  ///
+  /**
+   * @brief   Get size.
+   * @details Checks the current length of the queue.
+   * @return  The current length of the queue.
+   * @note    Suggested return identifier: length.
+   */
   public long size(JedisCluster jedis) {
     return jedis.llen(name);
   }
 
-  ///
-  /// @brief   Visit each element in the queue.
-  /// @details Enacts a visitor over each element in the queue.
-  /// @param   visitor A visitor for each visited element in the queue.
-  /// @note    Overloaded.
-  ///
+  /**
+   * @brief   Visit each element in the queue.
+   * @details Enacts a visitor over each element in the queue.
+   * @param   visitor A visitor for each visited element in the queue.
+   * @note    Overloaded.
+   */
   public void visit(JedisCluster jedis, StringVisitor visitor) {
     visit(jedis, name, visitor);
   }
 
-  ///
-  /// @brief   Visit each element in the dequeue.
-  /// @details Enacts a visitor over each element in the dequeue.
-  /// @param   visitor A visitor for each visited element in the queue.
-  ///
+  /**
+   * @brief   Visit each element in the dequeue.
+   * @details Enacts a visitor over each element in the dequeue.
+   * @param   visitor A visitor for each visited element in the queue.
+   */
   public void visitDequeue(JedisCluster jedis, StringVisitor visitor) {
     visit(jedis, getDequeueName(), visitor);
   }
 
-  ///
-  /// @brief   Visit each element in the queue via queue name.
-  /// @details Enacts a visitor over each element in the queue.
-  /// @param   queueName The name of the queue to visit.
-  /// @param   visitor   A visitor for each visited element in the queue.
-  /// @note    Overloaded.
-  ///
+  /**
+   * @brief   Visit each element in the queue via queue name.
+   * @details Enacts a visitor over each element in the queue.
+   * @param   queueName The name of the queue to visit.
+   * @param   visitor   A visitor for each visited element in the queue.
+   * @note    Overloaded.
+   */
   private void visit(JedisCluster jedis, String queueName, StringVisitor visitor) {
     int listPageSize = 10000;
 

--- a/src/main/java/build/buildfarm/common/redis/RedisSlotToHash.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisSlotToHash.java
@@ -23,28 +23,25 @@ import java.util.List;
 import redis.clients.jedis.util.JedisClusterCRC16;
 
 /**
- * @class   RedisSlotToHash
- * @brief   Get a redis hash tag for the provided slot number.
- * @details Sometimes in redis you want to hash a particular key to a
- *          particular node in the redis cluster. You might decide to do this
- *          in order to distribute data evenly across nodes and balance cpu
- *          utilization. Since redis nodes are decided based on the slot
- *          number that a value hashes to, you can force. A key to land on a
- *          particular node by choosing a redis hashtag which you know
- *          corresponds to the appropriate slot number. The class is used to
- *          convert a slot number to a corresponding string (which when
- *          hashed by redis's crc16 algorithm will return that slot number.
+ * @class RedisSlotToHash
+ * @brief Get a redis hash tag for the provided slot number.
+ * @details Sometimes in redis you want to hash a particular key to a particular node in the redis
+ *     cluster. You might decide to do this in order to distribute data evenly across nodes and
+ *     balance cpu utilization. Since redis nodes are decided based on the slot number that a value
+ *     hashes to, you can force. A key to land on a particular node by choosing a redis hashtag
+ *     which you know corresponds to the appropriate slot number. The class is used to convert a
+ *     slot number to a corresponding string (which when hashed by redis's crc16 algorithm will
+ *     return that slot number.
  */
 public class RedisSlotToHash {
 
   /**
-   * @brief   Convert slot number into string that hashes to slot.
-   * @details A short alphanumeric string will be given which when hashed by
-   *          redis's crc16 algorithm will return the slot number that was
-   *          given.
-   * @param   slotNumber The slot number to find a hashable string for.
-   * @return  The string value to be used in a key's hashtag.
-   * @note    Suggested return identifier: hashtag.
+   * @brief Convert slot number into string that hashes to slot.
+   * @details A short alphanumeric string will be given which when hashed by redis's crc16 algorithm
+   *     will return the slot number that was given.
+   * @param slotNumber The slot number to find a hashable string for.
+   * @return The string value to be used in a key's hashtag.
+   * @note Suggested return identifier: hashtag.
    */
   public static String correlate(long slotNumber) {
     Preconditions.checkState(slotNumber >= 0 && slotNumber < HASHSLOTS);
@@ -52,14 +49,14 @@ public class RedisSlotToHash {
   }
 
   /**
-   * @brief   Dynamically convert a range of slot number into string that
-   *          hashes to a slot within the range.
-   * @details Dynamically generates hashtags and tests them for valid slot
-   *          number. Slower than static lookup, but less code.
-   * @param   start The starting slot range number to find a hashable string for.
-   * @param   end   The ending slot range number to find a hashable string for.
-   * @return  The string value to be used in a key's hashtag.
-   * @note    Suggested return identifier: hashtag.
+   * @brief Dynamically convert a range of slot number into string that hashes to a slot within the
+   *     range.
+   * @details Dynamically generates hashtags and tests them for valid slot number. Slower than
+   *     static lookup, but less code.
+   * @param start The starting slot range number to find a hashable string for.
+   * @param end The ending slot range number to find a hashable string for.
+   * @return The string value to be used in a key's hashtag.
+   * @note Suggested return identifier: hashtag.
    */
   public static String correlateRange(long start, long end) {
     Preconditions.checkState(start >= 0 && end < HASHSLOTS);
@@ -74,15 +71,15 @@ public class RedisSlotToHash {
   }
 
   /**
-   * @brief   Dynamically convert a range of slot number into string that
-   *          hashes to a slot within the range.
-   * @details Dynamically generates hashtags and tests them for valid slot
-   *          number. Slower than static lookup, but less code.
-   * @param   start  The starting slot range number to find a hashable string for.
-   * @param   end    The ending slot range number to find a hashable string for.
-   * @param   prefix A string prefix to include as part of the generated hashtag.
-   * @return  The string value to be used in a key's hashtag.
-   * @note    Suggested return identifier: hashtag.
+   * @brief Dynamically convert a range of slot number into string that hashes to a slot within the
+   *     range.
+   * @details Dynamically generates hashtags and tests them for valid slot number. Slower than
+   *     static lookup, but less code.
+   * @param start The starting slot range number to find a hashable string for.
+   * @param end The ending slot range number to find a hashable string for.
+   * @param prefix A string prefix to include as part of the generated hashtag.
+   * @return The string value to be used in a key's hashtag.
+   * @note Suggested return identifier: hashtag.
    */
   public static String correlateRangeWithPrefix(long start, long end, String prefix) {
     Preconditions.checkState(start >= 0 && end < HASHSLOTS);
@@ -97,23 +94,23 @@ public class RedisSlotToHash {
   }
 
   /**
-   * @brief   Create hashtag.
+   * @brief Create hashtag.
    * @details Combine prefix with a generated number.
-   * @param   prefix    A prefix of the hashtag.
-   * @param   generated A generated number for the balancing the hashtag.
-   * @return  Created hashtag.
-   * @note    Suggested return identifier: hashtag.
+   * @param prefix A prefix of the hashtag.
+   * @param generated A generated number for the balancing the hashtag.
+   * @return Created hashtag.
+   * @note Suggested return identifier: hashtag.
    */
   private static String createHashtag(String prefix, long generated) {
     return String.format("%s:%d", prefix, generated);
   }
 
   /**
-   * @brief   Convert the slot to a hashtag using a static lookup table.
+   * @brief Convert the slot to a hashtag using a static lookup table.
    * @details Fastest, but requires all keys in memory.
-   * @param   slotNumber The slot number to find a hashable string for.
-   * @return  The string value to be used in a key's hashtag.
-   * @note    Suggested return identifier: hashtag.
+   * @param slotNumber The slot number to find a hashable string for.
+   * @return The string value to be used in a key's hashtag.
+   * @note Suggested return identifier: hashtag.
    */
   private static String staticLookup(long slotNumber) {
     List<String> lookupTable = getLookupTable();
@@ -121,13 +118,12 @@ public class RedisSlotToHash {
   }
 
   /**
-   * @brief   A table of the shortest possible alphanumeric string that is
-   *          mapped by redis' crc16 to any given redis cluster slot.
-   * @details The array indices are slot numbers, so that given a desired
-   *          slot, this string is guaranteed to make redis cluster route a
-   *          request to the shard holding this slot.
-   * @return  The hashtags organized by slot index.
-   * @note    Suggested return identifier: lookupTable.
+   * @brief A table of the shortest possible alphanumeric string that is mapped by redis' crc16 to
+   *     any given redis cluster slot.
+   * @details The array indices are slot numbers, so that given a desired slot, this string is
+   *     guaranteed to make redis cluster route a request to the shard holding this slot.
+   * @return The hashtags organized by slot index.
+   * @note Suggested return identifier: lookupTable.
    */
   private static List<String> getLookupTable() {
     List<String> lookupTable = new ArrayList<String>();
@@ -139,13 +135,12 @@ public class RedisSlotToHash {
   }
 
   /**
-   * @brief   A table of the shortest possible alphanumeric string that is
-   *          mapped by redis' crc16 to any given redis cluster slot.
-   * @details The array indices are slot numbers, so that given a desired
-   *          slot, this string is guaranteed to make redis cluster route a
-   *          request to the shard holding this slot.
-   * @return  The hashtags organized by slot index.
-   * @note    Suggested return identifier: lookupTable.
+   * @brief A table of the shortest possible alphanumeric string that is mapped by redis' crc16 to
+   *     any given redis cluster slot.
+   * @details The array indices are slot numbers, so that given a desired slot, this string is
+   *     guaranteed to make redis cluster route a request to the shard holding this slot.
+   * @return The hashtags organized by slot index.
+   * @note Suggested return identifier: lookupTable.
    */
   private static List<String> slots0To4999() {
     List<String> lookupTable =
@@ -542,13 +537,12 @@ public class RedisSlotToHash {
   }
 
   /**
-   * @brief   A table of the shortest possible alphanumeric string that is
-   *          mapped by redis' crc16 to any given redis cluster slot.
-   * @details The array indices are slot numbers, so that given a desired
-   *          slot, this string is guaranteed to make redis cluster route a
-   *          request to the shard holding this slot.
-   * @return  The hashtags organized by slot index.
-   * @note    Suggested return identifier: lookupTable.
+   * @brief A table of the shortest possible alphanumeric string that is mapped by redis' crc16 to
+   *     any given redis cluster slot.
+   * @details The array indices are slot numbers, so that given a desired slot, this string is
+   *     guaranteed to make redis cluster route a request to the shard holding this slot.
+   * @return The hashtags organized by slot index.
+   * @note Suggested return identifier: lookupTable.
    */
   private static List<String> slots5000To9999() {
     List<String> lookupTable =
@@ -945,13 +939,12 @@ public class RedisSlotToHash {
   }
 
   /**
-   * @brief   A table of the shortest possible alphanumeric string that is
-   *          mapped by redis' crc16 to any given redis cluster slot.
-   * @details The array indices are slot numbers, so that given a desired
-   *          slot, this string is guaranteed to make redis cluster route a
-   *          request to the shard holding this slot.
-   * @return  The hashtags organized by slot index.
-   * @note    Suggested return identifier: lookupTable.
+   * @brief A table of the shortest possible alphanumeric string that is mapped by redis' crc16 to
+   *     any given redis cluster slot.
+   * @details The array indices are slot numbers, so that given a desired slot, this string is
+   *     guaranteed to make redis cluster route a request to the shard holding this slot.
+   * @return The hashtags organized by slot index.
+   * @note Suggested return identifier: lookupTable.
    */
   private static List<String> slots10000To14999() {
     List<String> lookupTable =
@@ -1348,13 +1341,12 @@ public class RedisSlotToHash {
   }
 
   /**
-   * @brief   A table of the shortest possible alphanumeric string that is
-   *          mapped by redis' crc16 to any given redis cluster slot.
-   * @details The array indices are slot numbers, so that given a desired
-   *          slot, this string is guaranteed to make redis cluster route a
-   *          request to the shard holding this slot.
-   * @return  The hashtags organized by slot index.
-   * @note    Suggested return identifier: lookupTable.
+   * @brief A table of the shortest possible alphanumeric string that is mapped by redis' crc16 to
+   *     any given redis cluster slot.
+   * @details The array indices are slot numbers, so that given a desired slot, this string is
+   *     guaranteed to make redis cluster route a request to the shard holding this slot.
+   * @return The hashtags organized by slot index.
+   * @note Suggested return identifier: lookupTable.
    */
   private static List<String> slots15000To16383() {
     List<String> lookupTable =

--- a/src/main/java/build/buildfarm/common/redis/RedisSlotToHash.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisSlotToHash.java
@@ -22,44 +22,45 @@ import java.util.Arrays;
 import java.util.List;
 import redis.clients.jedis.util.JedisClusterCRC16;
 
-///
-/// @class   RedisSlotToHash
-/// @brief   Get a redis hash tag for the provided slot number.
-/// @details Sometimes in redis you want to hash a particular key to a
-///          particular node in the redis cluster. You might decide to do this
-///          in order to distribute data evenly across nodes and balance cpu
-///          utilization. Since redis nodes are decided based on the slot
-///          number that a value hashes to, you can force. A key to land on a
-///          particular node by choosing a redis hashtag which you know
-///          corresponds to the appropriate slot number. The class is used to
-///          convert a slot number to a corresponding string (which when
-///          hashed by redis's crc16 algorithm will return that slot number.
-///
+/**
+ * @class   RedisSlotToHash
+ * @brief   Get a redis hash tag for the provided slot number.
+ * @details Sometimes in redis you want to hash a particular key to a
+ *          particular node in the redis cluster. You might decide to do this
+ *          in order to distribute data evenly across nodes and balance cpu
+ *          utilization. Since redis nodes are decided based on the slot
+ *          number that a value hashes to, you can force. A key to land on a
+ *          particular node by choosing a redis hashtag which you know
+ *          corresponds to the appropriate slot number. The class is used to
+ *          convert a slot number to a corresponding string (which when
+ *          hashed by redis's crc16 algorithm will return that slot number.
+ */
 public class RedisSlotToHash {
 
-  ///
-  /// @brief   Convert slot number into string that hashes to slot.
-  /// @details A short alphanumeric string will be given which when hashed by
-  ///          redis's crc16 algorithm will return the slot number that was
-  ///          given.
-  /// @param   slotNumber The slot number to find a hashable string for.
-  /// @return  The string value to be used in a key's hashtag.
-  /// @note    Suggested return identifier: hashtag.
-  ///
+  /**
+   * @brief   Convert slot number into string that hashes to slot.
+   * @details A short alphanumeric string will be given which when hashed by
+   *          redis's crc16 algorithm will return the slot number that was
+   *          given.
+   * @param   slotNumber The slot number to find a hashable string for.
+   * @return  The string value to be used in a key's hashtag.
+   * @note    Suggested return identifier: hashtag.
+   */
   public static String correlate(long slotNumber) {
     Preconditions.checkState(slotNumber >= 0 && slotNumber < HASHSLOTS);
     return staticLookup(slotNumber);
   }
-  ///
-  /// @brief   Dynamically convert a range of slot number into string that
-  ///          hashes to a slot within the range.
-  /// @details Dynamically generates hashtags and tests them for valid slot
-  ///          number. Slower than static lookup, but less code.
-  /// @param   start The starting slot range number to find a hashable string for.
-  /// @param   end   The ending slot range number to find a hashable string for.
-  /// @return  The string value to be used in a key's hashtag.
-  /// @note    Suggested return identifier: hashtag.
-  ///
+
+  /**
+   * @brief   Dynamically convert a range of slot number into string that
+   *          hashes to a slot within the range.
+   * @details Dynamically generates hashtags and tests them for valid slot
+   *          number. Slower than static lookup, but less code.
+   * @param   start The starting slot range number to find a hashable string for.
+   * @param   end   The ending slot range number to find a hashable string for.
+   * @return  The string value to be used in a key's hashtag.
+   * @note    Suggested return identifier: hashtag.
+   */
   public static String correlateRange(long start, long end) {
     Preconditions.checkState(start >= 0 && end < HASHSLOTS);
 
@@ -71,17 +72,18 @@ public class RedisSlotToHash {
     }
     return Long.toString(hashNumber);
   }
-  ///
-  /// @brief   Dynamically convert a range of slot number into string that
-  ///          hashes to a slot within the range.
-  /// @details Dynamically generates hashtags and tests them for valid slot
-  ///          number. Slower than static lookup, but less code.
-  /// @param   start  The starting slot range number to find a hashable string for.
-  /// @param   end    The ending slot range number to find a hashable string for.
-  /// @param   prefix A string prefix to include as part of the generated hashtag.
-  /// @return  The string value to be used in a key's hashtag.
-  /// @note    Suggested return identifier: hashtag.
-  ///
+
+  /**
+   * @brief   Dynamically convert a range of slot number into string that
+   *          hashes to a slot within the range.
+   * @details Dynamically generates hashtags and tests them for valid slot
+   *          number. Slower than static lookup, but less code.
+   * @param   start  The starting slot range number to find a hashable string for.
+   * @param   end    The ending slot range number to find a hashable string for.
+   * @param   prefix A string prefix to include as part of the generated hashtag.
+   * @return  The string value to be used in a key's hashtag.
+   * @note    Suggested return identifier: hashtag.
+   */
   public static String correlateRangeWithPrefix(long start, long end, String prefix) {
     Preconditions.checkState(start >= 0 && end < HASHSLOTS);
 
@@ -93,37 +95,40 @@ public class RedisSlotToHash {
     }
     return createHashtag(prefix, hashNumber);
   }
-  ///
-  /// @brief   Create hashtag.
-  /// @details Combine prefix with a generated number.
-  /// @param   prefix    A prefix of the hashtag.
-  /// @param   generated A generated number for the balancing the hashtag.
-  /// @return  Created hashtag.
-  /// @note    Suggested return identifier: hashtag.
-  ///
+
+  /**
+   * @brief   Create hashtag.
+   * @details Combine prefix with a generated number.
+   * @param   prefix    A prefix of the hashtag.
+   * @param   generated A generated number for the balancing the hashtag.
+   * @return  Created hashtag.
+   * @note    Suggested return identifier: hashtag.
+   */
   private static String createHashtag(String prefix, long generated) {
     return String.format("%s:%d", prefix, generated);
   }
-  ///
-  /// @brief   Convert the slot to a hashtag using a static lookup table.
-  /// @details Fastest, but requires all keys in memory.
-  /// @param   slotNumber The slot number to find a hashable string for.
-  /// @return  The string value to be used in a key's hashtag.
-  /// @note    Suggested return identifier: hashtag.
-  ///
+
+  /**
+   * @brief   Convert the slot to a hashtag using a static lookup table.
+   * @details Fastest, but requires all keys in memory.
+   * @param   slotNumber The slot number to find a hashable string for.
+   * @return  The string value to be used in a key's hashtag.
+   * @note    Suggested return identifier: hashtag.
+   */
   private static String staticLookup(long slotNumber) {
     List<String> lookupTable = getLookupTable();
     return lookupTable.get((int) slotNumber);
   }
-  ///
-  /// @brief   A table of the shortest possible alphanumeric string that is
-  ///          mapped by redis' crc16 to any given redis cluster slot.
-  /// @details The array indices are slot numbers, so that given a desired
-  ///          slot, this string is guaranteed to make redis cluster route a
-  ///          request to the shard holding this slot.
-  /// @return  The hashtags organized by slot index.
-  /// @note    Suggested return identifier: lookupTable.
-  ///
+
+  /**
+   * @brief   A table of the shortest possible alphanumeric string that is
+   *          mapped by redis' crc16 to any given redis cluster slot.
+   * @details The array indices are slot numbers, so that given a desired
+   *          slot, this string is guaranteed to make redis cluster route a
+   *          request to the shard holding this slot.
+   * @return  The hashtags organized by slot index.
+   * @note    Suggested return identifier: lookupTable.
+   */
   private static List<String> getLookupTable() {
     List<String> lookupTable = new ArrayList<String>();
     lookupTable.addAll(slots0To4999());
@@ -132,15 +137,16 @@ public class RedisSlotToHash {
     lookupTable.addAll(slots15000To16383());
     return lookupTable;
   }
-  ///
-  /// @brief   A table of the shortest possible alphanumeric string that is
-  ///          mapped by redis' crc16 to any given redis cluster slot.
-  /// @details The array indices are slot numbers, so that given a desired
-  ///          slot, this string is guaranteed to make redis cluster route a
-  ///          request to the shard holding this slot.
-  /// @return  The hashtags organized by slot index.
-  /// @note    Suggested return identifier: lookupTable.
-  ///
+
+  /**
+   * @brief   A table of the shortest possible alphanumeric string that is
+   *          mapped by redis' crc16 to any given redis cluster slot.
+   * @details The array indices are slot numbers, so that given a desired
+   *          slot, this string is guaranteed to make redis cluster route a
+   *          request to the shard holding this slot.
+   * @return  The hashtags organized by slot index.
+   * @note    Suggested return identifier: lookupTable.
+   */
   private static List<String> slots0To4999() {
     List<String> lookupTable =
         Arrays.asList(
@@ -534,15 +540,16 @@ public class RedisSlotToHash {
             "4Wk", "6bH", "Ow", "0lE", "02", "23B", "6Ld", "4yG");
     return lookupTable;
   }
-  ///
-  /// @brief   A table of the shortest possible alphanumeric string that is
-  ///          mapped by redis' crc16 to any given redis cluster slot.
-  /// @details The array indices are slot numbers, so that given a desired
-  ///          slot, this string is guaranteed to make redis cluster route a
-  ///          request to the shard holding this slot.
-  /// @return  The hashtags organized by slot index.
-  /// @note    Suggested return identifier: lookupTable.
-  ///
+
+  /**
+   * @brief   A table of the shortest possible alphanumeric string that is
+   *          mapped by redis' crc16 to any given redis cluster slot.
+   * @details The array indices are slot numbers, so that given a desired
+   *          slot, this string is guaranteed to make redis cluster route a
+   *          request to the shard holding this slot.
+   * @return  The hashtags organized by slot index.
+   * @note    Suggested return identifier: lookupTable.
+   */
   private static List<String> slots5000To9999() {
     List<String> lookupTable =
         Arrays.asList(
@@ -936,15 +943,16 @@ public class RedisSlotToHash {
             "mT", "0V7", "0CV", "4xx", "590", "4C5", "4VT", "0mz", "NH");
     return lookupTable;
   }
-  ///
-  /// @brief   A table of the shortest possible alphanumeric string that is
-  ///          mapped by redis' crc16 to any given redis cluster slot.
-  /// @details The array indices are slot numbers, so that given a desired
-  ///          slot, this string is guaranteed to make redis cluster route a
-  ///          request to the shard holding this slot.
-  /// @return  The hashtags organized by slot index.
-  /// @note    Suggested return identifier: lookupTable.
-  ///
+
+  /**
+   * @brief   A table of the shortest possible alphanumeric string that is
+   *          mapped by redis' crc16 to any given redis cluster slot.
+   * @details The array indices are slot numbers, so that given a desired
+   *          slot, this string is guaranteed to make redis cluster route a
+   *          request to the shard holding this slot.
+   * @return  The hashtags organized by slot index.
+   * @note    Suggested return identifier: lookupTable.
+   */
   private static List<String> slots10000To14999() {
     List<String> lookupTable =
         Arrays.asList(
@@ -1338,15 +1346,16 @@ public class RedisSlotToHash {
             "4lh", "6YK", "tt", "0WF", "0XG", "2md", "6VJ", "4ci", "4ME", "6xf", "UY", "02c");
     return lookupTable;
   }
-  ///
-  /// @brief   A table of the shortest possible alphanumeric string that is
-  ///          mapped by redis' crc16 to any given redis cluster slot.
-  /// @details The array indices are slot numbers, so that given a desired
-  ///          slot, this string is guaranteed to make redis cluster route a
-  ///          request to the shard holding this slot.
-  /// @return  The hashtags organized by slot index.
-  /// @note    Suggested return identifier: lookupTable.
-  ///
+
+  /**
+   * @brief   A table of the shortest possible alphanumeric string that is
+   *          mapped by redis' crc16 to any given redis cluster slot.
+   * @details The array indices are slot numbers, so that given a desired
+   *          slot, this string is guaranteed to make redis cluster route a
+   *          request to the shard holding this slot.
+   * @return  The hashtags organized by slot index.
+   * @note    Suggested return identifier: lookupTable.
+   */
   private static List<String> slots15000To16383() {
     List<String> lookupTable =
         Arrays.asList(

--- a/src/main/java/build/buildfarm/instance/shard/JedisClusterFactory.java
+++ b/src/main/java/build/buildfarm/instance/shard/JedisClusterFactory.java
@@ -30,21 +30,21 @@ import redis.clients.jedis.JedisPoolConfig;
 import redis.clients.jedis.ScanParams;
 import redis.clients.jedis.ScanResult;
 
-///
-/// @class   JedisClusterFactory
-/// @brief   Create a jedis cluster instance from proto configs.
-/// @details A factory for creating a jedis cluster instance.
-///
+/**
+ * @class   JedisClusterFactory
+ * @brief   Create a jedis cluster instance from proto configs.
+ * @details A factory for creating a jedis cluster instance.
+ */
 public class JedisClusterFactory {
 
-  ///
-  /// @brief   Create a jedis cluster instance.
-  /// @details Use proto configuration to connect to a redis cluster server and
-  ///          provide a jedis client.
-  /// @param   config Configuration for connecting to a redis cluster server.
-  /// @return  An established jedis client used to operate on the redis cluster.
-  /// @note    Suggested return identifier: jedis.
-  ///
+  /**
+   * @brief   Create a jedis cluster instance.
+   * @details Use proto configuration to connect to a redis cluster server and
+   *          provide a jedis client.
+   * @param   config Configuration for connecting to a redis cluster server.
+   * @return  An established jedis client used to operate on the redis cluster.
+   * @note    Suggested return identifier: jedis.
+   */
   public static Supplier<JedisCluster> create(RedisShardBackplaneConfig config)
       throws ConfigurationException {
     // null password is required to elicit no auth in jedis
@@ -55,13 +55,14 @@ public class JedisClusterFactory {
         config.getRedisPassword().isEmpty() ? null : config.getRedisPassword(),
         createJedisPoolConfig(config));
   }
-  ///
-  /// @brief   Create a test jedis cluster instance.
-  /// @details Use pre-defined proto configuration to connect to a redis
-  ///          cluster server and provide a jedis client.
-  /// @return  An established test jedis client used to operate on a redis cluster.
-  /// @note    Suggested return identifier: jedis.
-  ///
+
+  /**
+   * @brief   Create a test jedis cluster instance.
+   * @details Use pre-defined proto configuration to connect to a redis
+   *          cluster server and provide a jedis client.
+   * @return  An established test jedis client used to operate on a redis cluster.
+   * @note    Suggested return identifier: jedis.
+   */
   public static JedisCluster createTest() throws Exception {
     // create the a client to interact with redis.
     // we assume you are running a local cluster of redis.
@@ -80,26 +81,28 @@ public class JedisClusterFactory {
 
     return redis;
   }
-  ///
-  /// @brief   Delete existing keys on a redis cluster.
-  /// @details Delete all of the keys on a redis cluster and ensure that the
-  ///          database is empty.
-  /// @param   cluster An established jedis client to operate on a redis cluster.
-  /// @note    Overloaded.
-  ///
+
+  /**
+   * @brief   Delete existing keys on a redis cluster.
+   * @details Delete all of the keys on a redis cluster and ensure that the
+   *          database is empty.
+   * @param   cluster An established jedis client to operate on a redis cluster.
+   * @note    Overloaded.
+   */
   private static void deleteExistingKeys(JedisCluster cluster) throws Exception {
     for (JedisPool pool : cluster.getClusterNodes().values()) {
       Jedis node = pool.getResource();
       deleteExistingKeys(node);
     }
   }
-  ///
-  /// @brief   Delete existing keys on a redis node.
-  /// @details Delete all of the keys on a particular redis node and ensure
-  ///          that the node's contribution to the database is empty.
-  /// @param   node An established jedis client to operate on a redis node.
-  /// @note    Overloaded.
-  ///
+
+  /**
+   * @brief   Delete existing keys on a redis node.
+   * @details Delete all of the keys on a particular redis node and ensure
+   *          that the node's contribution to the database is empty.
+   * @param   node An established jedis client to operate on a redis node.
+   * @note    Overloaded.
+   */
   private static void deleteExistingKeys(Jedis node) throws Exception {
     String nextCursor = "0";
     Set<String> matchingKeys = new HashSet<>();
@@ -128,17 +131,17 @@ public class JedisClusterFactory {
     }
   }
 
-  ///
-  /// @brief   Create a jedis cluster instance with connection settings.
-  /// @details Use the URI, pool and connection information to connect to a redis cluster
-  ///          server and provide a jedis client.
-  /// @param   redisUri   A valid uri to a redis instance.
-  /// @param   timeout Connection timeout
-  /// @param   maxAttempts Number of connection attempts
-  /// @param   poolConfig Configuration related to redis pools.
-  /// @return  An established jedis client used to operate on the redis cluster.
-  /// @note    Suggested return identifier: jedis.
-  ///
+  /**
+   * @brief   Create a jedis cluster instance with connection settings.
+   * @details Use the URI, pool and connection information to connect to a redis cluster
+   *          server and provide a jedis client.
+   * @param   redisUri   A valid uri to a redis instance.
+   * @param   timeout Connection timeout
+   * @param   maxAttempts Number of connection attempts
+   * @param   poolConfig Configuration related to redis pools.
+   * @return  An established jedis client used to operate on the redis cluster.
+   * @note    Suggested return identifier: jedis.
+   */
   private static Supplier<JedisCluster> createJedisClusterFactory(
       URI redisUri, int timeout, int maxAttempts, String password, JedisPoolConfig poolConfig) {
     return () ->
@@ -150,28 +153,30 @@ public class JedisClusterFactory {
             password,
             poolConfig);
   }
-  ///
-  /// @brief   Create a jedis pool config.
-  /// @details Use configuration to build the appropriate jedis pool
-  ///          configuration.
-  /// @param   config Configuration for connecting to a redis cluster server.
-  /// @return  A created jedis pool config.
-  /// @note    Suggested return identifier: poolConfig.
-  ///
+
+  /**
+   * @brief   Create a jedis pool config.
+   * @details Use configuration to build the appropriate jedis pool
+   *          configuration.
+   * @param   config Configuration for connecting to a redis cluster server.
+   * @return  A created jedis pool config.
+   * @note    Suggested return identifier: poolConfig.
+   */
   private static JedisPoolConfig createJedisPoolConfig(RedisShardBackplaneConfig config) {
     JedisPoolConfig jedisPoolConfig = new JedisPoolConfig();
     jedisPoolConfig.setMaxTotal(config.getJedisPoolMaxTotal());
     return jedisPoolConfig;
   }
-  ///
-  /// @brief   Parse string URI into URI object.
-  /// @details Convert the string representation of the URI into a URI object.
-  ///          If the URI object is invalid a configuration exception will be
-  ///          thrown.
-  /// @param   uri A uri.
-  /// @return  A parsed and valid URI.
-  /// @note    Suggested return identifier: uri.
-  ///
+
+  /**
+   * @brief   Parse string URI into URI object.
+   * @details Convert the string representation of the URI into a URI object.
+   *          If the URI object is invalid a configuration exception will be
+   *          thrown.
+   * @param   uri A uri.
+   * @return  A parsed and valid URI.
+   * @note    Suggested return identifier: uri.
+   */
   private static URI parseUri(String uri) throws ConfigurationException {
     try {
       return new URI(uri);

--- a/src/main/java/build/buildfarm/instance/shard/JedisClusterFactory.java
+++ b/src/main/java/build/buildfarm/instance/shard/JedisClusterFactory.java
@@ -31,19 +31,19 @@ import redis.clients.jedis.ScanParams;
 import redis.clients.jedis.ScanResult;
 
 /**
- * @class   JedisClusterFactory
- * @brief   Create a jedis cluster instance from proto configs.
+ * @class JedisClusterFactory
+ * @brief Create a jedis cluster instance from proto configs.
  * @details A factory for creating a jedis cluster instance.
  */
 public class JedisClusterFactory {
 
   /**
-   * @brief   Create a jedis cluster instance.
-   * @details Use proto configuration to connect to a redis cluster server and
-   *          provide a jedis client.
-   * @param   config Configuration for connecting to a redis cluster server.
-   * @return  An established jedis client used to operate on the redis cluster.
-   * @note    Suggested return identifier: jedis.
+   * @brief Create a jedis cluster instance.
+   * @details Use proto configuration to connect to a redis cluster server and provide a jedis
+   *     client.
+   * @param config Configuration for connecting to a redis cluster server.
+   * @return An established jedis client used to operate on the redis cluster.
+   * @note Suggested return identifier: jedis.
    */
   public static Supplier<JedisCluster> create(RedisShardBackplaneConfig config)
       throws ConfigurationException {
@@ -57,11 +57,11 @@ public class JedisClusterFactory {
   }
 
   /**
-   * @brief   Create a test jedis cluster instance.
-   * @details Use pre-defined proto configuration to connect to a redis
-   *          cluster server and provide a jedis client.
-   * @return  An established test jedis client used to operate on a redis cluster.
-   * @note    Suggested return identifier: jedis.
+   * @brief Create a test jedis cluster instance.
+   * @details Use pre-defined proto configuration to connect to a redis cluster server and provide a
+   *     jedis client.
+   * @return An established test jedis client used to operate on a redis cluster.
+   * @note Suggested return identifier: jedis.
    */
   public static JedisCluster createTest() throws Exception {
     // create the a client to interact with redis.
@@ -83,11 +83,10 @@ public class JedisClusterFactory {
   }
 
   /**
-   * @brief   Delete existing keys on a redis cluster.
-   * @details Delete all of the keys on a redis cluster and ensure that the
-   *          database is empty.
-   * @param   cluster An established jedis client to operate on a redis cluster.
-   * @note    Overloaded.
+   * @brief Delete existing keys on a redis cluster.
+   * @details Delete all of the keys on a redis cluster and ensure that the database is empty.
+   * @param cluster An established jedis client to operate on a redis cluster.
+   * @note Overloaded.
    */
   private static void deleteExistingKeys(JedisCluster cluster) throws Exception {
     for (JedisPool pool : cluster.getClusterNodes().values()) {
@@ -97,11 +96,11 @@ public class JedisClusterFactory {
   }
 
   /**
-   * @brief   Delete existing keys on a redis node.
-   * @details Delete all of the keys on a particular redis node and ensure
-   *          that the node's contribution to the database is empty.
-   * @param   node An established jedis client to operate on a redis node.
-   * @note    Overloaded.
+   * @brief Delete existing keys on a redis node.
+   * @details Delete all of the keys on a particular redis node and ensure that the node's
+   *     contribution to the database is empty.
+   * @param node An established jedis client to operate on a redis node.
+   * @note Overloaded.
    */
   private static void deleteExistingKeys(Jedis node) throws Exception {
     String nextCursor = "0";
@@ -132,15 +131,15 @@ public class JedisClusterFactory {
   }
 
   /**
-   * @brief   Create a jedis cluster instance with connection settings.
-   * @details Use the URI, pool and connection information to connect to a redis cluster
-   *          server and provide a jedis client.
-   * @param   redisUri   A valid uri to a redis instance.
-   * @param   timeout Connection timeout
-   * @param   maxAttempts Number of connection attempts
-   * @param   poolConfig Configuration related to redis pools.
-   * @return  An established jedis client used to operate on the redis cluster.
-   * @note    Suggested return identifier: jedis.
+   * @brief Create a jedis cluster instance with connection settings.
+   * @details Use the URI, pool and connection information to connect to a redis cluster server and
+   *     provide a jedis client.
+   * @param redisUri A valid uri to a redis instance.
+   * @param timeout Connection timeout
+   * @param maxAttempts Number of connection attempts
+   * @param poolConfig Configuration related to redis pools.
+   * @return An established jedis client used to operate on the redis cluster.
+   * @note Suggested return identifier: jedis.
    */
   private static Supplier<JedisCluster> createJedisClusterFactory(
       URI redisUri, int timeout, int maxAttempts, String password, JedisPoolConfig poolConfig) {
@@ -155,12 +154,11 @@ public class JedisClusterFactory {
   }
 
   /**
-   * @brief   Create a jedis pool config.
-   * @details Use configuration to build the appropriate jedis pool
-   *          configuration.
-   * @param   config Configuration for connecting to a redis cluster server.
-   * @return  A created jedis pool config.
-   * @note    Suggested return identifier: poolConfig.
+   * @brief Create a jedis pool config.
+   * @details Use configuration to build the appropriate jedis pool configuration.
+   * @param config Configuration for connecting to a redis cluster server.
+   * @return A created jedis pool config.
+   * @note Suggested return identifier: poolConfig.
    */
   private static JedisPoolConfig createJedisPoolConfig(RedisShardBackplaneConfig config) {
     JedisPoolConfig jedisPoolConfig = new JedisPoolConfig();
@@ -169,13 +167,12 @@ public class JedisClusterFactory {
   }
 
   /**
-   * @brief   Parse string URI into URI object.
-   * @details Convert the string representation of the URI into a URI object.
-   *          If the URI object is invalid a configuration exception will be
-   *          thrown.
-   * @param   uri A uri.
-   * @return  A parsed and valid URI.
-   * @note    Suggested return identifier: uri.
+   * @brief Parse string URI into URI object.
+   * @details Convert the string representation of the URI into a URI object. If the URI object is
+   *     invalid a configuration exception will be thrown.
+   * @param uri A uri.
+   * @return A parsed and valid URI.
+   * @note Suggested return identifier: uri.
    */
   private static URI parseUri(String uri) throws ConfigurationException {
     try {

--- a/src/main/java/build/buildfarm/instance/shard/OperationQueue.java
+++ b/src/main/java/build/buildfarm/instance/shard/OperationQueue.java
@@ -26,50 +26,52 @@ import java.util.ArrayList;
 import java.util.List;
 import redis.clients.jedis.JedisCluster;
 
-///
-/// @class   OperationQueue
-/// @brief   The operation queue of the shard backplane.
-/// @details The operation queue can be split into multiple queues according
-///          to platform execution information.
-///
+/**
+ * @class   OperationQueue
+ * @brief   The operation queue of the shard backplane.
+ * @details The operation queue can be split into multiple queues according
+ *          to platform execution information.
+ */
 public class OperationQueue {
 
-  ///
-  /// @field   queues
-  /// @brief   Different queues based on platform execution requirements.
-  /// @details The appropriate queues are chosen based on given properties.
-  ///
+  /**
+   * @field   queues
+   * @brief   Different queues based on platform execution requirements.
+   * @details The appropriate queues are chosen based on given properties.
+   */
   private List<ProvisionedRedisQueue> queues;
 
-  ///
-  /// @brief   Constructor.
-  /// @details Construct the operation queue with various provisioned redis
-  ///          queues.
-  /// @param   queues Provisioned queues.
-  ///
+  /**
+   * @brief   Constructor.
+   * @details Construct the operation queue with various provisioned redis
+   *          queues.
+   * @param   queues Provisioned queues.
+   */
   public OperationQueue(List<ProvisionedRedisQueue> queues) {
     this.queues = queues;
   }
-  ///
-  /// @brief   Visit each element in the dequeue.
-  /// @details Enacts a visitor over each element in the dequeue.
-  /// @param   jedis   Jedis cluster client.
-  /// @param   visitor A visitor for each visited element in the queue.
-  ///
+
+  /**
+   * @brief   Visit each element in the dequeue.
+   * @details Enacts a visitor over each element in the dequeue.
+   * @param   jedis   Jedis cluster client.
+   * @param   visitor A visitor for each visited element in the queue.
+   */
   public void visitDequeue(JedisCluster jedis, StringVisitor visitor) {
     for (ProvisionedRedisQueue provisionedQueue : queues) {
       provisionedQueue.queue().visitDequeue(jedis, visitor);
     }
   }
-  ///
-  /// @brief   Remove element from dequeue.
-  /// @details Removes an element from the dequeue and specifies whether it was
-  ///          removed.
-  /// @param   jedis Jedis cluster client.
-  /// @param   val   The value to remove.
-  /// @return  Whether or not the value was removed.
-  /// @note    Suggested return identifier: wasRemoved.
-  ///
+
+  /**
+   * @brief   Remove element from dequeue.
+   * @details Removes an element from the dequeue and specifies whether it was
+   *          removed.
+   * @param   jedis Jedis cluster client.
+   * @param   val   The value to remove.
+   * @return  Whether or not the value was removed.
+   * @note    Suggested return identifier: wasRemoved.
+   */
   public boolean removeFromDequeue(JedisCluster jedis, String val) {
     for (ProvisionedRedisQueue provisionedQueue : queues) {
       if (provisionedQueue.queue().removeFromDequeue(jedis, val)) {
@@ -78,89 +80,96 @@ public class OperationQueue {
     }
     return false;
   }
-  ///
-  /// @brief   Visit each element in the queue.
-  /// @details Enacts a visitor over each element in the queue.
-  /// @param   jedis   Jedis cluster client.
-  /// @param   visitor A visitor for each visited element in the queue.
-  ///
+
+  /**
+   * @brief   Visit each element in the queue.
+   * @details Enacts a visitor over each element in the queue.
+   * @param   jedis   Jedis cluster client.
+   * @param   visitor A visitor for each visited element in the queue.
+   */
   public void visit(JedisCluster jedis, StringVisitor visitor) {
     for (ProvisionedRedisQueue provisionedQueue : queues) {
       provisionedQueue.queue().visit(jedis, visitor);
     }
   }
-  ///
-  /// @brief   Get size.
-  /// @details Checks the current length of the queue.
-  /// @param   jedis Jedis cluster client.
-  /// @return  The current length of the queue.
-  /// @note    Suggested return identifier: length.
-  ///
+
+  /**
+   * @brief   Get size.
+   * @details Checks the current length of the queue.
+   * @param   jedis Jedis cluster client.
+   * @return  The current length of the queue.
+   * @note    Suggested return identifier: length.
+   */
   public long size(JedisCluster jedis) {
     // the accumulated size of all of the queues
     return queues.stream().mapToInt(i -> (int) i.queue().size(jedis)).sum();
   }
-  ///
-  /// @brief   Get dequeue name.
-  /// @details Get the name of the internal dequeue used by the queue. since
-  ///          each internal queue has their own dequeue, this name is generic
-  ///          without the hashtag.
-  /// @return  The name of the queue.
-  /// @note    Overloaded.
-  /// @note    Suggested return identifier: name.
-  ///
+
+  /**
+   * @brief   Get dequeue name.
+   * @details Get the name of the internal dequeue used by the queue. since
+   *          each internal queue has their own dequeue, this name is generic
+   *          without the hashtag.
+   * @return  The name of the queue.
+   * @note    Overloaded.
+   * @note    Suggested return identifier: name.
+   */
   public String getDequeueName() {
     return "operation_dequeue";
   }
-  ///
-  /// @brief   Get dequeue name.
-  /// @details Get the name of the internal dequeue used by the queue. since
-  ///          each internal queue has their own dequeue, this name is generic
-  ///          without the hashtag.
-  /// @param   provisions Provisions used to select an eligible queue.
-  /// @return  The name of the queue.
-  /// @note    Overloaded.
-  /// @note    Suggested return identifier: name.
-  ///
+
+  /**
+   * @brief   Get dequeue name.
+   * @details Get the name of the internal dequeue used by the queue. since
+   *          each internal queue has their own dequeue, this name is generic
+   *          without the hashtag.
+   * @param   provisions Provisions used to select an eligible queue.
+   * @return  The name of the queue.
+   * @note    Overloaded.
+   * @note    Suggested return identifier: name.
+   */
   public String getDequeueName(List<Platform.Property> provisions) {
     BalancedRedisQueue queue = chooseEligibleQueue(provisions);
     return queue.getDequeueName();
   }
-  ///
-  /// @brief   Push a value onto the queue.
-  /// @details Adds the value into one of the internal backend redis queues.
-  /// @param   jedis      Jedis cluster client.
-  /// @param   provisions Provisions used to select an eligible queue.
-  /// @param   val        The value to push onto the queue.
-  ///
+
+  /**
+   * @brief   Push a value onto the queue.
+   * @details Adds the value into one of the internal backend redis queues.
+   * @param   jedis      Jedis cluster client.
+   * @param   provisions Provisions used to select an eligible queue.
+   * @param   val        The value to push onto the queue.
+   */
   public void push(JedisCluster jedis, List<Platform.Property> provisions, String val) {
     BalancedRedisQueue queue = chooseEligibleQueue(provisions);
     queue.push(jedis, val);
   }
-  ///
-  /// @brief   Pop element into internal dequeue and return value.
-  /// @details This pops the element from one queue atomically into an internal
-  ///          list called the dequeue. It will perform an exponential backoff.
-  ///          Null is returned if the overall backoff times out.
-  /// @param   jedis      Jedis cluster client.
-  /// @param   provisions Provisions used to select an eligible queue.
-  /// @return  The value of the transfered element. null if the thread was interrupted.
-  /// @note    Suggested return identifier: val.
-  ///
+
+  /**
+   * @brief   Pop element into internal dequeue and return value.
+   * @details This pops the element from one queue atomically into an internal
+   *          list called the dequeue. It will perform an exponential backoff.
+   *          Null is returned if the overall backoff times out.
+   * @param   jedis      Jedis cluster client.
+   * @param   provisions Provisions used to select an eligible queue.
+   * @return  The value of the transfered element. null if the thread was interrupted.
+   * @note    Suggested return identifier: val.
+   */
   public String dequeue(JedisCluster jedis, List<Platform.Property> provisions)
       throws InterruptedException {
     BalancedRedisQueue queue = chooseEligibleQueue(provisions);
     return queue.dequeue(jedis);
   }
-  ///
-  /// @brief   Get status information about the queue.
-  /// @details Helpful for understanding the current load on the queue and how
-  ///          elements are balanced.
-  /// @param   jedis Jedis cluster client.
-  /// @return  The current status of the queue.
-  /// @note    Overloaded.
-  /// @note    Suggested return identifier: status.
-  ///
+
+  /**
+   * @brief   Get status information about the queue.
+   * @details Helpful for understanding the current load on the queue and how
+   *          elements are balanced.
+   * @param   jedis Jedis cluster client.
+   * @return  The current status of the queue.
+   * @note    Overloaded.
+   * @note    Suggested return identifier: status.
+   */
   public OperationQueueStatus status(JedisCluster jedis) {
     // get properties
     List<QueueStatus> provisions = new ArrayList<>();
@@ -173,28 +182,30 @@ public class OperationQueue {
         OperationQueueStatus.newBuilder().setSize(size(jedis)).addAllProvisions(provisions).build();
     return status;
   }
-  ///
-  /// @brief   Get status information about the queue.
-  /// @details Helpful for understanding the current load on the queue and how
-  ///          elements are balanced.
-  /// @param   jedis      Jedis cluster client.
-  /// @param   provisions Provisions used to select an eligible queue.
-  /// @return  The current status of the queue.
-  /// @note    Overloaded.
-  /// @note    Suggested return identifier: status.
-  ///
+
+  /**
+   * @brief   Get status information about the queue.
+   * @details Helpful for understanding the current load on the queue and how
+   *          elements are balanced.
+   * @param   jedis      Jedis cluster client.
+   * @param   provisions Provisions used to select an eligible queue.
+   * @return  The current status of the queue.
+   * @note    Overloaded.
+   * @note    Suggested return identifier: status.
+   */
   public QueueStatus status(JedisCluster jedis, List<Platform.Property> provisions) {
     BalancedRedisQueue queue = chooseEligibleQueue(provisions);
     return queue.status(jedis);
   }
-  ///
-  /// @brief   Checks required properties for eligibility.
-  /// @details Checks whether the properties given fulfill all of the required
-  ///          provisions for the operation queue to accept it.
-  /// @param   properties Properties to check that requirements are met.
-  /// @return  Whether the operation queue will accept an operation containing the given properties.
-  /// @note    Suggested return identifier: isEligible.
-  ///
+
+  /**
+   * @brief   Checks required properties for eligibility.
+   * @details Checks whether the properties given fulfill all of the required
+   *          provisions for the operation queue to accept it.
+   * @param   properties Properties to check that requirements are met.
+   * @return  Whether the operation queue will accept an operation containing the given properties.
+   * @note    Suggested return identifier: isEligible.
+   */
   public boolean isEligible(List<Platform.Property> properties) {
     for (ProvisionedRedisQueue provisionedQueue : queues) {
       if (provisionedQueue.isEligible(toMultimap(properties))) {
@@ -203,15 +214,16 @@ public class OperationQueue {
     }
     return false;
   }
-  ///
-  /// @brief   Choose an eligible queue based on given properties.
-  /// @details We use the platform execution properties of a queue entry to
-  ///          determine the appropriate queue. If there no eligible queues, an
-  ///          exception is thrown.
-  /// @param   provisions Provisions to check that requirements are met.
-  /// @return  The chosen queue.
-  /// @note    Suggested return identifier: queue.
-  ///
+
+  /**
+   * @brief   Choose an eligible queue based on given properties.
+   * @details We use the platform execution properties of a queue entry to
+   *          determine the appropriate queue. If there no eligible queues, an
+   *          exception is thrown.
+   * @param   provisions Provisions to check that requirements are met.
+   * @return  The chosen queue.
+   * @note    Suggested return identifier: queue.
+   */
   private BalancedRedisQueue chooseEligibleQueue(List<Platform.Property> provisions) {
     for (ProvisionedRedisQueue provisionedQueue : queues) {
       if (provisionedQueue.isEligible(toMultimap(provisions))) {
@@ -223,14 +235,15 @@ public class OperationQueue {
             + " One solution to is to configure a provision queue with no requirements which would be eligible to all operations."
             + " See https://github.com/bazelbuild/bazel-buildfarm/wiki/Shard-Platform-Operation-Queue for details");
   }
-  ///
-  /// @brief   Convert proto provisions into java multimap.
-  /// @details This conversion is done to more easily check if a key/value
-  ///          exists in the provisions.
-  /// @param   provisions Provisions list to convert.
-  /// @return  The provisions as a set.
-  /// @note    Suggested return identifier: provisionSet.
-  ///
+
+  /**
+   * @brief   Convert proto provisions into java multimap.
+   * @details This conversion is done to more easily check if a key/value
+   *          exists in the provisions.
+   * @param   provisions Provisions list to convert.
+   * @return  The provisions as a set.
+   * @note    Suggested return identifier: provisionSet.
+   */
   private SetMultimap<String, String> toMultimap(List<Platform.Property> provisions) {
     SetMultimap<String, String> set = LinkedHashMultimap.create();
     for (Platform.Property property : provisions) {

--- a/src/main/java/build/buildfarm/instance/shard/OperationQueue.java
+++ b/src/main/java/build/buildfarm/instance/shard/OperationQueue.java
@@ -27,35 +27,34 @@ import java.util.List;
 import redis.clients.jedis.JedisCluster;
 
 /**
- * @class   OperationQueue
- * @brief   The operation queue of the shard backplane.
- * @details The operation queue can be split into multiple queues according
- *          to platform execution information.
+ * @class OperationQueue
+ * @brief The operation queue of the shard backplane.
+ * @details The operation queue can be split into multiple queues according to platform execution
+ *     information.
  */
 public class OperationQueue {
 
   /**
-   * @field   queues
-   * @brief   Different queues based on platform execution requirements.
+   * @field queues
+   * @brief Different queues based on platform execution requirements.
    * @details The appropriate queues are chosen based on given properties.
    */
   private List<ProvisionedRedisQueue> queues;
 
   /**
-   * @brief   Constructor.
-   * @details Construct the operation queue with various provisioned redis
-   *          queues.
-   * @param   queues Provisioned queues.
+   * @brief Constructor.
+   * @details Construct the operation queue with various provisioned redis queues.
+   * @param queues Provisioned queues.
    */
   public OperationQueue(List<ProvisionedRedisQueue> queues) {
     this.queues = queues;
   }
 
   /**
-   * @brief   Visit each element in the dequeue.
+   * @brief Visit each element in the dequeue.
    * @details Enacts a visitor over each element in the dequeue.
-   * @param   jedis   Jedis cluster client.
-   * @param   visitor A visitor for each visited element in the queue.
+   * @param jedis Jedis cluster client.
+   * @param visitor A visitor for each visited element in the queue.
    */
   public void visitDequeue(JedisCluster jedis, StringVisitor visitor) {
     for (ProvisionedRedisQueue provisionedQueue : queues) {
@@ -64,13 +63,12 @@ public class OperationQueue {
   }
 
   /**
-   * @brief   Remove element from dequeue.
-   * @details Removes an element from the dequeue and specifies whether it was
-   *          removed.
-   * @param   jedis Jedis cluster client.
-   * @param   val   The value to remove.
-   * @return  Whether or not the value was removed.
-   * @note    Suggested return identifier: wasRemoved.
+   * @brief Remove element from dequeue.
+   * @details Removes an element from the dequeue and specifies whether it was removed.
+   * @param jedis Jedis cluster client.
+   * @param val The value to remove.
+   * @return Whether or not the value was removed.
+   * @note Suggested return identifier: wasRemoved.
    */
   public boolean removeFromDequeue(JedisCluster jedis, String val) {
     for (ProvisionedRedisQueue provisionedQueue : queues) {
@@ -82,10 +80,10 @@ public class OperationQueue {
   }
 
   /**
-   * @brief   Visit each element in the queue.
+   * @brief Visit each element in the queue.
    * @details Enacts a visitor over each element in the queue.
-   * @param   jedis   Jedis cluster client.
-   * @param   visitor A visitor for each visited element in the queue.
+   * @param jedis Jedis cluster client.
+   * @param visitor A visitor for each visited element in the queue.
    */
   public void visit(JedisCluster jedis, StringVisitor visitor) {
     for (ProvisionedRedisQueue provisionedQueue : queues) {
@@ -94,11 +92,11 @@ public class OperationQueue {
   }
 
   /**
-   * @brief   Get size.
+   * @brief Get size.
    * @details Checks the current length of the queue.
-   * @param   jedis Jedis cluster client.
-   * @return  The current length of the queue.
-   * @note    Suggested return identifier: length.
+   * @param jedis Jedis cluster client.
+   * @return The current length of the queue.
+   * @note Suggested return identifier: length.
    */
   public long size(JedisCluster jedis) {
     // the accumulated size of all of the queues
@@ -106,27 +104,25 @@ public class OperationQueue {
   }
 
   /**
-   * @brief   Get dequeue name.
-   * @details Get the name of the internal dequeue used by the queue. since
-   *          each internal queue has their own dequeue, this name is generic
-   *          without the hashtag.
-   * @return  The name of the queue.
-   * @note    Overloaded.
-   * @note    Suggested return identifier: name.
+   * @brief Get dequeue name.
+   * @details Get the name of the internal dequeue used by the queue. since each internal queue has
+   *     their own dequeue, this name is generic without the hashtag.
+   * @return The name of the queue.
+   * @note Overloaded.
+   * @note Suggested return identifier: name.
    */
   public String getDequeueName() {
     return "operation_dequeue";
   }
 
   /**
-   * @brief   Get dequeue name.
-   * @details Get the name of the internal dequeue used by the queue. since
-   *          each internal queue has their own dequeue, this name is generic
-   *          without the hashtag.
-   * @param   provisions Provisions used to select an eligible queue.
-   * @return  The name of the queue.
-   * @note    Overloaded.
-   * @note    Suggested return identifier: name.
+   * @brief Get dequeue name.
+   * @details Get the name of the internal dequeue used by the queue. since each internal queue has
+   *     their own dequeue, this name is generic without the hashtag.
+   * @param provisions Provisions used to select an eligible queue.
+   * @return The name of the queue.
+   * @note Overloaded.
+   * @note Suggested return identifier: name.
    */
   public String getDequeueName(List<Platform.Property> provisions) {
     BalancedRedisQueue queue = chooseEligibleQueue(provisions);
@@ -134,11 +130,11 @@ public class OperationQueue {
   }
 
   /**
-   * @brief   Push a value onto the queue.
+   * @brief Push a value onto the queue.
    * @details Adds the value into one of the internal backend redis queues.
-   * @param   jedis      Jedis cluster client.
-   * @param   provisions Provisions used to select an eligible queue.
-   * @param   val        The value to push onto the queue.
+   * @param jedis Jedis cluster client.
+   * @param provisions Provisions used to select an eligible queue.
+   * @param val The value to push onto the queue.
    */
   public void push(JedisCluster jedis, List<Platform.Property> provisions, String val) {
     BalancedRedisQueue queue = chooseEligibleQueue(provisions);
@@ -146,14 +142,14 @@ public class OperationQueue {
   }
 
   /**
-   * @brief   Pop element into internal dequeue and return value.
-   * @details This pops the element from one queue atomically into an internal
-   *          list called the dequeue. It will perform an exponential backoff.
-   *          Null is returned if the overall backoff times out.
-   * @param   jedis      Jedis cluster client.
-   * @param   provisions Provisions used to select an eligible queue.
-   * @return  The value of the transfered element. null if the thread was interrupted.
-   * @note    Suggested return identifier: val.
+   * @brief Pop element into internal dequeue and return value.
+   * @details This pops the element from one queue atomically into an internal list called the
+   *     dequeue. It will perform an exponential backoff. Null is returned if the overall backoff
+   *     times out.
+   * @param jedis Jedis cluster client.
+   * @param provisions Provisions used to select an eligible queue.
+   * @return The value of the transfered element. null if the thread was interrupted.
+   * @note Suggested return identifier: val.
    */
   public String dequeue(JedisCluster jedis, List<Platform.Property> provisions)
       throws InterruptedException {
@@ -162,13 +158,12 @@ public class OperationQueue {
   }
 
   /**
-   * @brief   Get status information about the queue.
-   * @details Helpful for understanding the current load on the queue and how
-   *          elements are balanced.
-   * @param   jedis Jedis cluster client.
-   * @return  The current status of the queue.
-   * @note    Overloaded.
-   * @note    Suggested return identifier: status.
+   * @brief Get status information about the queue.
+   * @details Helpful for understanding the current load on the queue and how elements are balanced.
+   * @param jedis Jedis cluster client.
+   * @return The current status of the queue.
+   * @note Overloaded.
+   * @note Suggested return identifier: status.
    */
   public OperationQueueStatus status(JedisCluster jedis) {
     // get properties
@@ -184,14 +179,13 @@ public class OperationQueue {
   }
 
   /**
-   * @brief   Get status information about the queue.
-   * @details Helpful for understanding the current load on the queue and how
-   *          elements are balanced.
-   * @param   jedis      Jedis cluster client.
-   * @param   provisions Provisions used to select an eligible queue.
-   * @return  The current status of the queue.
-   * @note    Overloaded.
-   * @note    Suggested return identifier: status.
+   * @brief Get status information about the queue.
+   * @details Helpful for understanding the current load on the queue and how elements are balanced.
+   * @param jedis Jedis cluster client.
+   * @param provisions Provisions used to select an eligible queue.
+   * @return The current status of the queue.
+   * @note Overloaded.
+   * @note Suggested return identifier: status.
    */
   public QueueStatus status(JedisCluster jedis, List<Platform.Property> provisions) {
     BalancedRedisQueue queue = chooseEligibleQueue(provisions);
@@ -199,12 +193,12 @@ public class OperationQueue {
   }
 
   /**
-   * @brief   Checks required properties for eligibility.
-   * @details Checks whether the properties given fulfill all of the required
-   *          provisions for the operation queue to accept it.
-   * @param   properties Properties to check that requirements are met.
-   * @return  Whether the operation queue will accept an operation containing the given properties.
-   * @note    Suggested return identifier: isEligible.
+   * @brief Checks required properties for eligibility.
+   * @details Checks whether the properties given fulfill all of the required provisions for the
+   *     operation queue to accept it.
+   * @param properties Properties to check that requirements are met.
+   * @return Whether the operation queue will accept an operation containing the given properties.
+   * @note Suggested return identifier: isEligible.
    */
   public boolean isEligible(List<Platform.Property> properties) {
     for (ProvisionedRedisQueue provisionedQueue : queues) {
@@ -216,13 +210,12 @@ public class OperationQueue {
   }
 
   /**
-   * @brief   Choose an eligible queue based on given properties.
-   * @details We use the platform execution properties of a queue entry to
-   *          determine the appropriate queue. If there no eligible queues, an
-   *          exception is thrown.
-   * @param   provisions Provisions to check that requirements are met.
-   * @return  The chosen queue.
-   * @note    Suggested return identifier: queue.
+   * @brief Choose an eligible queue based on given properties.
+   * @details We use the platform execution properties of a queue entry to determine the appropriate
+   *     queue. If there no eligible queues, an exception is thrown.
+   * @param provisions Provisions to check that requirements are met.
+   * @return The chosen queue.
+   * @note Suggested return identifier: queue.
    */
   private BalancedRedisQueue chooseEligibleQueue(List<Platform.Property> provisions) {
     for (ProvisionedRedisQueue provisionedQueue : queues) {
@@ -237,12 +230,11 @@ public class OperationQueue {
   }
 
   /**
-   * @brief   Convert proto provisions into java multimap.
-   * @details This conversion is done to more easily check if a key/value
-   *          exists in the provisions.
-   * @param   provisions Provisions list to convert.
-   * @return  The provisions as a set.
-   * @note    Suggested return identifier: provisionSet.
+   * @brief Convert proto provisions into java multimap.
+   * @details This conversion is done to more easily check if a key/value exists in the provisions.
+   * @param provisions Provisions list to convert.
+   * @return The provisions as a set.
+   * @note Suggested return identifier: provisionSet.
    */
   private SetMultimap<String, String> toMultimap(List<Platform.Property> provisions) {
     SetMultimap<String, String> set = LinkedHashMultimap.create();

--- a/src/main/java/build/buildfarm/operations/EnrichedOperation.java
+++ b/src/main/java/build/buildfarm/operations/EnrichedOperation.java
@@ -27,45 +27,42 @@ import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 
 /**
- * @class   EnrichedOperation
- * @brief   Operations with resolved metadata.
- * @details Operations contain metadata which is not readily available when
- *          obtaining the operation. Additional calls must be made to
- *          retrieve parts of metadata based on digests. Often times an
- *          operation can't be evaluated without also evaluating the command
- *          of the operation. In these contexts, it would be more helpful to
- *          operate on an enriched operation that already has its important
- *          metadata resolved.
+ * @class EnrichedOperation
+ * @brief Operations with resolved metadata.
+ * @details Operations contain metadata which is not readily available when obtaining the operation.
+ *     Additional calls must be made to retrieve parts of metadata based on digests. Often times an
+ *     operation can't be evaluated without also evaluating the command of the operation. In these
+ *     contexts, it would be more helpful to operate on an enriched operation that already has its
+ *     important metadata resolved.
  */
 public class EnrichedOperation {
 
   /**
-   * @field   operation
-   * @brief   The main operation object which contains digests to the
-   *          remaining data members.
+   * @field operation
+   * @brief The main operation object which contains digests to the remaining data members.
    * @details Its digests are used to resolve other data members.
    */
   public Operation operation;
 
   /**
-   * @field   action
-   * @brief   The resolved action of the operation.
+   * @field action
+   * @brief The resolved action of the operation.
    * @details Created from the digest in the operation.
    */
   public Action action;
 
   /**
-   * @field   command
-   * @brief   The resolved command of the action.
+   * @field command
+   * @brief The resolved command of the action.
    * @details Created from the digest in the action.
    */
   public Command command;
 
   /**
-   * @brief   Convert the structure into a json string.
+   * @brief Convert the structure into a json string.
    * @details Uses proto to json serialization where appropriate.
-   * @return  The structure as a json string.
-   * @note    Suggested return identifier: json.
+   * @return The structure as a json string.
+   * @note Suggested return identifier: json.
    */
   public String asJsonString() {
     JSONObject obj = new JSONObject();

--- a/src/main/java/build/buildfarm/operations/EnrichedOperation.java
+++ b/src/main/java/build/buildfarm/operations/EnrichedOperation.java
@@ -26,47 +26,47 @@ import com.google.rpc.PreconditionFailure;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 
-///
-/// @class   EnrichedOperation
-/// @brief   Operations with resolved metadata.
-/// @details Operations contain metadata which is not readily available when
-///          obtaining the operation. Additional calls must be made to
-///          retrieve parts of metadata based on digests. Often times an
-///          operation can't be evaluated without also evaluating the command
-///          of the operation. In these contexts, it would be more helpful to
-///          operate on an enriched operation that already has its important
-///          metadata resolved.
-///
+/**
+ * @class   EnrichedOperation
+ * @brief   Operations with resolved metadata.
+ * @details Operations contain metadata which is not readily available when
+ *          obtaining the operation. Additional calls must be made to
+ *          retrieve parts of metadata based on digests. Often times an
+ *          operation can't be evaluated without also evaluating the command
+ *          of the operation. In these contexts, it would be more helpful to
+ *          operate on an enriched operation that already has its important
+ *          metadata resolved.
+ */
 public class EnrichedOperation {
 
-  ///
-  /// @field   operation
-  /// @brief   The main operation object which contains digests to the
-  ///          remaining data members.
-  /// @details Its digests are used to resolve other data members.
-  ///
+  /**
+   * @field   operation
+   * @brief   The main operation object which contains digests to the
+   *          remaining data members.
+   * @details Its digests are used to resolve other data members.
+   */
   public Operation operation;
 
-  ///
-  /// @field   action
-  /// @brief   The resolved action of the operation.
-  /// @details Created from the digest in the operation.
-  ///
+  /**
+   * @field   action
+   * @brief   The resolved action of the operation.
+   * @details Created from the digest in the operation.
+   */
   public Action action;
 
-  ///
-  /// @field   command
-  /// @brief   The resolved command of the action.
-  /// @details Created from the digest in the action.
-  ///
+  /**
+   * @field   command
+   * @brief   The resolved command of the action.
+   * @details Created from the digest in the action.
+   */
   public Command command;
 
-  ///
-  /// @brief   Convert the structure into a json string.
-  /// @details Uses proto to json serialization where appropriate.
-  /// @return  The structure as a json string.
-  /// @note    Suggested return identifier: json.
-  ///
+  /**
+   * @brief   Convert the structure into a json string.
+   * @details Uses proto to json serialization where appropriate.
+   * @return  The structure as a json string.
+   * @note    Suggested return identifier: json.
+   */
   public String asJsonString() {
     JSONObject obj = new JSONObject();
     try {

--- a/src/main/java/build/buildfarm/operations/EnrichedOperationBuilder.java
+++ b/src/main/java/build/buildfarm/operations/EnrichedOperationBuilder.java
@@ -32,23 +32,23 @@ import com.google.rpc.PreconditionFailure;
 import redis.clients.jedis.JedisCluster;
 
 /**
- * @class   EnrichedOperationBuilder
- * @brief   Builds an operation from an operation key with the operation's
- *          important metadata pre-populated.
- * @details For performance reasons, only build these enriched operations
- *          when you intend to use the extra provided metadata.
+ * @class EnrichedOperationBuilder
+ * @brief Builds an operation from an operation key with the operation's important metadata
+ *     pre-populated.
+ * @details For performance reasons, only build these enriched operations when you intend to use the
+ *     extra provided metadata.
  */
 public class EnrichedOperationBuilder {
 
   /**
-   * @brief   Create an enriched operation based on an operation key.
-   * @details This will make calls to get blobs, and resolve digests into the
-   *          appropriate data structures.
-   * @param   cluster      An established redis cluster.
-   * @param   instance     An instance is used to get additional information about the operation.
-   * @param   operationKey Key to get operation from.
-   * @return  Operation with populated metadata.
-   * @note    Suggested return identifier: operation.
+   * @brief Create an enriched operation based on an operation key.
+   * @details This will make calls to get blobs, and resolve digests into the appropriate data
+   *     structures.
+   * @param cluster An established redis cluster.
+   * @param instance An instance is used to get additional information about the operation.
+   * @param operationKey Key to get operation from.
+   * @return Operation with populated metadata.
+   * @note Suggested return identifier: operation.
    */
   public static EnrichedOperation build(
       JedisCluster cluster, Instance instance, String operationKey) {
@@ -62,13 +62,12 @@ public class EnrichedOperationBuilder {
   }
 
   /**
-   * @brief   Convert an operation key into the actual Operation type.
-   * @details Extracts json from redis and parses it. Null if json was
-   *          invalid.
-   * @param   cluster      An established redis cluster.
-   * @param   operationKey The key to lookup and get back the operation of.
-   * @return  The looked up operation.
-   * @note    Suggested return identifier: operation.
+   * @brief Convert an operation key into the actual Operation type.
+   * @details Extracts json from redis and parses it. Null if json was invalid.
+   * @param cluster An established redis cluster.
+   * @param operationKey The key to lookup and get back the operation of.
+   * @return The looked up operation.
+   * @note Suggested return identifier: operation.
    */
   private static Operation operationKeyToOperation(JedisCluster cluster, String operationKey) {
     String json = cluster.get(operationKey);
@@ -77,11 +76,11 @@ public class EnrichedOperationBuilder {
   }
 
   /**
-   * @brief   Convert string json into operation type.
+   * @brief Convert string json into operation type.
    * @details Parses json and returns null if invalid.
-   * @param   json The json to convert to Operation type.
-   * @return  The created operation.
-   * @note    Suggested return identifier: operation.
+   * @param json The json to convert to Operation type.
+   * @return The created operation.
+   * @note Suggested return identifier: operation.
    */
   private static Operation jsonToOperation(String json) {
     // create a json parser
@@ -110,11 +109,11 @@ public class EnrichedOperationBuilder {
   }
 
   /**
-   * @brief   Get the action digest of the operation.
+   * @brief Get the action digest of the operation.
    * @details Extracted out of the relevant operation metadata.
-   * @param   operation The operation.
-   * @return  The extracted digest.
-   * @note    Suggested return identifier: digest.
+   * @param operation The operation.
+   * @return The extracted digest.
+   * @note Suggested return identifier: digest.
    */
   private static Digest operationToActionDigest(Operation operation) {
     ExecuteOperationMetadata metadata;
@@ -149,12 +148,12 @@ public class EnrichedOperationBuilder {
   }
 
   /**
-   * @brief   Get the action based on the action digest.
+   * @brief Get the action based on the action digest.
    * @details Instance used to fetch the blob.
-   * @param   instance An instance is used to get additional information about the operation.
-   * @param   digest   The action digest.
-   * @return  The action from the provided digest.
-   * @note    Suggested return identifier: action.
+   * @param instance An instance is used to get additional information about the operation.
+   * @param digest The action digest.
+   * @return The action from the provided digest.
+   * @note Suggested return identifier: action.
    */
   private static Action actionDigestToAction(Instance instance, Digest digest) {
     try {
@@ -172,12 +171,12 @@ public class EnrichedOperationBuilder {
   }
 
   /**
-   * @brief   Get the command based on the command digest.
+   * @brief Get the command based on the command digest.
    * @details Instance used to fetch the blob.
-   * @param   instance An instance is used to get additional information about the operation.
-   * @param   digest   The command digest.
-   * @return  The Command from the provided digest.
-   * @note    Suggested return identifier: command.
+   * @param instance An instance is used to get additional information about the operation.
+   * @param digest The command digest.
+   * @return The Command from the provided digest.
+   * @note Suggested return identifier: command.
    */
   private static Command commandDigestToCommand(Instance instance, Digest digest) {
     try {

--- a/src/main/java/build/buildfarm/operations/EnrichedOperationBuilder.java
+++ b/src/main/java/build/buildfarm/operations/EnrichedOperationBuilder.java
@@ -31,25 +31,25 @@ import com.google.protobuf.util.JsonFormat;
 import com.google.rpc.PreconditionFailure;
 import redis.clients.jedis.JedisCluster;
 
-///
-/// @class   EnrichedOperationBuilder
-/// @brief   Builds an operation from an operation key with the operation's
-///          important metadata pre-populated.
-/// @details For performance reasons, only build these enriched operations
-///          when you intend to use the extra provided metadata.
-///
+/**
+ * @class   EnrichedOperationBuilder
+ * @brief   Builds an operation from an operation key with the operation's
+ *          important metadata pre-populated.
+ * @details For performance reasons, only build these enriched operations
+ *          when you intend to use the extra provided metadata.
+ */
 public class EnrichedOperationBuilder {
 
-  ///
-  /// @brief   Create an enriched operation based on an operation key.
-  /// @details This will make calls to get blobs, and resolve digests into the
-  ///          appropriate data structures.
-  /// @param   cluster      An established redis cluster.
-  /// @param   instance     An instance is used to get additional information about the operation.
-  /// @param   operationKey Key to get operation from.
-  /// @return  Operation with populated metadata.
-  /// @note    Suggested return identifier: operation.
-  ///
+  /**
+   * @brief   Create an enriched operation based on an operation key.
+   * @details This will make calls to get blobs, and resolve digests into the
+   *          appropriate data structures.
+   * @param   cluster      An established redis cluster.
+   * @param   instance     An instance is used to get additional information about the operation.
+   * @param   operationKey Key to get operation from.
+   * @return  Operation with populated metadata.
+   * @note    Suggested return identifier: operation.
+   */
   public static EnrichedOperation build(
       JedisCluster cluster, Instance instance, String operationKey) {
     EnrichedOperation operationWithMetadata = new EnrichedOperation();
@@ -60,27 +60,29 @@ public class EnrichedOperationBuilder {
         commandDigestToCommand(instance, operationWithMetadata.action.getCommandDigest());
     return operationWithMetadata;
   }
-  ///
-  /// @brief   Convert an operation key into the actual Operation type.
-  /// @details Extracts json from redis and parses it. Null if json was
-  ///          invalid.
-  /// @param   cluster      An established redis cluster.
-  /// @param   operationKey The key to lookup and get back the operation of.
-  /// @return  The looked up operation.
-  /// @note    Suggested return identifier: operation.
-  ///
+
+  /**
+   * @brief   Convert an operation key into the actual Operation type.
+   * @details Extracts json from redis and parses it. Null if json was
+   *          invalid.
+   * @param   cluster      An established redis cluster.
+   * @param   operationKey The key to lookup and get back the operation of.
+   * @return  The looked up operation.
+   * @note    Suggested return identifier: operation.
+   */
   private static Operation operationKeyToOperation(JedisCluster cluster, String operationKey) {
     String json = cluster.get(operationKey);
     Operation operation = jsonToOperation(json);
     return operation;
   }
-  ///
-  /// @brief   Convert string json into operation type.
-  /// @details Parses json and returns null if invalid.
-  /// @param   json The json to convert to Operation type.
-  /// @return  The created operation.
-  /// @note    Suggested return identifier: operation.
-  ///
+
+  /**
+   * @brief   Convert string json into operation type.
+   * @details Parses json and returns null if invalid.
+   * @param   json The json to convert to Operation type.
+   * @return  The created operation.
+   * @note    Suggested return identifier: operation.
+   */
   private static Operation jsonToOperation(String json) {
     // create a json parser
     JsonFormat.Parser operationParser =
@@ -106,13 +108,14 @@ public class EnrichedOperationBuilder {
       return null;
     }
   }
-  ///
-  /// @brief   Get the action digest of the operation.
-  /// @details Extracted out of the relevant operation metadata.
-  /// @param   operation The operation.
-  /// @return  The extracted digest.
-  /// @note    Suggested return identifier: digest.
-  ///
+
+  /**
+   * @brief   Get the action digest of the operation.
+   * @details Extracted out of the relevant operation metadata.
+   * @param   operation The operation.
+   * @return  The extracted digest.
+   * @note    Suggested return identifier: digest.
+   */
   private static Digest operationToActionDigest(Operation operation) {
     ExecuteOperationMetadata metadata;
     RequestMetadata requestMetadata;
@@ -144,14 +147,15 @@ public class EnrichedOperationBuilder {
 
     return metadata.getActionDigest();
   }
-  ///
-  /// @brief   Get the action based on the action digest.
-  /// @details Instance used to fetch the blob.
-  /// @param   instance An instance is used to get additional information about the operation.
-  /// @param   digest   The action digest.
-  /// @return  The action from the provided digest.
-  /// @note    Suggested return identifier: action.
-  ///
+
+  /**
+   * @brief   Get the action based on the action digest.
+   * @details Instance used to fetch the blob.
+   * @param   instance An instance is used to get additional information about the operation.
+   * @param   digest   The action digest.
+   * @return  The action from the provided digest.
+   * @note    Suggested return identifier: action.
+   */
   private static Action actionDigestToAction(Instance instance, Digest digest) {
     try {
       ByteString blob = Utils.getBlob(instance, digest, RequestMetadata.getDefaultInstance());
@@ -166,14 +170,15 @@ public class EnrichedOperationBuilder {
       return null;
     }
   }
-  ///
-  /// @brief   Get the command based on the command digest.
-  /// @details Instance used to fetch the blob.
-  /// @param   instance An instance is used to get additional information about the operation.
-  /// @param   digest   The command digest.
-  /// @return  The Command from the provided digest.
-  /// @note    Suggested return identifier: command.
-  ///
+
+  /**
+   * @brief   Get the command based on the command digest.
+   * @details Instance used to fetch the blob.
+   * @param   instance An instance is used to get additional information about the operation.
+   * @param   digest   The command digest.
+   * @return  The Command from the provided digest.
+   * @note    Suggested return identifier: command.
+   */
   private static Command commandDigestToCommand(Instance instance, Digest digest) {
     try {
       ByteString blob = Utils.getBlob(instance, digest, RequestMetadata.getDefaultInstance());

--- a/src/main/java/build/buildfarm/operations/FindOperationsResults.java
+++ b/src/main/java/build/buildfarm/operations/FindOperationsResults.java
@@ -18,25 +18,25 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * @class   FindOperationsResults
- * @brief   The results from searching for an operation.
+ * @class FindOperationsResults
+ * @brief The results from searching for an operation.
  * @details This will only observe operations; not affect their state.
  */
 public class FindOperationsResults {
 
   /**
-   * @field   operations
-   * @brief   All of the operations found based on the search query.
-   * @details The key is the operation keu, and the value is all the collected
-   *          information about the operation.
+   * @field operations
+   * @brief All of the operations found based on the search query.
+   * @details The key is the operation keu, and the value is all the collected information about the
+   *     operation.
    */
   public Map<String, EnrichedOperation> operations = new HashMap<String, EnrichedOperation>();
 
   /**
-   * @brief   Get a string message for the results.
+   * @brief Get a string message for the results.
    * @details This message is useful for logging.
-   * @return  A message representation of the FindOperationsResults.
-   * @note    Suggested return identifier: message.
+   * @return A message representation of the FindOperationsResults.
+   * @note Suggested return identifier: message.
    */
   public String toMessage() {
     StringBuilder message = new StringBuilder();

--- a/src/main/java/build/buildfarm/operations/FindOperationsResults.java
+++ b/src/main/java/build/buildfarm/operations/FindOperationsResults.java
@@ -17,27 +17,27 @@ package build.buildfarm.operations;
 import java.util.HashMap;
 import java.util.Map;
 
-///
-/// @class   FindOperationsResults
-/// @brief   The results from searching for an operation.
-/// @details This will only observe operations; not affect their state.
-///
+/**
+ * @class   FindOperationsResults
+ * @brief   The results from searching for an operation.
+ * @details This will only observe operations; not affect their state.
+ */
 public class FindOperationsResults {
 
-  ///
-  /// @field   operations
-  /// @brief   All of the operations found based on the search query.
-  /// @details The key is the operation keu, and the value is all the collected
-  ///          information about the operation.
-  ///
+  /**
+   * @field   operations
+   * @brief   All of the operations found based on the search query.
+   * @details The key is the operation keu, and the value is all the collected
+   *          information about the operation.
+   */
   public Map<String, EnrichedOperation> operations = new HashMap<String, EnrichedOperation>();
 
-  ///
-  /// @brief   Get a string message for the results.
-  /// @details This message is useful for logging.
-  /// @return  A message representation of the FindOperationsResults.
-  /// @note    Suggested return identifier: message.
-  ///
+  /**
+   * @brief   Get a string message for the results.
+   * @details This message is useful for logging.
+   * @return  A message representation of the FindOperationsResults.
+   * @note    Suggested return identifier: message.
+   */
   public String toMessage() {
     StringBuilder message = new StringBuilder();
     message.append(String.format("results: %d\n", operations.size()));

--- a/src/main/java/build/buildfarm/operations/FindOperationsSettings.java
+++ b/src/main/java/build/buildfarm/operations/FindOperationsSettings.java
@@ -14,32 +14,32 @@
 
 package build.buildfarm.operations;
 
-///
-/// @class   FindOperationsSettings
-/// @brief   Settings used to find operations.
-/// @details These are used to discover the state of operations given a
-///          particular context (such as who spawned the operation).
-///
+/**
+ * @class   FindOperationsSettings
+ * @brief   Settings used to find operations.
+ * @details These are used to discover the state of operations given a
+ *         particular context (such as who spawned the operation).
+ */
 public class FindOperationsSettings {
 
-  ///
-  /// @field   filterPredicate
-  /// @brief   The search query used to find particular operations.
-  /// @details https://github.com/json-path/JsonPath#predicates
-  ///
+  /**
+   * @field   filterPredicate
+   * @brief   The search query used to find particular operations.
+   * @details https://github.com/json-path/JsonPath#predicates
+   */
   public String filterPredicate;
 
-  ///
-  /// @field   scanAmount
-  /// @brief   The number of redis entries to scan at a time.
-  /// @details Larger amounts will be faster but require more memory.
-  ///
+  /**
+    * @field   scanAmount
+    * @brief   The number of redis entries to scan at a time.
+    * @details Larger amounts will be faster but require more memory.
+    */
   public int scanAmount;
 
-  ///
-  /// @field   operationQuery
-  /// @brief   How to query all of the operation entries in redis.
-  /// @details The operation key is a global buildfarm config.
-  ///
+  /**
+   * @field   operationQuery
+   * @brief   How to query all of the operation entries in redis.
+   * @details The operation key is a global buildfarm config.
+   */
   public String operationQuery;
 }

--- a/src/main/java/build/buildfarm/operations/FindOperationsSettings.java
+++ b/src/main/java/build/buildfarm/operations/FindOperationsSettings.java
@@ -15,30 +15,30 @@
 package build.buildfarm.operations;
 
 /**
- * @class   FindOperationsSettings
- * @brief   Settings used to find operations.
- * @details These are used to discover the state of operations given a
- *         particular context (such as who spawned the operation).
+ * @class FindOperationsSettings
+ * @brief Settings used to find operations.
+ * @details These are used to discover the state of operations given a particular context (such as
+ *     who spawned the operation).
  */
 public class FindOperationsSettings {
 
   /**
-   * @field   filterPredicate
-   * @brief   The search query used to find particular operations.
+   * @field filterPredicate
+   * @brief The search query used to find particular operations.
    * @details https://github.com/json-path/JsonPath#predicates
    */
   public String filterPredicate;
 
   /**
-    * @field   scanAmount
-    * @brief   The number of redis entries to scan at a time.
-    * @details Larger amounts will be faster but require more memory.
-    */
+   * @field scanAmount
+   * @brief The number of redis entries to scan at a time.
+   * @details Larger amounts will be faster but require more memory.
+   */
   public int scanAmount;
 
   /**
-   * @field   operationQuery
-   * @brief   How to query all of the operation entries in redis.
+   * @field operationQuery
+   * @brief How to query all of the operation entries in redis.
    * @details The operation key is a global buildfarm config.
    */
   public String operationQuery;

--- a/src/main/java/build/buildfarm/operations/OperationsFinder.java
+++ b/src/main/java/build/buildfarm/operations/OperationsFinder.java
@@ -25,24 +25,24 @@ import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.ScanParams;
 import redis.clients.jedis.ScanResult;
 
-///
-/// @class   OperationsFinder
-/// @brief   Finds operations based on search settings.
-/// @details Operations can be found based on different search queries
-///          depending on the context a caller has or wants to filter on.
-///
+/**
+ * @class   OperationsFinder
+ * @brief   Finds operations based on search settings.
+ * @details Operations can be found based on different search queries
+ *          depending on the context a caller has or wants to filter on.
+ */
 public class OperationsFinder {
 
-  ///
-  /// @brief   Finds operations based on search settings.
-  /// @details Operations can be found based on different search queries
-  ///          depending on the context a caller has or wants to filter on.
-  /// @param   cluster  An established redis cluster.
-  /// @param   instance An instance is used to get additional information about the operation.
-  /// @param   settings Settings on how to find and filter operations.
-  /// @return  Results from searching for operations.
-  /// @note    Suggested return identifier: results.
-  ///
+  /**
+   * @brief   Finds operations based on search settings.
+   * @details Operations can be found based on different search queries
+   *          depending on the context a caller has or wants to filter on.
+   * @param   cluster  An established redis cluster.
+   * @param   instance An instance is used to get additional information about the operation.
+   * @param   settings Settings on how to find and filter operations.
+   * @return  Results from searching for operations.
+   * @note    Suggested return identifier: results.
+   */
   public static FindOperationsResults findOperations(
       JedisCluster cluster, Instance instance, FindOperationsSettings settings) {
     FindOperationsResults results = new FindOperationsResults();
@@ -63,12 +63,13 @@ public class OperationsFinder {
 
     return results;
   }
-  ///
-  /// @brief   Adjust the user provided filter if needed.
-  /// @details This is used to ensure certain expectations on particular given
-  ///          filters.
-  /// @param   settings Settings on how to find and filter operations.
-  ///
+
+  /**
+   * @brief   Adjust the user provided filter if needed.
+   * @details This is used to ensure certain expectations on particular given
+   *          filters.
+   * @param   settings Settings on how to find and filter operations.
+   */
   private static void adjustFilter(FindOperationsSettings settings) {
     // be generous. if no filter is provided assume the user wants to select all operations instead
     // of no operations
@@ -76,16 +77,17 @@ public class OperationsFinder {
       settings.filterPredicate = "*";
     }
   }
-  ///
-  /// @brief   Scan all operation entires on existing Jedis node and keep ones
-  ///          that meet query requirements.
-  /// @details Results are accumulated onto.
-  /// @param   cluster  An established redis cluster.
-  /// @param   node     A node of the cluster.
-  /// @param   instance An instance is used to get additional information about the operation.
-  /// @param   settings Settings on what operations to find and keep.
-  /// @param   results  Accumulating results from performing a search.
-  ///
+
+  /**
+   * @brief   Scan all operation entires on existing Jedis node and keep ones
+   *          that meet query requirements.
+   * @details Results are accumulated onto.
+   * @param   cluster  An established redis cluster.
+   * @param   node     A node of the cluster.
+   * @param   instance An instance is used to get additional information about the operation.
+   * @param   settings Settings on what operations to find and keep.
+   * @param   results  Accumulating results from performing a search.
+   */
   private static void findOperationNode(
       JedisCluster cluster,
       Jedis node,
@@ -100,15 +102,16 @@ public class OperationsFinder {
 
     } while (!cursor.equals("0"));
   }
-  ///
-  /// @brief   Scan the operations list to obtain operation keys.
-  /// @details Scanning is done incrementally via a cursor.
-  /// @param   node     A node of the cluster.
-  /// @param   cursor   Scan cursor.
-  /// @param   settings Settings on how to traverse the Operations.
-  /// @return  Resulting operation keys from scanning.
-  /// @note    Suggested return identifier: operationKeys.
-  ///
+
+  /**
+   * @brief   Scan the operations list to obtain operation keys.
+   * @details Scanning is done incrementally via a cursor.
+   * @param   node     A node of the cluster.
+   * @param   cursor   Scan cursor.
+   * @param   settings Settings on how to traverse the Operations.
+   * @return  Resulting operation keys from scanning.
+   * @note    Suggested return identifier: operationKeys.
+   */
   private static List<String> scanOperations(
       Jedis node, String cursor, FindOperationsSettings settings) {
     // construct query
@@ -124,16 +127,17 @@ public class OperationsFinder {
     }
     return new ArrayList<>();
   }
-  ///
-  /// @brief   Collect operations based on settings.
-  /// @details Populates results.
-  /// @param   cluster         An established redis cluster.
-  /// @param   instance        An instance is used to get additional information about the
-  // operation.
-  /// @param   operationKeys   Keys to get operations from.
-  /// @param   filterPredicate The search query used to find particular operations.
-  /// @param   results         Accumulating results from finding operations.
-  ///
+
+  /**
+   * @brief   Collect operations based on settings.
+   * @details Populates results.
+   * @param   cluster         An established redis cluster.
+   * @param   instance        An instance is used to get additional information about the
+   *operation.
+   * @param   operationKeys   Keys to get operations from.
+   * @param   filterPredicate The search query used to find particular operations.
+   * @param   results         Accumulating results from finding operations.
+   */
   private static void collectOperations(
       JedisCluster cluster,
       Instance instance,
@@ -147,15 +151,16 @@ public class OperationsFinder {
       }
     }
   }
-  ///
-  /// @brief   Whether or not to keep operation based on filter settings.
-  /// @details True if the operation should be returned. false if it should be
-  ///          ignored.
-  /// @param   operation       The operation to analyze based on filter settings.
-  /// @param   filterPredicate The search query used to find particular operations.
-  /// @return  Whether to keep the operation based on the filter settings.
-  /// @note    Suggested return identifier: shouldKeep.
-  ///
+
+  /**
+   * @brief   Whether or not to keep operation based on filter settings.
+   * @details True if the operation should be returned. false if it should be
+   *          ignored.
+   * @param   operation       The operation to analyze based on filter settings.
+   * @param   filterPredicate The search query used to find particular operations.
+   * @return  Whether to keep the operation based on the filter settings.
+   * @note    Suggested return identifier: shouldKeep.
+   */
   private static boolean shouldKeepOperation(EnrichedOperation operation, String filterPredicate) {
     String json = operation.asJsonString();
     System.out.println(json);

--- a/src/main/java/build/buildfarm/operations/OperationsFinder.java
+++ b/src/main/java/build/buildfarm/operations/OperationsFinder.java
@@ -26,22 +26,22 @@ import redis.clients.jedis.ScanParams;
 import redis.clients.jedis.ScanResult;
 
 /**
- * @class   OperationsFinder
- * @brief   Finds operations based on search settings.
- * @details Operations can be found based on different search queries
- *          depending on the context a caller has or wants to filter on.
+ * @class OperationsFinder
+ * @brief Finds operations based on search settings.
+ * @details Operations can be found based on different search queries depending on the context a
+ *     caller has or wants to filter on.
  */
 public class OperationsFinder {
 
   /**
-   * @brief   Finds operations based on search settings.
-   * @details Operations can be found based on different search queries
-   *          depending on the context a caller has or wants to filter on.
-   * @param   cluster  An established redis cluster.
-   * @param   instance An instance is used to get additional information about the operation.
-   * @param   settings Settings on how to find and filter operations.
-   * @return  Results from searching for operations.
-   * @note    Suggested return identifier: results.
+   * @brief Finds operations based on search settings.
+   * @details Operations can be found based on different search queries depending on the context a
+   *     caller has or wants to filter on.
+   * @param cluster An established redis cluster.
+   * @param instance An instance is used to get additional information about the operation.
+   * @param settings Settings on how to find and filter operations.
+   * @return Results from searching for operations.
+   * @note Suggested return identifier: results.
    */
   public static FindOperationsResults findOperations(
       JedisCluster cluster, Instance instance, FindOperationsSettings settings) {
@@ -65,10 +65,9 @@ public class OperationsFinder {
   }
 
   /**
-   * @brief   Adjust the user provided filter if needed.
-   * @details This is used to ensure certain expectations on particular given
-   *          filters.
-   * @param   settings Settings on how to find and filter operations.
+   * @brief Adjust the user provided filter if needed.
+   * @details This is used to ensure certain expectations on particular given filters.
+   * @param settings Settings on how to find and filter operations.
    */
   private static void adjustFilter(FindOperationsSettings settings) {
     // be generous. if no filter is provided assume the user wants to select all operations instead
@@ -79,14 +78,14 @@ public class OperationsFinder {
   }
 
   /**
-   * @brief   Scan all operation entires on existing Jedis node and keep ones
-   *          that meet query requirements.
+   * @brief Scan all operation entires on existing Jedis node and keep ones that meet query
+   *     requirements.
    * @details Results are accumulated onto.
-   * @param   cluster  An established redis cluster.
-   * @param   node     A node of the cluster.
-   * @param   instance An instance is used to get additional information about the operation.
-   * @param   settings Settings on what operations to find and keep.
-   * @param   results  Accumulating results from performing a search.
+   * @param cluster An established redis cluster.
+   * @param node A node of the cluster.
+   * @param instance An instance is used to get additional information about the operation.
+   * @param settings Settings on what operations to find and keep.
+   * @param results Accumulating results from performing a search.
    */
   private static void findOperationNode(
       JedisCluster cluster,
@@ -104,13 +103,13 @@ public class OperationsFinder {
   }
 
   /**
-   * @brief   Scan the operations list to obtain operation keys.
+   * @brief Scan the operations list to obtain operation keys.
    * @details Scanning is done incrementally via a cursor.
-   * @param   node     A node of the cluster.
-   * @param   cursor   Scan cursor.
-   * @param   settings Settings on how to traverse the Operations.
-   * @return  Resulting operation keys from scanning.
-   * @note    Suggested return identifier: operationKeys.
+   * @param node A node of the cluster.
+   * @param cursor Scan cursor.
+   * @param settings Settings on how to traverse the Operations.
+   * @return Resulting operation keys from scanning.
+   * @note Suggested return identifier: operationKeys.
    */
   private static List<String> scanOperations(
       Jedis node, String cursor, FindOperationsSettings settings) {
@@ -129,14 +128,13 @@ public class OperationsFinder {
   }
 
   /**
-   * @brief   Collect operations based on settings.
+   * @brief Collect operations based on settings.
    * @details Populates results.
-   * @param   cluster         An established redis cluster.
-   * @param   instance        An instance is used to get additional information about the
-   *operation.
-   * @param   operationKeys   Keys to get operations from.
-   * @param   filterPredicate The search query used to find particular operations.
-   * @param   results         Accumulating results from finding operations.
+   * @param cluster An established redis cluster.
+   * @param instance An instance is used to get additional information about the operation.
+   * @param operationKeys Keys to get operations from.
+   * @param filterPredicate The search query used to find particular operations.
+   * @param results Accumulating results from finding operations.
    */
   private static void collectOperations(
       JedisCluster cluster,
@@ -153,13 +151,12 @@ public class OperationsFinder {
   }
 
   /**
-   * @brief   Whether or not to keep operation based on filter settings.
-   * @details True if the operation should be returned. false if it should be
-   *          ignored.
-   * @param   operation       The operation to analyze based on filter settings.
-   * @param   filterPredicate The search query used to find particular operations.
-   * @return  Whether to keep the operation based on the filter settings.
-   * @note    Suggested return identifier: shouldKeep.
+   * @brief Whether or not to keep operation based on filter settings.
+   * @details True if the operation should be returned. false if it should be ignored.
+   * @param operation The operation to analyze based on filter settings.
+   * @param filterPredicate The search query used to find particular operations.
+   * @return Whether to keep the operation based on the filter settings.
+   * @note Suggested return identifier: shouldKeep.
    */
   private static boolean shouldKeepOperation(EnrichedOperation operation, String filterPredicate) {
     String json = operation.asJsonString();

--- a/src/main/java/build/buildfarm/worker/DequeueMatchEvaluator.java
+++ b/src/main/java/build/buildfarm/worker/DequeueMatchEvaluator.java
@@ -20,67 +20,67 @@ import build.buildfarm.v1test.QueueEntry;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.SetMultimap;
 
-///
-/// @class   DequeueMatchEvaluator
-/// @brief   Algorithm for deciding whether a worker should keep a dequeued
-///          operation.
-/// @details When a worker takes an entry off of the queue, should it decide
-///          to keep that entry or reject and requeue it? In some sense, it
-///          should keep all entries because they have already been vetted for
-///          that particular worker. This is because the scheduler matches
-///          operations to particular queues, and workers match themselves to
-///          which queues they want to read from. But should the worker always
-///          blindly take what it pops off? And can they trust the scheduler?
-///          There may be situations where the worker chooses to give
-///          operations back based on particular contexts not known to the
-///          scheduler. For example, you might have a variety of workers with
-///          different amounts of cpu cores all sharing the same queue. The
-///          queue may accept N-core operations, because N-core workers exist
-///          in the pool, but there are additionally some lower core workers
-///          that would need to forfeit running the operation. All the reasons
-///          a worker may decide it can't take on the operation and should
-///          give it back are implemented here. The settings provided allow
-///          varying amount of leniency when evaluating the platform
-///          properties.
-///
+/**
+ * @class   DequeueMatchEvaluator
+ * @brief   Algorithm for deciding whether a worker should keep a dequeued
+ *          operation.
+ * @details When a worker takes an entry off of the queue, should it decide
+ *          to keep that entry or reject and requeue it? In some sense, it
+ *          should keep all entries because they have already been vetted for
+ *          that particular worker. This is because the scheduler matches
+ *          operations to particular queues, and workers match themselves to
+ *          which queues they want to read from. But should the worker always
+ *          blindly take what it pops off? And can they trust the scheduler?
+ *          There may be situations where the worker chooses to give
+ *          operations back based on particular contexts not known to the
+ *          scheduler. For example, you might have a variety of workers with
+ *          different amounts of cpu cores all sharing the same queue. The
+ *          queue may accept N-core operations, because N-core workers exist
+ *          in the pool, but there are additionally some lower core workers
+ *          that would need to forfeit running the operation. All the reasons
+ *          a worker may decide it can't take on the operation and should
+ *          give it back are implemented here. The settings provided allow
+ *          varying amount of leniency when evaluating the platform
+ *          properties.
+ */
 public class DequeueMatchEvaluator {
 
-  ///
-  /// @field   EXEC_PROPERTY_MIN_CORES
-  /// @brief   The exec_property and platform property name for setting min
-  ///          cores.
-  /// @details This is decided between client and server.
-  ///
+  /**
+   * @field   EXEC_PROPERTY_MIN_CORES
+   * @brief   The exec_property and platform property name for setting min
+   *          cores.
+   * @details This is decided between client and server.
+   */
   private static final String EXEC_PROPERTY_MIN_CORES = "min-cores";
 
-  ///
-  /// @field   EXEC_PROPERTY_MAX_CORES
-  /// @brief   The exec_property and platform property name for setting max
-  ///          cores.
-  /// @details This is decided between client and server.
-  ///
+  /**
+   * @field   EXEC_PROPERTY_MAX_CORES
+   * @brief   The exec_property and platform property name for setting max
+   *          cores.
+   * @details This is decided between client and server.
+   */
   private static final String EXEC_PROPERTY_MAX_CORES = "max-cores";
 
-  ///
-  /// @field   WORKER_PLATFORM_CORES_PROPERTY
-  /// @brief   A platform property decided and assigned to a worker.
-  /// @details This often correlates to execute width of the workers (the max
-  ///          amount of cores it is willing to give an operation).
-  ///
+  /**
+   * @field   WORKER_PLATFORM_CORES_PROPERTY
+   * @brief   A platform property decided and assigned to a worker.
+   * @details This often correlates to execute width of the workers (the max
+   *          amount of cores it is willing to give an operation).
+   */
   private static final String WORKER_PLATFORM_CORES_PROPERTY = "cores";
 
-  ///
-  /// @brief   Decide whether the worker should keep the operation or put it
-  ///          back on the queue.
-  /// @details Compares the platform properties of the worker to the
-  ///          operation's platform properties.
-  /// @param   matchSettings    The provisions of the worker.
-  /// @param   workerProvisions The provisions of the worker.
-  /// @param   queueEntry       An entry recently removed from the queue.
-  /// @return  Whether or not the worker should accept or reject the queue entry.
-  /// @note    Overloaded.
-  /// @note    Suggested return identifier: shouldKeepOperation.
-  ///
+  /**
+   * @brief   Decide whether the worker should keep the operation or put it
+   *          back on the queue.
+   * @details Compares the platform properties of the worker to the
+   *          operation's platform properties.
+   * @param   matchSettings    The provisions of the worker.
+   * @param   workerProvisions The provisions of the worker.
+   * @param   queueEntry       An entry recently removed from the queue.
+   * @return  Whether or not the worker should accept or reject the queue entry.
+   * @note    Overloaded.
+   * @note    Suggested return identifier: shouldKeepOperation.
+   */
   public static boolean shouldKeepOperation(
       DequeueMatchSettings matchSettings,
       SetMultimap<String, String> workerProvisions,
@@ -93,35 +93,37 @@ public class DequeueMatchEvaluator {
 
     return shouldKeepViaPlatform(matchSettings, workerProvisions, queueEntry.getPlatform());
   }
-  ///
-  /// @brief   Decide whether the worker should keep the operation or put it
-  ///          back on the queue.
-  /// @details Compares the platform properties of the worker to the
-  ///          operation's platform properties.
-  /// @param   matchSettings    The provisions of the worker.
-  /// @param   workerProvisions The provisions of the worker.
-  /// @param   command          A command to evaluate.
-  /// @return  Whether or not the worker should accept or reject the queue entry.
-  /// @note    Overloaded.
-  /// @note    Suggested return identifier: shouldKeepOperation.
-  ///
+
+  /**
+   * @brief   Decide whether the worker should keep the operation or put it
+   *          back on the queue.
+   * @details Compares the platform properties of the worker to the
+   *          operation's platform properties.
+   * @param   matchSettings    The provisions of the worker.
+   * @param   workerProvisions The provisions of the worker.
+   * @param   command          A command to evaluate.
+   * @return  Whether or not the worker should accept or reject the queue entry.
+   * @note    Overloaded.
+   * @note    Suggested return identifier: shouldKeepOperation.
+   */
   public static boolean shouldKeepOperation(
       DequeueMatchSettings matchSettings,
       SetMultimap<String, String> workerProvisions,
       Command command) {
     return shouldKeepViaPlatform(matchSettings, workerProvisions, command.getPlatform());
   }
-  ///
-  /// @brief   Decide whether the worker should keep the operation via platform
-  ///          or put it back on the queue.
-  /// @details Compares the platform properties of the worker to the platform
-  ///          properties of the operation.
-  /// @param   matchSettings    The provisions of the worker.
-  /// @param   workerProvisions The provisions of the worker.
-  /// @param   platform         The platforms of operation.
-  /// @return  Whether or not the worker should accept or reject the operation.
-  /// @note    Suggested return identifier: shouldKeepOperation.
-  ///
+
+  /**
+   * @brief   Decide whether the worker should keep the operation via platform
+   *          or put it back on the queue.
+   * @details Compares the platform properties of the worker to the platform
+   *          properties of the operation.
+   * @param   matchSettings    The provisions of the worker.
+   * @param   workerProvisions The provisions of the worker.
+   * @param   platform         The platforms of operation.
+   * @return  Whether or not the worker should accept or reject the operation.
+   * @note    Suggested return identifier: shouldKeepOperation.
+   */
   private static boolean shouldKeepViaPlatform(
       DequeueMatchSettings matchSettings,
       SetMultimap<String, String> workerProvisions,
@@ -133,17 +135,18 @@ public class DequeueMatchEvaluator {
 
     return satisfiesProperties(matchSettings, workerProvisions, platform);
   }
-  ///
-  /// @brief   Decide whether the worker should keep the operation by comparing
-  ///          its platform properties with the queue entry.
-  /// @details Compares the platform properties of the worker to the platform
-  ///          properties.
-  /// @param   matchSettings    The provisions of the worker.
-  /// @param   workerProvisions The provisions of the worker.
-  /// @param   platform         The platforms of operation.
-  /// @return  Whether or not the worker should accept or reject the queue entry.
-  /// @note    Suggested return identifier: shouldKeepOperation.
-  ///
+
+  /**
+   * @brief   Decide whether the worker should keep the operation by comparing
+   *          its platform properties with the queue entry.
+   * @details Compares the platform properties of the worker to the platform
+   *          properties.
+   * @param   matchSettings    The provisions of the worker.
+   * @param   workerProvisions The provisions of the worker.
+   * @param   platform         The platforms of operation.
+   * @return  Whether or not the worker should accept or reject the queue entry.
+   * @note    Suggested return identifier: shouldKeepOperation.
+   */
   private static boolean satisfiesProperties(
       DequeueMatchSettings matchSettings,
       SetMultimap<String, String> workerProvisions,
@@ -155,16 +158,17 @@ public class DequeueMatchEvaluator {
     }
     return true;
   }
-  ///
-  /// @brief   Decide whether the worker should keep the operation by comparing
-  ///          its platform properties with a queue entry property.
-  /// @details Checks for certain exact matches on key/values.
-  /// @param   matchSettings    The provisions of the worker.
-  /// @param   workerProvisions The provisions of the worker.
-  /// @param   property         A property of the queued entry.
-  /// @return  Whether or not the worker should accept or reject the queue entry.
-  /// @note    Suggested return identifier: shouldKeepOperation.
-  ///
+
+  /**
+   * @brief   Decide whether the worker should keep the operation by comparing
+   *          its platform properties with a queue entry property.
+   * @details Checks for certain exact matches on key/values.
+   * @param   matchSettings    The provisions of the worker.
+   * @param   workerProvisions The provisions of the worker.
+   * @param   property         A property of the queued entry.
+   * @return  Whether or not the worker should accept or reject the queue entry.
+   * @note    Suggested return identifier: shouldKeepOperation.
+   */
   private static boolean satisfiesProperty(
       DequeueMatchSettings matchSettings,
       SetMultimap<String, String> workerProvisions,

--- a/src/main/java/build/buildfarm/worker/DequeueMatchEvaluator.java
+++ b/src/main/java/build/buildfarm/worker/DequeueMatchEvaluator.java
@@ -21,65 +21,54 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.SetMultimap;
 
 /**
- * @class   DequeueMatchEvaluator
- * @brief   Algorithm for deciding whether a worker should keep a dequeued
- *          operation.
- * @details When a worker takes an entry off of the queue, should it decide
- *          to keep that entry or reject and requeue it? In some sense, it
- *          should keep all entries because they have already been vetted for
- *          that particular worker. This is because the scheduler matches
- *          operations to particular queues, and workers match themselves to
- *          which queues they want to read from. But should the worker always
- *          blindly take what it pops off? And can they trust the scheduler?
- *          There may be situations where the worker chooses to give
- *          operations back based on particular contexts not known to the
- *          scheduler. For example, you might have a variety of workers with
- *          different amounts of cpu cores all sharing the same queue. The
- *          queue may accept N-core operations, because N-core workers exist
- *          in the pool, but there are additionally some lower core workers
- *          that would need to forfeit running the operation. All the reasons
- *          a worker may decide it can't take on the operation and should
- *          give it back are implemented here. The settings provided allow
- *          varying amount of leniency when evaluating the platform
- *          properties.
+ * @class DequeueMatchEvaluator
+ * @brief Algorithm for deciding whether a worker should keep a dequeued operation.
+ * @details When a worker takes an entry off of the queue, should it decide to keep that entry or
+ *     reject and requeue it? In some sense, it should keep all entries because they have already
+ *     been vetted for that particular worker. This is because the scheduler matches operations to
+ *     particular queues, and workers match themselves to which queues they want to read from. But
+ *     should the worker always blindly take what it pops off? And can they trust the scheduler?
+ *     There may be situations where the worker chooses to give operations back based on particular
+ *     contexts not known to the scheduler. For example, you might have a variety of workers with
+ *     different amounts of cpu cores all sharing the same queue. The queue may accept N-core
+ *     operations, because N-core workers exist in the pool, but there are additionally some lower
+ *     core workers that would need to forfeit running the operation. All the reasons a worker may
+ *     decide it can't take on the operation and should give it back are implemented here. The
+ *     settings provided allow varying amount of leniency when evaluating the platform properties.
  */
 public class DequeueMatchEvaluator {
 
   /**
-   * @field   EXEC_PROPERTY_MIN_CORES
-   * @brief   The exec_property and platform property name for setting min
-   *          cores.
+   * @field EXEC_PROPERTY_MIN_CORES
+   * @brief The exec_property and platform property name for setting min cores.
    * @details This is decided between client and server.
    */
   private static final String EXEC_PROPERTY_MIN_CORES = "min-cores";
 
   /**
-   * @field   EXEC_PROPERTY_MAX_CORES
-   * @brief   The exec_property and platform property name for setting max
-   *          cores.
+   * @field EXEC_PROPERTY_MAX_CORES
+   * @brief The exec_property and platform property name for setting max cores.
    * @details This is decided between client and server.
    */
   private static final String EXEC_PROPERTY_MAX_CORES = "max-cores";
 
   /**
-   * @field   WORKER_PLATFORM_CORES_PROPERTY
-   * @brief   A platform property decided and assigned to a worker.
-   * @details This often correlates to execute width of the workers (the max
-   *          amount of cores it is willing to give an operation).
+   * @field WORKER_PLATFORM_CORES_PROPERTY
+   * @brief A platform property decided and assigned to a worker.
+   * @details This often correlates to execute width of the workers (the max amount of cores it is
+   *     willing to give an operation).
    */
   private static final String WORKER_PLATFORM_CORES_PROPERTY = "cores";
 
   /**
-   * @brief   Decide whether the worker should keep the operation or put it
-   *          back on the queue.
-   * @details Compares the platform properties of the worker to the
-   *          operation's platform properties.
-   * @param   matchSettings    The provisions of the worker.
-   * @param   workerProvisions The provisions of the worker.
-   * @param   queueEntry       An entry recently removed from the queue.
-   * @return  Whether or not the worker should accept or reject the queue entry.
-   * @note    Overloaded.
-   * @note    Suggested return identifier: shouldKeepOperation.
+   * @brief Decide whether the worker should keep the operation or put it back on the queue.
+   * @details Compares the platform properties of the worker to the operation's platform properties.
+   * @param matchSettings The provisions of the worker.
+   * @param workerProvisions The provisions of the worker.
+   * @param queueEntry An entry recently removed from the queue.
+   * @return Whether or not the worker should accept or reject the queue entry.
+   * @note Overloaded.
+   * @note Suggested return identifier: shouldKeepOperation.
    */
   public static boolean shouldKeepOperation(
       DequeueMatchSettings matchSettings,
@@ -95,16 +84,14 @@ public class DequeueMatchEvaluator {
   }
 
   /**
-   * @brief   Decide whether the worker should keep the operation or put it
-   *          back on the queue.
-   * @details Compares the platform properties of the worker to the
-   *          operation's platform properties.
-   * @param   matchSettings    The provisions of the worker.
-   * @param   workerProvisions The provisions of the worker.
-   * @param   command          A command to evaluate.
-   * @return  Whether or not the worker should accept or reject the queue entry.
-   * @note    Overloaded.
-   * @note    Suggested return identifier: shouldKeepOperation.
+   * @brief Decide whether the worker should keep the operation or put it back on the queue.
+   * @details Compares the platform properties of the worker to the operation's platform properties.
+   * @param matchSettings The provisions of the worker.
+   * @param workerProvisions The provisions of the worker.
+   * @param command A command to evaluate.
+   * @return Whether or not the worker should accept or reject the queue entry.
+   * @note Overloaded.
+   * @note Suggested return identifier: shouldKeepOperation.
    */
   public static boolean shouldKeepOperation(
       DequeueMatchSettings matchSettings,
@@ -114,15 +101,15 @@ public class DequeueMatchEvaluator {
   }
 
   /**
-   * @brief   Decide whether the worker should keep the operation via platform
-   *          or put it back on the queue.
-   * @details Compares the platform properties of the worker to the platform
-   *          properties of the operation.
-   * @param   matchSettings    The provisions of the worker.
-   * @param   workerProvisions The provisions of the worker.
-   * @param   platform         The platforms of operation.
-   * @return  Whether or not the worker should accept or reject the operation.
-   * @note    Suggested return identifier: shouldKeepOperation.
+   * @brief Decide whether the worker should keep the operation via platform or put it back on the
+   *     queue.
+   * @details Compares the platform properties of the worker to the platform properties of the
+   *     operation.
+   * @param matchSettings The provisions of the worker.
+   * @param workerProvisions The provisions of the worker.
+   * @param platform The platforms of operation.
+   * @return Whether or not the worker should accept or reject the operation.
+   * @note Suggested return identifier: shouldKeepOperation.
    */
   private static boolean shouldKeepViaPlatform(
       DequeueMatchSettings matchSettings,
@@ -137,15 +124,14 @@ public class DequeueMatchEvaluator {
   }
 
   /**
-   * @brief   Decide whether the worker should keep the operation by comparing
-   *          its platform properties with the queue entry.
-   * @details Compares the platform properties of the worker to the platform
-   *          properties.
-   * @param   matchSettings    The provisions of the worker.
-   * @param   workerProvisions The provisions of the worker.
-   * @param   platform         The platforms of operation.
-   * @return  Whether or not the worker should accept or reject the queue entry.
-   * @note    Suggested return identifier: shouldKeepOperation.
+   * @brief Decide whether the worker should keep the operation by comparing its platform properties
+   *     with the queue entry.
+   * @details Compares the platform properties of the worker to the platform properties.
+   * @param matchSettings The provisions of the worker.
+   * @param workerProvisions The provisions of the worker.
+   * @param platform The platforms of operation.
+   * @return Whether or not the worker should accept or reject the queue entry.
+   * @note Suggested return identifier: shouldKeepOperation.
    */
   private static boolean satisfiesProperties(
       DequeueMatchSettings matchSettings,
@@ -160,14 +146,14 @@ public class DequeueMatchEvaluator {
   }
 
   /**
-   * @brief   Decide whether the worker should keep the operation by comparing
-   *          its platform properties with a queue entry property.
+   * @brief Decide whether the worker should keep the operation by comparing its platform properties
+   *     with a queue entry property.
    * @details Checks for certain exact matches on key/values.
-   * @param   matchSettings    The provisions of the worker.
-   * @param   workerProvisions The provisions of the worker.
-   * @param   property         A property of the queued entry.
-   * @return  Whether or not the worker should accept or reject the queue entry.
-   * @note    Suggested return identifier: shouldKeepOperation.
+   * @param matchSettings The provisions of the worker.
+   * @param workerProvisions The provisions of the worker.
+   * @param property A property of the queued entry.
+   * @return Whether or not the worker should accept or reject the queue entry.
+   * @note Suggested return identifier: shouldKeepOperation.
    */
   private static boolean satisfiesProperty(
       DequeueMatchSettings matchSettings,

--- a/src/main/java/build/buildfarm/worker/DequeueMatchSettings.java
+++ b/src/main/java/build/buildfarm/worker/DequeueMatchSettings.java
@@ -15,29 +15,25 @@
 package build.buildfarm.worker;
 
 /**
- * @class   DequeueMatchSettings
- * @brief   Settings used by a worker to determine whether they should keep
- *          dequeued operations.
- * @details This determines whether workers keep operations or decide to
- *          requeue them for a different worker.
+ * @class DequeueMatchSettings
+ * @brief Settings used by a worker to determine whether they should keep dequeued operations.
+ * @details This determines whether workers keep operations or decide to requeue them for a
+ *     different worker.
  */
 public class DequeueMatchSettings {
 
   /**
-   * @field   acceptEverything
-   * @brief   Whether or not the worker should accept everything it gets off
-   *          the queue.
-   * @details This will assume the worker can always execute operations from
-   *          the queue it matches with.
+   * @field acceptEverything
+   * @brief Whether or not the worker should accept everything it gets off the queue.
+   * @details This will assume the worker can always execute operations from the queue it matches
+   *     with.
    */
   public boolean acceptEverything = false;
 
   /**
-   * @field   allowUnmatched
-   * @brief   Whether or not the worker should accept platform properties that
-   *          it does not match with.
-   * @details This is often necessary if the queue is also configured to allow
-   *          unmatched properties.
-   *
+   * @field allowUnmatched
+   * @brief Whether or not the worker should accept platform properties that it does not match with.
+   * @details This is often necessary if the queue is also configured to allow unmatched properties.
+   */
   public boolean allowUnmatched = false;
 }

--- a/src/main/java/build/buildfarm/worker/DequeueMatchSettings.java
+++ b/src/main/java/build/buildfarm/worker/DequeueMatchSettings.java
@@ -14,30 +14,30 @@
 
 package build.buildfarm.worker;
 
-///
-/// @class   DequeueMatchSettings
-/// @brief   Settings used by a worker to determine whether they should keep
-///          dequeued operations.
-/// @details This determines whether workers keep operations or decide to
-///          requeue them for a different worker.
-///
+/**
+ * @class   DequeueMatchSettings
+ * @brief   Settings used by a worker to determine whether they should keep
+ *          dequeued operations.
+ * @details This determines whether workers keep operations or decide to
+ *          requeue them for a different worker.
+ */
 public class DequeueMatchSettings {
 
-  ///
-  /// @field   acceptEverything
-  /// @brief   Whether or not the worker should accept everything it gets off
-  ///          the queue.
-  /// @details This will assume the worker can always execute operations from
-  ///          the queue it matches with.
-  ///
+  /**
+   * @field   acceptEverything
+   * @brief   Whether or not the worker should accept everything it gets off
+   *          the queue.
+   * @details This will assume the worker can always execute operations from
+   *          the queue it matches with.
+   */
   public boolean acceptEverything = false;
 
-  ///
-  /// @field   allowUnmatched
-  /// @brief   Whether or not the worker should accept platform properties that
-  ///          it does not match with.
-  /// @details This is often necessary if the queue is also configured to allow
-  ///          unmatched properties.
-  ///
+  /**
+   * @field   allowUnmatched
+   * @brief   Whether or not the worker should accept platform properties that
+   *          it does not match with.
+   * @details This is often necessary if the queue is also configured to allow
+   *          unmatched properties.
+   *
   public boolean allowUnmatched = false;
 }

--- a/src/main/java/build/buildfarm/worker/resources/CpuLimits.java
+++ b/src/main/java/build/buildfarm/worker/resources/CpuLimits.java
@@ -14,51 +14,51 @@
 
 package build.buildfarm.worker;
 
-///
-/// @class   CpuLimits
-/// @brief   CPU resource limitations imposed on specific actions.
-/// @details These resource limitations are often specified by the client
-///          (via: exec_properties), but ultimately validated and decided by
-///          the server. Restricting core count can be beneficial to
-///          preventing hungry actions from bogging down the worker and
-///          affecting neighboring actions that may be sharing the same
-///          hardware. More importantly, being able to apply restrictions
-///          allows for a more efficient utilization of shared compute across
-///          different workers and action profiles. One might also consider
-///          even using higher core machine to take on highly parallel
-///          actions, while allowing lower core machines to take on single
-///          threaded actions. These restrictions will ultimately encourage
-///          action writers to implement their actions more efficiently or opt
-///          for local execution as an alternative.
-///
+/**
+ * @class   CpuLimits
+ * @brief   CPU resource limitations imposed on specific actions.
+ * @details These resource limitations are often specified by the client
+ *          (via: exec_properties), but ultimately validated and decided by
+ *          the server. Restricting core count can be beneficial to
+ *          preventing hungry actions from bogging down the worker and
+ *          affecting neighboring actions that may be sharing the same
+ *          hardware. More importantly, being able to apply restrictions
+ *          allows for a more efficient utilization of shared compute across
+ *          different workers and action profiles. One might also consider
+ *          even using higher core machine to take on highly parallel
+ *          actions, while allowing lower core machines to take on single
+ *          threaded actions. These restrictions will ultimately encourage
+ *          action writers to implement their actions more efficiently or opt
+ *          for local execution as an alternative.
+ */
 public class CpuLimits {
 
-  ///
-  /// @field   limit
-  /// @brief   Whether or not we perform CPU core limiting on the action.
-  /// @details Depending on the server implementation, we may skip applying any
-  ///          restrictions to core usage.
-  ///
+  /**
+   * @field   limit
+   * @brief   Whether or not we perform CPU core limiting on the action.
+   * @details Depending on the server implementation, we may skip applying any
+   *          restrictions to core usage.
+   */
   public boolean limit = true;
 
-  ///
-  /// @field   min
-  /// @brief   The minimum CPU cores required.
-  /// @details Client can suggest this though exec_properties.
-  ///
+  /**
+   * @field   min
+   * @brief   The minimum CPU cores required.
+   * @details Client can suggest this though exec_properties.
+   */
   public int min = 1;
 
-  ///
-  /// @field   max
-  /// @brief   The maximum CPU cores required.
-  /// @details Client can suggest this though exec_properties.
-  ///
+  /**
+   * @field   max
+   * @brief   The maximum CPU cores required.
+   * @details Client can suggest this though exec_properties.
+   */
   public int max = 1;
 
-  ///
-  /// @field   claimed
-  /// @brief   The amount of cores actually claimed for the action.
-  /// @details This will be in the range of (min,max) when limited.
-  ///
+  /**
+   * @field   claimed
+   * @brief   The amount of cores actually claimed for the action.
+   * @details This will be in the range of (min,max) when limited.
+   */
   public int claimed = 1;
 }

--- a/src/main/java/build/buildfarm/worker/resources/CpuLimits.java
+++ b/src/main/java/build/buildfarm/worker/resources/CpuLimits.java
@@ -15,49 +15,45 @@
 package build.buildfarm.worker;
 
 /**
- * @class   CpuLimits
- * @brief   CPU resource limitations imposed on specific actions.
- * @details These resource limitations are often specified by the client
- *          (via: exec_properties), but ultimately validated and decided by
- *          the server. Restricting core count can be beneficial to
- *          preventing hungry actions from bogging down the worker and
- *          affecting neighboring actions that may be sharing the same
- *          hardware. More importantly, being able to apply restrictions
- *          allows for a more efficient utilization of shared compute across
- *          different workers and action profiles. One might also consider
- *          even using higher core machine to take on highly parallel
- *          actions, while allowing lower core machines to take on single
- *          threaded actions. These restrictions will ultimately encourage
- *          action writers to implement their actions more efficiently or opt
- *          for local execution as an alternative.
+ * @class CpuLimits
+ * @brief CPU resource limitations imposed on specific actions.
+ * @details These resource limitations are often specified by the client (via: exec_properties), but
+ *     ultimately validated and decided by the server. Restricting core count can be beneficial to
+ *     preventing hungry actions from bogging down the worker and affecting neighboring actions that
+ *     may be sharing the same hardware. More importantly, being able to apply restrictions allows
+ *     for a more efficient utilization of shared compute across different workers and action
+ *     profiles. One might also consider even using higher core machine to take on highly parallel
+ *     actions, while allowing lower core machines to take on single threaded actions. These
+ *     restrictions will ultimately encourage action writers to implement their actions more
+ *     efficiently or opt for local execution as an alternative.
  */
 public class CpuLimits {
 
   /**
-   * @field   limit
-   * @brief   Whether or not we perform CPU core limiting on the action.
-   * @details Depending on the server implementation, we may skip applying any
-   *          restrictions to core usage.
+   * @field limit
+   * @brief Whether or not we perform CPU core limiting on the action.
+   * @details Depending on the server implementation, we may skip applying any restrictions to core
+   *     usage.
    */
   public boolean limit = true;
 
   /**
-   * @field   min
-   * @brief   The minimum CPU cores required.
+   * @field min
+   * @brief The minimum CPU cores required.
    * @details Client can suggest this though exec_properties.
    */
   public int min = 1;
 
   /**
-   * @field   max
-   * @brief   The maximum CPU cores required.
+   * @field max
+   * @brief The maximum CPU cores required.
    * @details Client can suggest this though exec_properties.
    */
   public int max = 1;
 
   /**
-   * @field   claimed
-   * @brief   The amount of cores actually claimed for the action.
+   * @field claimed
+   * @brief The amount of cores actually claimed for the action.
    * @details This will be in the range of (min,max) when limited.
    */
   public int claimed = 1;

--- a/src/main/java/build/buildfarm/worker/resources/ResourceDecider.java
+++ b/src/main/java/build/buildfarm/worker/resources/ResourceDecider.java
@@ -23,54 +23,52 @@ import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 
 /**
- * @class   ResourceDecider
- * @brief   Decide the resource limitations for a given command.
- * @details Platform properties from specified exec_properties are taken
- *          into account as well as global buildfarm configuration.
+ * @class ResourceDecider
+ * @brief Decide the resource limitations for a given command.
+ * @details Platform properties from specified exec_properties are taken into account as well as
+ *     global buildfarm configuration.
  */
 public class ResourceDecider {
 
   /**
-   * @field   EXEC_PROPERTY_MIN_CORES
-   * @brief   The exec_property and platform property name for setting min
-   *          cores.
+   * @field EXEC_PROPERTY_MIN_CORES
+   * @brief The exec_property and platform property name for setting min cores.
    * @details This is decided between client and server.
    */
   private static final String EXEC_PROPERTY_MIN_CORES = "min-cores";
 
   /**
-   * @field   EXEC_PROPERTY_MAX_CORES
-   * @brief   The exec_property and platform property name for setting max
-   *          cores.
+   * @field EXEC_PROPERTY_MAX_CORES
+   * @brief The exec_property and platform property name for setting max cores.
    * @details This is decided between client and server.
    */
   private static final String EXEC_PROPERTY_MAX_CORES = "max-cores";
 
   /**
-   * @field   EXEC_PROPERTY_ENV_VARS
-   * @brief   The exec_property and platform property name for providing
-   *          additional environment variables.
+   * @field EXEC_PROPERTY_ENV_VARS
+   * @brief The exec_property and platform property name for providing additional environment
+   *     variables.
    * @details This is decided between client and server.
    */
   private static final String EXEC_PROPERTY_ENV_VARS = "env-vars";
 
   /**
-   * @field   EXEC_PROPERTY_ENV_VAR
-   * @brief   The exec_property and platform property prefix name for
-   *          providing an additional environment variable.
+   * @field EXEC_PROPERTY_ENV_VAR
+   * @brief The exec_property and platform property prefix name for providing an additional
+   *     environment variable.
    * @details This is decided between client and server.
    */
   private static final String EXEC_PROPERTY_ENV_VAR = "env-var:";
 
   /**
-   * @brief   Decide resource limitations for the given command.
-   * @details Platform properties from specified exec_properties are taken
-   *          into account as well as global buildfarm configuration.
-   * @param   command            The command to decide resource limitations for.
-   * @param   onlyMulticoreTests Only allow ttests to be multicore.
-   * @param   executeStageWidth  The maximum amount of cores available for the operation.
-   * @return  Default resource limits.
-   * @note    Suggested return identifier: resourceLimits.
+   * @brief Decide resource limitations for the given command.
+   * @details Platform properties from specified exec_properties are taken into account as well as
+   *     global buildfarm configuration.
+   * @param command The command to decide resource limitations for.
+   * @param onlyMulticoreTests Only allow ttests to be multicore.
+   * @param executeStageWidth The maximum amount of cores available for the operation.
+   * @return Default resource limits.
+   * @note Suggested return identifier: resourceLimits.
    */
   public static ResourceLimits decideResourceLimitations(
       Command command, boolean onlyMulticoreTests, int executeStageWidth) {
@@ -83,13 +81,13 @@ public class ResourceDecider {
   }
 
   /**
-   * @brief   Decide CPU limitations.
-   * @details Given a default set of limitations, use the command and global
-   *          configuration to adjust CPU limitations.
-   * @param   limits             Current limits to apply changes to.
-   * @param   command            The command to decide resource limitations.
-   * @param   onlyMulticoreTests Only allow ttests to be multicore.
-   * @param   executeStageWidth  The maximum amount of cores available for the operation.
+   * @brief Decide CPU limitations.
+   * @details Given a default set of limitations, use the command and global configuration to adjust
+   *     CPU limitations.
+   * @param limits Current limits to apply changes to.
+   * @param command The command to decide resource limitations.
+   * @param onlyMulticoreTests Only allow ttests to be multicore.
+   * @param executeStageWidth The maximum amount of cores available for the operation.
    */
   private static void setCpuLimits(
       ResourceLimits limits, Command command, boolean onlyMulticoreTests, int executeStageWidth) {
@@ -108,12 +106,12 @@ public class ResourceDecider {
   }
 
   /**
-   * @brief   Decide extra environment variables.
-   * @details Given a default set of limitations, use the command and global
-   *          configuration to adjust the extra environment variables.
-   * @param   limits             Current limits to apply changes to.
-   * @param   command            The command to decide resource limitations.
-   * @param   onlyMulticoreTests Only allow ttests to be multicore.
+   * @brief Decide extra environment variables.
+   * @details Given a default set of limitations, use the command and global configuration to adjust
+   *     the extra environment variables.
+   * @param limits Current limits to apply changes to.
+   * @param command The command to decide resource limitations.
+   * @param onlyMulticoreTests Only allow ttests to be multicore.
    */
   private static void setEnvironmentVariables(
       ResourceLimits limits, Command command, boolean onlyMulticoreTests) {
@@ -140,11 +138,10 @@ public class ResourceDecider {
   }
 
   /**
-   * @brief   Extend env variables that were individual passed.
-   * @details These are discovered by identifying execution property key
-   *          names.
-   * @param   limits  Current limits to apply changes to.
-   * @param   command The command to decide resource limitations.
+   * @brief Extend env variables that were individual passed.
+   * @details These are discovered by identifying execution property key names.
+   * @param limits Current limits to apply changes to.
+   * @param command The command to decide resource limitations.
    */
   private static void addIndividualEnvVars(ResourceLimits limits, Command command) {
     command
@@ -162,11 +159,11 @@ public class ResourceDecider {
   }
 
   /**
-   * @brief   Get default resource limits.
-   * @details Get the default resource limits before adjusting based on
-   *          action's exec_properties global configuration.
-   * @return  Default resource limits.
-   * @note    Suggested return identifier: resourceLimits.
+   * @brief Get default resource limits.
+   * @details Get the default resource limits before adjusting based on action's exec_properties
+   *     global configuration.
+   * @return Default resource limits.
+   * @note Suggested return identifier: resourceLimits.
    */
   private static ResourceLimits getDefaultLimitations() {
     // These can be moved to configuration in the future
@@ -196,14 +193,14 @@ public class ResourceDecider {
   }
 
   /**
-   * @brief   Get an integer value from a platform property.
-   * @details Get the first value of the property name given. If the property
-   *          name does not exist the default provided is returned.
-   * @param   command    The command to extract the platform value from.
-   * @param   name       The platform property name.
-   * @param   defaultVal The default value if the property name does not exist.
-   * @return  The decided platform value.
-   * @note    Suggested return identifier: platformValue.
+   * @brief Get an integer value from a platform property.
+   * @details Get the first value of the property name given. If the property name does not exist
+   *     the default provided is returned.
+   * @param command The command to extract the platform value from.
+   * @param name The platform property name.
+   * @param defaultVal The default value if the property name does not exist.
+   * @return The decided platform value.
+   * @note Suggested return identifier: platformValue.
    */
   private static int getIntegerPlatformValue(Command command, String name, int defaultVal) {
     for (Property property : command.getPlatform().getPropertiesList()) {
@@ -215,14 +212,14 @@ public class ResourceDecider {
   }
 
   /**
-   * @brief   Get a string value from a platform property.
-   * @details Get the first value of the property name given. If the property
-   *          name does not exist the default provided is returned.
-   * @param   command    The command to extract the platform value from.
-   * @param   name       The platform property name.
-   * @param   defaultVal The default value if the property name does not exist.
-   * @return  The decided platform value.
-   * @note    Suggested return identifier: platformValue.
+   * @brief Get a string value from a platform property.
+   * @details Get the first value of the property name given. If the property name does not exist
+   *     the default provided is returned.
+   * @param command The command to extract the platform value from.
+   * @param name The platform property name.
+   * @param defaultVal The default value if the property name does not exist.
+   * @return The decided platform value.
+   * @note Suggested return identifier: platformValue.
    */
   private static String getStringPlatformValue(Command command, String name, String defaultVal) {
     for (Property property : command.getPlatform().getPropertiesList()) {
@@ -234,12 +231,11 @@ public class ResourceDecider {
   }
 
   /**
-   * @brief   Derive if command is a test run.
-   * @details Find a reliable way to identify whether a command is a test or
-   *          not.
-   * @param   command The command to identify as a test command.
-   * @return  Whether the command is a test.
-   * @note    Suggested return identifier: exists.
+   * @brief Derive if command is a test run.
+   * @details Find a reliable way to identify whether a command is a test or not.
+   * @param command The command to identify as a test command.
+   * @return Whether the command is a test.
+   * @note Suggested return identifier: exists.
    */
   private static boolean commandIsTest(Command command) {
     // only tests are setting this currently - other mechanisms are unreliable

--- a/src/main/java/build/buildfarm/worker/resources/ResourceDecider.java
+++ b/src/main/java/build/buildfarm/worker/resources/ResourceDecider.java
@@ -22,56 +22,56 @@ import java.util.Map;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 
-///
-/// @class   ResourceDecider
-/// @brief   Decide the resource limitations for a given command.
-/// @details Platform properties from specified exec_properties are taken
-///          into account as well as global buildfarm configuration.
-///
+/**
+ * @class   ResourceDecider
+ * @brief   Decide the resource limitations for a given command.
+ * @details Platform properties from specified exec_properties are taken
+ *          into account as well as global buildfarm configuration.
+ */
 public class ResourceDecider {
 
-  ///
-  /// @field   EXEC_PROPERTY_MIN_CORES
-  /// @brief   The exec_property and platform property name for setting min
-  ///          cores.
-  /// @details This is decided between client and server.
-  ///
+  /**
+   * @field   EXEC_PROPERTY_MIN_CORES
+   * @brief   The exec_property and platform property name for setting min
+   *          cores.
+   * @details This is decided between client and server.
+   */
   private static final String EXEC_PROPERTY_MIN_CORES = "min-cores";
 
-  ///
-  /// @field   EXEC_PROPERTY_MAX_CORES
-  /// @brief   The exec_property and platform property name for setting max
-  ///          cores.
-  /// @details This is decided between client and server.
-  ///
+  /**
+   * @field   EXEC_PROPERTY_MAX_CORES
+   * @brief   The exec_property and platform property name for setting max
+   *          cores.
+   * @details This is decided between client and server.
+   */
   private static final String EXEC_PROPERTY_MAX_CORES = "max-cores";
 
-  ///
-  /// @field   EXEC_PROPERTY_ENV_VARS
-  /// @brief   The exec_property and platform property name for providing
-  ///          additional environment variables.
-  /// @details This is decided between client and server.
-  ///
+  /**
+   * @field   EXEC_PROPERTY_ENV_VARS
+   * @brief   The exec_property and platform property name for providing
+   *          additional environment variables.
+   * @details This is decided between client and server.
+   */
   private static final String EXEC_PROPERTY_ENV_VARS = "env-vars";
 
-  ///
-  /// @field   EXEC_PROPERTY_ENV_VAR
-  /// @brief   The exec_property and platform property prefix name for
-  ///          providing an additional environment variable.
-  /// @details This is decided between client and server.
-  ///
+  /**
+   * @field   EXEC_PROPERTY_ENV_VAR
+   * @brief   The exec_property and platform property prefix name for
+   *          providing an additional environment variable.
+   * @details This is decided between client and server.
+   */
   private static final String EXEC_PROPERTY_ENV_VAR = "env-var:";
 
-  ///
-  /// @brief   Decide resource limitations for the given command.
-  /// @details Platform properties from specified exec_properties are taken
-  ///          into account as well as global buildfarm configuration.
-  /// @param   command            The command to decide resource limitations for.
-  /// @param   onlyMulticoreTests Only allow ttests to be multicore.
-  /// @param   executeStageWidth  The maximum amount of cores available for the operation.
-  /// @return  Default resource limits.
-  /// @note    Suggested return identifier: resourceLimits.
-  ///
+  /**
+   * @brief   Decide resource limitations for the given command.
+   * @details Platform properties from specified exec_properties are taken
+   *          into account as well as global buildfarm configuration.
+   * @param   command            The command to decide resource limitations for.
+   * @param   onlyMulticoreTests Only allow ttests to be multicore.
+   * @param   executeStageWidth  The maximum amount of cores available for the operation.
+   * @return  Default resource limits.
+   * @note    Suggested return identifier: resourceLimits.
+   */
   public static ResourceLimits decideResourceLimitations(
       Command command, boolean onlyMulticoreTests, int executeStageWidth) {
     ResourceLimits limits = getDefaultLimitations();
@@ -81,15 +81,16 @@ public class ResourceDecider {
 
     return limits;
   }
-  ///
-  /// @brief   Decide CPU limitations.
-  /// @details Given a default set of limitations, use the command and global
-  ///          configuration to adjust CPU limitations.
-  /// @param   limits             Current limits to apply changes to.
-  /// @param   command            The command to decide resource limitations.
-  /// @param   onlyMulticoreTests Only allow ttests to be multicore.
-  /// @param   executeStageWidth  The maximum amount of cores available for the operation.
-  ///
+
+  /**
+   * @brief   Decide CPU limitations.
+   * @details Given a default set of limitations, use the command and global
+   *          configuration to adjust CPU limitations.
+   * @param   limits             Current limits to apply changes to.
+   * @param   command            The command to decide resource limitations.
+   * @param   onlyMulticoreTests Only allow ttests to be multicore.
+   * @param   executeStageWidth  The maximum amount of cores available for the operation.
+   */
   private static void setCpuLimits(
       ResourceLimits limits, Command command, boolean onlyMulticoreTests, int executeStageWidth) {
     // apply cpu limits specified on command
@@ -105,14 +106,15 @@ public class ResourceDecider {
     // claim core amount according to execute stage width
     limits.cpu.claimed = Math.min(limits.cpu.min, executeStageWidth);
   }
-  ///
-  /// @brief   Decide extra environment variables.
-  /// @details Given a default set of limitations, use the command and global
-  ///          configuration to adjust the extra environment variables.
-  /// @param   limits             Current limits to apply changes to.
-  /// @param   command            The command to decide resource limitations.
-  /// @param   onlyMulticoreTests Only allow ttests to be multicore.
-  ///
+
+  /**
+   * @brief   Decide extra environment variables.
+   * @details Given a default set of limitations, use the command and global
+   *          configuration to adjust the extra environment variables.
+   * @param   limits             Current limits to apply changes to.
+   * @param   command            The command to decide resource limitations.
+   * @param   onlyMulticoreTests Only allow ttests to be multicore.
+   */
   private static void setEnvironmentVariables(
       ResourceLimits limits, Command command, boolean onlyMulticoreTests) {
     // parse any user given environment variables into a map
@@ -136,13 +138,14 @@ public class ResourceDecider {
           return val;
         });
   }
-  ///
-  /// @brief   Extend env variables that were individual passed.
-  /// @details These are discovered by identifying execution property key
-  ///          names.
-  /// @param   limits  Current limits to apply changes to.
-  /// @param   command The command to decide resource limitations.
-  ///
+
+  /**
+   * @brief   Extend env variables that were individual passed.
+   * @details These are discovered by identifying execution property key
+   *          names.
+   * @param   limits  Current limits to apply changes to.
+   * @param   command The command to decide resource limitations.
+   */
   private static void addIndividualEnvVars(ResourceLimits limits, Command command) {
     command
         .getPlatform()
@@ -157,13 +160,14 @@ public class ResourceDecider {
               }
             });
   }
-  ///
-  /// @brief   Get default resource limits.
-  /// @details Get the default resource limits before adjusting based on
-  ///          action's exec_properties global configuration.
-  /// @return  Default resource limits.
-  /// @note    Suggested return identifier: resourceLimits.
-  ///
+
+  /**
+   * @brief   Get default resource limits.
+   * @details Get the default resource limits before adjusting based on
+   *          action's exec_properties global configuration.
+   * @return  Default resource limits.
+   * @note    Suggested return identifier: resourceLimits.
+   */
   private static ResourceLimits getDefaultLimitations() {
     // These can be moved to configuration in the future
     ResourceLimits limits = new ResourceLimits();
@@ -190,16 +194,17 @@ public class ResourceDecider {
 
     return limits;
   }
-  ///
-  /// @brief   Get an integer value from a platform property.
-  /// @details Get the first value of the property name given. If the property
-  ///          name does not exist the default provided is returned.
-  /// @param   command    The command to extract the platform value from.
-  /// @param   name       The platform property name.
-  /// @param   defaultVal The default value if the property name does not exist.
-  /// @return  The decided platform value.
-  /// @note    Suggested return identifier: platformValue.
-  ///
+
+  /**
+   * @brief   Get an integer value from a platform property.
+   * @details Get the first value of the property name given. If the property
+   *          name does not exist the default provided is returned.
+   * @param   command    The command to extract the platform value from.
+   * @param   name       The platform property name.
+   * @param   defaultVal The default value if the property name does not exist.
+   * @return  The decided platform value.
+   * @note    Suggested return identifier: platformValue.
+   */
   private static int getIntegerPlatformValue(Command command, String name, int defaultVal) {
     for (Property property : command.getPlatform().getPropertiesList()) {
       if (property.getName().equals(name)) {
@@ -208,16 +213,17 @@ public class ResourceDecider {
     }
     return defaultVal;
   }
-  ///
-  /// @brief   Get a string value from a platform property.
-  /// @details Get the first value of the property name given. If the property
-  ///          name does not exist the default provided is returned.
-  /// @param   command    The command to extract the platform value from.
-  /// @param   name       The platform property name.
-  /// @param   defaultVal The default value if the property name does not exist.
-  /// @return  The decided platform value.
-  /// @note    Suggested return identifier: platformValue.
-  ///
+
+  /**
+   * @brief   Get a string value from a platform property.
+   * @details Get the first value of the property name given. If the property
+   *          name does not exist the default provided is returned.
+   * @param   command    The command to extract the platform value from.
+   * @param   name       The platform property name.
+   * @param   defaultVal The default value if the property name does not exist.
+   * @return  The decided platform value.
+   * @note    Suggested return identifier: platformValue.
+   */
   private static String getStringPlatformValue(Command command, String name, String defaultVal) {
     for (Property property : command.getPlatform().getPropertiesList()) {
       if (property.getName().equals(name)) {
@@ -226,14 +232,15 @@ public class ResourceDecider {
     }
     return defaultVal;
   }
-  ///
-  /// @brief   Derive if command is a test run.
-  /// @details Find a reliable way to identify whether a command is a test or
-  ///          not.
-  /// @param   command The command to identify as a test command.
-  /// @return  Whether the command is a test.
-  /// @note    Suggested return identifier: exists.
-  ///
+
+  /**
+   * @brief   Derive if command is a test run.
+   * @details Find a reliable way to identify whether a command is a test or
+   *          not.
+   * @param   command The command to identify as a test command.
+   * @return  Whether the command is a test.
+   * @note    Suggested return identifier: exists.
+   */
   private static boolean commandIsTest(Command command) {
     // only tests are setting this currently - other mechanisms are unreliable
     return Iterables.any(

--- a/src/main/java/build/buildfarm/worker/resources/ResourceLimits.java
+++ b/src/main/java/build/buildfarm/worker/resources/ResourceLimits.java
@@ -18,34 +18,29 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * @class   ResourceLimits
- * @brief   Resource limitations imposed on specific actions.
- * @details These resource limitations are often specified by the client
- *          (via: exec_properties), but ultimately validated and decided by
- *          the server. Restricting the available resources for actions can
- *          have benefits on efficiency and stability as actions commonly
- *          share the same underlying resources. Keep in mind, that although
- *          workers will limit their resources for their actions, certain
- *          resource limitations may have already been taken into account in
- *          order to decide the eligibility of which workers can execute
- *          which actions.
+ * @class ResourceLimits
+ * @brief Resource limitations imposed on specific actions.
+ * @details These resource limitations are often specified by the client (via: exec_properties), but
+ *     ultimately validated and decided by the server. Restricting the available resources for
+ *     actions can have benefits on efficiency and stability as actions commonly share the same
+ *     underlying resources. Keep in mind, that although workers will limit their resources for
+ *     their actions, certain resource limitations may have already been taken into account in order
+ *     to decide the eligibility of which workers can execute which actions.
  */
 public class ResourceLimits {
 
   /**
-   * @field   cpu
-   * @brief   Resource limitations on CPUs.
-   * @details Decides specific CPU limitations and whether to apply them for a
-   *          given action.
+   * @field cpu
+   * @brief Resource limitations on CPUs.
+   * @details Decides specific CPU limitations and whether to apply them for a given action.
    */
   public CpuLimits cpu = new CpuLimits();
 
   /**
-   * @field   extraEnvironmentVariables
-   * @brief   Decides whether we should add extra environment variables when
-   *          executing an operation.
-   * @details These variables are added to the end of the existing environment
-   *          variables in the Command.
+   * @field extraEnvironmentVariables
+   * @brief Decides whether we should add extra environment variables when executing an operation.
+   * @details These variables are added to the end of the existing environment variables in the
+   *     Command.
    */
   public Map<String, String> extraEnvironmentVariables = new HashMap<String, String>();
 }

--- a/src/main/java/build/buildfarm/worker/resources/ResourceLimits.java
+++ b/src/main/java/build/buildfarm/worker/resources/ResourceLimits.java
@@ -17,35 +17,35 @@ package build.buildfarm.worker;
 import java.util.HashMap;
 import java.util.Map;
 
-///
-/// @class   ResourceLimits
-/// @brief   Resource limitations imposed on specific actions.
-/// @details These resource limitations are often specified by the client
-///          (via: exec_properties), but ultimately validated and decided by
-///          the server. Restricting the available resources for actions can
-///          have benefits on efficiency and stability as actions commonly
-///          share the same underlying resources. Keep in mind, that although
-///          workers will limit their resources for their actions, certain
-///          resource limitations may have already been taken into account in
-///          order to decide the eligibility of which workers can execute
-///          which actions.
-///
+/**
+ * @class   ResourceLimits
+ * @brief   Resource limitations imposed on specific actions.
+ * @details These resource limitations are often specified by the client
+ *          (via: exec_properties), but ultimately validated and decided by
+ *          the server. Restricting the available resources for actions can
+ *          have benefits on efficiency and stability as actions commonly
+ *          share the same underlying resources. Keep in mind, that although
+ *          workers will limit their resources for their actions, certain
+ *          resource limitations may have already been taken into account in
+ *          order to decide the eligibility of which workers can execute
+ *          which actions.
+ */
 public class ResourceLimits {
 
-  ///
-  /// @field   cpu
-  /// @brief   Resource limitations on CPUs.
-  /// @details Decides specific CPU limitations and whether to apply them for a
-  ///          given action.
-  ///
+  /**
+   * @field   cpu
+   * @brief   Resource limitations on CPUs.
+   * @details Decides specific CPU limitations and whether to apply them for a
+   *          given action.
+   */
   public CpuLimits cpu = new CpuLimits();
 
-  ///
-  /// @field   extraEnvironmentVariables
-  /// @brief   Decides whether we should add extra environment variables when
-  ///          executing an operation.
-  /// @details These variables are added to the end of the existing environment
-  ///          variables in the Command.
-  ///
+  /**
+   * @field   extraEnvironmentVariables
+   * @brief   Decides whether we should add extra environment variables when
+   *          executing an operation.
+   * @details These variables are added to the end of the existing environment
+   *          variables in the Command.
+   */
   public Map<String, String> extraEnvironmentVariables = new HashMap<String, String>();
 }

--- a/src/test/java/build/buildfarm/common/redis/BalancedRedisQueueMockTest.java
+++ b/src/test/java/build/buildfarm/common/redis/BalancedRedisQueueMockTest.java
@@ -31,17 +31,15 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import redis.clients.jedis.JedisCluster;
 
-///
-/// @class   BalancedRedisQueueMockTest
-/// @brief   tests A balanced redis queue.
-/// @details A balanced redis queue is an implementation of a queue data
-///          structure which internally uses multiple redis nodes to
-///          distribute the data across the cluster. Its important to know
-///          that the lifetime of the queue persists before and after the
-///          queue data structure is created (since it exists in redis).
-///          Therefore, two redis queues with the same name, would in fact be
-///          the same underlying redis queues.
-///
+/**
+ * @class BalancedRedisQueueMockTest
+ * @brief tests A balanced redis queue.
+ * @details A balanced redis queue is an implementation of a queue data structure which internally
+ *     uses multiple redis nodes to distribute the data across the cluster. Its important to know
+ *     that the lifetime of the queue persists before and after the queue data structure is created
+ *     (since it exists in redis). Therefore, two redis queues with the same name, would in fact be
+ *     the same underlying redis queues.
+ */
 @RunWith(JUnit4.class)
 public class BalancedRedisQueueMockTest {
 

--- a/src/test/java/build/buildfarm/common/redis/BalancedRedisQueueTest.java
+++ b/src/test/java/build/buildfarm/common/redis/BalancedRedisQueueTest.java
@@ -29,17 +29,15 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import redis.clients.jedis.JedisCluster;
 
-///
-/// @class   BalancedRedisQueueTest
-/// @brief   tests A balanced redis queue.
-/// @details A balanced redis queue is an implementation of a queue data
-///          structure which internally uses multiple redis nodes to
-///          distribute the data across the cluster. Its important to know
-///          that the lifetime of the queue persists before and after the
-///          queue data structure is created (since it exists in redis).
-///          Therefore, two redis queues with the same name, would in fact be
-///          the same underlying redis queues.
-///
+/**
+ * @class BalancedRedisQueueTest
+ * @brief tests A balanced redis queue.
+ * @details A balanced redis queue is an implementation of a queue data structure which internally
+ *     uses multiple redis nodes to distribute the data across the cluster. Its important to know
+ *     that the lifetime of the queue persists before and after the queue data structure is created
+ *     (since it exists in redis). Therefore, two redis queues with the same name, would in fact be
+ *     the same underlying redis queues.
+ */
 @RunWith(JUnit4.class)
 public class BalancedRedisQueueTest {
 

--- a/src/test/java/build/buildfarm/common/redis/ProvisionedRedisQueueTest.java
+++ b/src/test/java/build/buildfarm/common/redis/ProvisionedRedisQueueTest.java
@@ -23,29 +23,23 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-///
-/// @class   ProvisionedRedisQueueTest
-/// @brief   tests A queue that is designed to hold particularly provisioned
-///          elements.
-/// @details A provisioned redis queue is an implementation of a queue data
-///          structure which internally uses a redis cluster to distribute the
-///          data across shards. Its important to know that the lifetime of
-///          the queue persists before and after the queue data structure is
-///          created (since it exists in redis). Therefore, two redis queues
-///          with the same name, would in fact be the same underlying redis
-///          queue. This redis queue comes with a list of required provisions.
-///          If the queue element does not meet the required provisions, it
-///          should not be stored in the queue. Provision queues are intended
-///          to represent particular operations that should only be processed
-///          by particular workers. An example use case for this would be to
-///          have two dedicated provision queues for CPU and GPU operations.
-///          CPU/GPU requirements would be determined through the remote api's
-///          command platform properties. We designate provision queues to
-///          have a set of "required provisions" (which match the platform
-///          properties). This allows the scheduler to distribute operations
-///          by their properties and allows workers to dequeue from particular
-///          queues.
-///
+/**
+ * @class ProvisionedRedisQueueTest
+ * @brief tests A queue that is designed to hold particularly provisioned elements.
+ * @details A provisioned redis queue is an implementation of a queue data structure which
+ *     internally uses a redis cluster to distribute the data across shards. Its important to know
+ *     that the lifetime of the queue persists before and after the queue data structure is created
+ *     (since it exists in redis). Therefore, two redis queues with the same name, would in fact be
+ *     the same underlying redis queue. This redis queue comes with a list of required provisions.
+ *     If the queue element does not meet the required provisions, it should not be stored in the
+ *     queue. Provision queues are intended to represent particular operations that should only be
+ *     processed by particular workers. An example use case for this would be to have two dedicated
+ *     provision queues for CPU and GPU operations. CPU/GPU requirements would be determined through
+ *     the remote api's command platform properties. We designate provision queues to have a set of
+ *     "required provisions" (which match the platform properties). This allows the scheduler to
+ *     distribute operations by their properties and allows workers to dequeue from particular
+ *     queues.
+ */
 @RunWith(JUnit4.class)
 public class ProvisionedRedisQueueTest {
 

--- a/src/test/java/build/buildfarm/common/redis/RedisHashtagsTest.java
+++ b/src/test/java/build/buildfarm/common/redis/RedisHashtagsTest.java
@@ -20,13 +20,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-///
-/// @class   RedisHashtagsTest
-/// @brief   tests String utilities when dealing with key names that involve
-///          hashtags.
-/// @details Simple parsers for extracting out / adding hashtags to redis
-///          keys.
-///
+/**
+ * @class RedisHashtagsTest
+ * @brief tests String utilities when dealing with key names that involve hashtags.
+ * @details Simple parsers for extracting out / adding hashtags to redis keys.
+ */
 @RunWith(JUnit4.class)
 public class RedisHashtagsTest {
 

--- a/src/test/java/build/buildfarm/common/redis/RedisMapMockTest.java
+++ b/src/test/java/build/buildfarm/common/redis/RedisMapMockTest.java
@@ -25,16 +25,14 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import redis.clients.jedis.JedisCluster;
 
-///
-/// @class   RedisMapMockTest
-/// @brief   tests A redis map.
-/// @details A redis map is an implementation of a map data structure which
-///          internally uses redis to store and distribute the data. Its
-///          important to know that the lifetime of the map persists before
-///          and after the map data structure is created (since it exists in
-///          redis). Therefore, two redis maps with the same name, would in
-///          fact be the same underlying redis map.
-///
+/**
+ * @class RedisMapMockTest
+ * @brief tests A redis map.
+ * @details A redis map is an implementation of a map data structure which internally uses redis to
+ *     store and distribute the data. Its important to know that the lifetime of the map persists
+ *     before and after the map data structure is created (since it exists in redis). Therefore, two
+ *     redis maps with the same name, would in fact be the same underlying redis map.
+ */
 @RunWith(JUnit4.class)
 public class RedisMapMockTest {
 

--- a/src/test/java/build/buildfarm/common/redis/RedisNodeHashesMockTest.java
+++ b/src/test/java/build/buildfarm/common/redis/RedisNodeHashesMockTest.java
@@ -29,15 +29,13 @@ import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.JedisPool;
 
-///
-/// @class   RedisNodeHashesMockTest
-/// @brief   tests A list of redis hashtags that each map to different nodes in the
-///          cluster.
-/// @details When looking to evenly distribute keys across nodes, specific
-///          hashtags need obtained in which each hashtag hashes to a
-///          particular slot owned by a particular worker. This class is used
-///          to obtain the hashtags needed to hit every node in the cluster.
-///
+/**
+ * @class RedisNodeHashesMockTest
+ * @brief tests A list of redis hashtags that each map to different nodes in the cluster.
+ * @details When looking to evenly distribute keys across nodes, specific hashtags need obtained in
+ *     which each hashtag hashes to a particular slot owned by a particular worker. This class is
+ *     used to obtain the hashtags needed to hit every node in the cluster.
+ */
 @RunWith(JUnit4.class)
 public class RedisNodeHashesMockTest {
 

--- a/src/test/java/build/buildfarm/common/redis/RedisNodeHashesTest.java
+++ b/src/test/java/build/buildfarm/common/redis/RedisNodeHashesTest.java
@@ -23,15 +23,13 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import redis.clients.jedis.JedisCluster;
 
-///
-/// @class   RedisNodeHashesTest
-/// @brief   tests A list of redis hashtags that each map to different nodes in the
-///          cluster.
-/// @details When looking to evenly distribute keys across nodes, specific
-///          hashtags need obtained in which each hashtag hashes to a
-///          particular slot owned by a particular worker. This class is used
-///          to obtain the hashtags needed to hit every node in the cluster.
-///
+/**
+ * @class RedisNodeHashesTest
+ * @brief tests A list of redis hashtags that each map to different nodes in the cluster.
+ * @details When looking to evenly distribute keys across nodes, specific hashtags need obtained in
+ *     which each hashtag hashes to a particular slot owned by a particular worker. This class is
+ *     used to obtain the hashtags needed to hit every node in the cluster.
+ */
 @RunWith(JUnit4.class)
 public class RedisNodeHashesTest {
 

--- a/src/test/java/build/buildfarm/common/redis/RedisQueueMockTest.java
+++ b/src/test/java/build/buildfarm/common/redis/RedisQueueMockTest.java
@@ -32,16 +32,15 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import redis.clients.jedis.JedisCluster;
 
-///
-/// @class   RedisQueueMockTest
-/// @brief   tests A redis queue.
-/// @details A redis queue is an implementation of a queue data structure
-///          which internally uses redis to store and distribute the data. Its
-///          important to know that the lifetime of the queue persists before
-///          and after the queue data structure is created (since it exists in
-///          redis). Therefore, two redis queues with the same name, would in
-///          fact be the same underlying redis queue.
-///
+/**
+ * @class RedisQueueMockTest
+ * @brief tests A redis queue.
+ * @details A redis queue is an implementation of a queue data structure which internally uses redis
+ *     to store and distribute the data. Its important to know that the lifetime of the queue
+ *     persists before and after the queue data structure is created (since it exists in redis).
+ *     Therefore, two redis queues with the same name, would in fact be the same underlying redis
+ *     queue.
+ */
 @RunWith(JUnit4.class)
 public class RedisQueueMockTest {
 

--- a/src/test/java/build/buildfarm/common/redis/RedisQueueTest.java
+++ b/src/test/java/build/buildfarm/common/redis/RedisQueueTest.java
@@ -28,16 +28,14 @@ import org.junit.runners.JUnit4;
 import redis.clients.jedis.JedisCluster;
 
 /**
- * @class   RedisQueueTest
- * @brief   tests A redis queue.
- * @details A redis queue is an implementation of a queue data structure
- * which internally uses redis to store and distribute the data. Its
- * important to know that the lifetime of the queue persists before
- * and after the queue data structure is created (since it exists in
- * redis). Therefore, two redis queues with the same name, would in
- * fact be the same underlying redis queue.
+ * @class RedisQueueTest
+ * @brief tests A redis queue.
+ * @details A redis queue is an implementation of a queue data structure which internally uses redis
+ *     to store and distribute the data. Its important to know that the lifetime of the queue
+ *     persists before and after the queue data structure is created (since it exists in redis).
+ *     Therefore, two redis queues with the same name, would in fact be the same underlying redis
+ *     queue.
  */
-
 @RunWith(JUnit4.class)
 public class RedisQueueTest {
 

--- a/src/test/java/build/buildfarm/common/redis/RedisQueueTest.java
+++ b/src/test/java/build/buildfarm/common/redis/RedisQueueTest.java
@@ -27,16 +27,17 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import redis.clients.jedis.JedisCluster;
 
-///
-/// @class   RedisQueueTest
-/// @brief   tests A redis queue.
-/// @details A redis queue is an implementation of a queue data structure
-///          which internally uses redis to store and distribute the data. Its
-///          important to know that the lifetime of the queue persists before
-///          and after the queue data structure is created (since it exists in
-///          redis). Therefore, two redis queues with the same name, would in
-///          fact be the same underlying redis queue.
-///
+/**
+ * @class   RedisQueueTest
+ * @brief   tests A redis queue.
+ * @details A redis queue is an implementation of a queue data structure
+ * which internally uses redis to store and distribute the data. Its
+ * important to know that the lifetime of the queue persists before
+ * and after the queue data structure is created (since it exists in
+ * redis). Therefore, two redis queues with the same name, would in
+ * fact be the same underlying redis queue.
+ */
+
 @RunWith(JUnit4.class)
 public class RedisQueueTest {
 

--- a/src/test/java/build/buildfarm/common/redis/RedisSlotToHashTest.java
+++ b/src/test/java/build/buildfarm/common/redis/RedisSlotToHashTest.java
@@ -22,19 +22,17 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import redis.clients.jedis.util.JedisClusterCRC16;
 
-///
-/// @class   RedisSlotToHashTest
-/// @brief   tests Get a redis hash tag for the provided slot number.
-/// @details Sometimes in redis you want to hash a particular key to a
-///          particular node in the redis cluster. You might decide to do this
-///          in order to distribute data evenly across nodes and balance cpu
-///          utilization. Since redis nodes are decided based on the slot
-///          number that a value hashes to, you can force. A key to land on a
-///          particular node by choosing a redis hashtag which you know
-///          corresponds to the appropriate slot number. The class is used to
-///          convert a slot number to a corresponding string (which when
-///          hashed by redis's crc16 algorithm will return that slot number.
-///
+/**
+ * @class RedisSlotToHashTest
+ * @brief tests Get a redis hash tag for the provided slot number.
+ * @details Sometimes in redis you want to hash a particular key to a particular node in the redis
+ *     cluster. You might decide to do this in order to distribute data evenly across nodes and
+ *     balance cpu utilization. Since redis nodes are decided based on the slot number that a value
+ *     hashes to, you can force. A key to land on a particular node by choosing a redis hashtag
+ *     which you know corresponds to the appropriate slot number. The class is used to convert a
+ *     slot number to a corresponding string (which when hashed by redis's crc16 algorithm will
+ *     return that slot number.
+ */
 @RunWith(JUnit4.class)
 public class RedisSlotToHashTest {
 

--- a/src/test/java/build/buildfarm/worker/DequeueMatchEvaluatorTest.java
+++ b/src/test/java/build/buildfarm/worker/DequeueMatchEvaluatorTest.java
@@ -24,29 +24,22 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-///
-/// @class   DequeueMatchEvaluatorTest
-/// @brief   tests Algorithm for deciding whether a worker should keep a dequeued
-///          operation.
-/// @details When a worker takes an entry off of the queue, should it decide
-///          to keep that entry or reject and requeue it? In some sense, it
-///          should keep all entries because they have already been vetted for
-///          that particular worker. This is because the scheduler matches
-///          operations to particular queues, and workers match themselves to
-///          which queues they want to read from. But should the worker always
-///          blindly take what it pops off? And can they trust the scheduler?
-///          There may be situations where the worker chooses to give
-///          operations back based on particular contexts not known to the
-///          scheduler. For example, you might have a variety of workers with
-///          different amounts of cpu cores all sharing the same queue. The
-///          queue may accept N-core operations, because N-core workers exist
-///          in the pool, but there are additionally some lower core workers
-///          that would need to forfeit running the operation. All the reasons
-///          a worker may decide it can't take on the operation and should
-///          give it back are implemented here. The settings provided allow
-///          varying amount of leniency when evaluating the platform
-///          properties.
-///
+/**
+ * @class DequeueMatchEvaluatorTest
+ * @brief tests Algorithm for deciding whether a worker should keep a dequeued operation.
+ * @details When a worker takes an entry off of the queue, should it decide to keep that entry or
+ *     reject and requeue it? In some sense, it should keep all entries because they have already
+ *     been vetted for that particular worker. This is because the scheduler matches operations to
+ *     particular queues, and workers match themselves to which queues they want to read from. But
+ *     should the worker always blindly take what it pops off? And can they trust the scheduler?
+ *     There may be situations where the worker chooses to give operations back based on particular
+ *     contexts not known to the scheduler. For example, you might have a variety of workers with
+ *     different amounts of cpu cores all sharing the same queue. The queue may accept N-core
+ *     operations, because N-core workers exist in the pool, but there are additionally some lower
+ *     core workers that would need to forfeit running the operation. All the reasons a worker may
+ *     decide it can't take on the operation and should give it back are implemented here. The
+ *     settings provided allow varying amount of leniency when evaluating the platform properties.
+ */
 @RunWith(JUnit4.class)
 public class DequeueMatchEvaluatorTest {
 

--- a/src/test/java/build/buildfarm/worker/resources/ResourceDeciderTest.java
+++ b/src/test/java/build/buildfarm/worker/resources/ResourceDeciderTest.java
@@ -22,12 +22,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-///
-/// @class   ResourceDeciderTest
-/// @brief   tests Decide the resource limitations for a given command.
-/// @details Platform properties from specified exec_properties are taken
-///          into account as well as global buildfarm configuration.
-///
+/**
+ * @class ResourceDeciderTest
+ * @brief tests Decide the resource limitations for a given command.
+ * @details Platform properties from specified exec_properties are taken into account as well as
+ *     global buildfarm configuration.
+ */
 @RunWith(JUnit4.class)
 public class ResourceDeciderTest {
 


### PR DESCRIPTION
There are multiple documentation comment styles existing in bf codebase. Per most java code style guides ([Google java documentation style](https://google.github.io/styleguide/javaguide.html#s7-javadoc) and [Oracle java documentation comment convention](https://www.oracle.com/java/technologies/javase/codeconventions-comments.html)), the following style is recommended.
/**
 *
 */
Besides, github can also recognize this comment style and can highlight key information in the documentation comments:
![Screen Shot 2021-01-08 at 5 59 51 PM](https://user-images.githubusercontent.com/54453872/104073571-0bf20f00-51dc-11eb-9061-57f172c841a8.png)
![Screen Shot 2021-01-08 at 6 00 00 PM](https://user-images.githubusercontent.com/54453872/104073574-0eecff80-51dc-11eb-8894-c8a58558107c.png)

I didn't find a java formatter that can enforce this until now. Once we found one, we should enforce this in CI.