### PR TITLE
remove slow metric calculations

### DIFF
--- a/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
@@ -1425,14 +1425,11 @@ public class RedisShardBackplane implements Backplane {
 
   @Override
   public BackplaneStatus backplaneStatus() throws IOException {
-    int casLookupSize = casWorkerMap.size(client);
     return client.call(
         jedis ->
             BackplaneStatus.newBuilder()
                 .setPrequeue(prequeue.status(jedis))
                 .setOperationQueue(operationQueue.status(jedis))
-                .setCasLookupSize(casLookupSize)
-                .setActionCacheSize(actionCache.size(jedis))
                 .setBlockedActionsSize(blockedActions.size(jedis))
                 .setBlockedInvocationsSize(blockedInvocations.size(jedis))
                 .setDispatchedSize(jedis.hlen(config.getDispatchedOperationsHashName()))


### PR DESCRIPTION
Skip calculating action cache size and cas worker map size.