### PR TITLE
integrate bazel sandbox

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -31,5 +31,8 @@ genrule(
 
 cc_binary(
     name = "as-nobody.binary",
-    srcs = ["as-nobody.c"],
+    srcs = select({
+        "//config:windows": ["as-nobody-windows.c"],
+        "//conditions:default": ["as-nobody.c"],
+    }),
 )

--- a/BUILD
+++ b/BUILD
@@ -3,3 +3,33 @@ load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
 buildifier(
     name = "buildifier",
 )
+
+# These are execution wrappers that buildfarm may choose to use when executing actions.
+# For their availability on a worker, they should be provided to a java_image as a "runtime_dep".
+# The relevant configuration for workers is the "execution policy".
+# That is where these binaries can be used and stacked.
+genrule(
+    name = "process-wrapper.binary",
+    srcs = ["@bazel//src/main/tools:process-wrapper"],
+    outs = ["process-wrapper"],
+    cmd = "cp $< $@;",
+)
+
+genrule(
+    name = "linux-sandbox.binary",
+    srcs = ["@bazel//src/main/tools:linux-sandbox"],
+    outs = ["linux-sandbox"],
+    cmd = "cp $< $@;",
+)
+
+genrule(
+    name = "tini.binary",
+    srcs = ["@tini//file"],
+    outs = ["tini"],
+    cmd = "cp $< $@ && chmod +x $@",
+)
+
+cc_binary(
+    name = "as-nobody.binary",
+    srcs = ["as-nobody.c"],
+)

--- a/BUILD
+++ b/BUILD
@@ -8,6 +8,8 @@ buildifier(
 # For their availability on a worker, they should be provided to a java_image as a "runtime_dep".
 # The relevant configuration for workers is the "execution policy".
 # That is where these binaries can be used and stacked.
+# Be aware that the process-wrapper and linux-sandbox come from bazel itself.
+# Therefore, users may want to ensure that the same bazel version is sourced here as is used locally.
 genrule(
     name = "process-wrapper.binary",
     srcs = ["@bazel//src/main/tools:process-wrapper"],

--- a/as-nobody-windows.c
+++ b/as-nobody-windows.c
@@ -1,0 +1,6 @@
+
+// not implemented for Windows
+int
+main(int argc, char *argv[])
+{
+}

--- a/as-nobody.c
+++ b/as-nobody.c
@@ -1,0 +1,30 @@
+#include <pwd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <grp.h>
+
+int
+main(int argc, char *argv[])
+{
+  struct passwd *pw = getpwnam("nobody");
+  if (pw == NULL) {
+    perror("getpwnam");
+    return EXIT_FAILURE;
+  }
+  if (setgroups(0, NULL) < 0) {
+    perror("setgroups");
+    return EXIT_FAILURE;
+  }
+  if (setregid(pw->pw_gid, pw->pw_gid) < 0) {
+    perror("setgroups");
+    return EXIT_FAILURE;
+  }
+  if (setreuid(pw->pw_uid, pw->pw_uid) < 0) {
+    perror("setreuid");
+    return EXIT_FAILURE;
+  }
+  execvp(argv[1], argv);
+  perror("execvp");
+  return EXIT_FAILURE;
+}

--- a/deps.bzl
+++ b/deps.bzl
@@ -74,9 +74,9 @@ def archive_dependencies(third_party):
         # Bazel is referenced as a dependency so that buildfarm can access the linux-sandbox as a potential execution wrapper.
         {
             "name": "bazel",
-            "sha256": "abdb1118e6b013062ed0d47f08d5311fd9ab506c10c093216df89f2b2be382f2",
-            "strip_prefix": "bazel-6b33bdb1e22514304c0e35ce8e067f2175685245",
-            "urls": ["https://github.com/bazelbuild/bazel/archive/6b33bdb1e22514304c0e35ce8e067f2175685245.tar.gz"],
+            "sha256": "bca2303a43c696053317a8c7ac09a5e6d90a62fec4726e55357108bb60d7a807",
+            "strip_prefix": "bazel-3.7.2",
+            "urls": ["https://github.com/bazelbuild/bazel/archive/3.7.2.tar.gz"],
             "patch_args": ["-p1"],
             "patches": ["%s/bazel:bazel_visibility.patch" % third_party],
         },

--- a/deps.bzl
+++ b/deps.bzl
@@ -70,6 +70,16 @@ def archive_dependencies(third_party):
             "strip_prefix": "rules_docker-f4822f3921f0c343dd9e5ae65c760d0fb70be1b3",
             "urls": ["https://github.com/bazelbuild/rules_docker/archive/f4822f3921f0c343dd9e5ae65c760d0fb70be1b3.tar.gz"],
         },
+        
+        # Bazel is referenced as a dependency so that buildfarm can access the linux-sandbox as a potential execution wrapper.
+        {
+            "name": "bazel",
+            "sha256": "abdb1118e6b013062ed0d47f08d5311fd9ab506c10c093216df89f2b2be382f2",
+            "strip_prefix": "bazel-6b33bdb1e22514304c0e35ce8e067f2175685245",
+            "urls": ["https://github.com/bazelbuild/bazel/archive/6b33bdb1e22514304c0e35ce8e067f2175685245.tar.gz"],
+            "patch_args": ["-p1"],
+            "patches": ["%s/bazel:bazel_visibility.patch" % third_party],
+        },
     ]
 
 def buildfarm_dependencies(repository_name = "build_buildfarm"):

--- a/third_party/bazel/bazel_visibility.patch
+++ b/third_party/bazel/bazel_visibility.patch
@@ -1,0 +1,12 @@
+diff --git a/src/main/tools/BUILD b/src/main/tools/BUILD
+index 9f64e09..e7679d3 100644
+--- a/src/main/tools/BUILD
++++ b/src/main/tools/BUILD
+@@ -1,6 +1,6 @@
+ load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+ 
+-package(default_visibility = ["//src:__subpackages__"])
++package(default_visibility = ["//visibility:public"])
+ 
+ cc_binary(
+     name = "daemonize",


### PR DESCRIPTION
Allow buildfarm to use bazel's sandbox for compatibility with locally running actions.  
This organizes the current execution wrappers so they can be used by workers.
Workers use these in their configuration via "execution_wrapper".