### PR TITLE
 fix bug when 'global limit execution' is used but cores are not limited

### DIFF
--- a/src/main/java/build/buildfarm/worker/resources/ResourceDecider.java
+++ b/src/main/java/build/buildfarm/worker/resources/ResourceDecider.java
@@ -37,12 +37,16 @@ public class ResourceDecider {
    *     global buildfarm configuration.
    * @param command The command to decide resource limitations for.
    * @param onlyMulticoreTests Only allow tests to be multicore.
+   * @param limitGlobalExecution Whether cpu limiting should be explicitly performed.
    * @param executeStageWidth The maximum amount of cores available for the operation.
    * @return Default resource limits.
    * @note Suggested return identifier: resourceLimits.
    */
   public static ResourceLimits decideResourceLimitations(
-      Command command, boolean onlyMulticoreTests, int executeStageWidth) {
+      Command command,
+      boolean onlyMulticoreTests,
+      boolean limitGlobalExecution,
+      int executeStageWidth) {
     ResourceLimits limits = new ResourceLimits();
 
     command
@@ -76,7 +80,7 @@ public class ResourceDecider {
     // Should we limit the cores of the action during execution? by default, no.
     // If the action has suggested core restrictions on itself, then yes.
     // Claim minimal core amount with regards to execute stage width.
-    limits.cpu.limit = (limits.cpu.min > 0 || limits.cpu.max > 0);
+    limits.cpu.limit = (limits.cpu.min > 0 || limits.cpu.max > 0) || limitGlobalExecution;
     limits.cpu.claimed = Math.min(limits.cpu.min, executeStageWidth);
 
     // Should we limit the memory of the action during execution? by default, no.

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -879,7 +879,7 @@ class ShardWorkerContext implements WorkerContext {
   public ResourceLimits commandExecutionSettings(Command command) {
     ResourceLimits limits =
         ResourceDecider.decideResourceLimitations(
-            command, onlyMulticoreTests, getExecuteStageWidth());
+            command, onlyMulticoreTests, limitGlobalExecution, getExecuteStageWidth());
     return limits;
   }
 
@@ -889,7 +889,7 @@ class ShardWorkerContext implements WorkerContext {
     if (limitExecution) {
       ResourceLimits limits =
           ResourceDecider.decideResourceLimitations(
-              command, onlyMulticoreTests, getExecuteStageWidth());
+              command, onlyMulticoreTests, limitGlobalExecution, getExecuteStageWidth());
 
       return limitSpecifiedExecution(limits, operationName, arguments);
     }
@@ -954,7 +954,7 @@ class ShardWorkerContext implements WorkerContext {
     }
 
     // Decide the CLI for running under cgroups
-    if (limitGlobalExecution || !usedGroups.isEmpty()) {
+    if (!usedGroups.isEmpty()) {
       arguments.add(
           "/usr/bin/cgexec", "-g", String.join(",", usedGroups) + ":" + group.getHierarchy());
     }

--- a/src/test/java/build/buildfarm/worker/resources/ResourceDeciderTest.java
+++ b/src/test/java/build/buildfarm/worker/resources/ResourceDeciderTest.java
@@ -106,6 +106,54 @@ public class ResourceDeciderTest {
   }
 
   // Function under test: decideResourceLimitations
+  // Reason for testing: test that we limit cpu is globalLimitExecution is given.
+  // Failure explanation: expected limit flag set.
+  @Test
+  public void decideResourceLimitationsEnsureLimitGlobalSet() throws Exception {
+
+    // ARRANGE
+    Command command =
+        Command.newBuilder()
+            .setPlatform(
+                Platform.newBuilder()
+                    .addProperties(
+                        Platform.Property.newBuilder().setName("min-cores").setValue("0"))
+                    .addProperties(
+                        Platform.Property.newBuilder().setName("max-cores").setValue("0")))
+            .build();
+
+    // ACT
+    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, false, true, 100);
+
+    // ASSERT
+    assertThat(limits.cpu.limit).isTrue();
+  }
+
+  // Function under test: decideResourceLimitations
+  // Reason for testing: test that we do not limit cpu is globalLimitExecution is false.
+  // Failure explanation: Did not expect limit flag set.
+  @Test
+  public void decideResourceLimitationsEnsureNoLimitNoGlobalSet() throws Exception {
+
+    // ARRANGE
+    Command command =
+        Command.newBuilder()
+            .setPlatform(
+                Platform.newBuilder()
+                    .addProperties(
+                        Platform.Property.newBuilder().setName("min-cores").setValue("0"))
+                    .addProperties(
+                        Platform.Property.newBuilder().setName("max-cores").setValue("0")))
+            .build();
+
+    // ACT
+    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, false, false, 100);
+
+    // ASSERT
+    assertThat(limits.cpu.limit).isFalse();
+  }
+
+  // Function under test: decideResourceLimitations
   // Reason for testing: test that claims are set to the specified minimum
   // Failure explanation: claims were not the same as minimum
   @Test

--- a/src/test/java/build/buildfarm/worker/resources/ResourceDeciderTest.java
+++ b/src/test/java/build/buildfarm/worker/resources/ResourceDeciderTest.java
@@ -49,7 +49,7 @@ public class ResourceDeciderTest {
             .build();
 
     // ACT
-    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, false, 100);
+    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, false, false, 100);
 
     // ASSERT
     assertThat(limits.cpu.min).isEqualTo(7);
@@ -74,7 +74,7 @@ public class ResourceDeciderTest {
             .build();
 
     // ACT
-    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, true, 100);
+    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, true, false, 100);
 
     // ASSERT
     assertThat(limits.cpu.min).isEqualTo(1);
