### PR TITLE
[refactor] remove unnecessary null check

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -95,6 +95,7 @@ def buildfarm_init(name = "buildfarm"):
                         "org.redisson:redisson:3.13.1",
                         "org.threeten:threetenbp:1.3.3",
                         "org.xerial:sqlite-jdbc:3.34.0",
+                        "org.jetbrains:annotations:16.0.2",
                     ],
         generate_compat_repositories = True,
         repositories = [

--- a/src/main/java/build/buildfarm/worker/BUILD
+++ b/src/main/java/build/buildfarm/worker/BUILD
@@ -29,5 +29,6 @@ java_library(
         "@maven//:io_grpc_grpc_protobuf",
         "@maven//:io_grpc_grpc_stub",
         "@maven//:io_prometheus_simpleclient",
+        "@maven//:org_jetbrains_annotations",
     ],
 )

--- a/src/main/java/build/buildfarm/worker/DequeueMatchEvaluator.java
+++ b/src/main/java/build/buildfarm/worker/DequeueMatchEvaluator.java
@@ -20,6 +20,7 @@ import build.buildfarm.common.ExecutionProperties;
 import build.buildfarm.v1test.QueueEntry;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.SetMultimap;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * @class DequeueMatchEvaluator
@@ -48,6 +49,7 @@ public class DequeueMatchEvaluator {
    * @note Overloaded.
    * @note Suggested return identifier: shouldKeepOperation.
    */
+  @NotNull
   public static boolean shouldKeepOperation(
       DequeueMatchSettings matchSettings,
       SetMultimap<String, String> workerProvisions,
@@ -65,6 +67,7 @@ public class DequeueMatchEvaluator {
    * @note Overloaded.
    * @note Suggested return identifier: shouldKeepOperation.
    */
+  @NotNull
   public static boolean shouldKeepOperation(
       DequeueMatchSettings matchSettings,
       SetMultimap<String, String> workerProvisions,
@@ -83,11 +86,12 @@ public class DequeueMatchEvaluator {
    * @return Whether or not the worker should accept or reject the operation.
    * @note Suggested return identifier: shouldKeepOperation.
    */
+  @NotNull
   private static boolean shouldKeepViaPlatform(
       DequeueMatchSettings matchSettings,
       SetMultimap<String, String> workerProvisions,
       Platform platform) {
-    // attempt to execute everything it gets off the queue.
+    // attempt to execute everything the worker gets off the queue.
     // this is a recommended configuration.
     if (matchSettings.acceptEverything) {
       return true;
@@ -106,6 +110,7 @@ public class DequeueMatchEvaluator {
    * @return Whether or not the worker should accept or reject the queue entry.
    * @note Suggested return identifier: shouldKeepOperation.
    */
+  @NotNull
   private static boolean satisfiesProperties(
       DequeueMatchSettings matchSettings,
       SetMultimap<String, String> workerProvisions,
@@ -128,6 +133,7 @@ public class DequeueMatchEvaluator {
    * @return Whether or not the worker should accept or reject the queue entry.
    * @note Suggested return identifier: shouldKeepOperation.
    */
+  @NotNull
   private static boolean satisfiesProperty(
       DequeueMatchSettings matchSettings,
       SetMultimap<String, String> workerProvisions,

--- a/src/main/java/build/buildfarm/worker/DequeueMatchEvaluator.java
+++ b/src/main/java/build/buildfarm/worker/DequeueMatchEvaluator.java
@@ -52,12 +52,6 @@ public class DequeueMatchEvaluator {
       DequeueMatchSettings matchSettings,
       SetMultimap<String, String> workerProvisions,
       QueueEntry queueEntry) {
-    // if the queue entry was not actually dequeued, should we still accept it?
-    // TODO(luxe): find out why its currently like this, and if that still makes sense.
-    if (queueEntry == null) {
-      return true;
-    }
-
     return shouldKeepViaPlatform(matchSettings, workerProvisions, queueEntry.getPlatform());
   }
 
@@ -94,6 +88,7 @@ public class DequeueMatchEvaluator {
       SetMultimap<String, String> workerProvisions,
       Platform platform) {
     // attempt to execute everything it gets off the queue.
+    // this is a recommended configuration.
     if (matchSettings.acceptEverything) {
       return true;
     }

--- a/src/test/java/build/buildfarm/worker/DequeueMatchEvaluatorTest.java
+++ b/src/test/java/build/buildfarm/worker/DequeueMatchEvaluatorTest.java
@@ -42,23 +42,6 @@ import org.junit.runners.JUnit4;
  */
 @RunWith(JUnit4.class)
 public class DequeueMatchEvaluatorTest {
-  // Function under test: shouldKeepOperation
-  // Reason for testing: null queue entries should be kept
-  // Failure explanation: this decision has changed
-  @Test
-  public void shouldKeepOperationKeepNullQueueEntry() throws Exception {
-    // ARRANGE
-    DequeueMatchSettings settings = new DequeueMatchSettings();
-    SetMultimap<String, String> workerProvisions = HashMultimap.create();
-    QueueEntry entry = null;
-
-    // ACT
-    boolean shouldKeep =
-        DequeueMatchEvaluator.shouldKeepOperation(settings, workerProvisions, entry);
-
-    // ASSERT
-    assertThat(shouldKeep).isTrue();
-  }
 
   // Function under test: shouldKeepOperation
   // Reason for testing: empty plaform queue entries should be kept

--- a/src/test/java/build/buildfarm/worker/DequeueMatchEvaluatorTest.java
+++ b/src/test/java/build/buildfarm/worker/DequeueMatchEvaluatorTest.java
@@ -42,7 +42,6 @@ import org.junit.runners.JUnit4;
  */
 @RunWith(JUnit4.class)
 public class DequeueMatchEvaluatorTest {
-
   // Function under test: shouldKeepOperation
   // Reason for testing: empty plaform queue entries should be kept
   // Failure explanation: properties are being evaluated differently now


### PR DESCRIPTION
Resolve the TODO comment about the null check while dequeuing operations.  
I know this check is not needed because we already accept all operations during dequeue.
Additionally, it doesn't make sense to have null objects at this API context.
We will now enforce this at the API level using @NotNull annotations.
