### PR TITLE
use Thread.interrupt() insteasd of Thread.stop() to terminate threads

### DIFF
--- a/src/main/java/build/buildfarm/instance/shard/DispatchedMonitor.java
+++ b/src/main/java/build/buildfarm/instance/shard/DispatchedMonitor.java
@@ -127,6 +127,9 @@ class DispatchedMonitor implements Runnable {
 
   private void runInterruptibly() throws InterruptedException {
     while (!backplane.isStopped()) {
+      if (Thread.currentThread().isInterrupted()) {
+        throw new InterruptedException();
+      }
       TimeUnit.SECONDS.sleep(intervalSeconds);
       iterate();
     }

--- a/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
@@ -487,7 +487,7 @@ public class RedisShardBackplane implements Backplane {
     failsafeOperationThread =
         new Thread(
             () -> {
-              while (true) {
+              while (!Thread.currentThread().isInterrupted()) {
                 try {
                   TimeUnit.SECONDS.sleep(10);
                   client.run(this::updateWatchers);
@@ -599,7 +599,7 @@ public class RedisShardBackplane implements Backplane {
   @Override
   public synchronized void stop() throws InterruptedException {
     if (failsafeOperationThread != null) {
-      failsafeOperationThread.stop();
+      failsafeOperationThread.interrupt();
       failsafeOperationThread.join();
       logger.log(Level.FINE, "failsafeOperationThread has been stopped");
     }

--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -457,7 +457,7 @@ public class ShardInstance extends AbstractServerInstance {
     prometheusMetricsThread =
         new Thread(
             () -> {
-              while (true) {
+              while (!Thread.currentThread().isInterrupted()) {
                 try {
                   TimeUnit.SECONDS.sleep(30);
                   OperationsStatus operationsStatus = operationsStatus();
@@ -530,10 +530,10 @@ public class ShardInstance extends AbstractServerInstance {
       operationQueuer.stop();
     }
     if (dispatchedMonitor != null) {
-      dispatchedMonitor.stop();
+      dispatchedMonitor.interrupt();
     }
     if (prometheusMetricsThread != null) {
-      prometheusMetricsThread.stop();
+      prometheusMetricsThread.interrupt();
     }
     contextDeadlineScheduler.shutdown();
     operationDeletionService.shutdown();


### PR DESCRIPTION
Thread.stop() method is deprecated due to [issues](https://docs.oracle.com/javase/8/docs/technotes/guides/concurrency/threadPrimitiveDeprecation.html). 