### PR TITLE
skip execution policies when sandbox is chosen

### DIFF
--- a/src/main/java/build/buildfarm/common/ExecutionProperties.java
+++ b/src/main/java/build/buildfarm/common/ExecutionProperties.java
@@ -131,4 +131,26 @@ public class ExecutionProperties {
    *     with say different execution policies.
    */
   public static final String LINUX_SANDBOX = "linux-sandbox";
+
+  /**
+   * @field AS_NOBODY
+   * @brief The exec_property to inform the executor to run the action as a 'nobody' user.
+   * @details The "as nobody" functionality is supported by the bazel sandbox. This execution
+   *     property may be fulfilled through the sandbox or a standalone program. This execution
+   *     wrapper was previously used as a configured execution policy, but due to its involvement
+   *     with the sandbox, we find it better to make its usage explicit in buildfarm and easier to
+   *     test dynamically.
+   */
+  public static final String AS_NOBODY = "as-nobody";
+
+  /**
+   * @field PROCESS_WRAPPER
+   * @brief The exec_property to inform the executor to run the action with the process-wrapper.
+   * @details The "as nobody" functionality is supported by the bazel sandbox. This execution
+   *     property may be fulfilled through the sandbox or a standalone program. This execution
+   *     wrapper was previously used as a configured execution policy, but due to its involvement
+   *     with the sandbox, we find it better to make its usage explicit in buildfarm and easier to
+   *     test dynamically.
+   */
+  public static final String PROCESS_WRAPPER = "process-wrapper";
 }

--- a/src/main/java/build/buildfarm/common/ExecutionWrappers.java
+++ b/src/main/java/build/buildfarm/common/ExecutionWrappers.java
@@ -1,0 +1,61 @@
+// Copyright 2021 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.common;
+
+/**
+ * @class Execution Wrappers
+ * @brief Execution wrappers understood and used by buildfarm.
+ * @details These are the program names chosen when indicated through execution properties which
+ *     wrappers to use. Users can still configure their own unique execution wrappers as execution
+ *     policies in the worker configuration file.
+ */
+public class ExecutionWrappers {
+
+  /**
+   * @field CGROUPS
+   * @brief The program to use when running actions under cgroups.
+   * @details This program is expected to be packaged with the worker image.
+   */
+  public static final String CGROUPS = "/usr/bin/cgexec";
+
+  /**
+   * @field UNSHARE
+   * @brief The program to use when desiring to unshare namespaces from the action.
+   * @details This program is expected to be packaged with the worker image.
+   */
+  public static final String UNSHARE = "/usr/bin/unshare";
+
+  /**
+   * @field LINUX_SANDBOX
+   * @brief The program to use when running actions under bazel's sandbox.
+   * @details This program is expected to be packaged with the worker image.
+   */
+  public static final String LINUX_SANDBOX = "/app/buildfarm/linux-sandbox";
+
+  /**
+   * @field AS_NOBODY
+   * @brief The program to use when running actions as "as-nobody".
+   * @details This program is expected to be packaged with the worker image. The linux-sandbox is
+   *     also capable of doing what this standalone programs does and may be chosen instead.
+   */
+  public static final String AS_NOBODY = "/app/buildfarm/as-nobody";
+
+  /**
+   * @field PROCESS_WRAPPER
+   * @brief The program to use when running actions under bazel's process-wrapper
+   * @details This program is expected to be packaged with the worker image.
+   */
+  public static final String PROCESS_WRAPPER = "/app/buildfarm/process-wrapper";
+}

