### PR TITLE
fix issues in graceful shutdown and add separate client to test grpc calls

### DIFF
--- a/src/main/java/build/buildfarm/BUILD
+++ b/src/main/java/build/buildfarm/BUILD
@@ -925,30 +925,13 @@ java_binary(
 java_binary(
     name = "GracefulShutdownTest",
     srcs = ["GracefulShutdownTest.java"],
-    classpath_resources = [
-        ":configs",
-    ],
     main_class = "build.buildfarm.GracefulShutdownTest",
     visibility = ["//visibility:public"],
     deps = [
-        ":common",
-        ":instance",
-        ":stub-instance",
-        ":shard-instance",
-        ":shard-worker",
         "//src/main/protobuf:build_buildfarm_v1test_buildfarm_java_proto",
-        "//third_party/jedis",
-        "@maven//:com_google_guava_guava",
-        "@maven//:com_github_pcj_google_options",
-        "@maven//:com_google_protobuf_protobuf_java",
-        "@maven//:com_google_protobuf_protobuf_java_util",
-        "@maven//:io_grpc_grpc_api",
-        "@maven//:io_grpc_grpc_context",
-        "@maven//:io_grpc_grpc_core",
-        "@maven//:io_grpc_grpc_netty",
-        "@maven//:io_grpc_grpc_protobuf",
-        "@maven//:io_grpc_grpc_stub",
         "//src/main/protobuf:build_buildfarm_v1test_buildfarm_java_grpc",
+        "@maven//:io_grpc_grpc_api",
+        "@maven//:io_grpc_grpc_netty",
     ],
 )
 

--- a/src/main/java/build/buildfarm/BUILD
+++ b/src/main/java/build/buildfarm/BUILD
@@ -923,6 +923,36 @@ java_binary(
 )
 
 java_binary(
+    name = "GracefulShutdownTest",
+    srcs = ["GracefulShutdownTest.java"],
+    classpath_resources = [
+        ":configs",
+    ],
+    main_class = "build.buildfarm.GracefulShutdownTest",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":common",
+        ":instance",
+        ":stub-instance",
+        ":shard-instance",
+        ":shard-worker",
+        "//src/main/protobuf:build_buildfarm_v1test_buildfarm_java_proto",
+        "//third_party/jedis",
+        "@maven//:com_google_guava_guava",
+        "@maven//:com_github_pcj_google_options",
+        "@maven//:com_google_protobuf_protobuf_java",
+        "@maven//:com_google_protobuf_protobuf_java_util",
+        "@maven//:io_grpc_grpc_api",
+        "@maven//:io_grpc_grpc_context",
+        "@maven//:io_grpc_grpc_core",
+        "@maven//:io_grpc_grpc_netty",
+        "@maven//:io_grpc_grpc_protobuf",
+        "@maven//:io_grpc_grpc_stub",
+        "//src/main/protobuf:build_buildfarm_v1test_buildfarm_java_grpc",
+    ],
+)
+
+java_binary(
     name = "bf-hist",
     srcs = ["Hist.java"],
     main_class = "build.buildfarm.Hist",

--- a/src/main/java/build/buildfarm/GracefulShutdownTest.java
+++ b/src/main/java/build/buildfarm/GracefulShutdownTest.java
@@ -31,7 +31,7 @@ class GracefulShutdownTest {
   }
 
   /**
-   * Example command: GracefulShutdownTest ShutDown workerIp buildfarm-(@= env @).aws.uberatc.net
+   * Example command: GracefulShutdownTest ShutDown workerIp buildfarm-endpoint
    *
    * @param args
    */
@@ -69,8 +69,7 @@ class GracefulShutdownTest {
   }
 
   /**
-   * Example command: GracefulShutdownTest DisableProtection WorkerIp buildfarm-(@=
-   * env @).aws.uberatc.net
+   * Example command: GracefulShutdownTest DisableProtection WorkerIp buildfarm_endpoint
    *
    * @param args
    */

--- a/src/main/java/build/buildfarm/GracefulShutdownTest.java
+++ b/src/main/java/build/buildfarm/GracefulShutdownTest.java
@@ -1,0 +1,89 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm;
+
+import build.buildfarm.v1test.AdminGrpc;
+import build.buildfarm.v1test.DisableScaleInProtectionRequest;
+import build.buildfarm.v1test.PrepareWorkerForGracefulShutDownRequest;
+import build.buildfarm.v1test.ShutDownWorkerGrpc;
+import io.grpc.ManagedChannel;
+import io.grpc.netty.NegotiationType;
+import io.grpc.netty.NettyChannelBuilder;
+
+class GracefulShutdownTest {
+  private static ManagedChannel createChannel(String target) {
+    NettyChannelBuilder builder =
+        NettyChannelBuilder.forTarget(target).negotiationType(NegotiationType.PLAINTEXT);
+    return builder.build();
+  }
+
+  /**
+   * Example command: GracefulShutdownTest ShutDown workerIp buildfarm-(@= env @).aws.uberatc.net
+   *
+   * @param args
+   */
+  private static void shutDownGracefully(String[] args) {
+    System.out.println("Sending ShutDownWorkerGracefully request to bf");
+    String bfEndpoint = args[2];
+    String hostPrivateIp = args[1];
+    ManagedChannel channel = createChannel(bfEndpoint);
+  }
+
+  private static void prepareWorkerForShutDown(String[] args) {
+    System.out.println("Inform worker " + args[1] + " to prepare for shutdown!");
+    ManagedChannel channel = createChannel(args[1]);
+    ShutDownWorkerGrpc.ShutDownWorkerBlockingStub shutDownWorkerBlockingStub =
+        ShutDownWorkerGrpc.newBlockingStub(channel);
+    shutDownWorkerBlockingStub.prepareWorkerForGracefulShutdown(
+        PrepareWorkerForGracefulShutDownRequest.newBuilder().build());
+    System.out.println("Worker " + args[1] + " informed!");
+  }
+
+  /**
+   * Example command: GracefulShutdownTest DisableProtection WorkerIp buildfarm-(@=
+   * env @).aws.uberatc.net
+   *
+   * @param args
+   */
+  private static void disableScaleInProtection(String[] args) {
+    String bfEndpoint = args[2];
+    String instancePrivateIp = args[1];
+    System.out.println("Ready to disable scale in protection of " + instancePrivateIp);
+    ManagedChannel channel = createChannel(bfEndpoint);
+    AdminGrpc.AdminBlockingStub adminBlockingStub = AdminGrpc.newBlockingStub(channel);
+    adminBlockingStub.disableScaleInProtection(
+        DisableScaleInProtectionRequest.newBuilder().setInstanceName(instancePrivateIp).build());
+    System.out.println("Request for " + instancePrivateIp + " sent");
+  }
+
+  /**
+   * Example command: GracefulShutdownTest PrepareWorker WorkerIp:port
+   *
+   * @param args
+   * @throws Exception
+   */
+  public static void main(String[] args) throws Exception {
+    if (args[0].equals("ShutDown")) {
+      shutDownGracefully(args);
+    } else if (args[0].equals("PrepareWorker")) {
+      prepareWorkerForShutDown(args);
+    } else if (args[0].equals("DisableProtection")) {
+      disableScaleInProtection(args);
+    } else {
+      System.out.println(
+          "The action your choose is wrong. Please choose between ShutDown, PrepareWorker, and DisableProtection");
+    }
+  }
+}

--- a/src/main/java/build/buildfarm/server/AdminService.java
+++ b/src/main/java/build/buildfarm/server/AdminService.java
@@ -226,12 +226,27 @@ public class AdminService extends AdminGrpc.AdminImplBase {
       DisableScaleInProtectionRequest request,
       StreamObserver<DisableScaleInProtectionRequestResults> responseObserver) {
     try {
-      adminController.disableHostScaleInProtection(request.getInstanceName());
+      String hostPrivateIp = trimHostPrivateDns(request.getInstanceName());
+      adminController.disableHostScaleInProtection(hostPrivateIp);
       responseObserver.onNext(DisableScaleInProtectionRequestResults.newBuilder().build());
       responseObserver.onCompleted();
     } catch (RuntimeException e) {
       responseObserver.onError(e);
     }
+  }
+
+  /**
+   * The private dns get from worker might be suffixed with ":portNumber", which should be trimmed.
+   *
+   * @param hostPrivateIp the private dns should be trimmed.
+   * @return
+   */
+  private String trimHostPrivateDns(String hostPrivateIp) {
+    String portSeparator = ":";
+    if (hostPrivateIp.contains(portSeparator)) {
+      hostPrivateIp = hostPrivateIp.split(portSeparator)[0];
+    }
+    return hostPrivateIp;
   }
 
   private static Admin getAdminController(AdminConfig config) {

--- a/src/main/java/build/buildfarm/worker/Pipeline.java
+++ b/src/main/java/build/buildfarm/worker/Pipeline.java
@@ -60,6 +60,16 @@ public class Pipeline {
     join(true);
   }
 
+  /** Inform MatchStage to stop matching or picking up new Operations from queue. */
+  public void stopMatchingOperations() {
+    for (PipelineStage stage : stageClosePriorities.keySet()) {
+      if (stage instanceof MatchStage) {
+        ((MatchStage) stage).prepareForGracefulShutdown();
+        return;
+      }
+    }
+  }
+
   /**
    * Checking if there is any ongoing actions in any stages of the pipeline.
    *

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -238,8 +238,9 @@ public class Worker extends LoggingMain {
    * scale in protection when the worker is ready. If unexpected errors happened, it will cancel the
    * graceful shutdown progress make the worker available again.
    */
-  public void prepareWorkerForGracefulShutdown() {
+  public void prepareWorkerForGracefulShutdown() throws IOException {
     inGracefulShutdown = true;
+    backplane.deregisterWorker(config.getPublicName());
     logger.log(Level.INFO, "The current worker is deregistered and should be shutdown gracefully!");
     int scanRate = 30; // check every 30 seconds
     int timeWaited = 0;

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -240,7 +240,7 @@ public class Worker extends LoggingMain {
    */
   public void prepareWorkerForGracefulShutdown() {
     inGracefulShutdown = true;
-    logger.log(Level.INFO, "The current worker is deregistered and should be shutdown gracefully!");
+    logger.log(Level.INFO, "The current worker will not be registered again and should be shutdown gracefully!");
     pipeline.stopMatchingOperations();
     int scanRate = 30; // check every 30 seconds
     int timeWaited = 0;

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -238,10 +238,10 @@ public class Worker extends LoggingMain {
    * scale in protection when the worker is ready. If unexpected errors happened, it will cancel the
    * graceful shutdown progress make the worker available again.
    */
-  public void prepareWorkerForGracefulShutdown() throws IOException {
+  public void prepareWorkerForGracefulShutdown() {
     inGracefulShutdown = true;
-    backplane.deregisterWorker(config.getPublicName());
     logger.log(Level.INFO, "The current worker is deregistered and should be shutdown gracefully!");
+    pipeline.stopMatchingOperations();
     int scanRate = 30; // check every 30 seconds
     int timeWaited = 0;
     int timeOut = 60 * 15; // 15 minutes

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -240,7 +240,9 @@ public class Worker extends LoggingMain {
    */
   public void prepareWorkerForGracefulShutdown() {
     inGracefulShutdown = true;
-    logger.log(Level.INFO, "The current worker will not be registered again and should be shutdown gracefully!");
+    logger.log(
+        Level.INFO,
+        "The current worker will not be registered again and should be shutdown gracefully!");
     pipeline.stopMatchingOperations();
     int scanRate = 30; // check every 30 seconds
     int timeWaited = 0;


### PR DESCRIPTION
Fix the following issues in worker graceful shutdown:
1 handle the port suffixed worker private dns name format in AdminService;
2 prevent worker from matching any operations from the queue after received prepare for graceful shutdown request.

Besides, a separate class with 3 rpc service client sides are added to test their functionality. 