### PR TITLE
[refactor] use longs for timeout utilities 

### DIFF
--- a/src/main/java/build/buildfarm/common/Time.java
+++ b/src/main/java/build/buildfarm/common/Time.java
@@ -56,7 +56,7 @@ public class Time {
    * @note Suggested return identifier: nanoseconds.
    */
   public static long secondsToNanoseconds(long seconds) {
-    return seconds * 1000000000;
+    return seconds * 1000000000L;
   }
 
   /**
@@ -66,7 +66,7 @@ public class Time {
    * @return Seconds converted from milliseconds.
    * @note Suggested return identifier: seconds.
    */
-  public static int millisecondsToSeconds(int milliseconds) {
-    return milliseconds / 1000;
+  public static long millisecondsToSeconds(long milliseconds) {
+    return milliseconds / 1000L;
   }
 }

--- a/src/main/java/build/buildfarm/common/redis/RedisMap.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisMap.java
@@ -51,9 +51,25 @@ public class RedisMap {
    * @param key The name of the key.
    * @param value The value for the key.
    * @param timeout_s Timeout to expire the entry. (units: seconds (s))
+   * @note Overloaded.
    */
   public void insert(JedisCluster jedis, String key, String value, int timeout_s) {
     jedis.setex(createKeyName(key), timeout_s, value);
+  }
+
+  /**
+   * @brief Set key to hold the string value and set key to timeout after a given number of seconds.
+   * @details If the key already exists, then the value is replaced.
+   * @param jedis Jedis cluster client.
+   * @param key The name of the key.
+   * @param value The value for the key.
+   * @param timeout_s Timeout to expire the entry. (units: seconds (s))
+   * @note Overloaded.
+   */
+  public void insert(JedisCluster jedis, String key, String value, long timeout_s) {
+    // Jedis only provides int precision.  this is fine as the units are seconds.
+    // We supply an interface for longs as a convenience to callers.
+    jedis.setex(createKeyName(key), (int) timeout_s, value);
   }
 
   /**

--- a/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
@@ -252,7 +252,7 @@ public class RedisShardBackplane implements Backplane {
           protected void visit(ExecuteEntry executeEntry, String executeEntryJson) {
             String operationName = executeEntry.getOperationName();
             String value = processingOperations.get(jedis, operationName);
-            int defaultTimeout_ms = config.getProcessingTimeoutMillis();
+            long defaultTimeout_ms = config.getProcessingTimeoutMillis();
 
             // get the operation's expiration
             Instant expiresAt = convertToMilliInstant(value, operationName);
@@ -261,7 +261,7 @@ public class RedisShardBackplane implements Backplane {
             if (expiresAt == null) {
               expiresAt = now.plusMillis(defaultTimeout_ms);
               String keyValue = String.format("%d", expiresAt.toEpochMilli());
-              int timeout_s = Time.millisecondsToSeconds(defaultTimeout_ms);
+              long timeout_s = Time.millisecondsToSeconds(defaultTimeout_ms);
               processingOperations.insert(jedis, operationName, keyValue, timeout_s);
             }
 
@@ -285,7 +285,7 @@ public class RedisShardBackplane implements Backplane {
           protected void visit(QueueEntry queueEntry, String queueEntryJson) {
             String operationName = queueEntry.getExecuteEntry().getOperationName();
             String value = dispatchedOperations.get(jedis, operationName);
-            int defaultTimeout_ms = config.getDispatchingTimeoutMillis();
+            long defaultTimeout_ms = config.getDispatchingTimeoutMillis();
 
             // get the operation's expiration
             Instant expiresAt = convertToMilliInstant(value, operationName);
@@ -294,7 +294,7 @@ public class RedisShardBackplane implements Backplane {
             if (expiresAt == null) {
               expiresAt = now.plusMillis(defaultTimeout_ms);
               String keyValue = String.format("%d", expiresAt.toEpochMilli());
-              int timeout_s = Time.millisecondsToSeconds(defaultTimeout_ms);
+              long timeout_s = Time.millisecondsToSeconds(defaultTimeout_ms);
               dispatchedOperations.insert(jedis, operationName, keyValue, timeout_s);
             }
 


### PR DESCRIPTION
- make time utility functions match in data type
- avoid any time-related overflows (for example: expiresAt.toEpochMilli() would not fit into `int`)
- provide overload for Redis container (this is for calling convenience as Jedis needs `int` in seconds anyways) 