### PR TITLE
refactor exec_properties

### DIFF
--- a/src/main/java/build/buildfarm/common/ExecutionProperties.java
+++ b/src/main/java/build/buildfarm/common/ExecutionProperties.java
@@ -1,0 +1,86 @@
+// Copyright 2021 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.common;
+
+/**
+ * @brief Execution properties understood and used by buildfarm.
+ * @details These are the execution property key names that have special meaning when applied to
+ *     actions. Users can still configure their own unique execution properties along side these for
+ *     workers and the operation queue.
+ */
+public class ExecutionProperties {
+
+  /**
+   * @field MIN_CORES
+   * @brief The exec_property and platform property name for setting min cores.
+   * @details This is decided between client and server. The key value is expected to be an integer.
+   */
+  public static final String MIN_CORES = "min-cores";
+
+  /**
+   * @field MAX_CORES
+   * @brief The exec_property and platform property name for setting max cores.
+   * @details This is decided between client and server. The key value is expected to be an integer.
+   */
+  public static final String MAX_CORES = "max-cores";
+
+  /**
+   * @field ENV_VARS
+   * @brief The exec_property and platform property name for providing additional environment
+   *     variables.
+   * @details This is decided between client and server. The key value should be a json dictionary,
+   *     where each entry is a key/value representing env variable name and env variable value.
+   */
+  public static final String ENV_VARS = "env-vars";
+
+  /**
+   * @field ENV_VAR
+   * @brief The exec_property and platform property prefix name for providing an additional
+   *     environment variable.
+   * @details This is decided between client and server. The colon is intentional as it is used as a
+   *     prefix key. The remaining part of the key is the env variable name, the value is the value
+   *     of the env variable.
+   */
+  public static final String ENV_VAR = "env-var:";
+
+  /**
+   * @field DEBUG_BEFORE_EXECUTION
+   * @brief The exec_property and platform property name for indicating whether a user wants to
+   *     debug the before action state of an execution.
+   * @details This is intended to be used interactively to debug remote executions. The key value
+   *     should be a boolean.
+   */
+  public static final String DEBUG_BEFORE_EXECUTION = "debug-before-execution";
+
+  /**
+   * @field DEBUG_AFTER_EXECUTION
+   * @brief The exec_property and platform property name for indicating whether a user wants to get
+   *     debug information from after the execution.
+   * @details This is intended to be used interactively to debug remote executions. The key value
+   *     should be a boolean.
+   */
+  public static final String DEBUG_AFTER_EXECUTION = "debug-after-execution";
+
+  /**
+   * @field CHOOSE_QUEUE
+   * @brief The exec_property to allow directly matching with a queue.
+   * @details This is to support a paradigm where actions want to specifically request the queue to
+   *     be placed in. Its less generic than having buildfarm choose the queue for you, and it leaks
+   *     implementation details about how buildfarm is queuing your work. However, its desirable to
+   *     match similar remote execution solutions that use exec_properties to choose which "pool"
+   *     they want to run in.
+   */
+  public static final String CHOOSE_QUEUE = "choose-queue";
+}

--- a/src/main/java/build/buildfarm/common/redis/ProvisionedRedisQueue.java
+++ b/src/main/java/build/buildfarm/common/redis/ProvisionedRedisQueue.java
@@ -14,6 +14,7 @@
 
 package build.buildfarm.common.redis;
 
