### PR TITLE
Avoid referencing likely null out on reset

### DIFF
--- a/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
+++ b/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
@@ -797,11 +797,8 @@ public abstract class CASFileCache implements ContentAddressableStorage {
           @Override
           public synchronized void reset() {
             try {
-              Path path = out.getPath();
               if (out != null) {
                 out.cancel();
-              } else if (path != null && Files.exists(path)) {
-                Files.delete(path);
               }
             } catch (IOException e) {
               logger.log(


### PR DESCRIPTION
The cancel is expected to handle deletes, and out is never reassigned to
non-null ownership after it has been opened for a file.