### PR TITLE
add java_image to utilize tini + docker patch for entry_point

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -68,6 +68,7 @@ java_image(
     main_class = "build.buildfarm.worker.shard.Worker",
     runtime_deps = [
         ":process-wrapper.binary",
+        ":linux-sandbox.binary",
         ":tini.binary",
         "//src/main/java/build/buildfarm/worker/shard",
     ],

--- a/BUILD
+++ b/BUILD
@@ -1,4 +1,5 @@
 load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
+load("@io_bazel_rules_docker//java:image.bzl", "java_image")
 
 buildifier(
     name = "buildifier",
@@ -37,4 +38,36 @@ cc_binary(
         "//config:windows": ["as-nobody-windows.c"],
         "//conditions:default": ["as-nobody.c"],
     }),
+)
+
+
+# Docker images for buildfarm components
+java_image(
+    name = "buildfarm-server",
+    base = "@amazon_corretto_java_image_base//image",
+    classpath_resources = [
+        "@build_buildfarm//src/main/java/build/buildfarm:configs",
+    ],
+    main_class = "build.buildfarm.server.BuildFarmServer",
+    runtime_deps = [
+        "@build_buildfarm//src/main/java/build/buildfarm/server",
+    ],
+)
+
+java_image(
+    name = "buildfarm-shard-worker",
+    base = "@ubuntu-bionic//image",
+    classpath_resources = [
+        "@build_buildfarm//src/main/java/build/buildfarm:configs",
+    ],
+    entrypoint = [
+        "/app/buildfarm/tini",
+        "--",
+    ],
+    main_class = "build.buildfarm.worker.shard.Worker",
+    runtime_deps = [
+        ":process-wrapper.binary",
+        ":tini.binary",
+        "@build_buildfarm//src/main/java/build/buildfarm/worker/shard",
+    ],
 )

--- a/BUILD
+++ b/BUILD
@@ -46,11 +46,11 @@ java_image(
     name = "buildfarm-server",
     base = "@amazon_corretto_java_image_base//image",
     classpath_resources = [
-        "@build_buildfarm//src/main/java/build/buildfarm:configs",
+        "//src/main/java/build/buildfarm:configs",
     ],
     main_class = "build.buildfarm.server.BuildFarmServer",
     runtime_deps = [
-        "@build_buildfarm//src/main/java/build/buildfarm/server",
+        "//src/main/java/build/buildfarm/server",
     ],
 )
 
@@ -58,7 +58,7 @@ java_image(
     name = "buildfarm-shard-worker",
     base = "@ubuntu-bionic//image",
     classpath_resources = [
-        "@build_buildfarm//src/main/java/build/buildfarm:configs",
+        "//src/main/java/build/buildfarm:configs",
     ],
     entrypoint = [
         "/app/buildfarm/tini",
@@ -68,6 +68,6 @@ java_image(
     runtime_deps = [
         ":process-wrapper.binary",
         ":tini.binary",
-        "@build_buildfarm//src/main/java/build/buildfarm/worker/shard",
+        "//src/main/java/build/buildfarm/worker/shard",
     ],
 )

--- a/BUILD
+++ b/BUILD
@@ -52,6 +52,7 @@ java_image(
     runtime_deps = [
         "//src/main/java/build/buildfarm/server",
     ],
+    tags = ["container"],
 )
 
 java_image(
@@ -70,4 +71,5 @@ java_image(
         ":tini.binary",
         "//src/main/java/build/buildfarm/worker/shard",
     ],
+    tags = ["container"],
 )

--- a/BUILD
+++ b/BUILD
@@ -40,7 +40,6 @@ cc_binary(
     }),
 )
 
-
 # Docker images for buildfarm components
 java_image(
     name = "buildfarm-server",
@@ -49,10 +48,10 @@ java_image(
         "//src/main/java/build/buildfarm:configs",
     ],
     main_class = "build.buildfarm.server.BuildFarmServer",
+    tags = ["container"],
     runtime_deps = [
         "//src/main/java/build/buildfarm/server",
     ],
-    tags = ["container"],
 )
 
 java_image(
@@ -66,11 +65,11 @@ java_image(
         "--",
     ],
     main_class = "build.buildfarm.worker.shard.Worker",
+    tags = ["container"],
     runtime_deps = [
-        ":process-wrapper.binary",
         ":linux-sandbox.binary",
+        ":process-wrapper.binary",
         ":tini.binary",
         "//src/main/java/build/buildfarm/worker/shard",
     ],
-    tags = ["container"],
 )

