### PR TITLE
[metrics] disable "blocked container" metrics + add backplane fetch time

### DIFF
--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -265,6 +265,13 @@ public class ShardInstance extends AbstractServerInstance {
           .name("blocked_invocations_size")
           .help("The number of blocked invocations")
           .register();
+
+  private static final Gauge bacplaneFetchTimeMs =
+      Gauge.build()
+          .name("backplane_fetch_time_ms")
+          .help("The amount of time is took to capture backplane metrics in milliseconds.")
+          .register();
+
   private static final Summary ioMetric =
       Summary.build().name("io_bytes_read").help("I/O (bytes)").register();
 
@@ -592,6 +599,7 @@ public class ShardInstance extends AbstractServerInstance {
                       backplaneStatus.getDispatchedOperations().getUniqueClientsAmount());
                   requeuedOperationsAmount.set(
                       backplaneStatus.getDispatchedOperations().getRequeuedOperationsAmount());
+                  bacplaneFetchTimeMs.set(backplaneStatus.getFetchTimeMs());
                 } catch (InterruptedException e) {
                   Thread.currentThread().interrupt();
                   break;

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -848,6 +848,8 @@ message BackplaneStatus {
   int64 blocked_actions_size = 7;
   
   int64 blocked_invocations_size = 8;
+  
+  int64 fetch_time_ms = 10;
 }
 
 message QueuedOperationMetadata {


### PR DESCRIPTION
In regards to https://github.com/bazelbuild/bazel-buildfarm/issues/839, we need to see if metrics are getting stuck, and how long those metrics take to calculate.  We also want to disable the metrics related to blocked containers.  This may not resolve any problems in the immediate term, but it will give us more insight in production.