### PR TITLE
Report more current worker set for BackplaneStatus

### DIFF
--- a/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
@@ -1433,6 +1433,7 @@ public class RedisShardBackplane implements Backplane {
 
   @Override
   public BackplaneStatus backplaneStatus(Instance instance) throws IOException {
+    Set<String> workers = getWorkers();
     return client.call(
         jedis ->
             BackplaneStatus.newBuilder()
@@ -1441,7 +1442,7 @@ public class RedisShardBackplane implements Backplane {
                 .setBlockedActionsSize(blockedActions.size(jedis))
                 .setBlockedInvocationsSize(blockedInvocations.size(jedis))
                 .setDispatchedOperations(getDispatchedOperationsStatus(jedis, instance))
-                .addAllActiveWorkers(workerSet)
+                .addAllActiveWorkers(workers)
                 .build());
   }
 


### PR DESCRIPTION
The workers a scheduler reports should be relatively current, and
consistent with those used during enumerations. Avoid requiring those
enumeration requests by going through the cache invalidation mechanism.