### PR TITLE
call sandbox under cgroups instead of cgroups under sandbox

### DIFF
--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -927,6 +927,12 @@ class ShardWorkerContext implements WorkerContext {
       usedGroups.add(group.getMem().getName());
     }
 
+    // Decide the CLI for running under cgroups
+    if (!usedGroups.isEmpty()) {
+      arguments.add(
+          "/usr/bin/cgexec", "-g", String.join(",", usedGroups) + ":" + group.getHierarchy());
+    }
+
     // Possibly set network restrictions.
     // This is not the ideal implementation of block-network.
     // For now, without the linux-sandbox, we will unshare the network namespace.
@@ -951,12 +957,6 @@ class ShardWorkerContext implements WorkerContext {
         arguments.add("-N");
       }
       arguments.add("--");
-    }
-
-    // Decide the CLI for running under cgroups
-    if (!usedGroups.isEmpty()) {
-      arguments.add(
-          "/usr/bin/cgexec", "-g", String.join(",", usedGroups) + ":" + group.getHierarchy());
     }
 
     // The executor expects a single IOResource.


### PR DESCRIPTION
I'm seeing cgroup errors when trying to build targets under the sandbox.  The sandbox is likely blocking file access to cgroup files.  Let's flip the order and run the sandbox under `cgexec`.  This makes more sense, as that's how the process-wrapper and as-nobody is being used.