### PR TITLE
Add prometheus metrics publishing

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -79,6 +79,9 @@ def buildfarm_init(name = "buildfarm"):
                     ] + ["io.netty:netty-%s:4.1.38.Final" % module for module in IO_NETTY_MODULES] +
                     ["io.grpc:grpc-%s:1.26.0" % module for module in IO_GRPC_MODULES] +
                     [
+                        "io.prometheus:simpleclient:0.10.0",
+                        "io.prometheus:simpleclient_hotspot:0.10.0",
+                        "io.prometheus:simpleclient_httpserver:0.10.0",
                         "junit:junit:4.12",
                         "org.apache.commons:commons-pool2:2.9.0",
                         "org.checkerframework:checker-qual:2.5.2",

--- a/src/main/java/build/buildfarm/BUILD
+++ b/src/main/java/build/buildfarm/BUILD
@@ -160,6 +160,7 @@ java_library(
         "metrics/MetricsPublisher.java",
     ]),
     deps = [
+        ":prometheus-metrics",
         "//src/main/protobuf:build_buildfarm_v1test_buildfarm_java_proto",
         "@googleapis//:google_rpc_code_java_proto",
         "@googleapis//:google_rpc_error_details_java_proto",
@@ -223,6 +224,18 @@ java_library(
         "@maven//:com_google_guava_guava",
         "@maven//:com_google_protobuf_protobuf_java_util",
         "@remote_apis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
+    ],
+)
+
+java_library(
+    name = "prometheus-metrics",
+    srcs = glob([
+        "metrics/prometheus/PrometheusPublisher.java",
+    ]),
+    deps = [
+        "@maven//:io_prometheus_simpleclient",
+        "@maven//:io_prometheus_simpleclient_hotspot",
+        "@maven//:io_prometheus_simpleclient_httpserver",
     ],
 )
 
