### PR TITLE
Support for M1 arm64 macos

### DIFF
--- a/bazelw
+++ b/bazelw
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # From: https://github.com/philwo/bazelisk/blob/042926be3cebfeeabf036b3f170def243f2d3217/bazelisk.py 
+#
+# werkt: Modified to support M1 arm64
 """
 Copyright 2018 Google Inc. All rights reserved.
 
@@ -136,9 +138,9 @@ def resolve_latest_version(version_history, offset):
 
 def determine_bazel_filename(version):
     machine = normalized_machine_arch_name()
-    if machine != "x86_64":
+    if machine not in ["x86_64", "arm64"]:
         raise Exception(
-            'Unsupported machine architecture "{}". Bazel currently only supports x86_64.'.format(
+            'Unsupported machine architecture "{}". Bazel currently only supports x86_64, arm64.'.format(
                 machine
             )
         )

--- a/defs.bzl
+++ b/defs.bzl
@@ -94,7 +94,7 @@ def buildfarm_init(name = "buildfarm"):
                         "org.openjdk.jmh:jmh-generator-annprocess:1.23",
                         "org.redisson:redisson:3.13.1",
                         "org.threeten:threetenbp:1.3.3",
-                        "org.xerial:sqlite-jdbc:3.31.1",
+                        "org.xerial:sqlite-jdbc:3.34.0",
                     ],
         generate_compat_repositories = True,
         repositories = [


### PR DESCRIPTION
Sqlite support for M1 was added in 3.34.0. Include the arm64
architecture, available as a release from bazel, with the bazelw
bazelisk adaptation.