### PR TITLE
Show match results on OperationQueue 

### DIFF
--- a/src/main/java/build/buildfarm/instance/shard/OperationQueue.java
+++ b/src/main/java/build/buildfarm/instance/shard/OperationQueue.java
@@ -224,7 +224,7 @@ public class OperationQueue {
       }
     }
 
-    // A this point, we were unable to match an action to an eligible queue.
+    // At this point, we were unable to match an action to an eligible queue.
     // We will build an error explaining why the matching failed. This will help user's properly
     // configure their queue or adjust the execution_properties of their actions.
     String eligibilityResults = "Below are the eligibility results for each provisioned queue:\n";

--- a/src/main/java/build/buildfarm/instance/shard/OperationQueue.java
+++ b/src/main/java/build/buildfarm/instance/shard/OperationQueue.java
@@ -223,10 +223,20 @@ public class OperationQueue {
         return provisionedQueue.queue();
       }
     }
+
+    // A this point, we were unable to match an action to an eligible queue.
+    // We will build an error explaining why the matching failed. This will help user's properly
+    // configure their queue or adjust the execution_properties of their actions.
+    String eligibilityResults = "Below are the eligibility results for each provisioned queue:\n";
+    for (ProvisionedRedisQueue provisionedQueue : queues) {
+      eligibilityResults += provisionedQueue.explainEligibility(toMultimap(provisions));
+    }
+
     throw new RuntimeException(
         "there are no eligible queues for the provided execution requirements."
             + " One solution to is to configure a provision queue with no requirements which would be eligible to all operations."
-            + " See https://github.com/bazelbuild/bazel-buildfarm/wiki/Shard-Platform-Operation-Queue for details");
+            + " See https://github.com/bazelbuild/bazel-buildfarm/wiki/Shard-Platform-Operation-Queue for details. "
+            + eligibilityResults);
   }
 
   /**


### PR DESCRIPTION
This is for the following discussion: https://github.com/bazelbuild/bazel-buildfarm/issues/656.  

Currently, it's not obvious why properties are deemed invalid for the operation queue.   
To make the matching algorithm more transparent, we will show the match results when matching has failed.  
This will make it easier for user's to properly configure their queues as well as action/worker properties.