### PR TITLE
Make directories writable before rename

### DIFF
--- a/src/main/java/build/buildfarm/common/io/Directories.java
+++ b/src/main/java/build/buildfarm/common/io/Directories.java
@@ -89,6 +89,8 @@ public class Directories {
     String tmpFilename = filename + ".tmp." + suffix;
     Path tmpPath = path.resolveSibling(tmpFilename);
     try {
+      // MacOS does not permit renames unless the directory is permissioned appropriately
+      makeWritable(path, true);
       // rename must be synchronous to call
       Files.move(path, tmpPath);
     } catch (IOException e) {


### PR DESCRIPTION
MacOS appears to deny renames for directories which are not themselves
writable. Ensure that the toplevel directory being renamed is reset to
writable ahead of a remove.