### PR TITLE
set package visibility on execution wrappers

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,5 +1,6 @@
 load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
 load("@io_bazel_rules_docker//java:image.bzl", "java_image")
+
 package(default_visibility = ["//visibility:public"])
 
 buildifier(

--- a/BUILD
+++ b/BUILD
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
 load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
 load("@io_bazel_rules_docker//java:image.bzl", "java_image")
+package(default_visibility = ["//visibility:public"])
 
 buildifier(
     name = "buildifier",

--- a/BUILD
+++ b/BUILD
@@ -1,3 +1,4 @@
+package(default_visibility = ["//visibility:public"])
 load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
 load("@io_bazel_rules_docker//java:image.bzl", "java_image")
 


### PR DESCRIPTION
This is needed so we can source the execution wrappers as runtime dependencies from an internal repo.