@@ -99,7 +99,7 @@ public class ResourceDeciderTest {
             .build();
 
     // ACT
-    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, false, 100);
+    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, false, false, 100);
 
     // ASSERT
     assertThat(limits.cpu.claimed).isEqualTo(0);
@@ -123,7 +123,7 @@ public class ResourceDeciderTest {
             .build();
 
     // ACT
-    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, false, 100);
+    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, false, false, 100);
 
     // ASSERT
     assertThat(limits.cpu.claimed).isEqualTo(3);
@@ -146,7 +146,7 @@ public class ResourceDeciderTest {
             .build();
 
     // ACT
-    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, false, 100);
+    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, false, false, 100);
 
     // ASSERT
     assertThat(limits.mem.min).isEqualTo(5);
@@ -164,7 +164,7 @@ public class ResourceDeciderTest {
     Command command = Command.newBuilder().build();
 
     // ACT
-    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, true, 100);
+    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, true, false, 100);
 
     // ASSERT
     assertThat(limits.extraEnvironmentVariables.isEmpty()).isTrue();
@@ -186,7 +186,7 @@ public class ResourceDeciderTest {
             .build();
 
     // ACT
-    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, true, 100);
+    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, true, false, 100);
 
     // ASSERT
     assertThat(limits.extraEnvironmentVariables.isEmpty()).isTrue();
@@ -211,7 +211,7 @@ public class ResourceDeciderTest {
             .build();
 
     // ACT
-    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, true, 100);
+    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, true, false, 100);
 
     // ASSERT
     assertThat(limits.extraEnvironmentVariables.size()).isEqualTo(1);
@@ -238,7 +238,7 @@ public class ResourceDeciderTest {
             .build();
 
     // ACT
-    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, true, 100);
+    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, true, false, 100);
 
     // ASSERT
     assertThat(limits.extraEnvironmentVariables.size()).isEqualTo(2);
@@ -267,7 +267,7 @@ public class ResourceDeciderTest {
             .build();
 
     // ACT
-    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, true, 100);
+    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, true, false, 100);
 
     // ASSERT
     assertThat(limits.extraEnvironmentVariables.size()).isEqualTo(0);
@@ -296,7 +296,7 @@ public class ResourceDeciderTest {
             .build();
 
     // ACT
-    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, false, 100);
+    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, false, false, 100);
 
     // ASSERT
     assertThat(limits.extraEnvironmentVariables.size()).isEqualTo(2);
@@ -323,7 +323,7 @@ public class ResourceDeciderTest {
             .build();
 
     // ACT
-    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, true, 100);
+    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, true, false, 100);
 
     // ASSERT
     assertThat(limits.extraEnvironmentVariables.size()).isEqualTo(1);
@@ -351,7 +351,7 @@ public class ResourceDeciderTest {
             .build();
 
     // ACT
-    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, true, 100);
+    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, true, false, 100);
 
     // ASSERT
     assertThat(limits.extraEnvironmentVariables.size()).isEqualTo(2);
@@ -379,7 +379,7 @@ public class ResourceDeciderTest {
             .build();
 
     // ACT
-    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, true, 100);
+    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, true, false, 100);
 
     // ASSERT
     assertThat(limits.extraEnvironmentVariables.size()).isEqualTo(1);
