### PR TITLE
Isolate call to resource decider

### DIFF
--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -867,9 +867,7 @@ class ShardWorkerContext implements WorkerContext {
 
   @Override
   public int commandExecutionClaims(Command command) {
-    ResourceLimits limits =
-        ResourceDecider.decideResourceLimitations(
-            command, onlyMulticoreTests, getExecuteStageWidth());
+    ResourceLimits limits = commandExecutionSettings(command);
     return limits.cpu.claimed;
   }
 


### PR DESCRIPTION
small refactor.  I want to isolate the entry point on how resource constraints are decided.