--- a/deps.bzl
+++ b/deps.bzl
@@ -66,6 +66,7 @@ def archive_dependencies(third_party):
         {
             "name": "io_bazel_rules_docker",
             "patch_args": ["-p1"],
+            "patches": ["%s/io_bazel_rules_docker:entrypoint.patch" % third_party],
             "sha256": "d5609b7858246fa11e76237aa9b3e681615bdc8acf2ed29058426cf7c4cea099",
             "strip_prefix": "rules_docker-f4822f3921f0c343dd9e5ae65c760d0fb70be1b3",
             "urls": ["https://github.com/bazelbuild/rules_docker/archive/f4822f3921f0c343dd9e5ae65c760d0fb70be1b3.tar.gz"],

--- a/images.bzl
+++ b/images.bzl
@@ -6,6 +6,8 @@ load("@io_bazel_rules_docker//repositories:deps.bzl", container_deps = "deps")
 load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
 
 def buildfarm_images():
+"""Pull the necessary base containers to be used for image definitions."""
+
     container_deps()
 
     container_pull(

--- a/images.bzl
+++ b/images.bzl
@@ -37,5 +37,5 @@ def buildfarm_images():
         name = "amazon_corretto_java_image_base",
         registry = "index.docker.io",
         repository = "amazoncorretto",
-        tag = "15"
+        tag = "15",
     )

--- a/images.bzl
+++ b/images.bzl
@@ -6,7 +6,9 @@ load("@io_bazel_rules_docker//repositories:deps.bzl", container_deps = "deps")
 load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
 
 def buildfarm_images():
-"""Pull the necessary base containers to be used for image definitions."""
+"""
+Pull the necessary base containers to be used for image definitions.
+"""
 
     container_deps()
 

--- a/images.bzl
+++ b/images.bzl
@@ -6,9 +6,9 @@ load("@io_bazel_rules_docker//repositories:deps.bzl", container_deps = "deps")
 load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
 
 def buildfarm_images():
-"""
-Pull the necessary base containers to be used for image definitions.
-"""
+    """
+    Pull the necessary base containers to be used for image definitions.
+    """
 
     container_deps()
 

--- a/images.bzl
+++ b/images.bzl
@@ -21,3 +21,17 @@ def buildfarm_images():
         registry = "gcr.io",
         repository = "distroless/java",
     )
+
+    container_pull(
+        name = "ubuntu-bionic",
+        registry = "index.docker.io",
+        repository = "bazelbuild/buildfarm-worker-base",
+        tag = "bionic-java11-gcc",
+    )
+
+    container_pull(
+        name = "amazon_corretto_java_image_base",
+        registry = "index.docker.io",
+        repository = "amazoncorretto",
+        tag = "15"
+    )

--- a/third_party/io_bazel_rules_docker/entrypoint.patch
+++ b/third_party/io_bazel_rules_docker/entrypoint.patch
@@ -1,0 +1,29 @@
+diff --git a/java/image.bzl b/java/image.bzl
+index 1203c94..6c16680 100644
+--- a/java/image.bzl
++++ b/java/image.bzl
+@@ -190,7 +190,7 @@ def _jar_app_layer_impl(ctx):
+     args = [ctx.expand_location(arg, ctx.attr.data) for arg in ctx.attr.args]
+     jvm_flags = [ctx.expand_location(flag, ctx.attr.data) for flag in ctx.attr.jvm_flags]
+ 
+-    entrypoint = [
++    entrypoint = ctx.attr.entrypoint + [
+         "/usr/bin/java",
+         "-cp",
+         # Support optionally passing the classpath as a file.
+@@ -254,6 +254,7 @@ def java_image(
+         name,
+         base = None,
+         main_class = None,
++        entrypoint = [],
+         deps = [],
+         runtime_deps = [],
+         layers = [],
+@@ -305,6 +306,7 @@ def java_image(
+         name = name,
+         base = base,
+         binary = binary_name,
++        entrypoint = entrypoint,
+         main_class = main_class,
+         jvm_flags = jvm_flags,
+         deps = deps,


### PR DESCRIPTION
These java images were added in response to https://github.com/bazelbuild/bazel-buildfarm/issues/552.  
The linux sandbox is provided to the worker image so it may be used as an execution wrapper.