@@ -408,7 +408,7 @@ public class ResourceDeciderTest {
             .build();
 
     // ACT
-    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, true, 100);
+    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, true, false, 100);
 
     // ASSERT
     assertThat(limits.debugBeforeExecution).isTrue();
@@ -435,7 +435,7 @@ public class ResourceDeciderTest {
             .build();
 
     // ACT
-    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, true, 100);
+    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, true, false, 100);
 
     // ASSERT
     assertThat(limits.debugAfterExecution).isTrue();
@@ -462,7 +462,7 @@ public class ResourceDeciderTest {
             .build();
 
     // ACT
-    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, true, 100);
+    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, true, false, 100);
 
     // ASSERT
     assertThat(limits.debugBeforeExecution).isFalse();


### PR DESCRIPTION
### summary:

If a buildfarm worker is configured with `limit_global_execution: true`, but the action does not provide a core amount, the executor constructs an invalid `cgexec` command. We provide the limit_global flag to the `ResourceDecider` so it can properly emit the need to create a cpu cgroup.  What follows is a demonstration of the problem.  The diff fixes the behavior and adds unit tests.

### example:

```
./user_test --test_output=streamed --remote_default_exec_properties='debug-before-execution=true'  --remote_executor=grpc://127.0.0.1:8980 --noremote_accept_cached  --nocache_test_results //code/programs/example_tests/bash_env_test:main
{
  "description": "Buildfarm debug information before execution",
  "command": "/usr/bin/cgexec -g :executions/operations/47afd08e-1c88-4672-835a-50057871f348 external/bazel_tools/tools/test/test-setup.sh code/programs/example_tests/bash_env_test/main",
  "workingDirectory": "/tmp/worker2/shard/operations/47afd08e-1c88-4672-835a-50057871f348",
  "limits": {
    "useLinuxSandbox": false,
    "cpu": {
      "limit": false,
      "min": 0,
      "max": 0,
      "claimed": 0
    },
    "mem": {
      "limit": false,
      "min": 0,
      "max": 0,
      "claimed": 0
    },
    "network": {
      "blockNetwork": false
    },
    "extraEnvironmentVariables": {},
    "debugBeforeExecution": true,
    "debugAfterExecution": false,
    "debugTestsOnly": true
  }
}
```

Note the missing group: `"/usr/bin/cgexec -g <MISSING>:executions/`.  

However, if we were to provide a core limit (since we are configured to limit globally), the command would be constructed correctly: 
```
./user_test --test_output=streamed --remote_default_exec_properties='debug-before-execution=true' --remote_default_exec_properties='min-cores=1' --remote_executor=grpc://127.0.0.1:8980 --noremote_accept_cached  --nocache_test_results //code/programs/example_tests/bash_env_test:main
INFO: Invocation ID: 28820c15-2d08-4a93-917d-cb5500591b06
WARNING: Streamed test output requested. All tests will be run locally, without sharding, one at a time
INFO: Analyzed target //code/programs/example_tests/bash_env_test:main (0 packages loaded, 0 targets configured).
INFO: Found 1 test target...
{
  "description": "Buildfarm debug information before execution",
  "command": "/usr/bin/cgexec -g cpu:executions/operations/e2873403-72ca-43e9-9a0a-007a2a36aacb external/bazel_tools/tools/test/test-setup.sh code/programs/example_tests/bash_env_test/main",
  "workingDirectory": "/tmp/worker/shard/operations/e2873403-72ca-43e9-9a0a-007a2a36aacb",
  "limits": {
    "useLinuxSandbox": false,
    "cpu": {
      "limit": true,
      "min": 1,
      "max": 0,
      "claimed": 1
    },
    "mem": {
      "limit": false,
      "min": 0,
      "max": 0,
      "claimed": 0
    },
    "network": {
      "blockNetwork": false
    },
    "extraEnvironmentVariables": {},
    "debugBeforeExecution": true,
    "debugAfterExecution": false,
    "debugTestsOnly": true
  }
}
```

Note the added group: `"/usr/bin/cgexec -g cpu:executions/`.  thanks to using `--remote_default_exec_properties='min-cores=1'`

### solution:
The construction of an invalid cgexec command is a mistake, and we should preserve the old behavior in which a cpu group is provided regardless of cores given.  This diff restores that behavior.