### PR TITLE
Document CAS hex_bucket_levels

### DIFF
--- a/examples/shard-worker.config.example
+++ b/examples/shard-worker.config.example
@@ -69,6 +69,10 @@ cas: {
     # whether the file directories bidirectional mapping should be stored in memory (HashMap) or
     # in sqlite
     file_directories_index_in_memory: false
+
+    # setup a folder hierarchy to improve filesystem performance
+    # see https://github.com/bazelbuild/bazel-buildfarm/issues/568#issuecomment-728223668
+    hex_bucket_levels: 2
   }
 
   # whether the transient data on the worker should be loaded into the CAS on worker startup.


### PR DESCRIPTION
And provide a sensible default in the example config file.

Fixes #695.