### PR TITLE
Fix access denied problem on windows during destroyExecDir

### DIFF
--- a/src/main/java/build/buildfarm/instance/stub/ByteStreamUploader.java
+++ b/src/main/java/build/buildfarm/instance/stub/ByteStreamUploader.java
@@ -397,11 +397,11 @@ public class ByteStreamUploader {
                 // If upload was completed by someone else or already present, then chunker does
                 // does not close the Filehandle. Do it here to be sure it's always closed.
                 chunker.reset();
-              } catch (IOException e1) {
+              } catch (IOException e) {
                 // This exception indicates that closing the underlying input stream failed.
                 // We don't expect this to ever happen, but don't want to swallow the exception
                 // completely.
-                logger.log(Level.WARNING, format("Chunker failed closing data source: %s", e1));
+                logger.log(Level.WARNING, "Chunker failed closing data source", e);
               }
 
               if (status.isOk() || Code.ALREADY_EXISTS.equals(status.getCode())) {

--- a/src/main/java/build/buildfarm/instance/stub/Chunker.java
+++ b/src/main/java/build/buildfarm/instance/stub/Chunker.java
@@ -175,6 +175,7 @@ public final class Chunker {
     maybeInitialize();
 
     if (size == 0) {
+      data.close();
       data = null;
       return emptyChunk;
     }
@@ -183,6 +184,7 @@ public final class Chunker {
     int bytesToRead = (int) Math.min(bytesLeft(), chunkSize);
     if (bytesToRead == 0) {
       chunkCache = null;
+      data.close();
       data = null;
       throw new NoSuchElementException();
     }

--- a/src/main/java/build/buildfarm/instance/stub/Chunker.java
+++ b/src/main/java/build/buildfarm/instance/stub/Chunker.java
@@ -175,17 +175,14 @@ public final class Chunker {
     maybeInitialize();
 
     if (size == 0) {
-      data.close();
-      data = null;
+      reset();
       return emptyChunk;
     }
 
     // The cast to int is safe, because the return value is capped at chunkSize.
     int bytesToRead = (int) Math.min(bytesLeft(), chunkSize);
     if (bytesToRead == 0) {
-      chunkCache = null;
-      data.close();
-      data = null;
+      reset();
       throw new NoSuchElementException();
     }
 


### PR DESCRIPTION
Close the open filedescriptor after upload finished due to zero size, or it's already present in cache.
This is a must on windows, otherwise destroyExecdir will fail(access denied).