### PR TITLE
Filter findMissingBlobs in CFC and GrpcCAS

### DIFF
--- a/src/main/java/build/buildfarm/cas/GrpcCAS.java
+++ b/src/main/java/build/buildfarm/cas/GrpcCAS.java
@@ -124,6 +124,11 @@ public class GrpcCAS implements ContentAddressableStorage {
 
   @Override
   public Iterable<Digest> findMissingBlobs(Iterable<Digest> digests) {
+    digests = Iterables.filter(digests, digest -> digest.getSizeBytes() != 0);
+    if (Iterables.isEmpty(digests)) {
+      return ImmutableList.of();
+    }
+
     List<Digest> missingDigests =
         casBlockingStub
             .get()

--- a/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
+++ b/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
@@ -444,7 +444,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
     ImmutableList.Builder<Digest> builder = ImmutableList.builder();
     ImmutableList.Builder<String> found = ImmutableList.builder();
     for (Digest digest : digests) {
-      if (!containsLocal(digest, found::add)) {
+      if (digest.getSizeBytes() == 0 || !containsLocal(digest, found::add)) {
         builder.add(digest);
       }
     }

--- a/src/test/java/build/buildfarm/BUILD
+++ b/src/test/java/build/buildfarm/BUILD
@@ -141,6 +141,7 @@ java_test(
         "@maven//:io_grpc_grpc_core",
         "@maven//:io_grpc_grpc_stub",
         "@maven//:org_mockito_mockito_core",
+        "@remote_apis//:build_bazel_remote_execution_v2_remote_execution_java_grpc",
         "@remote_apis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
     ],
     jvm_flags = ensure_accurate_metadata(),

--- a/src/test/java/build/buildfarm/cas/cfc/CASFileCacheTest.java
+++ b/src/test/java/build/buildfarm/cas/cfc/CASFileCacheTest.java
@@ -915,6 +915,12 @@ class CASFileCacheTest {
     }
   }
 
+  @Test
+  public void findMissingBlobsFiltersEmptyBlobs() throws Exception {
+    Digest emptyDigest = Digest.getDefaultInstance();
+    assertThat(fileCache.findMissingBlobs(ImmutableList.of(emptyDigest))).isEmpty();
+  }
+
   @RunWith(JUnit4.class)
   public static class NativeFileDirsIndexInMemoryCASFileCacheTest extends CASFileCacheTest {
     public NativeFileDirsIndexInMemoryCASFileCacheTest() throws IOException {


### PR DESCRIPTION
Fixes #669 by preventing empty blobs from being considered for
validation of inputs.