### PR TITLE
Suppress errors for unused return value of proto `.build()`

### DIFF
--- a/src/main/java/build/buildfarm/instance/memory/MemoryInstance.java
+++ b/src/main/java/build/buildfarm/instance/memory/MemoryInstance.java
@@ -496,6 +496,7 @@ public class MemoryInstance extends AbstractServerInstance {
     return null;
   }
 
+  @SuppressWarnings({"ProtoBuilderReturnValueIgnored", "ReturnValueIgnored"})
   private Action getActionForTimeoutMonitor(
       Operation operation, com.google.rpc.Status.Builder status) throws InterruptedException {
     Digest actionDigest = expectActionDigest(operation);


### PR DESCRIPTION
Fixes:
```
src/main/java/build/buildfarm/instance/memory/MemoryInstance.java:529: error: [ProtoBuilderReturnValueIgnored] Unnecessary call to proto's #build() method.  If you don't consume the return value of #build(), the result is discarded and the only effect is to verify that all required fields are set, which can be expressed more directly with #isInitialized().
          .build();
                ^
    (see https://errorprone.info/bugpattern/ProtoBuilderReturnValueIgnored)
  Did you mean '.addDetails(Any.pack(preconditionFailure));' or 'checkState(status'?
src/main/java/build/buildfarm/instance/memory/MemoryInstance.java:529: error: [ReturnValueIgnored] Return value of this method must be used
          .build();
                ^
    (see https://errorprone.info/bugpattern/ReturnValueIgnored)
  Did you mean to remove this line?
src/main/java/build/buildfarm/instance/memory/MemoryInstance.java:552: error: [ProtoBuilderReturnValueIgnored] Unnecessary call to proto's #build() method.  If you don't consume the return value of #build(), the result is discarded and the only effect is to verify that all required fields are set, which can be expressed more directly with #isInitialized().
          .build();
                ^
    (see https://errorprone.info/bugpattern/ProtoBuilderReturnValueIgnored)
  Did you mean '.addDetails(Any.pack(preconditionFailure));' or 'checkState(status'?
src/main/java/build/buildfarm/instance/memory/MemoryInstance.java:552: error: [ReturnValueIgnored] Return value of this method must be used
          .build();
                ^
```

This was discovered in downstream test https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/1996#c74f40ce-78a3-49a2-9b83-dc11fbf70dbd.
I compiled by hand to verify this is the last place where this error is reported.