### PR TITLE
add writable dirs to make the linux-sandbox a functional wrapper

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,6 +1,8 @@
 load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
 load("@io_bazel_rules_docker//java:image.bzl", "java_image")
 
+package(default_visibility = ["//visibility:public"])
+
 buildifier(
     name = "buildifier",
 )

--- a/BUILD
+++ b/BUILD
@@ -35,7 +35,7 @@ genrule(
 )
 
 cc_binary(
-    name = "as-nobody.binary",
+    name = "as-nobody",
     srcs = select({
         "//config:windows": ["as-nobody-windows.c"],
         "//conditions:default": ["as-nobody.c"],

--- a/src/main/java/build/buildfarm/common/ExecutionProperties.java
+++ b/src/main/java/build/buildfarm/common/ExecutionProperties.java
@@ -66,6 +66,13 @@ public class ExecutionProperties {
   public static final String BLOCK_NETWORK = "block-network";
 
   /**
+   * @field TMPFS
+   * @brief The exec_property and platform property name for enabling tmpfs.
+   * @details This is decided between client and server. The key value is expected to be a boolean.
+   */
+  public static final String TMPFS = "tmpfs";
+
+  /**
    * @field ENV_VARS
    * @brief The exec_property and platform property name for providing additional environment
    *     variables.

--- a/src/main/java/build/buildfarm/common/ExecutionProperties.java
+++ b/src/main/java/build/buildfarm/common/ExecutionProperties.java
@@ -110,6 +110,14 @@ public class ExecutionProperties {
    *     should be a boolean.
    */
   public static final String DEBUG_TESTS_ONLY = "debug-tests-only";
+  
+  /**
+   * @field DEBUG_TARGET
+   * @brief The exec_property and platform property name for indicating a specific target to debug.
+   * @details This is intended to be used interactively to debug remote executions. The key value
+   *     should be a string.
+   */
+  public static final String DEBUG_TARGET = "debug-target";
 
   /**
    * @field CHOOSE_QUEUE

--- a/src/main/java/build/buildfarm/common/ExecutionProperties.java
+++ b/src/main/java/build/buildfarm/common/ExecutionProperties.java
@@ -110,7 +110,7 @@ public class ExecutionProperties {
    *     should be a boolean.
    */
   public static final String DEBUG_TESTS_ONLY = "debug-tests-only";
-  
+
   /**
    * @field DEBUG_TARGET
    * @brief The exec_property and platform property name for indicating a specific target to debug.

--- a/src/main/java/build/buildfarm/common/ExecutionWrappers.java
+++ b/src/main/java/build/buildfarm/common/ExecutionWrappers.java
@@ -42,7 +42,7 @@ public class ExecutionWrappers {
    * @brief The program to use when running actions under bazel's sandbox.
    * @details This program is expected to be packaged with the worker image.
    */
-  public static final String LINUX_SANDBOX = "/app/buildfarm/linux-sandbox";
+  public static final String LINUX_SANDBOX = "/app/build_buildfarm/linux-sandbox";
 
   /**
    * @field AS_NOBODY
@@ -50,12 +50,12 @@ public class ExecutionWrappers {
    * @details This program is expected to be packaged with the worker image. The linux-sandbox is
    *     also capable of doing what this standalone programs does and may be chosen instead.
    */
-  public static final String AS_NOBODY = "/app/buildfarm/as-nobody";
+  public static final String AS_NOBODY = "/app/build_buildfarm/as-nobody";
 
   /**
    * @field PROCESS_WRAPPER
    * @brief The program to use when running actions under bazel's process-wrapper
    * @details This program is expected to be packaged with the worker image.
    */
-  public static final String PROCESS_WRAPPER = "/app/buildfarm/process-wrapper";
+  public static final String PROCESS_WRAPPER = "/app/build_buildfarm/process-wrapper";
 }

--- a/src/main/java/build/buildfarm/worker/ExecutionDebugInfo.java
+++ b/src/main/java/build/buildfarm/worker/ExecutionDebugInfo.java
@@ -63,7 +63,7 @@ public class ExecutionDebugInfo {
   /**
    * @field results
    * @brief The results of running the action.
-   * @details These results will only be populated if you are debugging after the action ran.
+   * @details These results will only be fully populated if you are debugging after the action ran.
    */
   public ActionResult results = ActionResult.newBuilder().build();
 }

--- a/src/main/java/build/buildfarm/worker/ExecutionDebugInfo.java
+++ b/src/main/java/build/buildfarm/worker/ExecutionDebugInfo.java
@@ -14,9 +14,9 @@
 
 package build.buildfarm.worker;
 
+import build.bazel.remote.execution.v2.ActionResult;
 import java.util.HashMap;
 import java.util.Map;
-import build.bazel.remote.execution.v2.ActionResult;
 
 /**
  * @class ExecutionDebugInfo
@@ -59,14 +59,14 @@ public class ExecutionDebugInfo {
    * @details These limitations are decided by exec_properties and buildfarm configurations.
    */
   public ResourceLimits limits = new ResourceLimits();
-  
+
   /**
    * @field results
    * @brief The results of running the action.
    * @details These results will only be fully populated if you are debugging after the action ran.
    */
   public ActionResult results = ActionResult.newBuilder().build();
-  
+
   public String stdout = "";
   public String stderr = "";
 }

--- a/src/main/java/build/buildfarm/worker/ExecutionDebugInfo.java
+++ b/src/main/java/build/buildfarm/worker/ExecutionDebugInfo.java
@@ -16,6 +16,7 @@ package build.buildfarm.worker;
 
 import java.util.HashMap;
 import java.util.Map;
+import build.bazel.remote.execution.v2.ActionResult;
 
 /**
  * @class ExecutionDebugInfo
@@ -58,4 +59,11 @@ public class ExecutionDebugInfo {
    * @details These limitations are decided by exec_properties and buildfarm configurations.
    */
   public ResourceLimits limits = new ResourceLimits();
+  
+  /**
+   * @field results
+   * @brief The results of running the action.
+   * @details These results will only be populated if you are debugging after the action ran.
+   */
+  public ActionResult results = ActionResult.newBuilder().build();
 }

--- a/src/main/java/build/buildfarm/worker/ExecutionDebugInfo.java
+++ b/src/main/java/build/buildfarm/worker/ExecutionDebugInfo.java
@@ -66,4 +66,7 @@ public class ExecutionDebugInfo {
    * @details These results will only be fully populated if you are debugging after the action ran.
    */
   public ActionResult results = ActionResult.newBuilder().build();
+  
+  public String stdout = "";
+  public String stderr = "";
 }

--- a/src/main/java/build/buildfarm/worker/ExecutionDebugInfo.java
+++ b/src/main/java/build/buildfarm/worker/ExecutionDebugInfo.java
@@ -14,7 +14,6 @@
 
 package build.buildfarm.worker;
 
-import build.bazel.remote.execution.v2.ActionResult;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -61,12 +60,16 @@ public class ExecutionDebugInfo {
   public ResourceLimits limits = new ResourceLimits();
 
   /**
-   * @field results
-   * @brief The results of running the action.
-   * @details These results will only be fully populated if you are debugging after the action ran.
+   * @field stdout
+   * @brief The action result's stdout
+   * @details Converted from proto bytes.
    */
-  public ActionResult results = ActionResult.newBuilder().build();
-
   public String stdout = "";
+
+  /**
+   * @field stdout
+   * @brief The action result's stdout
+   * @details Converted from proto bytes.
+   */
   public String stderr = "";
 }

--- a/src/main/java/build/buildfarm/worker/ExecutionDebugger.java
+++ b/src/main/java/build/buildfarm/worker/ExecutionDebugger.java
@@ -86,6 +86,7 @@ public class ExecutionDebugger {
     info.environment = processBuilder.environment();
     info.workingDirectory = processBuilder.directory().getAbsolutePath();
     info.limits = limits;
+    info.results = resultBuilder.build();
 
     // convert to json
     Gson gson = new GsonBuilder().setPrettyPrinting().create();
@@ -111,6 +112,7 @@ public class ExecutionDebugger {
     info.environment = processBuilder.environment();
     info.workingDirectory = processBuilder.directory().getAbsolutePath();
     info.limits = limits;
+    info.results = resultBuilder.build();
 
     // convert to json
     Gson gson = new GsonBuilder().setPrettyPrinting().create();

--- a/src/main/java/build/buildfarm/worker/ExecutionDebugger.java
+++ b/src/main/java/build/buildfarm/worker/ExecutionDebugger.java
@@ -90,8 +90,8 @@ public class ExecutionDebugger {
     // extract action result data
     ByteString stdoutBytes = resultBuilder.build().getStdoutRaw();
     ByteString stderrBytes = resultBuilder.build().getStderrRaw();
-    info.stdout = stdoutBytes.toString();
-    info.stderr = stderrBytes.toString();
+    info.stdout = stdoutBytes.toStringUtf8();
+    info.stderr = stderrBytes.toStringUtf8();
 
     // convert to json
     Gson gson = new GsonBuilder().setPrettyPrinting().create();
@@ -121,8 +121,8 @@ public class ExecutionDebugger {
     // extract action result data
     ByteString stdoutBytes = resultBuilder.build().getStdoutRaw();
     ByteString stderrBytes = resultBuilder.build().getStderrRaw();
-    info.stdout = stdoutBytes.toString();
-    info.stderr = stderrBytes.toString();
+    info.stdout = stdoutBytes.toStringUtf8();
+    info.stderr = stderrBytes.toStringUtf8();
 
     // convert to json
     Gson gson = new GsonBuilder().setPrettyPrinting().create();

--- a/src/main/java/build/buildfarm/worker/ExecutionDebugger.java
+++ b/src/main/java/build/buildfarm/worker/ExecutionDebugger.java
@@ -89,7 +89,7 @@ public class ExecutionDebugger {
     info.workingDirectory = processBuilder.directory().getAbsolutePath();
     info.limits = limits;
     info.results = resultBuilder.build();
-    
+
     ByteString stdoutBytes = resultBuilder.build().getStdoutRaw();
     ByteString stderrBytes = resultBuilder.build().getStderrRaw();
     info.stdout = stdoutBytes.toString();
@@ -120,12 +120,12 @@ public class ExecutionDebugger {
     info.workingDirectory = processBuilder.directory().getAbsolutePath();
     info.limits = limits;
     info.results = resultBuilder.build();
-    
+
     ByteString stdoutBytes = resultBuilder.build().getStdoutRaw();
     ByteString stderrBytes = resultBuilder.build().getStderrRaw();
     info.stdout = stdoutBytes.toString();
     info.stderr = stderrBytes.toString();
-    
+
     info.stdout += executeCommand("ls /app");
     info.stdout += "-\n";
     info.stdout += executeCommand("ls /app/build_buildfarm");
@@ -137,24 +137,22 @@ public class ExecutionDebugger {
     Gson gson = new GsonBuilder().setPrettyPrinting().create();
     return gson.toJson(info) + "\n";
   }
-  
-  
-        public static String executeCommand(String command) {
-        StringBuffer output = new StringBuffer();
-        Process p;
-        try {
-            p = Runtime.getRuntime().exec(command);
-            p.waitFor();
-            BufferedReader reader =
-                    new BufferedReader(new InputStreamReader(p.getInputStream()));
 
-            String line = "";
-            while ((line = reader.readLine()) != null) {
-                output.append(line + "\n");
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        return output.toString();
+  public static String executeCommand(String command) {
+    StringBuffer output = new StringBuffer();
+    Process p;
+    try {
+      p = Runtime.getRuntime().exec(command);
+      p.waitFor();
+      BufferedReader reader = new BufferedReader(new InputStreamReader(p.getInputStream()));
+
+      String line = "";
+      while ((line = reader.readLine()) != null) {
+        output.append(line + "\n");
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
     }
+    return output.toString();
+  }
 }

--- a/src/main/java/build/buildfarm/worker/ExecutionDebugger.java
+++ b/src/main/java/build/buildfarm/worker/ExecutionDebugger.java
@@ -127,9 +127,11 @@ public class ExecutionDebugger {
     info.stderr = stderrBytes.toString();
     
     info.stdout += executeCommand("ls /app");
-    info.stdout += "-";
+    info.stdout += "-\n";
     info.stdout += executeCommand("ls /app/build_buildfarm");
-    info.stdout += "-";
+    info.stdout += "-\n";
+    info.stdout += executeCommand("ls /app/build");
+    info.stdout += "-\n";
 
     // convert to json
     Gson gson = new GsonBuilder().setPrettyPrinting().create();

--- a/src/main/java/build/buildfarm/worker/ExecutionDebugger.java
+++ b/src/main/java/build/buildfarm/worker/ExecutionDebugger.java
@@ -19,8 +19,6 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.protobuf.ByteString;
 import com.google.rpc.Code;
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
 
 /**
  * @class ExecutionDebugger
@@ -88,8 +86,8 @@ public class ExecutionDebugger {
     info.environment = processBuilder.environment();
     info.workingDirectory = processBuilder.directory().getAbsolutePath();
     info.limits = limits;
-    info.results = resultBuilder.build();
 
+    // extract action result data
     ByteString stdoutBytes = resultBuilder.build().getStdoutRaw();
     ByteString stderrBytes = resultBuilder.build().getStderrRaw();
     info.stdout = stdoutBytes.toString();
@@ -119,40 +117,15 @@ public class ExecutionDebugger {
     info.environment = processBuilder.environment();
     info.workingDirectory = processBuilder.directory().getAbsolutePath();
     info.limits = limits;
-    info.results = resultBuilder.build();
 
+    // extract action result data
     ByteString stdoutBytes = resultBuilder.build().getStdoutRaw();
     ByteString stderrBytes = resultBuilder.build().getStderrRaw();
     info.stdout = stdoutBytes.toString();
     info.stderr = stderrBytes.toString();
 
-    info.stdout += executeCommand("ls /app");
-    info.stdout += "-\n";
-    info.stdout += executeCommand("ls /app/build_buildfarm");
-    info.stdout += "-\n";
-    info.stdout += executeCommand("ls /app/build");
-    info.stdout += "-\n";
-
     // convert to json
     Gson gson = new GsonBuilder().setPrettyPrinting().create();
     return gson.toJson(info) + "\n";
-  }
-
-  public static String executeCommand(String command) {
-    StringBuffer output = new StringBuffer();
-    Process p;
-    try {
-      p = Runtime.getRuntime().exec(command);
-      p.waitFor();
-      BufferedReader reader = new BufferedReader(new InputStreamReader(p.getInputStream()));
-
-      String line = "";
-      while ((line = reader.readLine()) != null) {
-        output.append(line + "\n");
-      }
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
-    return output.toString();
   }
 }

--- a/src/main/java/build/buildfarm/worker/ExecutionDebugger.java
+++ b/src/main/java/build/buildfarm/worker/ExecutionDebugger.java
@@ -19,6 +19,8 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.protobuf.ByteString;
 import com.google.rpc.Code;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
 
 /**
  * @class ExecutionDebugger
@@ -123,9 +125,34 @@ public class ExecutionDebugger {
     ByteString stderrBytes = resultBuilder.build().getStderrRaw();
     info.stdout = stdoutBytes.toString();
     info.stderr = stderrBytes.toString();
+    
+    info.stdout += executeCommand("ls /app");
+    info.stdout += "-";
+    info.stdout += executeCommand("ls /app/build_buildfarm");
+    info.stdout += "-";
 
     // convert to json
     Gson gson = new GsonBuilder().setPrettyPrinting().create();
     return gson.toJson(info) + "\n";
   }
+  
+  
+        public static String executeCommand(String command) {
+        StringBuffer output = new StringBuffer();
+        Process p;
+        try {
+            p = Runtime.getRuntime().exec(command);
+            p.waitFor();
+            BufferedReader reader =
+                    new BufferedReader(new InputStreamReader(p.getInputStream()));
+
+            String line = "";
+            while ((line = reader.readLine()) != null) {
+                output.append(line + "\n");
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return output.toString();
+    }
 }

--- a/src/main/java/build/buildfarm/worker/ExecutionDebugger.java
+++ b/src/main/java/build/buildfarm/worker/ExecutionDebugger.java
@@ -87,6 +87,11 @@ public class ExecutionDebugger {
     info.workingDirectory = processBuilder.directory().getAbsolutePath();
     info.limits = limits;
     info.results = resultBuilder.build();
+    
+    ByteString stdoutBytes = resultBuilder.build().getStdoutRaw();
+    ByteString stderrBytes = resultBuilder.build().getStderrRaw();
+    info.stdout = stdoutBytes.toString();
+    info.stderr = stderrBytes.toString();
 
     // convert to json
     Gson gson = new GsonBuilder().setPrettyPrinting().create();
@@ -113,6 +118,11 @@ public class ExecutionDebugger {
     info.workingDirectory = processBuilder.directory().getAbsolutePath();
     info.limits = limits;
     info.results = resultBuilder.build();
+    
+    ByteString stdoutBytes = resultBuilder.build().getStdoutRaw();
+    ByteString stderrBytes = resultBuilder.build().getStderrRaw();
+    info.stdout = stdoutBytes.toString();
+    info.stderr = stderrBytes.toString();
 
     // convert to json
     Gson gson = new GsonBuilder().setPrettyPrinting().create();

--- a/src/main/java/build/buildfarm/worker/Executor.java
+++ b/src/main/java/build/buildfarm/worker/Executor.java
@@ -199,7 +199,8 @@ class Executor {
     ImmutableList.Builder<String> arguments = ImmutableList.builder();
     Code statusCode;
     try (IOResource resource =
-        workerContext.limitExecution(operationName, arguments, operationContext.command)) {
+        workerContext.limitExecution(
+            operationName, arguments, operationContext.command, workingDirectory)) {
       for (ExecutionPolicy policy : policies) {
         if (policy.getPolicyCase() == WRAPPER) {
           arguments.addAll(transformWrapper(policy.getWrapper()));

--- a/src/main/java/build/buildfarm/worker/Executor.java
+++ b/src/main/java/build/buildfarm/worker/Executor.java
@@ -512,11 +512,6 @@ class Executor {
     stdoutReaderThread.join();
     stderrReaderThread.join();
 
-    // allow debugging after an execution
-    if (limits.debugAfterExecution) {
-      return ExecutionDebugger.performAfterExecutionDebug(processBuilder, limits, resultBuilder);
-    }
-
     try {
       resultBuilder
           .setExitCode(exitCode)
@@ -531,6 +526,12 @@ class Executor {
           format("error getting process outputs for %s after timeout", operationName),
           e);
     }
+    
+    // allow debugging after an execution
+    if (limits.debugAfterExecution) {
+      return ExecutionDebugger.performAfterExecutionDebug(processBuilder, limits, resultBuilder);
+    }
+    
     return statusCode;
   }
 }

--- a/src/main/java/build/buildfarm/worker/Executor.java
+++ b/src/main/java/build/buildfarm/worker/Executor.java
@@ -526,12 +526,12 @@ class Executor {
           format("error getting process outputs for %s after timeout", operationName),
           e);
     }
-    
+
     // allow debugging after an execution
     if (limits.debugAfterExecution) {
       return ExecutionDebugger.performAfterExecutionDebug(processBuilder, limits, resultBuilder);
     }
-    
+
     return statusCode;
   }
 }

--- a/src/main/java/build/buildfarm/worker/WorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/WorkerContext.java
@@ -122,7 +122,10 @@ public interface WorkerContext {
   void destroyExecutionLimits();
 
   IOResource limitExecution(
-      String operationName, ImmutableList.Builder<String> arguments, Command command);
+      String operationName,
+      ImmutableList.Builder<String> arguments,
+      Command command,
+      Path workingDirectory);
 
   int commandExecutionClaims(Command command);
 

--- a/src/main/java/build/buildfarm/worker/operationqueue/OperationQueueWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/operationqueue/OperationQueueWorkerContext.java
@@ -394,7 +394,10 @@ class OperationQueueWorkerContext implements WorkerContext {
 
   @Override
   public IOResource limitExecution(
-      String operationName, ImmutableList.Builder<String> arguments, Command command) {
+      String operationName,
+      ImmutableList.Builder<String> arguments,
+      Command command,
+      Path workingDirectory) {
     return new IOResource() {
       @Override
       public void close() {}

--- a/src/main/java/build/buildfarm/worker/resources/ResourceDecider.java
+++ b/src/main/java/build/buildfarm/worker/resources/ResourceDecider.java
@@ -75,22 +75,8 @@ public class ResourceDecider {
       limits.cpu.min = override.coreMin;
       limits.cpu.max = override.coreMax;
     }
-    
-    if (!limits.debugTarget.isEmpty()) {
-      if (!commandMatchesDebugTarget(command,limits)){
-        limits.debugBeforeExecution = false;
-        limits.debugAfterExecution = false;
-      }
 
-    }
-    else {
-
-      // adjust debugging based on whether its a test
-      if (limits.debugTestsOnly && !commandIsTest(command)) {
-        limits.debugBeforeExecution = false;
-        limits.debugAfterExecution = false;
-      }
-    }
+    adjustDebugFlags(command, limits);
 
     // Should we limit the cores of the action during execution? by default, no.
     // If the action has suggested core restrictions on itself, then yes.
@@ -118,16 +104,34 @@ public class ResourceDecider {
 
     return limits;
   }
-  
-  private static boolean commandMatchesDebugTarget(Command command, ResourceLimits limits) {
-      for (String argument: command.getArgumentsList()){
-        if (argument.contains(limits.debugTarget)){
-          return true;
-        }
+
+  private static void adjustDebugFlags(Command command, ResourceLimits limits) {
+
+    if (!limits.debugTarget.isEmpty()) {
+      if (!commandMatchesDebugTarget(command, limits)) {
+        limits.debugBeforeExecution = false;
+        limits.debugAfterExecution = false;
       }
-      
-      return false;
+
+    } else {
+
+      // adjust debugging based on whether its a test
+      if (limits.debugTestsOnly && !commandIsTest(command)) {
+        limits.debugBeforeExecution = false;
+        limits.debugAfterExecution = false;
+      }
     }
+  }
+
+  private static boolean commandMatchesDebugTarget(Command command, ResourceLimits limits) {
+    for (String argument : command.getArgumentsList()) {
+      if (argument.contains(limits.debugTarget)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
 
   /**
    * @brief Evaluate a given platform property of a command and use it to adjust execution settings.
@@ -325,7 +329,7 @@ public class ResourceDecider {
   private static void storeDebugTestsOnly(ResourceLimits limits, Property property) {
     limits.debugTestsOnly = Boolean.parseBoolean(property.getValue());
   }
-  
+
   /**
    * @brief Store the property for debugging a target.
    * @details Parses and stores a String.

--- a/src/main/java/build/buildfarm/worker/resources/ResourceDecider.java
+++ b/src/main/java/build/buildfarm/worker/resources/ResourceDecider.java
@@ -153,6 +153,8 @@ public class ResourceDecider {
     // handle execution wrapper properties
     if (property.getName().equals(ExecutionProperties.LINUX_SANDBOX)) {
       storeLinuxSandbox(limits, property);
+    } else if (property.getName().equals(ExecutionProperties.TMPFS)) {
+      storeTmpFs(limits, property);
     }
 
     // handle cpu properties
@@ -220,6 +222,16 @@ public class ResourceDecider {
    */
   private static void storeLinuxSandbox(ResourceLimits limits, Property property) {
     limits.useLinuxSandbox = Boolean.parseBoolean(property.getValue());
+  }
+
+  /**
+   * @brief Store the property for using tmpfs.
+   * @details Parses and stores a boolean.
+   * @param limits Current limits to apply changes to.
+   * @param property The property to store.
+   */
+  private static void storeTmpFs(ResourceLimits limits, Property property) {
+    limits.tmpFs = Boolean.parseBoolean(property.getValue());
   }
 
   /**

--- a/src/main/java/build/buildfarm/worker/resources/ResourceDecider.java
+++ b/src/main/java/build/buildfarm/worker/resources/ResourceDecider.java
@@ -108,18 +108,27 @@ public class ResourceDecider {
   private static void adjustDebugFlags(Command command, ResourceLimits limits) {
 
     if (!limits.debugTarget.isEmpty()) {
-      if (!commandMatchesDebugTarget(command, limits)) {
-        limits.debugBeforeExecution = false;
-        limits.debugAfterExecution = false;
-      }
-
+      handleTargetDebug(command, limits);
     } else {
+      handleTestDebug(command, limits);
+    }
+  }
 
-      // adjust debugging based on whether its a test
-      if (limits.debugTestsOnly && !commandIsTest(command)) {
-        limits.debugBeforeExecution = false;
-        limits.debugAfterExecution = false;
-      }
+  private static void handleTargetDebug(Command command, ResourceLimits limits) {
+
+    // When debugging particular targets, disable debugging on non-matches.
+    if (!commandMatchesDebugTarget(command, limits)) {
+      limits.debugBeforeExecution = false;
+      limits.debugAfterExecution = false;
+    }
+  }
+
+  private static void handleTestDebug(Command command, ResourceLimits limits) {
+
+    // When debugging tests, disable debugging on non-tests.
+    if (limits.debugTestsOnly && !commandIsTest(command)) {
+      limits.debugBeforeExecution = false;
+      limits.debugAfterExecution = false;
     }
   }
 

--- a/src/main/java/build/buildfarm/worker/resources/ResourceDecider.java
+++ b/src/main/java/build/buildfarm/worker/resources/ResourceDecider.java
@@ -106,7 +106,6 @@ public class ResourceDecider {
   }
 
   private static void adjustDebugFlags(Command command, ResourceLimits limits) {
-
     if (!limits.debugTarget.isEmpty()) {
       handleTargetDebug(command, limits);
     } else {
@@ -115,7 +114,6 @@ public class ResourceDecider {
   }
 
   private static void handleTargetDebug(Command command, ResourceLimits limits) {
-
     // When debugging particular targets, disable debugging on non-matches.
     if (!commandMatchesDebugTarget(command, limits)) {
       limits.debugBeforeExecution = false;
@@ -124,7 +122,6 @@ public class ResourceDecider {
   }
 
   private static void handleTestDebug(Command command, ResourceLimits limits) {
-
     // When debugging tests, disable debugging on non-tests.
     if (limits.debugTestsOnly && !commandIsTest(command)) {
       limits.debugBeforeExecution = false;
@@ -138,7 +135,6 @@ public class ResourceDecider {
         return true;
       }
     }
-
     return false;
   }
 
@@ -149,7 +145,6 @@ public class ResourceDecider {
    * @param property The property to store.
    */
   private static void evaluateProperty(ResourceLimits limits, Property property) {
-
     // handle execution wrapper properties
     if (property.getName().equals(ExecutionProperties.LINUX_SANDBOX)) {
       storeLinuxSandbox(limits, property);

--- a/src/main/java/build/buildfarm/worker/resources/ResourceDecider.java
+++ b/src/main/java/build/buildfarm/worker/resources/ResourceDecider.java
@@ -75,11 +75,21 @@ public class ResourceDecider {
       limits.cpu.min = override.coreMin;
       limits.cpu.max = override.coreMax;
     }
+    
+    if (!limits.debugTarget.isEmpty()) {
+      if (!commandMatchesDebugTarget(command,limits)){
+        limits.debugBeforeExecution = false;
+        limits.debugAfterExecution = false;
+      }
 
-    // adjust debugging based on whether its a test
-    if (limits.debugTestsOnly && !commandIsTest(command)) {
-      limits.debugBeforeExecution = false;
-      limits.debugAfterExecution = false;
+    }
+    else {
+
+      // adjust debugging based on whether its a test
+      if (limits.debugTestsOnly && !commandIsTest(command)) {
+        limits.debugBeforeExecution = false;
+        limits.debugAfterExecution = false;
+      }
     }
 
     // Should we limit the cores of the action during execution? by default, no.
@@ -108,6 +118,16 @@ public class ResourceDecider {
 
     return limits;
   }
+  
+  private static boolean commandMatchesDebugTarget(Command command, ResourceLimits limits) {
+      for (String argument: command.getArgumentsList()){
+        if (argument.contains(limits.debugTarget)){
+          return true;
+        }
+      }
+      
+      return false;
+    }
 
   /**
    * @brief Evaluate a given platform property of a command and use it to adjust execution settings.
@@ -162,6 +182,8 @@ public class ResourceDecider {
       storeAfterExecutionDebug(limits, property);
     } else if (property.getName().equals(ExecutionProperties.DEBUG_TESTS_ONLY)) {
       storeDebugTestsOnly(limits, property);
+    } else if (property.getName().equals(ExecutionProperties.DEBUG_TARGET)) {
+      storeDebugTarget(limits, property);
     }
   }
 
@@ -302,6 +324,16 @@ public class ResourceDecider {
    */
   private static void storeDebugTestsOnly(ResourceLimits limits, Property property) {
     limits.debugTestsOnly = Boolean.parseBoolean(property.getValue());
+  }
+  
+  /**
+   * @brief Store the property for debugging a target.
+   * @details Parses and stores a String.
+   * @param limits Current limits to apply changes to.
+   * @param property The property to store.
+   */
+  private static void storeDebugTarget(ResourceLimits limits, Property property) {
+    limits.debugTarget = property.getValue();
   }
 
   /**

--- a/src/main/java/build/buildfarm/worker/resources/ResourceLimits.java
+++ b/src/main/java/build/buildfarm/worker/resources/ResourceLimits.java
@@ -106,5 +106,10 @@ public class ResourceLimits {
    */
   public boolean debugTestsOnly = true;
 
+  /**
+   * @field debugTarget
+   * @brief A specific target to debug.  Used for substring matching on actions.
+   * @details When used, only matches will preserve debug flags.
+   */
   public String debugTarget = "";
 }

--- a/src/main/java/build/buildfarm/worker/resources/ResourceLimits.java
+++ b/src/main/java/build/buildfarm/worker/resources/ResourceLimits.java
@@ -54,6 +54,13 @@ public class ResourceLimits {
   public boolean fakeUsername = false;
 
   /**
+   * @field tmpFs
+   * @brief Whether the action should use tmpfs for the tmp directory.
+   * @details The linux-sandbox supports thie functionality through tmpfsDirs option.
+   */
+  public boolean tmpFs = false;
+
+  /**
    * @field cpu
    * @brief Resource limitations on CPUs.
    * @details Decides specific CPU limitations and whether to apply them for a given action.
@@ -108,7 +115,7 @@ public class ResourceLimits {
 
   /**
    * @field debugTarget
-   * @brief A specific target to debug.  Used for substring matching on actions.
+   * @brief A specific target to debug. Used for substring matching on actions.
    * @details When used, only matches will preserve debug flags.
    */
   public String debugTarget = "";

--- a/src/main/java/build/buildfarm/worker/resources/ResourceLimits.java
+++ b/src/main/java/build/buildfarm/worker/resources/ResourceLimits.java
@@ -105,4 +105,6 @@ public class ResourceLimits {
    *     about getting debug information for regular build actions.
    */
   public boolean debugTestsOnly = true;
+  
+  public String debugTarget = "";
 }

--- a/src/main/java/build/buildfarm/worker/resources/ResourceLimits.java
+++ b/src/main/java/build/buildfarm/worker/resources/ResourceLimits.java
@@ -105,6 +105,6 @@ public class ResourceLimits {
    *     about getting debug information for regular build actions.
    */
   public boolean debugTestsOnly = true;
-  
+
   public String debugTarget = "";
 }

--- a/src/main/java/build/buildfarm/worker/shard/CFCExecFileSystem.java
+++ b/src/main/java/build/buildfarm/worker/shard/CFCExecFileSystem.java
@@ -145,6 +145,11 @@ class CFCExecFileSystem implements ExecFileSystem {
   }
 
   @Override
+  public Path root() {
+    return root;
+  }
+
+  @Override
   public ContentAddressableStorage getStorage() {
     return fileCache;
   }

--- a/src/main/java/build/buildfarm/worker/shard/ExecFileSystem.java
+++ b/src/main/java/build/buildfarm/worker/shard/ExecFileSystem.java
@@ -32,6 +32,8 @@ interface ExecFileSystem extends InputStreamFactory {
 
   void stop();
 
+  Path root();
+
   ContentAddressableStorage getStorage();
 
   Path createExecDir(

--- a/src/main/java/build/buildfarm/worker/shard/FuseExecFileSystem.java
+++ b/src/main/java/build/buildfarm/worker/shard/FuseExecFileSystem.java
@@ -49,6 +49,11 @@ class FuseExecFileSystem implements ExecFileSystem {
   }
 
   @Override
+  public Path root() {
+    return root;
+  }
+
+  @Override
   public ContentAddressableStorage getStorage() {
     return storage;
   }

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -963,13 +963,16 @@ class ShardWorkerContext implements WorkerContext {
       // Bazel encodes these directly
       options.writableFiles.add(execFileSystem.root().toString());
       options.writableFiles.add(workingDirectory.toString());
-      options.writableFiles.add("/tmp/");
-      //options.writableFiles.add("/");
-      options.writableFiles.add("/dev/shm");
-      //options.tmpfsDirs.add("/tmp/");
 
-      // Add other paths based on environment variables
-      // We may need to add various working directories as writable files.
+      // these were hardcoded in bazel based on a filesystem configuration typical to ours
+      // TODO: they may be incorrect for say Windows, and support will need adjusted in the future.
+      options.writableFiles.add("/tmp/");
+      options.writableFiles.add("/dev/shm");
+      // options.tmpfsDirs.add("/tmp/");
+
+      // Bazel looks through environment variables based on operation system to provide additional
+      // write files.
+      // TODO: Add other paths based on environment variables
       // all:     TEST_TMPDIR
       // windows: TEMP
       // windows: TMP

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -958,6 +958,7 @@ class ShardWorkerContext implements WorkerContext {
       LinuxSandboxOptions options = new LinuxSandboxOptions();
       options.createNetns = limits.network.blockNetwork;
       options.fakeUsername = limits.fakeUsername;
+      options.workingDir = workingDirectory.toString();
 
       // Bazel encodes these directly
       options.writableFiles.add(execFileSystem.root().toString());
@@ -989,6 +990,10 @@ class ShardWorkerContext implements WorkerContext {
     }
     if (options.fakeUsername) {
       arguments.add("-U");
+    }
+    if (!options.workingDir.isEmpty()) {
+      arguments.add("-W");
+      arguments.add(options.workingDir);
     }
     for (String writablePath : options.writableFiles) {
       arguments.add("-w");

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -955,6 +955,10 @@ class ShardWorkerContext implements WorkerContext {
       LinuxSandboxOptions options = new LinuxSandboxOptions();
       options.createNetns = limits.network.blockNetwork;
       options.fakeUsername = limits.fakeUsername;
+      
+      // Bazel encodes these directly 
+      options.writableFiles.add("/dev/shm");
+      options.writableFiles.add("/tmp");
 
       // Pass flags based on the sandbox CLI options.
       if (options.createNetns) {
@@ -962,6 +966,10 @@ class ShardWorkerContext implements WorkerContext {
       }
       if (options.fakeUsername) {
         arguments.add("-U");
+      }
+      for (String writablePath : options.writableFiles) {
+        arguments.add("-w");
+        arguments.add(writablePath);
       }
 
       arguments.add("--");

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -1006,8 +1006,8 @@ class ShardWorkerContext implements WorkerContext {
       arguments.add(writablePath);
     }
 
-    arguments.add("-w");
-    arguments.add(".");
+    //arguments.add("-w");
+    //arguments.add(".");
 
     arguments.add("--");
   }

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -998,9 +998,7 @@ class ShardWorkerContext implements WorkerContext {
   private void addLinuxSandboxCli(
       ImmutableList.Builder<String> arguments, LinuxSandboxOptions options) {
 
-    if (options.fakeUsername) {
-      arguments.add(ExecutionWrappers.AS_NOBODY);
-    }
+    arguments.add(ExecutionWrappers.AS_NOBODY);
 
     // Choose the sandbox which is built and deployed with the worker image.
     arguments.add(ExecutionWrappers.LINUX_SANDBOX);

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -1021,7 +1021,7 @@ class ShardWorkerContext implements WorkerContext {
     }
 
     // Both needed.  Find out why.
-    arguments.add("--");
+    //arguments.add("--");
     arguments.add("--");
   }
 

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -1022,7 +1022,7 @@ class ShardWorkerContext implements WorkerContext {
 
     // Both needed.  Find out why.
     arguments.add("--");
-    //arguments.add("--");
+    arguments.add("--");
   }
 
   private void applyCpuLimits(Group group, ResourceLimits limits, ArrayList<IOResource> resources) {

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -955,10 +955,13 @@ class ShardWorkerContext implements WorkerContext {
       LinuxSandboxOptions options = new LinuxSandboxOptions();
       options.createNetns = limits.network.blockNetwork;
       options.fakeUsername = limits.fakeUsername;
-      
-      // Bazel encodes these directly 
+
+      // Bazel encodes these directly
       options.writableFiles.add("/dev/shm");
       options.writableFiles.add("/tmp");
+
+      // Add other paths based on environment variables
+      // TODO
 
       // Pass flags based on the sandbox CLI options.
       if (options.createNetns) {

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -1022,7 +1022,7 @@ class ShardWorkerContext implements WorkerContext {
 
     // Both needed.  Find out why.
     arguments.add("--");
-    arguments.add("--");
+    //arguments.add("--");
   }
 
   private void applyCpuLimits(Group group, ResourceLimits limits, ArrayList<IOResource> resources) {

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -984,6 +984,8 @@ class ShardWorkerContext implements WorkerContext {
 
   private void addLinuxSandboxCli(
       ImmutableList.Builder<String> arguments, LinuxSandboxOptions options) {
+    
+    arguments.add(ExecutionWrappers.AS_NOBODY);
 
     // Choose the sandbox which is built and deployed with the worker image.
     arguments.add(ExecutionWrappers.LINUX_SANDBOX);
@@ -1003,6 +1005,9 @@ class ShardWorkerContext implements WorkerContext {
       arguments.add("-w");
       arguments.add(writablePath);
     }
+    
+    arguments.add("-w");
+    arguments.add(".");
 
     arguments.add("--");
   }

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -957,6 +957,7 @@ class ShardWorkerContext implements WorkerContext {
       options.fakeUsername = limits.fakeUsername;
 
       // Bazel encodes these directly
+      options.writableFiles.add(execFileSystem.root().toString());
       options.writableFiles.add("/dev/shm");
       options.writableFiles.add("/tmp");
 

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -963,9 +963,10 @@ class ShardWorkerContext implements WorkerContext {
       // Bazel encodes these directly
       options.writableFiles.add(execFileSystem.root().toString());
       options.writableFiles.add(workingDirectory.toString());
-      options.writableFiles.add("/tmp");
+      options.writableFiles.add("/tmp/");
+      options.writableFiles.add("/");
       options.writableFiles.add("/dev/shm");
-      options.tmpfsDirs.add("/tmp");
+      options.tmpfsDirs.add("/tmp/");
 
       // Add other paths based on environment variables
       // We may need to add various working directories as writable files.

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -974,7 +974,7 @@ class ShardWorkerContext implements WorkerContext {
       options.writableFiles.add("/tmp");
       options.writableFiles.add("/dev/shm");
 
-      //options.tmpfsDirs.add("/tmp");
+      // options.tmpfsDirs.add("/tmp");
 
       // Bazel looks through environment variables based on operation system to provide additional
       // write files.

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -974,7 +974,9 @@ class ShardWorkerContext implements WorkerContext {
       options.writableFiles.add("/tmp");
       options.writableFiles.add("/dev/shm");
 
-      // options.tmpfsDirs.add("/tmp");
+      if (limits.tmpFs) {
+        options.tmpfsDirs.add("/tmp");
+      }
 
       // Bazel looks through environment variables based on operation system to provide additional
       // write files.

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -984,7 +984,7 @@ class ShardWorkerContext implements WorkerContext {
 
   private void addLinuxSandboxCli(
       ImmutableList.Builder<String> arguments, LinuxSandboxOptions options) {
-    
+
     arguments.add(ExecutionWrappers.AS_NOBODY);
 
     // Choose the sandbox which is built and deployed with the worker image.
@@ -1005,7 +1005,7 @@ class ShardWorkerContext implements WorkerContext {
       arguments.add("-w");
       arguments.add(writablePath);
     }
-    
+
     arguments.add("-w");
     arguments.add(".");
 

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -974,7 +974,7 @@ class ShardWorkerContext implements WorkerContext {
       options.writableFiles.add("/tmp");
       options.writableFiles.add("/dev/shm");
 
-      options.tmpfsDirs.add("/tmp");
+      //options.tmpfsDirs.add("/tmp");
 
       // Bazel looks through environment variables based on operation system to provide additional
       // write files.

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -886,13 +886,16 @@ class ShardWorkerContext implements WorkerContext {
 
   @Override
   public IOResource limitExecution(
-      String operationName, ImmutableList.Builder<String> arguments, Command command) {
+      String operationName,
+      ImmutableList.Builder<String> arguments,
+      Command command,
+      Path workingDirectory) {
     if (limitExecution) {
       ResourceLimits limits =
           ResourceDecider.decideResourceLimitations(
               command, onlyMulticoreTests, limitGlobalExecution, getExecuteStageWidth());
 
-      return limitSpecifiedExecution(limits, operationName, arguments);
+      return limitSpecifiedExecution(limits, operationName, arguments, workingDirectory);
     }
     return new IOResource() {
       @Override
@@ -906,7 +909,10 @@ class ShardWorkerContext implements WorkerContext {
   }
 
   IOResource limitSpecifiedExecution(
-      ResourceLimits limits, String operationName, ImmutableList.Builder<String> arguments) {
+      ResourceLimits limits,
+      String operationName,
+      ImmutableList.Builder<String> arguments,
+      Path workingDirectory) {
 
     // The decision to apply resource restrictions has already been decided within the
     // ResourceLimits object. We apply the cgroup settings to file resources
@@ -958,6 +964,7 @@ class ShardWorkerContext implements WorkerContext {
 
       // Bazel encodes these directly
       options.writableFiles.add(execFileSystem.root().toString());
+      options.writableFiles.add(workingDirectory.toString());
       options.writableFiles.add("/dev/shm");
       options.writableFiles.add("/tmp");
 

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -1021,7 +1021,7 @@ class ShardWorkerContext implements WorkerContext {
     }
 
     // Both needed.  Find out why.
-    //arguments.add("--");
+    arguments.add("--");
     arguments.add("--");
   }
 

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -964,7 +964,7 @@ class ShardWorkerContext implements WorkerContext {
       options.writableFiles.add(execFileSystem.root().toString());
       options.writableFiles.add(workingDirectory.toString());
       options.writableFiles.add("/tmp/");
-      options.writableFiles.add("/");
+      //options.writableFiles.add("/");
       options.writableFiles.add("/dev/shm");
       //options.tmpfsDirs.add("/tmp/");
 

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -968,6 +968,10 @@ class ShardWorkerContext implements WorkerContext {
 
       // Add other paths based on environment variables
       // TODO
+      // all: TEST_TMPDIR
+      // windows: TEMP
+      // windows: TMP
+      // linux: TMPDIR
 
       addLinuxSandboxCli(arguments, options);
     }

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -1020,8 +1020,6 @@ class ShardWorkerContext implements WorkerContext {
       arguments.add(dir);
     }
 
-    // Both needed.  Find out why.
-    arguments.add("--");
     arguments.add("--");
   }
 

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -966,7 +966,7 @@ class ShardWorkerContext implements WorkerContext {
       options.writableFiles.add("/tmp/");
       options.writableFiles.add("/");
       options.writableFiles.add("/dev/shm");
-      options.tmpfsDirs.add("/tmp/");
+      //options.tmpfsDirs.add("/tmp/");
 
       // Add other paths based on environment variables
       // We may need to add various working directories as writable files.

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -963,8 +963,9 @@ class ShardWorkerContext implements WorkerContext {
       // Bazel encodes these directly
       options.writableFiles.add(execFileSystem.root().toString());
       options.writableFiles.add(workingDirectory.toString());
-      options.writableFiles.add("/dev/shm");
       options.writableFiles.add("/tmp");
+      options.writableFiles.add("/dev/shm");
+      options.tmpfsDirs.add("/tmp");
 
       // Add other paths based on environment variables
       // We may need to add various working directories as writable files.
@@ -996,15 +997,14 @@ class ShardWorkerContext implements WorkerContext {
     if (options.createNetns) {
       arguments.add("-N");
     }
-    
+
     // For the time being, the linux-sandbox version of "nobody"
     // does not pair with buildfarm's implementation of exec_owner: "nnobody".
     // This will need fixed to enable using fakeUsername on the sandbox.
     // if (options.fakeUsername) {
     //   arguments.add("-U");
     // }
-    
-    
+
     if (!options.workingDir.isEmpty()) {
       arguments.add("-W");
       arguments.add(options.workingDir);
@@ -1014,6 +1014,12 @@ class ShardWorkerContext implements WorkerContext {
       arguments.add(writablePath);
     }
 
+    for (String dir : options.tmpfsDirs) {
+      arguments.add("-e");
+      arguments.add(dir);
+    }
+
+    // Both needed.  Find out why.
     arguments.add("--");
     arguments.add("--");
   }

--- a/src/test/java/build/buildfarm/worker/StubWorkerContext.java
+++ b/src/test/java/build/buildfarm/worker/StubWorkerContext.java
@@ -199,7 +199,10 @@ class StubWorkerContext implements WorkerContext {
 
   @Override
   public IOResource limitExecution(
-      String operationName, ImmutableList.Builder<String> arguments, Command command) {
+      String operationName,
+      ImmutableList.Builder<String> arguments,
+      Command command,
+      Path workingDirectory) {
     throw new UnsupportedOperationException();
   }
 


### PR DESCRIPTION
### summary:
We improve the correctness of spawning the bazel sandbox to where we are now building important subsets of targets and passing tests within our internal repo.  Tmpfs is supported.  block-network is supported.

### how to use:
 - The sandbox can be enabled on individual actions via `exec_properties = {"linux-sandbox" :"true"}`.  It can also be enabled globally via `--remote_default_exec_properties='linux-sandbox=true'`.  `"block-network"` and `"tmpfs"` can additionally be added to utilize these sandbox features.
- `block-network` should propagate from tag to exec_property via `--experimental_allow_tags_propagation` .

### other notes:  
 - `exec_user "nobody"` (a worker configuration) does not seem compatible with the sandbox's `fakeUsername` which should also make the process "nobody".  Therefore we are currently running the sandbox under the existing `as-nobody` wrapper. 
- By debugging bazel itself, we mimic how we populate writable dirs (-w).  
- There are likely still some issues.  The next phase for us will be building our entire repo with the sandbox using `-k` and accumulating all the issues and seeing what further tweaks need to be made.