### PR TITLE
Correctly substring for hex bucket digest path

### DIFF
--- a/src/main/java/build/buildfarm/cas/cfc/HexBucketEntryPathStrategy.java
+++ b/src/main/java/build/buildfarm/cas/cfc/HexBucketEntryPathStrategy.java
@@ -31,7 +31,7 @@ class HexBucketEntryPathStrategy implements EntryPathStrategy {
     checkState(levels == 0 || pattern.matcher(key).matches());
     Path keyPath = path;
     for (int i = 0; i < levels; i++) {
-      keyPath = keyPath.resolve(key.substring(i * 2, 2));
+      keyPath = keyPath.resolve(key.substring(i * 2, i * 2 + 2));
     }
     return keyPath.resolve(key);
   }

--- a/src/test/java/build/buildfarm/cas/cfc/HexBucketEntryPathStrategyTest.java
+++ b/src/test/java/build/buildfarm/cas/cfc/HexBucketEntryPathStrategyTest.java
@@ -63,4 +63,15 @@ public class HexBucketEntryPathStrategyTest {
     }
     assertThat(paths.hasNext()).isFalse();
   }
+
+  @Test
+  public void getPathMatchesLevels() {
+    Path path = Paths.get("cache");
+    EntryPathStrategy entryPathStrategy = new HexBucketEntryPathStrategy(path, 2);
+
+    String key = "aa55bb1100bb";
+    Path blobPath = entryPathStrategy.getPath(key);
+    assertThat(blobPath.toString())
+        .isEqualTo(path.resolve("aa").resolve("55").resolve(key).toString());
+  }
 }


### PR DESCRIPTION
Path was previously only using the first component and discarding
additional levels. Added tests to verify multiple levels are
appropriately used to compose the path.

Fixes #649