### PR TITLE
Add prometheus metrics for read/write and start/stop

### DIFF
--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -122,6 +122,7 @@ import io.grpc.protobuf.StatusProto;
 import io.grpc.stub.ServerCallStreamObserver;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Gauge;
+import io.prometheus.client.Summary;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -264,6 +265,8 @@ public class ShardInstance extends AbstractServerInstance {
           .name("blocked_invocations_size")
           .help("The number of blocked invocations")
           .register();
+  private static final Summary ioMetric =
+      Summary.build().name("io_bytes_read").help("I/O (bytes)").register();
 
   private final Runnable onStop;
   private final long maxBlobSize;
@@ -877,6 +880,7 @@ public class ShardInstance extends AbstractServerInstance {
               public void onNext(ByteString nextChunk) {
                 blobObserver.onNext(nextChunk);
                 received += nextChunk.size();
+                ioMetric.observe(received);
               }
 
               @Override

--- a/src/main/java/build/buildfarm/server/WriteStreamObserver.java
+++ b/src/main/java/build/buildfarm/server/WriteStreamObserver.java
@@ -41,6 +41,7 @@ import io.grpc.Context;
 import io.grpc.Context.CancellableContext;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
+import io.prometheus.client.Summary;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -51,6 +52,8 @@ import javax.annotation.concurrent.GuardedBy;
 
 class WriteStreamObserver implements StreamObserver<WriteRequest> {
   private static final Logger logger = Logger.getLogger(WriteStreamObserver.class.getName());
+  private static final Summary ioMetric =
+      Summary.build().name("io_bytes_write").help("I/O (bytes)").register();
 
   private final Instances instances;
   private final long deadlineAfter;
@@ -379,6 +382,7 @@ class WriteStreamObserver implements StreamObserver<WriteRequest> {
     try {
       data.writeTo(getOutput());
       requestNextIfReady();
+      ioMetric.observe(data.size());
     } catch (EntryLimitException e) {
       throw e;
     } catch (IOException e) {

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -89,6 +89,7 @@ import io.grpc.health.v1.HealthCheckResponse.ServingStatus;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.services.HealthStatusManager;
+import io.prometheus.client.Counter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -117,6 +118,12 @@ public class Worker extends LoggingMain {
   private static final java.util.logging.Logger nettyLogger =
       java.util.logging.Logger.getLogger("io.grpc.netty");
   private static final Logger logger = Logger.getLogger(Worker.class.getName());
+  private static final Counter healthCheckMetric =
+      Counter.build()
+          .name("health_check")
+          .labelNames("lifecycle")
+          .help("Service health check.")
+          .register();
 
   private static final int shutdownWaitTimeInSeconds = 10;
   private final boolean isCasShard;
@@ -733,6 +740,7 @@ public class Worker extends LoggingMain {
     }
     healthStatusManager.setStatus(
         HealthStatusManager.SERVICE_NAME_ALL_SERVICES, ServingStatus.NOT_SERVING);
+    healthCheckMetric.labels("stop").inc();
     if (execFileSystem != null) {
       logger.log(INFO, "Stopping exec filesystem");
       execFileSystem.stop();
@@ -917,6 +925,7 @@ public class Worker extends LoggingMain {
       return;
     }
     pipeline.start();
+    healthCheckMetric.labels("start").inc();
   }
 
   @Override


### PR DESCRIPTION
Add two new Prometheus metrics to aid with monitoring the system:

- io_bytes (Summary) with read_write label to show bytes read/written.
- health_check (Counter) with lifecycle label to indicate service start/stop.