### PR TITLE
Suppress errors for unused return value of proto `.build()`

### DIFF
--- a/src/test/java/build/buildfarm/examples/ExampleConfigsTest.java
+++ b/src/test/java/build/buildfarm/examples/ExampleConfigsTest.java
@@ -31,6 +31,7 @@ import org.junit.runners.JUnit4;
 
 // Test that example config files can load properly
 @RunWith(JUnit4.class)
+@SuppressWarnings({"ProtoBuilderReturnValueIgnored", "ReturnValueIgnored"})
 public class ExampleConfigsTest {
 
   @Before


### PR DESCRIPTION
Fixes

```
src/test/java/build/buildfarm/examples/ExampleConfigsTest.java:51: error: [ProtoBuilderReturnValueIgnored] Unnecessary call to proto's #build() method.  If you don't consume the return value of #build(), the result is discarded and the only effect is to verify that all required fields are set, which can be expressed more directly with #isInitialized().
      builder.build();
                   ^
    (see https://errorprone.info/bugpattern/ProtoBuilderReturnValueIgnored)
  Did you mean to remove this line or 'checkState(builder.isInitialized());'?
src/test/java/build/buildfarm/examples/ExampleConfigsTest.java:51: error: [ReturnValueIgnored] Return value of this method must be used
      builder.build();
                   ^
    (see https://errorprone.info/bugpattern/ReturnValueIgnored)
  Did you mean to remove this line?
```