### PR TITLE
 add "linux-sandbox" exec_property

### DIFF
--- a/src/main/java/build/buildfarm/common/ExecutionProperties.java
+++ b/src/main/java/build/buildfarm/common/ExecutionProperties.java
@@ -98,4 +98,14 @@ public class ExecutionProperties {
    *     they want to run in.
    */
   public static final String CHOOSE_QUEUE = "choose-queue";
+
+  /**
+   * @field LINUX_SANDBOX
+   * @brief The exec_property to inform the executor to use bazel's linux sandbox for actions.
+   * @details In order to compare builds with and without the linux sandbox its helpful to have this
+   *     property available. For example it could be set true as a global bazelrc option and this
+   *     makes it easier to dynamically try different execution models without redeploying buildfarm
+   *     with say different execution policies.
+   */
+  public static final String LINUX_SANDBOX = "linux-sandbox";
 }

--- a/src/main/java/build/buildfarm/worker/resources/ResourceDecider.java
+++ b/src/main/java/build/buildfarm/worker/resources/ResourceDecider.java
@@ -80,6 +80,12 @@ public class ResourceDecider {
    * @param property The property to store.
    */
   private static void evaluateProperty(ResourceLimits limits, Property property) {
+
+    // handle execution wrapper properties
+    if (property.getName().equals(ExecutionProperties.LINUX_SANDBOX)) {
+      storeLinuxSandbox(limits, property);
+    }
+
     // handle cpu properties
     if (property.getName().equals(ExecutionProperties.MIN_CORES)) {
       storeMinCores(limits, property);
@@ -107,6 +113,16 @@ public class ResourceDecider {
     } else if (property.getName().equals(ExecutionProperties.DEBUG_AFTER_EXECUTION)) {
       storeAfterExecutionDebug(limits, property);
     }
+  }
+
+  /**
+   * @brief Store the property for using bazel's linux sandbox.
+   * @details Parses and stores a boolean.
+   * @param limits Current limits to apply changes to.
+   * @param property The property to store.
+   */
+  private static void storeLinuxSandbox(ResourceLimits limits, Property property) {
+    limits.useLinuxSandbox = Boolean.parseBoolean(property.getValue());
   }
 
   /**

--- a/src/main/java/build/buildfarm/worker/resources/ResourceLimits.java
+++ b/src/main/java/build/buildfarm/worker/resources/ResourceLimits.java
@@ -30,6 +30,14 @@ import java.util.Map;
 public class ResourceLimits {
 
   /**
+   * @field useLinuxSandbox
+   * @brief Whether to use bazel's linux sandbox as an execution wrapper.
+   * @details Other resource limits will be translated into the appropriate CLI arguments for the
+   *     sandbox.
+   */
+  public boolean useLinuxSandbox = false;
+
+  /**
    * @field cpu
    * @brief Resource limitations on CPUs.
    * @details Decides specific CPU limitations and whether to apply them for a given action.


### PR DESCRIPTION
In order to support using bazel's linux-sandbox during action execution we add the necessary `exec_property`.  This way we can turn it on/off from the client side and see the differences while on the same buildfarm deployment.