### PR TITLE
remove unused constructor predicates from backplane

### DIFF
--- a/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
@@ -56,7 +56,6 @@ import build.buildfarm.v1test.QueuedOperationMetadata;
 import build.buildfarm.v1test.RedisShardBackplaneConfig;
 import build.buildfarm.v1test.ShardWorker;
 import build.buildfarm.v1test.WorkerChange;
-import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
@@ -138,8 +137,6 @@ public class RedisShardBackplane implements Backplane {
   private final String source; // used in operation change publication
   private final Function<Operation, Operation> onPublish;
   private final Function<Operation, Operation> onComplete;
-  private final Predicate<Operation> isPrequeued;
-  private final Predicate<Operation> isDispatched;
   private final Supplier<JedisCluster> jedisClusterFactory;
 
   private @Nullable InterruptingRunnable onUnsubscribe = null;
@@ -164,18 +161,9 @@ public class RedisShardBackplane implements Backplane {
       RedisShardBackplaneConfig config,
       String source,
       Function<Operation, Operation> onPublish,
-      Function<Operation, Operation> onComplete,
-      Predicate<Operation> isPrequeued,
-      Predicate<Operation> isDispatched)
+      Function<Operation, Operation> onComplete)
       throws ConfigurationException {
-    this(
-        config,
-        source,
-        onPublish,
-        onComplete,
-        isPrequeued,
-        isDispatched,
-        JedisClusterFactory.create(config));
+    this(config, source, onPublish, onComplete, JedisClusterFactory.create(config));
   }
 
   public RedisShardBackplane(
@@ -183,15 +171,11 @@ public class RedisShardBackplane implements Backplane {
       String source,
       Function<Operation, Operation> onPublish,
       Function<Operation, Operation> onComplete,
-      Predicate<Operation> isPrequeued,
-      Predicate<Operation> isDispatched,
       Supplier<JedisCluster> jedisClusterFactory) {
     this.config = config;
     this.source = source;
     this.onPublish = onPublish;
     this.onComplete = onComplete;
-    this.isPrequeued = isPrequeued;
-    this.isDispatched = isDispatched;
     this.jedisClusterFactory = jedisClusterFactory;
   }
 

--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -22,7 +22,6 @@ import static build.buildfarm.common.Errors.VIOLATION_TYPE_MISSING;
 import static build.buildfarm.instance.shard.Util.SHARD_IS_RETRIABLE;
 import static build.buildfarm.instance.shard.Util.correctMissingBlob;
 import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.base.Predicates.or;
 import static com.google.common.util.concurrent.Futures.addCallback;
 import static com.google.common.util.concurrent.Futures.allAsList;
 import static com.google.common.util.concurrent.Futures.catching;
@@ -245,9 +244,7 @@ public class ShardInstance extends AbstractServerInstance {
             config.getRedisShardBackplaneConfig(),
             identifier,
             ShardInstance::stripOperation,
-            ShardInstance::stripQueuedOperation,
-            /* isPrequeued=*/ ShardInstance::isUnknown,
-            /* isExecuting=*/ or(ShardInstance::isExecuting, ShardInstance::isQueued));
+            ShardInstance::stripQueuedOperation);
     }
   }
 

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -361,9 +361,7 @@ public class Worker extends LoggingMain {
                 config.getRedisShardBackplaneConfig(),
                 identifier,
                 this::stripOperation,
-                this::stripQueuedOperation,
-                (o) -> false,
-                (o) -> false);
+                this::stripQueuedOperation);
         break;
     }
 

--- a/src/test/java/build/buildfarm/instance/shard/RedisShardBackplaneTest.java
+++ b/src/test/java/build/buildfarm/instance/shard/RedisShardBackplaneTest.java
@@ -72,8 +72,6 @@ public class RedisShardBackplaneTest {
             "invalid-protobuf-worker-removed-test",
             (o) -> o,
             (o) -> o,
-            (o) -> false,
-            (o) -> false,
             mockJedisClusterFactory);
     backplane.start("startTime/test:0000");
 
@@ -110,13 +108,7 @@ public class RedisShardBackplaneTest {
     when(mockJedisClusterFactory.get()).thenReturn(jedisCluster);
     backplane =
         new RedisShardBackplane(
-            config,
-            "prequeue-operation-test",
-            (o) -> o,
-            (o) -> o,
-            (o) -> false,
-            (o) -> false,
-            mockJedisClusterFactory);
+            config, "prequeue-operation-test", (o) -> o, (o) -> o, mockJedisClusterFactory);
     backplane.start("startTime/test:0000");
 
     final String opName = "op";
@@ -145,13 +137,7 @@ public class RedisShardBackplaneTest {
     when(mockJedisClusterFactory.get()).thenReturn(jedisCluster);
     backplane =
         new RedisShardBackplane(
-            config,
-            "requeue-operation-test",
-            (o) -> o,
-            (o) -> o,
-            (o) -> false,
-            (o) -> false,
-            mockJedisClusterFactory);
+            config, "requeue-operation-test", (o) -> o, (o) -> o, mockJedisClusterFactory);
     backplane.start("startTime/test:0000");
 
     final String opName = "op";
@@ -173,13 +159,7 @@ public class RedisShardBackplaneTest {
     when(mockJedisClusterFactory.get()).thenReturn(jedisCluster);
     backplane =
         new RedisShardBackplane(
-            config,
-            "requeue-operation-test",
-            (o) -> o,
-            (o) -> o,
-            (o) -> false,
-            (o) -> false,
-            mockJedisClusterFactory);
+            config, "requeue-operation-test", (o) -> o, (o) -> o, mockJedisClusterFactory);
     backplane.start("startTime/test:0000");
 
     final String opName = "op";
@@ -208,13 +188,7 @@ public class RedisShardBackplaneTest {
     when(mockJedisClusterFactory.get()).thenReturn(jedisCluster);
     backplane =
         new RedisShardBackplane(
-            config,
-            "complete-operation-test",
-            (o) -> o,
-            (o) -> o,
-            (o) -> false,
-            (o) -> false,
-            mockJedisClusterFactory);
+            config, "complete-operation-test", (o) -> o, (o) -> o, mockJedisClusterFactory);
     backplane.start("startTime/test:0000");
 
     final String opName = "op";
@@ -238,13 +212,7 @@ public class RedisShardBackplaneTest {
     when(mockJedisClusterFactory.get()).thenReturn(jedisCluster);
     backplane =
         new RedisShardBackplane(
-            config,
-            "delete-operation-test",
-            (o) -> o,
-            (o) -> o,
-            (o) -> false,
-            (o) -> false,
-            mockJedisClusterFactory);
+            config, "delete-operation-test", (o) -> o, (o) -> o, mockJedisClusterFactory);
     backplane.start("startTime/test:0000");
 
     final String opName = "op";
@@ -270,13 +238,7 @@ public class RedisShardBackplaneTest {
     when(mockJedisClusterFactory.get()).thenReturn(jedisCluster);
     backplane =
         new RedisShardBackplane(
-            config,
-            "invocation-blacklist-test",
-            o -> o,
-            o -> o,
-            o -> false,
-            o -> false,
-            mockJedisClusterFactory);
+            config, "invocation-blacklist-test", o -> o, o -> o, mockJedisClusterFactory);
     backplane.start("startTime/test:0000");
 
     final String opName = "op";


### PR DESCRIPTION
this code is not used.  Let's remove it to simplify the backplane.