### PR TITLE
[ci] display code coverage in pipeline

### DIFF
--- a/generate_coverage.sh
+++ b/generate_coverage.sh
@@ -82,12 +82,16 @@ gate_lcov_results() {
         print_error "line coverage is below gating percentage: "
         print_error "$line_percentage < $GATING_LINE_PERCENTAGE"
         exit 1;
+    else
+        echo "current line coverage: " $line_percentage
     fi
     
     if [ "$function_percentage" -lt "$GATING_FUNC_PERCENTAGE" ]; then
         print_error "function coverage is below gating percentage: "
         print_error "$function_percentage < $GATING_FUNC_PERCENTAGE"
         exit 1;
+    else
+        echo "current function coverage: " $function_percentage
     fi
     
     exit 0

--- a/generate_coverage.sh
+++ b/generate_coverage.sh
@@ -83,7 +83,7 @@ gate_lcov_results() {
         print_error "$line_percentage < $GATING_LINE_PERCENTAGE"
         exit 1;
     else
-        echo "current line coverage: " $line_percentage
+        echo "current line coverage: " $line_percentage%
     fi
     
     if [ "$function_percentage" -lt "$GATING_FUNC_PERCENTAGE" ]; then
@@ -91,7 +91,7 @@ gate_lcov_results() {
         print_error "$function_percentage < $GATING_FUNC_PERCENTAGE"
         exit 1;
     else
-        echo "current function coverage: " $function_percentage
+        echo "current function coverage: " $function_percentage%
     fi
     
     exit 0


### PR DESCRIPTION
Currently we report the code coverage when its too low and the pipeline fails.  
Now we show the current code coverage for every CI run.  This makes it easier to look at master and decide whether or not we should increase the overall coverage gate.

```
current line coverage:  44%
current function coverage:  50%
```

