### PR TITLE
fix format.sh issue in mac development

### DIFF
--- a/.bazelci/format.sh
+++ b/.bazelci/format.sh
@@ -43,7 +43,9 @@ fi
 for file in $files
 do
 	# Remove whitespace lines after starting bracket '{'
-        awk -i inplace -v n=-2 'NR==n+1 && !NF{next} /\{/ {n=NR}1' $file
+	# Ignore any issues if this does not succeed.
+	# The CI doesn't gate on this adjustment.
+        awk -i inplace -v n=-2 'NR==n+1 && !NF{next} /\{/ {n=NR}1' $file > /dev/null 2>&1
 done
 
 # Fixes formatting issues


### PR DESCRIPTION
Ensure that mac users don't see any errors when running the format.sh script.
The script is used by developers to automatically format code.  The CI also uses it to check that code is formatted.  We can avoid the errors while still being correct for the CI gate.
