### PR TITLE
Limit number of requeue attempts for an operation

### DIFF
--- a/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
@@ -1225,7 +1225,8 @@ public class RedisShardBackplane implements ShardBackplane {
       logger.log(Level.SEVERE, "error parsing queue entry", e);
       return null;
     }
-    QueueEntry queueEntry = queueEntryBuilder.build();
+    QueueEntry queueEntry =
+        queueEntryBuilder.setRequeueAttempts(queueEntryBuilder.getRequeueAttempts() + 1).build();
 
     String operationName = queueEntry.getExecuteEntry().getOperationName();
     Operation operation = keepaliveOperation(operationName);

--- a/src/main/java/build/buildfarm/metrics/prometheus/PrometheusPublisher.java
+++ b/src/main/java/build/buildfarm/metrics/prometheus/PrometheusPublisher.java
@@ -1,3 +1,17 @@
+// Copyright 2021 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package build.buildfarm.metrics.prometheus;
 
 import io.prometheus.client.Counter;

--- a/src/main/java/build/buildfarm/worker/cgroup/Group.java
+++ b/src/main/java/build/buildfarm/worker/cgroup/Group.java
@@ -22,9 +22,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
 public class Group {
+  private static final Logger logger = Logger.getLogger(Group.class.getName());
   private static final Group root = new Group(/* name=*/ null, /* parent=*/ null);
   private static final Path rootPath = Paths.get("/sys/fs/cgroup");
 
@@ -93,6 +95,7 @@ public class Group {
       // TODO check arg limits, exit status, etc
       Runtime.getRuntime()
           .exec("kill -SIGKILL " + pids.stream().map(pid -> pid.toString()).collect(joining(" ")));
+      logger.warning("Killed processes with PIDs: " + pids);
       return false;
     }
     return true;

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerInstance.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerInstance.java
@@ -199,7 +199,6 @@ public class ShardWorkerInstance extends AbstractServerInstance {
     while (!backplane.isStopped()) {
       listener.onWaitStart();
       try {
-
         List<Platform.Property> provisions = new ArrayList<>();
         QueueEntry queueEntry = backplane.dispatchOperation(provisions);
         if (queueEntry != null) {

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -738,6 +738,8 @@ message QueueEntry {
   build.bazel.remote.execution.v2.Digest queued_operation_digest = 2;
 
   build.bazel.remote.execution.v2.Platform platform = 3;
+
+  int32 requeue_attempts = 4;
 }
 
 message QueueStatus {


### PR DESCRIPTION
It is possible for a bad action (such as one requiring specific hardware to be present) to get stuck in the "EXECUTING" state indefinitely. Even upon the build termination, the executing operation persists until the worker is terminated. This change caps the amount of retries to 5, which will cause the stuck action to error out after it's retried this many times. Note that the action will still be retried by Bazel (for a default of 5 times), unless --remote_retries flag is specified otherwise.