+import build.buildfarm.common.ExecutionProperties;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.SetMultimap;
@@ -48,17 +49,6 @@ public class ProvisionedRedisQueue {
    * @details Symbol for identifying wildcard in both key/value of provisions.
    */
   public static final String WILDCARD_VALUE = "*";
-
-  /**
-   * @field CHOOSE_QUEUE_KEY
-   * @brief Special key to allow directly matching with a queue.
-   * @details This is to support another paradigm where actions want to specifically request the
-   *     queue to be placed in. Its less generic than having buildfarm choose the queue for you, and
-   *     it leaks implementation details about how buildfarm is queuing your work. However, its
-   *     desirable to match similar remote execution solutions that use exec_properties to choose
-   *     which "pool" they want to run in.
-   */
-  public static final String CHOOSE_QUEUE_KEY = "choose-queue";
 
   /**
    * @field isFullyWildcard
@@ -139,7 +129,7 @@ public class ProvisionedRedisQueue {
   public boolean isEligible(SetMultimap<String, String> properties) {
     // check if a property is specifically requesting to match with the queue
     // any attempt to specifically match will not evaluate other properties
-    Set<String> selected = properties.get(CHOOSE_QUEUE_KEY);
+    Set<String> selected = properties.get(ExecutionProperties.CHOOSE_QUEUE);
     if (!selected.isEmpty()) {
       return selected.contains(queue.getName());
     }
@@ -229,7 +219,7 @@ public class ProvisionedRedisQueue {
 
     // check if a property is specifically requesting to match with the queue
     // any attempt to specifically match will not evaluate other properties
-    Set<String> selected = properties.get(CHOOSE_QUEUE_KEY);
+    Set<String> selected = properties.get(ExecutionProperties.CHOOSE_QUEUE);
     if (!selected.isEmpty()) {
       result.isSpecificallyChosen = selected.contains(queue.getName());
     }

--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -61,6 +61,7 @@ import build.buildfarm.common.CasIndexResults;
 import build.buildfarm.common.DigestUtil;
 import build.buildfarm.common.DigestUtil.ActionKey;
 import build.buildfarm.common.EntryLimitException;
+import build.buildfarm.common.ExecutionProperties;
 import build.buildfarm.common.Poller;
 import build.buildfarm.common.TokenizableIterator;
 import build.buildfarm.common.TreeIterator;
@@ -1405,7 +1406,8 @@ public class ShardInstance extends AbstractServerInstance {
 
     for (Property property : platform.getPropertiesList()) {
       /* FIXME generalize with config */
-      if (property.getName().equals("min-cores") || property.getName().equals("max-cores")) {
+      if (property.getName().equals(ExecutionProperties.MIN_CORES)
+          || property.getName().equals(ExecutionProperties.MAX_CORES)) {
         try {
           int intValue = Integer.parseInt(property.getValue());
           if (intValue <= 0 || intValue > maxCpu) {
@@ -1439,7 +1441,13 @@ public class ShardInstance extends AbstractServerInstance {
           .addViolationsBuilder()
           .setType(VIOLATION_TYPE_INVALID)
           .setSubject(INVALID_PLATFORM)
-          .setDescription(format("max-cores (%d) must be >= min-cores (%d)", maxCores, minCores));
+          .setDescription(
+              format(
+                  "%s (%d) must be >= %s (%d)",
+                  ExecutionProperties.MAX_CORES,
+                  maxCores,
+                  ExecutionProperties.MIN_CORES,
+                  minCores));
     }
   }
 

--- a/src/main/java/build/buildfarm/worker/resources/BUILD
+++ b/src/main/java/build/buildfarm/worker/resources/BUILD
@@ -4,6 +4,7 @@ java_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/main/protobuf:build_buildfarm_v1test_buildfarm_java_proto",
+        "//src/main/java/build/buildfarm/common",
         "@maven//:com_google_guava_guava",
         "@maven//:com_googlecode_json_simple_json_simple",
     ],

--- a/src/main/java/build/buildfarm/worker/resources/ResourceDecider.java
+++ b/src/main/java/build/buildfarm/worker/resources/ResourceDecider.java
@@ -16,6 +16,7 @@ package build.buildfarm.worker;
 
 import build.bazel.remote.execution.v2.Command;
 import build.bazel.remote.execution.v2.Platform.Property;
+import build.buildfarm.common.ExecutionProperties;
 import com.google.common.collect.Iterables;
 import java.util.Map;
 import org.json.simple.parser.JSONParser;
@@ -34,52 +35,6 @@ import org.json.simple.parser.ParseException;
  *     global buildfarm configuration.
  */
 public class ResourceDecider {
-
-  /**
-   * @field EXEC_PROPERTY_MIN_CORES
-   * @brief The exec_property and platform property name for setting min cores.
-   * @details This is decided between client and server.
-   */
-  private static final String EXEC_PROPERTY_MIN_CORES = "min-cores";
-
-  /**
-   * @field EXEC_PROPERTY_MAX_CORES
-   * @brief The exec_property and platform property name for setting max cores.
-   * @details This is decided between client and server.
-   */
-  private static final String EXEC_PROPERTY_MAX_CORES = "max-cores";
-
-  /**
-   * @field EXEC_PROPERTY_ENV_VARS
-   * @brief The exec_property and platform property name for providing additional environment
-   *     variables.
-   * @details This is decided between client and server.
-   */
-  private static final String EXEC_PROPERTY_ENV_VARS = "env-vars";
-
-  /**
-   * @field EXEC_PROPERTY_ENV_VAR
-   * @brief The exec_property and platform property prefix name for providing an additional
-   *     environment variable.
-   * @details This is decided between client and server.
-   */
-  private static final String EXEC_PROPERTY_ENV_VAR = "env-var:";
-
-  /**
-   * @field EXEC_PROPERTY_DEBUG_BEFORE_EXECUTION
-   * @brief The exec_property and platform property name for indicating whether a user wants to
-   *     debug the before action state of an execution.
-   * @details This is intended to be used interactively to debug remote executions.
-   */
-  private static final String EXEC_PROPERTY_DEBUG_BEFORE_EXECUTION = "debug-before-execution";
-
-  /**
-   * @field EXEC_PROPERTY_DEBUG_AFTER_EXECUTION
-   * @brief The exec_property and platform property name for indicating whether a user wants to get
-   *     debug information from after the execution.
-   * @details This is intended to be used interactively to debug remote executions.
-   */
-  private static final String EXEC_PROPERTY_DEBUG_AFTER_EXECUTION = "debug-after-execution";
 
   /**
    * @brief Decide resource limitations for the given command.
@@ -126,23 +81,23 @@ public class ResourceDecider {
    */
   private static void evaluateProperty(ResourceLimits limits, Property property) {
     // handle cpu properties
-    if (property.getName().equals(EXEC_PROPERTY_MIN_CORES)) {
+    if (property.getName().equals(ExecutionProperties.MIN_CORES)) {
       storeMinCores(limits, property);
-    } else if (property.getName().equals(EXEC_PROPERTY_MAX_CORES)) {
+    } else if (property.getName().equals(ExecutionProperties.MAX_CORES)) {
       storeMaxCores(limits, property);
     }
 
     // handle env properties
-    else if (property.getName().equals(EXEC_PROPERTY_ENV_VARS)) {
+    else if (property.getName().equals(ExecutionProperties.ENV_VARS)) {
       storeEnvVars(limits, property);
-    } else if (property.getName().startsWith(EXEC_PROPERTY_ENV_VAR)) {
+    } else if (property.getName().startsWith(ExecutionProperties.ENV_VAR)) {
       storeEnvVar(limits, property);
     }
 
     // handle debug properties
-    else if (property.getName().equals(EXEC_PROPERTY_DEBUG_BEFORE_EXECUTION)) {
+    else if (property.getName().equals(ExecutionProperties.DEBUG_BEFORE_EXECUTION)) {
       storeBeforeExecutionDebug(limits, property);
-    } else if (property.getName().equals(EXEC_PROPERTY_DEBUG_AFTER_EXECUTION)) {
+    } else if (property.getName().equals(ExecutionProperties.DEBUG_AFTER_EXECUTION)) {
       storeAfterExecutionDebug(limits, property);
     }
   }


### PR DESCRIPTION
Organize existing exec_properties to prepare for the addition of "memory constraint" properties.
Improve the in-code documentation of exec_properties.  