@@ -394,6 +407,7 @@ java_library(
         ":common-grpc",
         ":common-redis",
         ":instance",
+        ":prometheus-metrics",
         ":server-instance",
         ":stub-instance",
         ":worker-queues",
@@ -464,6 +478,7 @@ java_library(
         ":log-metrics",
         ":memory-instance",
         ":metrics",
+        ":prometheus-metrics",
         ":shard-instance",
         "//src/main/protobuf:build_buildfarm_v1test_buildfarm_java_grpc",
         "//src/main/protobuf:build_buildfarm_v1test_buildfarm_java_proto",
@@ -563,6 +578,7 @@ java_library(
         ":common-grpc",
         ":instance",
         ":memory-instance",
+        "prometheus-metrics",
         ":server",
         ":server-instance",
         ":shard-instance",
@@ -645,6 +661,7 @@ java_library(
         ":cas",
         ":common",
         ":instance",
+        ":prometheus-metrics",
         ":stub-instance",
         ":worker-resources",
         "//src/main/protobuf:build_buildfarm_v1test_buildfarm_java_proto",

--- a/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
@@ -39,6 +39,7 @@ import build.buildfarm.common.redis.RedisMap;
 import build.buildfarm.common.redis.RedisNodeHashes;
 import build.buildfarm.instance.Instance;
 import build.buildfarm.instance.shard.RedisShardSubscriber.TimedWatchFuture;
+import build.buildfarm.metrics.prometheus.PrometheusPublisher;
 import build.buildfarm.operations.FindOperationsResults;
 import build.buildfarm.operations.FindOperationsSettings;
 import build.buildfarm.operations.OperationsFinder;
@@ -51,6 +52,7 @@ import build.buildfarm.v1test.OperationChange;
 import build.buildfarm.v1test.OperationsStatus;
 import build.buildfarm.v1test.ProvisionedQueue;
 import build.buildfarm.v1test.QueueEntry;
+import build.buildfarm.v1test.QueueStatus;
 import build.buildfarm.v1test.QueuedOperationMetadata;
 import build.buildfarm.v1test.RedisShardBackplaneConfig;
 import build.buildfarm.v1test.ShardWorker;
@@ -140,6 +142,7 @@ public class RedisShardBackplane implements ShardBackplane {
   private @Nullable InterruptingRunnable onUnsubscribe = null;
   private Thread subscriptionThread = null;
   private Thread failsafeOperationThread = null;
+  private Thread prometheusMetricsThread = null;
   private RedisShardSubscriber subscriber = null;
   private RedisShardSubscription operationSubscription = null;
   private ExecutorService subscriberService = null;
@@ -529,6 +532,9 @@ public class RedisShardBackplane implements ShardBackplane {
       startFailsafeOperationThread();
     }
 
+    // Start Prometheus metrics collector
+    startPrometheusMetricsCollector();
+
     // Record client start time
     client.call(
         jedis -> jedis.set("startTime/" + clientPublicName, Long.toString(new Date().getTime())));
@@ -608,6 +614,11 @@ public class RedisShardBackplane implements ShardBackplane {
         subscriptionThread.join();
       }
       logger.log(Level.FINE, "subscriptionThread has been stopped");
+    }
+    if (prometheusMetricsThread != null) {
+      prometheusMetricsThread.stop();
+      prometheusMetricsThread.join();
+      logger.log(Level.FINE, "prometheusMetricsThread has been stopped");
     }
     if (subscriberService != null) {
       subscriberService.shutdown();
@@ -1477,6 +1488,42 @@ public class RedisShardBackplane implements ShardBackplane {
                   .build());
     } catch (NumberFormatException nfe) {
       return GetClientStartTimeResult.newBuilder().build();
+    }
+  }
+
+  private void startPrometheusMetricsCollector() {
+    prometheusMetricsThread =
+      new Thread(
+        () -> {
+          while (true) {
+            try {
+              TimeUnit.SECONDS.sleep(30);
+              OperationsStatus operationsStatus = operationsStatus();
+              PrometheusPublisher.updateWorkerPoolSize(operationsStatus.getActiveWorkersCount());
+              PrometheusPublisher.updateDispatchedOperationsSize(operationsStatus.getDispatchedSize());
+              PrometheusPublisher.updatePreQueueSize(operationsStatus.getPrequeue().getSize());
+              PrometheusPublisher.updateClusterUtilization();
+              updateQueueSizes(operationsStatus.getOperationQueue().getProvisionsList());
+            } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
+              break;
+            } catch (Exception e) {
+              logger.log(Level.SEVERE, "Could not update RedisShardBackplane metrics", e);
+            }
+          }
+        },
+        "Prometheus Metrics Collector");
+
+    prometheusMetricsThread.start();
+  }
+
+  private void updateQueueSizes(List<QueueStatus> queues) {
+    for (QueueStatus queueStatus : queues) {
+      if (queueStatus.getName().contains("cpu")) {
+        PrometheusPublisher.updateCpuQueueSize(queueStatus.getSize());
+      } else if (queueStatus.getName().contains("gpu")) {
+        PrometheusPublisher.updateGpuQueueSize(queueStatus.getSize());
+      }
     }
   }
 }

--- a/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
@@ -1493,26 +1493,28 @@ public class RedisShardBackplane implements ShardBackplane {
 
   private void startPrometheusMetricsCollector() {
     prometheusMetricsThread =
-      new Thread(
-        () -> {
-          while (true) {
-            try {
-              TimeUnit.SECONDS.sleep(30);
-              OperationsStatus operationsStatus = operationsStatus();
-              PrometheusPublisher.updateWorkerPoolSize(operationsStatus.getActiveWorkersCount());
-              PrometheusPublisher.updateDispatchedOperationsSize(operationsStatus.getDispatchedSize());
-              PrometheusPublisher.updatePreQueueSize(operationsStatus.getPrequeue().getSize());
-              PrometheusPublisher.updateClusterUtilization();
-              updateQueueSizes(operationsStatus.getOperationQueue().getProvisionsList());
-            } catch (InterruptedException e) {
-              Thread.currentThread().interrupt();
-              break;
-            } catch (Exception e) {
-              logger.log(Level.SEVERE, "Could not update RedisShardBackplane metrics", e);
-            }
-          }
-        },
-        "Prometheus Metrics Collector");
+        new Thread(
+            () -> {
+              while (true) {
+                try {
+                  TimeUnit.SECONDS.sleep(30);
+                  OperationsStatus operationsStatus = operationsStatus();
+                  PrometheusPublisher.updateWorkerPoolSize(
+                      operationsStatus.getActiveWorkersCount());
+                  PrometheusPublisher.updateDispatchedOperationsSize(
+                      operationsStatus.getDispatchedSize());
+                  PrometheusPublisher.updatePreQueueSize(operationsStatus.getPrequeue().getSize());
+                  PrometheusPublisher.updateClusterUtilization();
+                  updateQueueSizes(operationsStatus.getOperationQueue().getProvisionsList());
+                } catch (InterruptedException e) {
+                  Thread.currentThread().interrupt();
+                  break;
+                } catch (Exception e) {
+                  logger.log(Level.SEVERE, "Could not update RedisShardBackplane metrics", e);
+                }
+              }
+            },
+            "Prometheus Metrics Collector");
 
     prometheusMetricsThread.start();
   }

--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -72,6 +72,7 @@ import build.buildfarm.common.cache.CacheLoader.InvalidCacheLoadException;
 import build.buildfarm.common.grpc.UniformDelegateServerCallStreamObserver;
 import build.buildfarm.instance.AbstractServerInstance;
 import build.buildfarm.instance.Instance;
+import build.buildfarm.metrics.prometheus.PrometheusPublisher;
 import build.buildfarm.operations.FindOperationsResults;
 import build.buildfarm.v1test.ExecuteEntry;
 import build.buildfarm.v1test.GetClientStartTimeResult;
@@ -367,7 +368,7 @@ public class ShardInstance extends AbstractServerInstance {
                     long operationTransformDispatchUSecs =
                         stopwatch.elapsed(MICROSECONDS) - canQueueUSecs;
                     logger.log(
-                        Level.INFO,
+                        Level.FINE,
                         format(
                             "OperationQueuer: Dispatched To Transform %s: %dus in canQueue, %dus in transform dispatch",
                             operationName, canQueueUSecs, operationTransformDispatchUSecs));
@@ -1682,9 +1683,9 @@ public class ShardInstance extends AbstractServerInstance {
 
       String operationName = createOperationName(UUID.randomUUID().toString());
 
-      // TODO: Convert to metrics
+      PrometheusPublisher.updateExecutionSuccess();
       logger.log(
-          Level.INFO,
+          Level.FINE,
           new StringBuilder()
               .append("ExecutionSuccess: ")
               .append(requestMetadata.getToolInvocationId())

--- a/src/main/java/build/buildfarm/metrics/prometheus/PrometheusPublisher.java
+++ b/src/main/java/build/buildfarm/metrics/prometheus/PrometheusPublisher.java
@@ -1,6 +1,8 @@
 package build.buildfarm.metrics.prometheus;
 
+import io.prometheus.client.Counter;
 import io.prometheus.client.Gauge;
+import io.prometheus.client.Summary;
 import io.prometheus.client.exporter.HTTPServer;
 import io.prometheus.client.hotspot.DefaultExports;
 import java.io.IOException;
@@ -13,49 +15,48 @@ public class PrometheusPublisher {
   private static int numInputFetchStages = 0;
 
   private static final Gauge cpuQueueSize =
-      Gauge.build().name("cpu_queue_size").help("[Server] CPU queue size.").register();
+      Gauge.build().name("cpu_queue_size").help("CPU queue size.").register();
   private static final Gauge gpuQueueSize =
-      Gauge.build().name("gpu_queue_size").help("[Server] GPU queue size.").register();
+      Gauge.build().name("gpu_queue_size").help("GPU queue size.").register();
   private static final Gauge preQueueSize =
-      Gauge.build().name("pre_queue_size").help("[Server] Pre queue size.").register();
+      Gauge.build().name("pre_queue_size").help("Pre queue size.").register();
   private static final Gauge dispatchedOperations =
       Gauge.build()
           .name("dispatched_operations_size")
-          .help("[Server] Dispatched operations size.")
+          .help("Dispatched operations size.")
           .register();
   private static final Gauge workerPoolSize =
-      Gauge.build().name("worker_pool_size").help("[Server] Active worker pool size.").register();
-  private static final Gauge actionResults =
-      Gauge.build().name("action_results").help("[Server] Action results.").register();
-  private static final Gauge executionTime =
-      Gauge.build().name("execution_time_ms").help("[Worker] Execution time in ms.").register();
-  private static final Gauge executionStallTime =
-      Gauge.build()
-          .name("execution_stall_time_ms")
-          .help("[Worker] Execution stall time in ms.")
-          .register();
+      Gauge.build().name("worker_pool_size").help("Active worker pool size.").register();
   private static final Gauge executionSlotUsage =
-      Gauge.build().name("execution_slot_usage").help("[Worker] Execution slot Usage.").register();
-  private static final Gauge inputFetchTime =
-      Gauge.build().name("input_fetch_time_ms").help("[Worker] Input fetch time in ms.").register();
-  private static final Gauge inputFetchStallTime =
-      Gauge.build()
-          .name("input_fetch_stall_time_ms")
-          .help("[Worker] Input fetch stall time in ms.")
-          .register();
+      Gauge.build().name("execution_slot_usage").help("Execution slot Usage.").register();
   private static final Gauge inputFetchSlotUsage =
-      Gauge.build()
-          .name("input_fetch_slot_usage")
-          .help("[Worker] Input fetch slot Usage.")
-          .register();
+      Gauge.build().name("input_fetch_slot_usage").help("Input fetch slot Usage.").register();
   private static final Gauge clusterUtilization =
-      Gauge.build().name("cluster_utilization").help("[Server] Cluster utilization.").register();
-  private static final Gauge executionSuccess =
-      Gauge.build().name("execution_success").help("[Server] Execution success.").register();
-  private static final Gauge completedOperations =
-      Gauge.build().name("completed_operations").help("[Worker] Completed operations.").register();
-  private static final Gauge missingBlobs =
-      Gauge.build().name("missing_blobs").help("[Server] Find missing blobs.").register();
+      Gauge.build().name("cluster_utilization").help("Cluster utilization.").register();
+
+  private static final Summary actionResults =
+      Summary.build().name("action_results").help("Action results.").register();
+  private static final Summary executionTime =
+      Summary.build().name("execution_time_ms").help("Execution time in ms.").register();
+  private static final Summary executionStallTime =
+      Summary.build()
+          .name("execution_stall_time_ms")
+          .help("Execution stall time in ms.")
+          .register();
+  private static final Summary inputFetchTime =
+      Summary.build().name("input_fetch_time_ms").help("Input fetch time in ms.").register();
+  private static final Summary inputFetchStallTime =
+      Summary.build()
+          .name("input_fetch_stall_time_ms")
+          .help("Input fetch stall time in ms.")
+          .register();
+  private static final Summary missingBlobs =
+      Summary.build().name("missing_blobs").help("Find missing blobs.").register();
+
+  private static final Counter executionSuccess =
+      Counter.build().name("execution_success").help("Execution success.").register();
+  private static final Counter completedOperations =
+      Counter.build().name("completed_operations").help("Completed operations.").register();
 
   public static void startHttpServer(int port) {
     try {
@@ -110,19 +111,19 @@ public class PrometheusPublisher {
   }
 
   public static void updateActionResults(long val) {
-    actionResults.inc(val);
+    actionResults.observe(val);
   }
 
   public static void updateMissingBlobs(long val) {
-    missingBlobs.inc(val);
+    missingBlobs.observe(val);
   }
 
   public static void updateExecutionTime(double val) {
-    executionTime.inc(val);
+    executionTime.observe(val);
   }
 
   public static void updateExecutionStallTime(double val) {
-    executionStallTime.inc(val);
+    executionStallTime.observe(val);
   }
 
   public static void updateExecutionSlotUsage(int val) {
@@ -130,11 +131,11 @@ public class PrometheusPublisher {
   }
 
   public static void updateInputFetchTime(double val) {
-    inputFetchTime.inc(val);
+    inputFetchTime.observe(val);
   }
 
   public static void updateInputFetchStallTime(double val) {
-    inputFetchStallTime.inc(val);
+    inputFetchStallTime.observe(val);
   }
 
   public static void updateInputFetchSlotUsage(int val) {

--- a/src/main/java/build/buildfarm/metrics/prometheus/PrometheusPublisher.java
+++ b/src/main/java/build/buildfarm/metrics/prometheus/PrometheusPublisher.java
@@ -12,22 +12,50 @@ public class PrometheusPublisher {
   private static int numExecuteStages = 0;
   private static int numInputFetchStages = 0;
 
-  private static final Gauge cpuQueueSize = Gauge.build().name("cpu_queue_size").help("[Server] CPU queue size.").register();
-  private static final Gauge gpuQueueSize = Gauge.build().name("gpu_queue_size").help("[Server] GPU queue size.").register();
-  private static final Gauge preQueueSize = Gauge.build().name("pre_queue_size").help("[Server] Pre queue size.").register();
-  private static final Gauge dispatchedOperations = Gauge.build().name("dispatched_operations_size").help("[Server] Dispatched operations size.").register();
-  private static final Gauge workerPoolSize = Gauge.build().name("worker_pool_size").help("[Server] Active worker pool size.").register();
-  private static final Gauge actionResults =  Gauge.build().name("action_results").help("[Server] Action results.").register();
-  private static final Gauge executionTime = Gauge.build().name("execution_time_ms").help("[Worker] Execution time in ms.").register();
-  private static final Gauge executionStallTime = Gauge.build().name("execution_stall_time_ms").help("[Worker] Execution stall time in ms.").register();
-  private static final Gauge executionSlotUsage = Gauge.build().name("execution_slot_usage").help("[Worker] Execution slot Usage.").register();
-  private static final Gauge inputFetchTime = Gauge.build().name("input_fetch_time_ms").help("[Worker] Input fetch time in ms.").register();
-  private static final Gauge inputFetchStallTime = Gauge.build().name("input_fetch_stall_time_ms").help("[Worker] Input fetch stall time in ms.").register();
-  private static final Gauge inputFetchSlotUsage = Gauge.build().name("input_fetch_slot_usage").help("[Worker] Input fetch slot Usage.").register();
-  private static final Gauge clusterUtilization = Gauge.build().name("cluster_utilization").help("[Server] Cluster utilization.").register();
-  private static final Gauge executionSuccess =  Gauge.build().name("execution_success").help("[Server] Execution success.").register();
-  private static final Gauge completedOperations =  Gauge.build().name("completed_operations").help("[Worker] Completed operations.").register();
-  private static final Gauge missingBlobs =  Gauge.build().name("missing_blobs").help("[Server] Find missing blobs.").register();
+  private static final Gauge cpuQueueSize =
+      Gauge.build().name("cpu_queue_size").help("[Server] CPU queue size.").register();
+  private static final Gauge gpuQueueSize =
+      Gauge.build().name("gpu_queue_size").help("[Server] GPU queue size.").register();
+  private static final Gauge preQueueSize =
+      Gauge.build().name("pre_queue_size").help("[Server] Pre queue size.").register();
+  private static final Gauge dispatchedOperations =
+      Gauge.build()
+          .name("dispatched_operations_size")
+          .help("[Server] Dispatched operations size.")
+          .register();
+  private static final Gauge workerPoolSize =
+      Gauge.build().name("worker_pool_size").help("[Server] Active worker pool size.").register();
+  private static final Gauge actionResults =
+      Gauge.build().name("action_results").help("[Server] Action results.").register();
+  private static final Gauge executionTime =
+      Gauge.build().name("execution_time_ms").help("[Worker] Execution time in ms.").register();
+  private static final Gauge executionStallTime =
+      Gauge.build()
+          .name("execution_stall_time_ms")
+          .help("[Worker] Execution stall time in ms.")
+          .register();
+  private static final Gauge executionSlotUsage =
+      Gauge.build().name("execution_slot_usage").help("[Worker] Execution slot Usage.").register();
+  private static final Gauge inputFetchTime =
+      Gauge.build().name("input_fetch_time_ms").help("[Worker] Input fetch time in ms.").register();
+  private static final Gauge inputFetchStallTime =
+      Gauge.build()
+          .name("input_fetch_stall_time_ms")
+          .help("[Worker] Input fetch stall time in ms.")
+          .register();
+  private static final Gauge inputFetchSlotUsage =
+      Gauge.build()
+          .name("input_fetch_slot_usage")
+          .help("[Worker] Input fetch slot Usage.")
+          .register();
+  private static final Gauge clusterUtilization =
+      Gauge.build().name("cluster_utilization").help("[Server] Cluster utilization.").register();
+  private static final Gauge executionSuccess =
+      Gauge.build().name("execution_success").help("[Server] Execution success.").register();
+  private static final Gauge completedOperations =
+      Gauge.build().name("completed_operations").help("[Worker] Completed operations.").register();
+  private static final Gauge missingBlobs =
+      Gauge.build().name("missing_blobs").help("[Server] Find missing blobs.").register();
 
   public static void startHttpServer(int port) {
     try {
@@ -115,8 +143,11 @@ public class PrometheusPublisher {
 
   public static void updateClusterUtilization() {
     try {
-      clusterUtilization.set(dispatchedOperations.get() * 100.0 / (workerPoolSize.get() * (numExecuteStages + numInputFetchStages)));
-      } catch (Exception e) {
+      clusterUtilization.set(
+          dispatchedOperations.get()
+              * 100.0
+              / (workerPoolSize.get() * (numExecuteStages + numInputFetchStages)));
+    } catch (Exception e) {
       clusterUtilization.set(0.0);
     }
   }

--- a/src/main/java/build/buildfarm/metrics/prometheus/PrometheusPublisher.java
+++ b/src/main/java/build/buildfarm/metrics/prometheus/PrometheusPublisher.java
@@ -1,0 +1,121 @@
+package build.buildfarm.metrics.prometheus;
+
+import io.prometheus.client.Counter;
+import io.prometheus.client.Gauge;
+import io.prometheus.client.exporter.HTTPServer;
+import io.prometheus.client.hotspot.DefaultExports;
+import java.io.IOException;
+import java.util.logging.Logger;
+
+public class PrometheusPublisher {
+  private static final Logger logger = Logger.getLogger(PrometheusPublisher.class.getName());
+  private static HTTPServer server;
+  private static int numExecuteStages = 0;
+  private static int numInputFetchStages = 0;
+
+  private static final Gauge cpuQueueSize = Gauge.build().name("cpu_queue_size").help("CPU queue size.").register();
+  private static final Gauge gpuQueueSize = Gauge.build().name("gpu_queue_size").help("GPU queue size.").register();
+  private static final Gauge preQueueSize = Gauge.build().name("pre_queue_size").help("Pre queue size.").register();
+  private static final Gauge dispatchedOperations = Gauge.build().name("dispatched_operations_size").help("Dispatched operations size.").register();
+  private static final Gauge workerPoolSize = Gauge.build().name("worker_pool_size").help("Active worker pool size.").register();
+  private static final Gauge actionResults =  Gauge.build().name("action_results").help("Action results.").register();
+  private static final Gauge executionTime = Gauge.build().name("execution_time_ms").help("Execution time in ms.").register();
+  private static final Gauge executionStallTime = Gauge.build().name("execution_stall_time_ms").help("Execution stall time in ms.").register();
+  private static final Gauge executionSlotUsage = Gauge.build().name("execution_slot_usage").help("Execution slot Usage.").register();
+  private static final Gauge inputFetchTime = Gauge.build().name("input_fetch_time_ms").help("Input fetch time in ms.").register();
+  private static final Gauge inputFetchStallTime = Gauge.build().name("input_fetch_stall_time_ms").help("Input fetch stall time in ms.").register();
+  private static final Gauge inputFetchSlotUsage = Gauge.build().name("input_fetch_slot_usage").help("Input fetch slot Usage.").register();
+  private static final Gauge clusterUtilization = Gauge.build().name("cluster_utilization").help("Cluster utilization.").register();
+
+  private static final Counter executionSuccess =  Counter.build().name("execution_success").help("Execution success.").register();
+  private static final Counter completedOperations =  Counter.build().name("completed_operations").help("Completed operations.").register();
+  private static final Counter missingBlobs =  Counter.build().name("missing_blobs").help("Find missing blobs.").register();
+
+  public static void startHttpServer(int port) {
+    try {
+      DefaultExports.initialize();
+      server = new HTTPServer(port);
+      logger.info("Started Prometheus HTTP Server on port " + port);
+    } catch (IOException e) {
+      logger.severe("Could not start Prometheus HTTP Server on port " + port);
+    }
+  }
+
+  public static void startHttpServer(int port, int exeStages, int ifStages) {
+    numExecuteStages = exeStages;
+    numInputFetchStages = ifStages;
+    startHttpServer(port);
+  }
+
+  public static void stopHttpServer() {
+    server.stop();
+  }
+
+  public static void updateCpuQueueSize(long val) {
+    cpuQueueSize.set(val);
+  }
+
+  public static void updateGpuQueueSize(long val) {
+    gpuQueueSize.set(val);
+  }
+
+  public static void updatePreQueueSize(long val) {
+    preQueueSize.set(val);
+  }
+
+  public static void updateDispatchedOperationsSize(long val) {
+    dispatchedOperations.set(val);
+  }
+
+  public static void updateWorkerPoolSize(int val) {
+    workerPoolSize.set(val);
+  }
+
+  public static void updateExecutionSuccess() {
+    executionSuccess.inc();
+  }
+
+  public static void updateCompletedOperations() {
+    completedOperations.inc();
+  }
+
+  public static void updateActionResults(long val) {
+    actionResults.inc(val);
+  }
+
+  public static void updateMissingBlobs(long val) {
+    missingBlobs.inc(val);
+  }
+
+  public static void updateExecutionTime(double val) {
+    executionTime.set(val);
+  }
+
+  public static void updateExecutionStallTime(double val) {
+    executionStallTime.set(val);
+  }
+
+  public static void updateExecutionSlotUsage(int val) {
+    executionSlotUsage.set(val);
+  }
+
+  public static void updateInputFetchTime(double val) {
+    inputFetchTime.set(val);
+  }
+
+  public static void updateInputFetchStallTime(double val) {
+    inputFetchStallTime.set(val);
+  }
+
+  public static void updateInputFetchSlotUsage(int val) {
+    inputFetchSlotUsage.set(val);
+  }
+
+  public static void updateClusterUtilization() {
+    try {
+      clusterUtilization.set(dispatchedOperations.get() * 100.0 / (workerPoolSize.get() * (numExecuteStages + numInputFetchStages)));
+      } catch (Exception e) {
+      clusterUtilization.set(0.0);
+    }
+  }
+}

--- a/src/main/java/build/buildfarm/metrics/prometheus/PrometheusPublisher.java
+++ b/src/main/java/build/buildfarm/metrics/prometheus/PrometheusPublisher.java
@@ -1,6 +1,5 @@
 package build.buildfarm.metrics.prometheus;
 
-import io.prometheus.client.Counter;
 import io.prometheus.client.Gauge;
 import io.prometheus.client.exporter.HTTPServer;
 import io.prometheus.client.hotspot.DefaultExports;
@@ -13,29 +12,32 @@ public class PrometheusPublisher {
   private static int numExecuteStages = 0;
   private static int numInputFetchStages = 0;
 
-  private static final Gauge cpuQueueSize = Gauge.build().name("cpu_queue_size").help("CPU queue size.").register();
-  private static final Gauge gpuQueueSize = Gauge.build().name("gpu_queue_size").help("GPU queue size.").register();
-  private static final Gauge preQueueSize = Gauge.build().name("pre_queue_size").help("Pre queue size.").register();
-  private static final Gauge dispatchedOperations = Gauge.build().name("dispatched_operations_size").help("Dispatched operations size.").register();
-  private static final Gauge workerPoolSize = Gauge.build().name("worker_pool_size").help("Active worker pool size.").register();
-  private static final Gauge actionResults =  Gauge.build().name("action_results").help("Action results.").register();
-  private static final Gauge executionTime = Gauge.build().name("execution_time_ms").help("Execution time in ms.").register();
-  private static final Gauge executionStallTime = Gauge.build().name("execution_stall_time_ms").help("Execution stall time in ms.").register();
-  private static final Gauge executionSlotUsage = Gauge.build().name("execution_slot_usage").help("Execution slot Usage.").register();
-  private static final Gauge inputFetchTime = Gauge.build().name("input_fetch_time_ms").help("Input fetch time in ms.").register();
-  private static final Gauge inputFetchStallTime = Gauge.build().name("input_fetch_stall_time_ms").help("Input fetch stall time in ms.").register();
-  private static final Gauge inputFetchSlotUsage = Gauge.build().name("input_fetch_slot_usage").help("Input fetch slot Usage.").register();
-  private static final Gauge clusterUtilization = Gauge.build().name("cluster_utilization").help("Cluster utilization.").register();
-
-  private static final Counter executionSuccess =  Counter.build().name("execution_success").help("Execution success.").register();
-  private static final Counter completedOperations =  Counter.build().name("completed_operations").help("Completed operations.").register();
-  private static final Counter missingBlobs =  Counter.build().name("missing_blobs").help("Find missing blobs.").register();
+  private static final Gauge cpuQueueSize = Gauge.build().name("cpu_queue_size").help("[Server] CPU queue size.").register();
+  private static final Gauge gpuQueueSize = Gauge.build().name("gpu_queue_size").help("[Server] GPU queue size.").register();
+  private static final Gauge preQueueSize = Gauge.build().name("pre_queue_size").help("[Server] Pre queue size.").register();
+  private static final Gauge dispatchedOperations = Gauge.build().name("dispatched_operations_size").help("[Server] Dispatched operations size.").register();
+  private static final Gauge workerPoolSize = Gauge.build().name("worker_pool_size").help("[Server] Active worker pool size.").register();
+  private static final Gauge actionResults =  Gauge.build().name("action_results").help("[Server] Action results.").register();
+  private static final Gauge executionTime = Gauge.build().name("execution_time_ms").help("[Worker] Execution time in ms.").register();
+  private static final Gauge executionStallTime = Gauge.build().name("execution_stall_time_ms").help("[Worker] Execution stall time in ms.").register();
+  private static final Gauge executionSlotUsage = Gauge.build().name("execution_slot_usage").help("[Worker] Execution slot Usage.").register();
+  private static final Gauge inputFetchTime = Gauge.build().name("input_fetch_time_ms").help("[Worker] Input fetch time in ms.").register();
+  private static final Gauge inputFetchStallTime = Gauge.build().name("input_fetch_stall_time_ms").help("[Worker] Input fetch stall time in ms.").register();
+  private static final Gauge inputFetchSlotUsage = Gauge.build().name("input_fetch_slot_usage").help("[Worker] Input fetch slot Usage.").register();
+  private static final Gauge clusterUtilization = Gauge.build().name("cluster_utilization").help("[Server] Cluster utilization.").register();
+  private static final Gauge executionSuccess =  Gauge.build().name("execution_success").help("[Server] Execution success.").register();
+  private static final Gauge completedOperations =  Gauge.build().name("completed_operations").help("[Worker] Completed operations.").register();
+  private static final Gauge missingBlobs =  Gauge.build().name("missing_blobs").help("[Server] Find missing blobs.").register();
 
   public static void startHttpServer(int port) {
     try {
-      DefaultExports.initialize();
-      server = new HTTPServer(port);
-      logger.info("Started Prometheus HTTP Server on port " + port);
+      if (port > 0) {
+        DefaultExports.initialize();
+        server = new HTTPServer(port);
+        logger.info("Started Prometheus HTTP Server on port " + port);
+      } else {
+        logger.info("Prometheus port is not configured. HTTP Server will not be started");
+      }
     } catch (IOException e) {
       logger.severe("Could not start Prometheus HTTP Server on port " + port);
     }
@@ -88,11 +90,11 @@ public class PrometheusPublisher {
   }
 
   public static void updateExecutionTime(double val) {
-    executionTime.set(val);
+    executionTime.inc(val);
   }
 
   public static void updateExecutionStallTime(double val) {
-    executionStallTime.set(val);
+    executionStallTime.inc(val);
   }
 
   public static void updateExecutionSlotUsage(int val) {
@@ -100,11 +102,11 @@ public class PrometheusPublisher {
   }
 
   public static void updateInputFetchTime(double val) {
-    inputFetchTime.set(val);
+    inputFetchTime.inc(val);
   }
 
   public static void updateInputFetchStallTime(double val) {
-    inputFetchStallTime.set(val);
+    inputFetchStallTime.inc(val);
   }
 
   public static void updateInputFetchSlotUsage(int val) {

--- a/src/main/java/build/buildfarm/server/ActionCacheRequestCounter.java
+++ b/src/main/java/build/buildfarm/server/ActionCacheRequestCounter.java
@@ -21,6 +21,7 @@ import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
+import build.buildfarm.metrics.prometheus.PrometheusPublisher;
 import com.google.common.util.concurrent.ListenableFuture;
 import java.time.Duration;
 import java.util.concurrent.ScheduledExecutorService;
@@ -54,8 +55,8 @@ class ActionCacheRequestCounter {
   private void logRequests() {
     long requestCount = counter.getAndSet(0l);
     if (requestCount > 0) {
-      // TODO: Convert to metrics
-      logger.log(Level.INFO, String.format("GetActionResult %d Requests", requestCount));
+      PrometheusPublisher.updateActionResults(requestCount);
+      logger.log(Level.FINE, String.format("GetActionResult %d Requests", requestCount));
     }
     schedule();
   }

--- a/src/main/java/build/buildfarm/server/BuildFarmServer.java
+++ b/src/main/java/build/buildfarm/server/BuildFarmServer.java
@@ -220,12 +220,11 @@ public class BuildFarmServer extends LoggingMain {
     session += "-" + UUID.randomUUID();
     BuildFarmServer server;
     try (InputStream configInputStream = Files.newInputStream(configPath)) {
-      BuildFarmServerConfig config = toBuildFarmServerConfig(new InputStreamReader(configInputStream), options);
+      BuildFarmServerConfig config =
+          toBuildFarmServerConfig(new InputStreamReader(configInputStream), options);
       // Start Prometheus web server
       PrometheusPublisher.startHttpServer(config.getPrometheusConfig().getPort());
-      server =
-          new BuildFarmServer(
-              session, config);
+      server = new BuildFarmServer(session, config);
       configInputStream.close();
       server.start(options.publicName);
       server.blockUntilShutdown();

--- a/src/main/java/build/buildfarm/server/BuildFarmServer.java
+++ b/src/main/java/build/buildfarm/server/BuildFarmServer.java
@@ -222,8 +222,7 @@ public class BuildFarmServer extends LoggingMain {
     try (InputStream configInputStream = Files.newInputStream(configPath)) {
       BuildFarmServerConfig config = toBuildFarmServerConfig(new InputStreamReader(configInputStream), options);
       // Start Prometheus web server
-      PrometheusPublisher.startHttpServer(
-        config.getPrometheusConfig().getPort() > 0 ? config.getPrometheusConfig().getPort() : 9090);
+      PrometheusPublisher.startHttpServer(config.getPrometheusConfig().getPort());
       server =
           new BuildFarmServer(
               session, config);

--- a/src/main/java/build/buildfarm/server/ContentAddressableStorageService.java
+++ b/src/main/java/build/buildfarm/server/ContentAddressableStorageService.java
@@ -38,6 +38,7 @@ import build.bazel.remote.execution.v2.GetTreeResponse;
 import build.buildfarm.common.DigestUtil;
 import build.buildfarm.common.grpc.TracingMetadataUtils;
 import build.buildfarm.instance.Instance;
+import build.buildfarm.metrics.prometheus.PrometheusPublisher;
 import build.buildfarm.v1test.Tree;
 import com.google.common.base.Function;
 import com.google.common.base.Stopwatch;
@@ -110,8 +111,9 @@ public class ContentAddressableStorageService
               responseObserver.onNext(response);
               responseObserver.onCompleted();
               long elapsedMicros = stopwatch.elapsed(MICROSECONDS);
+              PrometheusPublisher.updateMissingBlobs(request.getBlobDigestsList().size());
               logger.log(
-                  requestLogLevel,
+                  Level.FINE,
                   new StringBuilder()
                       .append("FindMissingBlobs(")
                       .append(instance.getName())

--- a/src/main/java/build/buildfarm/worker/ExecuteActionStage.java
+++ b/src/main/java/build/buildfarm/worker/ExecuteActionStage.java
@@ -14,6 +14,7 @@
 
 package build.buildfarm.worker;
 
+import build.buildfarm.metrics.prometheus.PrometheusPublisher;
 import com.google.common.collect.Sets;
 import java.io.IOException;
 import java.util.Set;
@@ -91,6 +92,9 @@ public class ExecuteActionStage extends SuperscalarPipelineStage {
   public void releaseExecutor(
       String operationName, int claims, long usecs, long stallUSecs, int exitCode) {
     size = removeAndRelease(operationName, claims);
+    PrometheusPublisher.updateExecutionTime(usecs / 1000.0);
+    PrometheusPublisher.updateExecutionStallTime(stallUSecs / 1000.0);
+    PrometheusPublisher.updateExecutionSlotUsage(size);
     logComplete(
         operationName,
         usecs,

--- a/src/main/java/build/buildfarm/worker/InputFetchStage.java
+++ b/src/main/java/build/buildfarm/worker/InputFetchStage.java
@@ -14,6 +14,7 @@
 
 package build.buildfarm.worker;
 
+import build.buildfarm.metrics.prometheus.PrometheusPublisher;
 import com.google.common.collect.Sets;
 import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -56,6 +57,9 @@ public class InputFetchStage extends SuperscalarPipelineStage {
   public void releaseInputFetcher(
       String operationName, long usecs, long stallUSecs, boolean success) {
     int size = removeAndRelease(operationName);
+    PrometheusPublisher.updateInputFetchTime(usecs / 1000.0);
+    PrometheusPublisher.updateInputFetchStallTime(stallUSecs / 1000.0);
+    PrometheusPublisher.updateInputFetchSlotUsage(size);
     logComplete(
         operationName,
         usecs,

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -45,6 +45,7 @@ import build.buildfarm.common.grpc.Retrier.Backoff;
 import build.buildfarm.instance.Instance;
 import build.buildfarm.instance.Instance.MatchListener;
 import build.buildfarm.instance.shard.ShardBackplane;
+import build.buildfarm.metrics.prometheus.PrometheusPublisher;
 import build.buildfarm.v1test.CASInsertionPolicy;
 import build.buildfarm.v1test.ExecutionPolicy;
 import build.buildfarm.v1test.QueueEntry;
@@ -743,7 +744,7 @@ class ShardWorkerContext implements WorkerContext {
       throws IOException, InterruptedException {
     boolean success = createBackplaneRetrier().execute(() -> instance.putOperation(operation));
     if (success && operation.getDone()) {
-      // TODO: Convert to metrics
+      PrometheusPublisher.updateCompletedOperations();
       logger.log(Level.INFO, "CompletedOperation: " + operation.getName());
     }
     return success;

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -745,7 +745,7 @@ class ShardWorkerContext implements WorkerContext {
     boolean success = createBackplaneRetrier().execute(() -> instance.putOperation(operation));
     if (success && operation.getDone()) {
       PrometheusPublisher.updateCompletedOperations();
-      logger.log(Level.INFO, "CompletedOperation: " + operation.getName());
+      logger.log(Level.FINE, "CompletedOperation: " + operation.getName());
     }
     return success;
   }

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -990,16 +990,15 @@ public class Worker extends LoggingMain {
     String session = UUID.randomUUID().toString();
     Worker worker;
     try (InputStream configInputStream = Files.newInputStream(configPath)) {
-      ShardWorkerConfig config = toShardWorkerConfig(
-        new InputStreamReader(configInputStream), parser.getOptions(WorkerOptions.class));
+      ShardWorkerConfig config =
+          toShardWorkerConfig(
+              new InputStreamReader(configInputStream), parser.getOptions(WorkerOptions.class));
       // Start Prometheus web server
       PrometheusPublisher.startHttpServer(
-        config.getPrometheusConfig().getPort(),
-        config.getExecuteStageWidth(), config.getInputFetchStageWidth());
-      worker =
-          new Worker(
-              session,
-              config);
+          config.getPrometheusConfig().getPort(),
+          config.getExecuteStageWidth(),
+          config.getInputFetchStageWidth());
+      worker = new Worker(session, config);
     }
     worker.start();
     worker.blockUntilShutdown();

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -994,7 +994,7 @@ public class Worker extends LoggingMain {
         new InputStreamReader(configInputStream), parser.getOptions(WorkerOptions.class));
       // Start Prometheus web server
       PrometheusPublisher.startHttpServer(
-        config.getPrometheusConfig().getPort() > 0 ? config.getPrometheusConfig().getPort() : 9090,
+        config.getPrometheusConfig().getPort(),
         config.getExecuteStageWidth(), config.getInputFetchStageWidth());
       worker =
           new Worker(

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -209,6 +209,8 @@ message BuildFarmServerConfig {
   MetricsConfig metrics_config = 5;
 
   AdminConfig admin_config = 6;
+
+  PrometheusConfig prometheus_config = 7;
 }
 
 message MetricsConfig {
@@ -239,6 +241,10 @@ message GcpMetricsConfig {
 
 message LogMetricsConfig {
   string log_level = 1;
+}
+
+message PrometheusConfig {
+  int32 port = 1;
 }
 
 message AdminConfig {
@@ -635,6 +641,8 @@ message ShardWorkerConfig {
   bool error_operation_remaining_resources = 34;
 
   AdminConfig admin_config = 35;
+
+  PrometheusConfig prometheus_config = 37;
 }
 
 message ShardWorker {


### PR DESCRIPTION
The following metrics will be exposed initially:

- JVM Metrics
- cpu_queue_size
- gpu_queue_size
- pre_queue_size
- dispatched_operations_size
- worker_pool_size
- action_results
- execution_time_ms
- execution_stall_time_ms
- execution_slot_usage
- input_fetch_time_ms
- input_fetch_stall_time_ms
- input_fetch_slot_usage
- cluster_utilization
- execution_success
- completed_operations
- missing_blobs