### PR TITLE
Add grpc reflection service

### DIFF
--- a/src/main/java/build/buildfarm/server/BuildFarmServer.java
+++ b/src/main/java/build/buildfarm/server/BuildFarmServer.java
@@ -35,6 +35,7 @@ import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.ServerInterceptor;
 import io.grpc.health.v1.HealthCheckResponse.ServingStatus;
+import io.grpc.protobuf.services.ProtoReflectionService;
 import io.grpc.services.HealthStatusManager;
 import io.grpc.util.TransmitStatusRuntimeExceptionInterceptor;
 import java.io.IOException;
@@ -109,6 +110,7 @@ public class BuildFarmServer extends LoggingMain {
             .addService(new OperationsService(instances))
             .addService(new AdminService(config.getAdminConfig(), instances))
             .addService(new FetchService(instances))
+            .addService(ProtoReflectionService.newInstance())
             .intercept(TransmitStatusRuntimeExceptionInterceptor.instance())
             .intercept(headersInterceptor)
             .build();


### PR DESCRIPTION
Add ability to utilize grpcurl for testing and to call admin services from a command line, opening up the ability to use aws lambda, metrics platforms, etc to control buildfarm deployment (scaling, restarts, indexing, etc.)