### PR TITLE
Fix CasFIleCache to not return empty blobs in findMissingBlobs

### DIFF
--- a/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
+++ b/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
@@ -444,7 +444,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
     ImmutableList.Builder<Digest> builder = ImmutableList.builder();
     ImmutableList.Builder<String> found = ImmutableList.builder();
     for (Digest digest : digests) {
-      if (digest.getSizeBytes() == 0 || !containsLocal(digest, found::add)) {
+      if (digest.getSizeBytes() != 0 && !containsLocal(digest, found::add)) {
         builder.add(digest);
       }
     }


### PR DESCRIPTION
@werkt I think the previous fix from PR #670 was not entirely correct. This one works (at least in my environment)