### PR TITLE
Document setup of local Redis cluster for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,35 @@ bazel run //src/main/java/build/buildfarm:buildfarm-server -- --debug=5005 $PWD/
 
 ## Developer Information
 
+### Setting up Redis for local testing
+
+This is done using [`examples/development-redis-cluster.sh`](examples/development-redis-cluster.sh).
+
+Tested with Redis `6.0.10`, other versions probably work fine as well.
+
+First of all you need Redis installed:
+* macOS: `brew install redis`
+* Debian / Ubuntu: `sudo apt-get update && sudo apt-get install redis-server redis-tools`
+
+Then  you need seven terminal panes for this, six for [a minimal Redis
+cluster](https://redis.io/topics/cluster-tutorial#creating-and-using-a-redis-cluster)
+and one for Buildfarm.
+
+* `./examples/development-redis-cluster.sh 0`
+* `./examples/development-redis-cluster.sh 1`
+* `./examples/development-redis-cluster.sh 2`
+* `./examples/development-redis-cluster.sh 3`
+* `./examples/development-redis-cluster.sh 4`
+* `./examples/development-redis-cluster.sh 5`
+* ```sh
+  redis-cli --cluster create 127.0.0.1:6379 127.0.0.1:6380 127.0.0.1:6381 127.0.0.1:6382 127.0.0.1:6383 127.0.0.1:6384 --cluster-replicas 1
+  ```
+
+Your Redis cluster is now up, and you can now start your Buildfarm server talking to it:
+```sh
+bazel run //src/main/java/build/buildfarm:buildfarm-server $PWD/examples/shard-server.config.example
+```
+
 ### Setting up intelliJ
 
 1. Check [which IntelliJ versions are supported by the Bazel

--- a/examples/development-redis-cluster.sh
+++ b/examples/development-redis-cluster.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# First, start six Redis instances using this script:
+#   ./development-redis-cluster.sh 0
+#   ./development-redis-cluster.sh 1
+#   ./development-redis-cluster.sh 2
+#   ./development-redis-cluster.sh 3
+#   ./development-redis-cluster.sh 4
+#   ./development-redis-cluster.sh 5
+#
+# Then, turn it into a cluster:
+#   redis-cli --cluster create 127.0.0.1:6379 127.0.0.1:6380 127.0.0.1:6381 127.0.0.1:6382 127.0.0.1:6383 127.0.0.1:6384 --cluster-replicas 1
+#
+# Then, check status with:
+#   redis-cli cluster nodes
+#   redis-cli cluster info
+#
+# Then, start your buildfarm server:
+#   bazel run //src/main/java/build/buildfarm:buildfarm-server $PWD/examples/shard-server.config.example
+set -eufo pipefail
+
+function print_usage() {
+    # Pretty up and print the header comment of this file
+    grep -E '^set ' -B1000 "$0" | sed -E 's/^# ?//' | tail -n+3 | sed '$d'
+}
+
+if [ -z ${1+x} ]; then
+    echo "ERROR: Need one parameter, 0-5"
+    echo
+    print_usage
+    exit 1
+fi
+
+if ! echo "0 1 2 3 4 5" | grep -q "$1" ; then
+    echo "ERROR: Parameter must be 0-5, was <$1>"
+    echo
+    print_usage
+    exit 1
+fi
+
+BASE_PORT=6379
+
+NUMBER="$1"
+PORT="$((BASE_PORT + NUMBER))"
+
+DBDIR="/tmp/redistest/$NUMBER"
+mkdir -p "$DBDIR"
+
+redis-server - <<EOF | cat
+port $PORT
+dir $DBDIR
+appendonly yes
+cluster-enabled yes
+always-show-logo no
+EOF


### PR DESCRIPTION
Following these instructions will get you a Buildfarm server talking to a local Redis cluster of six nodes.

Takes a minute or so.

Good for testing fault tolerance in both Redis and Buildfarm.