--- a/src/main/java/build/buildfarm/worker/Executor.java
+++ b/src/main/java/build/buildfarm/worker/Executor.java
@@ -45,6 +45,7 @@ import com.google.rpc.Code;
 import io.grpc.Deadline;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -93,9 +94,12 @@ class Executor {
     ExecuteOperationMetadata executingMetadata =
         metadata.toBuilder().setStage(ExecutionStage.Value.EXECUTING).build();
 
-    Iterable<ExecutionPolicy> policies =
-        ExecutionPolicies.forPlatform(
-            operationContext.command.getPlatform(), workerContext::getExecutionPolicies);
+    Iterable<ExecutionPolicy> policies = new ArrayList<ExecutionPolicy>();
+    if (limits.useExecutionPolicies) {
+      policies =
+          ExecutionPolicies.forPlatform(
+              operationContext.command.getPlatform(), workerContext::getExecutionPolicies);
+    }
 
     Operation operation =
         operationContext

--- a/src/main/java/build/buildfarm/worker/resources/ResourceDecider.java
+++ b/src/main/java/build/buildfarm/worker/resources/ResourceDecider.java
@@ -94,6 +94,15 @@ public class ResourceDecider {
     limits.mem.limit = (limits.mem.min > 0 || limits.mem.max > 0);
     limits.mem.claimed = limits.mem.min;
 
+    // Avoid using the existing execution policies when using the linux sandbox.
+    // Using these execution policies under the sandbox do not have the right permissions to work.
+    // For the time being, we want to experiment with dynamically choosing the sandbox-
+    // without affecting current configurations or relying on specific deployments.
+    // This will dynamically skip using the worker configured execution policies.
+    if (limits.useLinuxSandbox) {
+      limits.useExecutionPolicies = false;
+    }
+
     // we choose to resolve variables after the other variable values have been decided
     resolveEnvironmentVariables(limits);
 

--- a/src/main/java/build/buildfarm/worker/resources/ResourceDecider.java
+++ b/src/main/java/build/buildfarm/worker/resources/ResourceDecider.java
@@ -143,6 +143,10 @@ public class ResourceDecider {
       storeBlockNetwork(limits, property);
     }
 
+    if (property.getName().equals(ExecutionProperties.AS_NOBODY)) {
+      storeAsNobody(limits, property);
+    }
+
     // handle env properties
     else if (property.getName().equals(ExecutionProperties.ENV_VARS)) {
       storeEnvVars(limits, property);
@@ -230,6 +234,16 @@ public class ResourceDecider {
    */
   private static void storeBlockNetwork(ResourceLimits limits, Property property) {
     limits.network.blockNetwork = Boolean.parseBoolean(property.getValue());
+  }
+
+  /**
+   * @brief Store the property for faking username.
+   * @details Parses and stores a boolean.
+   * @param limits Current limits to apply changes to.
+   * @param property The property to store.
+   */
+  private static void storeAsNobody(ResourceLimits limits, Property property) {
+    limits.fakeUsername = Boolean.parseBoolean(property.getValue());
   }
 
   /**

--- a/src/main/java/build/buildfarm/worker/resources/ResourceDecider.java
+++ b/src/main/java/build/buildfarm/worker/resources/ResourceDecider.java
@@ -143,6 +143,7 @@ public class ResourceDecider {
       storeBlockNetwork(limits, property);
     }
 
+    // handle user properties
     if (property.getName().equals(ExecutionProperties.AS_NOBODY)) {
       storeAsNobody(limits, property);
     }

--- a/src/main/java/build/buildfarm/worker/resources/ResourceLimits.java
+++ b/src/main/java/build/buildfarm/worker/resources/ResourceLimits.java
@@ -38,6 +38,14 @@ public class ResourceLimits {
   public boolean useLinuxSandbox = false;
 
   /**
+   * @field useExecutionPolicies
+   * @brief Whether to use the worker's configured execution policies.
+   * @details Choosing a first-class execution wrapper, like the linux-sandbox, may decide to then
+   *     ignore the existing execution policies.
+   */
+  public boolean useExecutionPolicies = true;
+
+  /**
    * @field cpu
    * @brief Resource limitations on CPUs.
    * @details Decides specific CPU limitations and whether to apply them for a given action.

--- a/src/main/java/build/buildfarm/worker/resources/ResourceLimits.java
+++ b/src/main/java/build/buildfarm/worker/resources/ResourceLimits.java
@@ -46,6 +46,14 @@ public class ResourceLimits {
   public boolean useExecutionPolicies = true;
 
   /**
+   * @field fakeUsername
+   * @brief Whether the executor should fake the username of the action process.
+   * @details This can be faked by using the "as-nobody" wrapper or fakeUsername in the
+   *     linux-sandbox.
+   */
+  public boolean fakeUsername = false;
+
+  /**
    * @field cpu
    * @brief Resource limitations on CPUs.
    * @details Decides specific CPU limitations and whether to apply them for a given action.

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -37,6 +37,7 @@ import build.buildfarm.backplane.Backplane;
 import build.buildfarm.common.DigestUtil;
 import build.buildfarm.common.DigestUtil.ActionKey;
 import build.buildfarm.common.EntryLimitException;
+import build.buildfarm.common.ExecutionWrappers;
 import build.buildfarm.common.InputStreamFactory;
 import build.buildfarm.common.LinuxSandboxOptions;
 import build.buildfarm.common.Poller;
@@ -930,14 +931,16 @@ class ShardWorkerContext implements WorkerContext {
     // Decide the CLI for running under cgroups
     if (!usedGroups.isEmpty()) {
       arguments.add(
-          "/usr/bin/cgexec", "-g", String.join(",", usedGroups) + ":" + group.getHierarchy());
+          ExecutionWrappers.CGROUPS,
+          "-g",
+          String.join(",", usedGroups) + ":" + group.getHierarchy());
     }
 
     // Possibly set network restrictions.
     // This is not the ideal implementation of block-network.
     // For now, without the linux-sandbox, we will unshare the network namespace.
     if (limits.network.blockNetwork && !limits.useLinuxSandbox) {
-      arguments.add("/usr/bin/unshare", "-n", "-r");
+      arguments.add(ExecutionWrappers.UNSHARE, "-n", "-r");
     }
 
     // Decide the CLI for running the sandbox
@@ -946,7 +949,7 @@ class ShardWorkerContext implements WorkerContext {
     if (limits.useLinuxSandbox) {
 
       // Choose the sandbox which is built and deployed with the worker image.
-      arguments.add("/app/buildfarm/linux-sandbox");
+      arguments.add(ExecutionWrappers.LINUX_SANDBOX);
 
       // Construct the CLI options for this binary.
       LinuxSandboxOptions options = new LinuxSandboxOptions();

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -954,11 +954,16 @@ class ShardWorkerContext implements WorkerContext {
       // Construct the CLI options for this binary.
       LinuxSandboxOptions options = new LinuxSandboxOptions();
       options.createNetns = limits.network.blockNetwork;
+      options.fakeUsername = limits.fakeUsername;
 
       // Pass flags based on the sandbox CLI options.
       if (options.createNetns) {
         arguments.add("-N");
       }
+      if (options.fakeUsername) {
+        arguments.add("-U");
+      }
+
       arguments.add("--");
     }
 


### PR DESCRIPTION
### Problem:
The `linux-sandbox` does not work with our internal configuration of worker "execution policies".
Our internal deployment of buildfarm configures 2 execution policies on the worker:  
They are `as-nobody` and `process-wrapper` (both bundled in the public java image).  

`as-nobody` does not have proper permissions to run under the sandbox.  We can not flip the order since execution policies are applied in the executor.  We can't remove the execution policy because choosing the sandbox is done dynamically and we don't want to juggle different buildfarm deployments.

### Solution:
If you are using the sandbox, don't use the execution policies.