### PR TITLE
[refactor] move queue timeout up the callstack

### DIFF
--- a/src/main/java/build/buildfarm/instance/shard/DispatchedMonitor.java
+++ b/src/main/java/build/buildfarm/instance/shard/DispatchedMonitor.java
@@ -28,19 +28,22 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import java.util.function.BiFunction;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import com.google.protobuf.Duration;
+import com.google.protobuf.util.Durations;
 
 class DispatchedMonitor implements Runnable {
   private static final Logger logger = Logger.getLogger(DispatchedMonitor.class.getName());
 
   private final Backplane backplane;
-  private final Function<QueueEntry, ListenableFuture<Void>> requeuer;
+  private final BiFunction<QueueEntry, Duration, ListenableFuture<Void>> requeuer;
   private final int intervalSeconds;
 
   DispatchedMonitor(
       Backplane backplane,
-      Function<QueueEntry, ListenableFuture<Void>> requeuer,
+      BiFunction<QueueEntry, Duration, ListenableFuture<Void>> requeuer,
       int intervalSeconds) {
     this.backplane = backplane;
     this.requeuer = requeuer;
@@ -52,7 +55,7 @@ class DispatchedMonitor implements Runnable {
     String operationName = queueEntry.getExecuteEntry().getOperationName();
 
     logOverdueOperation(o, now);
-    ListenableFuture<Void> requeuedFuture = requeuer.apply(queueEntry);
+    ListenableFuture<Void> requeuedFuture = requeuer.apply(queueEntry,Durations.fromSeconds(60));
     long startTime = System.nanoTime();
     requeuedFuture.addListener(
         () -> {

--- a/src/main/java/build/buildfarm/instance/shard/DispatchedMonitor.java
+++ b/src/main/java/build/buildfarm/instance/shard/DispatchedMonitor.java
@@ -24,15 +24,14 @@ import build.buildfarm.v1test.QueueEntry;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.UncheckedExecutionException;
+import com.google.protobuf.Duration;
+import com.google.protobuf.util.Durations;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 import java.util.function.BiFunction;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import com.google.protobuf.Duration;
-import com.google.protobuf.util.Durations;
 
 class DispatchedMonitor implements Runnable {
   private static final Logger logger = Logger.getLogger(DispatchedMonitor.class.getName());
@@ -55,7 +54,7 @@ class DispatchedMonitor implements Runnable {
     String operationName = queueEntry.getExecuteEntry().getOperationName();
 
     logOverdueOperation(o, now);
-    ListenableFuture<Void> requeuedFuture = requeuer.apply(queueEntry,Durations.fromSeconds(60));
+    ListenableFuture<Void> requeuedFuture = requeuer.apply(queueEntry, Durations.fromSeconds(60));
     long startTime = System.nanoTime();
     requeuedFuture.addListener(
         () -> {

--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -2147,13 +2147,13 @@ public class ShardInstance extends AbstractServerInstance {
                     getName(), operation.getName(), checkCacheUSecs));
             return IMMEDIATE_VOID_FUTURE;
           }
-          return transformAndQueue(executeEntry, poller, operation, stopwatch);
+          return transformAndQueue(executeEntry, poller, operation, stopwatch, Durations.fromSeconds(60));
         },
         operationTransformService);
   }
 
   private ListenableFuture<Void> transformAndQueue(
-      ExecuteEntry executeEntry, Poller poller, Operation operation, Stopwatch stopwatch) {
+      ExecuteEntry executeEntry, Poller poller, Operation operation, Stopwatch stopwatch, Duration timeout) {
     long checkCacheUSecs = stopwatch.elapsed(MICROSECONDS);
     ExecuteOperationMetadata metadata;
     try {
@@ -2275,7 +2275,7 @@ public class ShardInstance extends AbstractServerInstance {
                   profiledQueuedMetadata.getQueuedOperationMetadata().getQueuedOperationDigest();
               long startUploadUSecs = stopwatch.elapsed(MICROSECONDS);
               return transform(
-                  writeBlobFuture(queuedOperationDigest, queuedOperationBlob, requestMetadata,Durations.fromSeconds(60)),
+                  writeBlobFuture(queuedOperationDigest, queuedOperationBlob, requestMetadata,timeout),
                   (committedSize) ->
                       profiledQueuedMetadata
                           .setUploadedIn(

--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -476,7 +476,7 @@ public class ShardInstance extends AbstractServerInstance {
                       Deadline.after(5, MINUTES));
                   try {
                     logger.log(Level.FINE, "queueing " + operationName);
-                    ListenableFuture<Void> queueFuture = queue(executeEntry, poller);
+                    ListenableFuture<Void> queueFuture = queue(executeEntry, poller,Durations.fromSeconds(60));
                     addCallback(
                         queueFuture,
                         new FutureCallback<Void>() {
@@ -2110,7 +2110,7 @@ public class ShardInstance extends AbstractServerInstance {
   }
 
   @VisibleForTesting
-  public ListenableFuture<Void> queue(ExecuteEntry executeEntry, Poller poller)
+  public ListenableFuture<Void> queue(ExecuteEntry executeEntry, Poller poller, Duration timeout)
       throws InterruptedException {
     ExecuteOperationMetadata metadata =
         ExecuteOperationMetadata.newBuilder()
@@ -2147,7 +2147,7 @@ public class ShardInstance extends AbstractServerInstance {
                     getName(), operation.getName(), checkCacheUSecs));
             return IMMEDIATE_VOID_FUTURE;
           }
-          return transformAndQueue(executeEntry, poller, operation, stopwatch, Durations.fromSeconds(60));
+          return transformAndQueue(executeEntry, poller, operation, stopwatch, timeout);
         },
         operationTransformService);
   }

--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -311,6 +311,9 @@ public class ShardInstance extends AbstractServerInstance {
   private boolean stopping = false;
   private boolean stopped = true;
   private Thread prometheusMetricsThread;
+  
+  //TODO: move to config
+  private static final Duration queueTimeout = Durations.fromSeconds(60);
 
   private static Duration getGrpcTimeout(ShardInstanceConfig config) {
     // return the configured
@@ -476,7 +479,7 @@ public class ShardInstance extends AbstractServerInstance {
                       Deadline.after(5, MINUTES));
                   try {
                     logger.log(Level.FINE, "queueing " + operationName);
-                    ListenableFuture<Void> queueFuture = queue(executeEntry, poller,Durations.fromSeconds(60));
+                    ListenableFuture<Void> queueFuture = queue(executeEntry, poller,queueTimeout);
                     addCallback(
                         queueFuture,
                         new FutureCallback<Void>() {

--- a/src/test/java/build/buildfarm/instance/shard/DispatchedMonitorTest.java
+++ b/src/test/java/build/buildfarm/instance/shard/DispatchedMonitorTest.java
@@ -32,10 +32,11 @@ import build.buildfarm.v1test.QueueEntry;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.UncheckedExecutionException;
+import com.google.protobuf.Duration;
+import com.google.protobuf.util.Durations;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Function;
 import java.util.function.BiFunction;
 import org.junit.Before;
 import org.junit.Test;
@@ -43,8 +44,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import com.google.protobuf.Duration;
-import com.google.protobuf.util.Durations;
 
 @RunWith(JUnit4.class)
 public class DispatchedMonitorTest {
@@ -57,7 +56,7 @@ public class DispatchedMonitorTest {
   @Before
   public void setUp() throws InterruptedException {
     MockitoAnnotations.initMocks(this);
-    when(requeuer.apply(any(QueueEntry.class),any(Duration.class)))
+    when(requeuer.apply(any(QueueEntry.class), any(Duration.class)))
         .thenReturn(immediateFailedFuture(new RuntimeException("unexpected requeue")));
     dispatchedMonitor = new DispatchedMonitor(backplane, requeuer, /* intervalSeconds=*/ 0);
   }
@@ -99,9 +98,9 @@ public class DispatchedMonitorTest {
                     .setRequeueAt(0)
                     .setQueueEntry(queueEntry)
                     .build()));
-    when(requeuer.apply(eq(queueEntry),any(Duration.class))).thenReturn(immediateFuture(null));
+    when(requeuer.apply(eq(queueEntry), any(Duration.class))).thenReturn(immediateFuture(null));
     dispatchedMonitor.iterate();
-    verify(requeuer, times(1)).apply(queueEntry,Durations.fromSeconds(60));
+    verify(requeuer, times(1)).apply(queueEntry, Durations.fromSeconds(60));
   }
 
   @Test
@@ -122,7 +121,7 @@ public class DispatchedMonitorTest {
                     .setRequeueAt(0)
                     .setQueueEntry(queueEntry)
                     .build()));
-    when(requeuer.apply(eq(queueEntry),any(Duration.class))).thenReturn(immediateFuture(null));
+    when(requeuer.apply(eq(queueEntry), any(Duration.class))).thenReturn(immediateFuture(null));
     dispatchedMonitor.iterate();
     verifyZeroInteractions(requeuer);
   }
@@ -153,10 +152,10 @@ public class DispatchedMonitorTest {
                     .setRequeueAt(0)
                     .setQueueEntry(queueEntry)
                     .build()));
-    when(requeuer.apply(eq(queueEntry),any(Duration.class)))
+    when(requeuer.apply(eq(queueEntry), any(Duration.class)))
         .thenReturn(immediateFailedFuture(new Exception("error during requeue")));
     dispatchedMonitor.iterate();
-    verify(requeuer, times(1)).apply(queueEntry,Durations.fromSeconds(60));
+    verify(requeuer, times(1)).apply(queueEntry, Durations.fromSeconds(60));
   }
 
   @Test

--- a/src/test/java/build/buildfarm/instance/shard/DispatchedMonitorTest.java
+++ b/src/test/java/build/buildfarm/instance/shard/DispatchedMonitorTest.java
@@ -36,25 +36,28 @@ import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
+import java.util.function.BiFunction;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import com.google.protobuf.Duration;
+import com.google.protobuf.util.Durations;
 
 @RunWith(JUnit4.class)
 public class DispatchedMonitorTest {
   @Mock private Backplane backplane;
 
-  @Mock private Function<QueueEntry, ListenableFuture<Void>> requeuer;
+  @Mock private BiFunction<QueueEntry, Duration, ListenableFuture<Void>> requeuer;
 
   private DispatchedMonitor dispatchedMonitor;
 
   @Before
   public void setUp() throws InterruptedException {
     MockitoAnnotations.initMocks(this);
-    when(requeuer.apply(any(QueueEntry.class)))
+    when(requeuer.apply(any(QueueEntry.class),any(Duration.class)))
         .thenReturn(immediateFailedFuture(new RuntimeException("unexpected requeue")));
     dispatchedMonitor = new DispatchedMonitor(backplane, requeuer, /* intervalSeconds=*/ 0);
   }
@@ -96,9 +99,9 @@ public class DispatchedMonitorTest {
                     .setRequeueAt(0)
                     .setQueueEntry(queueEntry)
                     .build()));
-    when(requeuer.apply(eq(queueEntry))).thenReturn(immediateFuture(null));
+    when(requeuer.apply(eq(queueEntry),any(Duration.class))).thenReturn(immediateFuture(null));
     dispatchedMonitor.iterate();
-    verify(requeuer, times(1)).apply(queueEntry);
+    verify(requeuer, times(1)).apply(queueEntry,Durations.fromSeconds(60));
   }
 
   @Test
@@ -119,7 +122,7 @@ public class DispatchedMonitorTest {
                     .setRequeueAt(0)
                     .setQueueEntry(queueEntry)
                     .build()));
-    when(requeuer.apply(eq(queueEntry))).thenReturn(immediateFuture(null));
+    when(requeuer.apply(eq(queueEntry),any(Duration.class))).thenReturn(immediateFuture(null));
     dispatchedMonitor.iterate();
     verifyZeroInteractions(requeuer);
   }
@@ -150,10 +153,10 @@ public class DispatchedMonitorTest {
                     .setRequeueAt(0)
                     .setQueueEntry(queueEntry)
                     .build()));
-    when(requeuer.apply(eq(queueEntry)))
+    when(requeuer.apply(eq(queueEntry),any(Duration.class)))
         .thenReturn(immediateFailedFuture(new Exception("error during requeue")));
     dispatchedMonitor.iterate();
-    verify(requeuer, times(1)).apply(queueEntry);
+    verify(requeuer, times(1)).apply(queueEntry,Durations.fromSeconds(60));
   }
 
   @Test

--- a/src/test/java/build/buildfarm/instance/shard/ShardInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/shard/ShardInstanceTest.java
@@ -115,6 +115,7 @@ import com.google.protobuf.util.Durations;
 public class ShardInstanceTest {
   private static final DigestUtil DIGEST_UTIL = new DigestUtil(HashFunction.SHA256);
   private static final long QUEUE_TEST_TIMEOUT_SECONDS = 3;
+  private static final Duration DEFAULT_TIMEOUT = Durations.fromSeconds(60);
   private static final Command SIMPLE_COMMAND =
       Command.newBuilder().addAllArguments(ImmutableList.of("true")).build();
 
@@ -290,7 +291,7 @@ public class ShardInstanceTest {
 
     boolean failedPreconditionExceptionCaught = false;
     try {
-      instance.queue(executeEntry, poller).get(QUEUE_TEST_TIMEOUT_SECONDS, SECONDS);
+      instance.queue(executeEntry, poller,DEFAULT_TIMEOUT).get(QUEUE_TEST_TIMEOUT_SECONDS, SECONDS);
     } catch (ExecutionException e) {
       com.google.rpc.Status status = StatusProto.fromThrowable(e);
       if (status.getCode() == Code.FAILED_PRECONDITION.getNumber()) {
@@ -353,7 +354,7 @@ public class ShardInstanceTest {
 
     boolean failedPreconditionExceptionCaught = false;
     try {
-      instance.queue(executeEntry, poller).get(QUEUE_TEST_TIMEOUT_SECONDS, SECONDS);
+      instance.queue(executeEntry, poller,DEFAULT_TIMEOUT).get(QUEUE_TEST_TIMEOUT_SECONDS, SECONDS);
     } catch (ExecutionException e) {
       com.google.rpc.Status status = StatusProto.fromThrowable(e);
       if (status.getCode() == Code.FAILED_PRECONDITION.getNumber()) {
@@ -402,7 +403,7 @@ public class ShardInstanceTest {
 
     boolean failedPreconditionExceptionCaught = false;
     try {
-      instance.queue(executeEntry, poller).get(QUEUE_TEST_TIMEOUT_SECONDS, SECONDS);
+      instance.queue(executeEntry, poller,DEFAULT_TIMEOUT).get(QUEUE_TEST_TIMEOUT_SECONDS, SECONDS);
     } catch (ExecutionException e) {
       com.google.rpc.Status status = StatusProto.fromThrowable(e);
       if (status.getCode() == Code.FAILED_PRECONDITION.getNumber()) {
@@ -481,7 +482,7 @@ public class ShardInstanceTest {
 
     boolean failedPreconditionExceptionCaught = false;
     try {
-      instance.queue(executeEntry, poller).get(QUEUE_TEST_TIMEOUT_SECONDS, SECONDS);
+      instance.queue(executeEntry, poller,DEFAULT_TIMEOUT).get(QUEUE_TEST_TIMEOUT_SECONDS, SECONDS);
     } catch (ExecutionException e) {
       com.google.rpc.Status status = StatusProto.fromThrowable(e);
       if (status.getCode() == Code.FAILED_PRECONDITION.getNumber()) {
@@ -548,7 +549,7 @@ public class ShardInstanceTest {
     boolean unavailableExceptionCaught = false;
     try {
       // anything more would be unreasonable
-      instance.queue(executeEntry, poller).get(QUEUE_TEST_TIMEOUT_SECONDS, SECONDS);
+      instance.queue(executeEntry, poller,DEFAULT_TIMEOUT).get(QUEUE_TEST_TIMEOUT_SECONDS, SECONDS);
     } catch (ExecutionException e) {
       com.google.rpc.Status status = StatusProto.fromThrowable(e);
       if (status.getCode() == Code.UNAVAILABLE.getNumber()) {
@@ -585,7 +586,7 @@ public class ShardInstanceTest {
 
     Poller poller = mock(Poller.class);
 
-    instance.queue(executeEntry, poller).get();
+    instance.queue(executeEntry, poller,DEFAULT_TIMEOUT).get();
 
     verify(mockBackplane, times(1)).putOperation(any(Operation.class), eq(CACHE_CHECK));
     verify(mockBackplane, never()).putOperation(any(Operation.class), eq(QUEUED));
@@ -627,7 +628,7 @@ public class ShardInstanceTest {
 
     Poller poller = mock(Poller.class);
 
-    instance.queue(executeEntry, poller).get(QUEUE_TEST_TIMEOUT_SECONDS, SECONDS);
+    instance.queue(executeEntry, poller,DEFAULT_TIMEOUT).get(QUEUE_TEST_TIMEOUT_SECONDS, SECONDS);
 
     verify(mockBackplane, times(1)).queue(any(QueueEntry.class), any(Operation.class));
     verify(mockBackplane, times(1)).putOperation(any(Operation.class), eq(CACHE_CHECK));
@@ -678,7 +679,7 @@ public class ShardInstanceTest {
             .setRequestMetadata(requestMetadata)
             .build();
     Poller poller = mock(Poller.class);
-    instance.queue(cacheServedExecuteEntry, poller).get(QUEUE_TEST_TIMEOUT_SECONDS, SECONDS);
+    instance.queue(cacheServedExecuteEntry, poller,DEFAULT_TIMEOUT).get(QUEUE_TEST_TIMEOUT_SECONDS, SECONDS);
 
     verify(poller, times(1)).pause();
     verify(mockBackplane, never()).queue(any(QueueEntry.class), any(Operation.class));

--- a/src/test/java/build/buildfarm/instance/shard/ShardInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/shard/ShardInstanceTest.java
@@ -80,6 +80,7 @@ import com.google.longrunning.Operation;
 import com.google.protobuf.Any;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Duration;
+import com.google.protobuf.util.Durations;
 import com.google.rpc.Code;
 import com.google.rpc.PreconditionFailure;
 import com.google.rpc.PreconditionFailure.Violation;
@@ -108,8 +109,6 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import com.google.protobuf.Duration;
-import com.google.protobuf.util.Durations;
 
 @RunWith(JUnit4.class)
 public class ShardInstanceTest {
@@ -291,7 +290,9 @@ public class ShardInstanceTest {
 
     boolean failedPreconditionExceptionCaught = false;
     try {
-      instance.queue(executeEntry, poller,DEFAULT_TIMEOUT).get(QUEUE_TEST_TIMEOUT_SECONDS, SECONDS);
+      instance
+          .queue(executeEntry, poller, DEFAULT_TIMEOUT)
+          .get(QUEUE_TEST_TIMEOUT_SECONDS, SECONDS);
     } catch (ExecutionException e) {
       com.google.rpc.Status status = StatusProto.fromThrowable(e);
       if (status.getCode() == Code.FAILED_PRECONDITION.getNumber()) {
@@ -354,7 +355,9 @@ public class ShardInstanceTest {
 
     boolean failedPreconditionExceptionCaught = false;
     try {
-      instance.queue(executeEntry, poller,DEFAULT_TIMEOUT).get(QUEUE_TEST_TIMEOUT_SECONDS, SECONDS);
+      instance
+          .queue(executeEntry, poller, DEFAULT_TIMEOUT)
+          .get(QUEUE_TEST_TIMEOUT_SECONDS, SECONDS);
     } catch (ExecutionException e) {
       com.google.rpc.Status status = StatusProto.fromThrowable(e);
       if (status.getCode() == Code.FAILED_PRECONDITION.getNumber()) {
@@ -403,7 +406,9 @@ public class ShardInstanceTest {
 
     boolean failedPreconditionExceptionCaught = false;
     try {
-      instance.queue(executeEntry, poller,DEFAULT_TIMEOUT).get(QUEUE_TEST_TIMEOUT_SECONDS, SECONDS);
+      instance
+          .queue(executeEntry, poller, DEFAULT_TIMEOUT)
+          .get(QUEUE_TEST_TIMEOUT_SECONDS, SECONDS);
     } catch (ExecutionException e) {
       com.google.rpc.Status status = StatusProto.fromThrowable(e);
       if (status.getCode() == Code.FAILED_PRECONDITION.getNumber()) {
@@ -482,7 +487,9 @@ public class ShardInstanceTest {
 
     boolean failedPreconditionExceptionCaught = false;
     try {
-      instance.queue(executeEntry, poller,DEFAULT_TIMEOUT).get(QUEUE_TEST_TIMEOUT_SECONDS, SECONDS);
+      instance
+          .queue(executeEntry, poller, DEFAULT_TIMEOUT)
+          .get(QUEUE_TEST_TIMEOUT_SECONDS, SECONDS);
     } catch (ExecutionException e) {
       com.google.rpc.Status status = StatusProto.fromThrowable(e);
       if (status.getCode() == Code.FAILED_PRECONDITION.getNumber()) {
@@ -549,7 +556,9 @@ public class ShardInstanceTest {
     boolean unavailableExceptionCaught = false;
     try {
       // anything more would be unreasonable
-      instance.queue(executeEntry, poller,DEFAULT_TIMEOUT).get(QUEUE_TEST_TIMEOUT_SECONDS, SECONDS);
+      instance
+          .queue(executeEntry, poller, DEFAULT_TIMEOUT)
+          .get(QUEUE_TEST_TIMEOUT_SECONDS, SECONDS);
     } catch (ExecutionException e) {
       com.google.rpc.Status status = StatusProto.fromThrowable(e);
       if (status.getCode() == Code.UNAVAILABLE.getNumber()) {
@@ -586,7 +595,7 @@ public class ShardInstanceTest {
 
     Poller poller = mock(Poller.class);
 
-    instance.queue(executeEntry, poller,DEFAULT_TIMEOUT).get();
+    instance.queue(executeEntry, poller, DEFAULT_TIMEOUT).get();
 
     verify(mockBackplane, times(1)).putOperation(any(Operation.class), eq(CACHE_CHECK));
     verify(mockBackplane, never()).putOperation(any(Operation.class), eq(QUEUED));
@@ -628,7 +637,7 @@ public class ShardInstanceTest {
 
     Poller poller = mock(Poller.class);
 
-    instance.queue(executeEntry, poller,DEFAULT_TIMEOUT).get(QUEUE_TEST_TIMEOUT_SECONDS, SECONDS);
+    instance.queue(executeEntry, poller, DEFAULT_TIMEOUT).get(QUEUE_TEST_TIMEOUT_SECONDS, SECONDS);
 
     verify(mockBackplane, times(1)).queue(any(QueueEntry.class), any(Operation.class));
     verify(mockBackplane, times(1)).putOperation(any(Operation.class), eq(CACHE_CHECK));
@@ -679,7 +688,9 @@ public class ShardInstanceTest {
             .setRequestMetadata(requestMetadata)
             .build();
     Poller poller = mock(Poller.class);
-    instance.queue(cacheServedExecuteEntry, poller,DEFAULT_TIMEOUT).get(QUEUE_TEST_TIMEOUT_SECONDS, SECONDS);
+    instance
+        .queue(cacheServedExecuteEntry, poller, DEFAULT_TIMEOUT)
+        .get(QUEUE_TEST_TIMEOUT_SECONDS, SECONDS);
 
     verify(poller, times(1)).pause();
     verify(mockBackplane, never()).queue(any(QueueEntry.class), any(Operation.class));
@@ -741,7 +752,7 @@ public class ShardInstanceTest {
                     .setSkipCacheLookup(true)
                     .setActionDigest(actionDigest))
             .build();
-    instance.requeueOperation(queueEntry,Durations.fromSeconds(60)).get();
+    instance.requeueOperation(queueEntry, Durations.fromSeconds(60)).get();
     ArgumentCaptor<Operation> operationCaptor = ArgumentCaptor.forClass(Operation.class);
     verify(mockBackplane, times(1)).putOperation(operationCaptor.capture(), eq(COMPLETED));
     Operation operation = operationCaptor.getValue();
@@ -812,7 +823,7 @@ public class ShardInstanceTest {
                     .setActionDigest(actionDigest))
             .setQueuedOperationDigest(queuedOperationDigest)
             .build();
-    instance.requeueOperation(queueEntry,Durations.fromSeconds(60)).get();
+    instance.requeueOperation(queueEntry, Durations.fromSeconds(60)).get();
   }
 
   @Test

--- a/src/test/java/build/buildfarm/instance/shard/ShardInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/shard/ShardInstanceTest.java
@@ -108,6 +108,8 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import com.google.protobuf.Duration;
+import com.google.protobuf.util.Durations;
 
 @RunWith(JUnit4.class)
 public class ShardInstanceTest {
@@ -738,7 +740,7 @@ public class ShardInstanceTest {
                     .setSkipCacheLookup(true)
                     .setActionDigest(actionDigest))
             .build();
-    instance.requeueOperation(queueEntry).get();
+    instance.requeueOperation(queueEntry,Durations.fromSeconds(60)).get();
     ArgumentCaptor<Operation> operationCaptor = ArgumentCaptor.forClass(Operation.class);
     verify(mockBackplane, times(1)).putOperation(operationCaptor.capture(), eq(COMPLETED));
     Operation operation = operationCaptor.getValue();
@@ -809,7 +811,7 @@ public class ShardInstanceTest {
                     .setActionDigest(actionDigest))
             .setQueuedOperationDigest(queuedOperationDigest)
             .build();
-    instance.requeueOperation(queueEntry).get();
+    instance.requeueOperation(queueEntry,Durations.fromSeconds(60)).get();
   }
 
   @Test


### PR DESCRIPTION
We are going to make this timeout configurable.  Before doing that, we will modify the call sites and make the timeout a property of shard instance.  This will make the next PR for configuration much smaller.