### PR TITLE
[static analysis burndown] avoid double brace initialization

### DIFF
--- a/.bazelci/static_analysis_checks.xml
+++ b/.bazelci/static_analysis_checks.xml
@@ -19,7 +19,6 @@
     <exclude name="CheckResultSet"/>
     <exclude name="ConstantsInInterface"/>
     <exclude name="DefaultLabelNotLastInSwitchStmt"/>
-    <exclude name="DoubleBraceInitialization"/>
     <exclude name="ForLoopCanBeForeach"/>
     <exclude name="ForLoopVariableCount"/>
     <exclude name="GuardLogStatement"/>

--- a/src/test/java/build/buildfarm/common/redis/RedisNodeHashesMockTest.java
+++ b/src/test/java/build/buildfarm/common/redis/RedisNodeHashesMockTest.java
@@ -52,12 +52,8 @@ public class RedisNodeHashesMockTest {
     when(pool.getResource()).thenReturn(node);
 
     JedisCluster redis = mock(JedisCluster.class);
-    Map<String, JedisPool> poolMap =
-        new HashMap<String, JedisPool>() {
-          {
-            put("key1", pool);
-          }
-        };
+    Map<String, JedisPool> poolMap = new HashMap<>();
+    poolMap.put("key1", pool);
     when(redis.getClusterNodes()).thenReturn(poolMap);
 
     // ACT
@@ -106,12 +102,8 @@ public class RedisNodeHashesMockTest {
     when(pool.getResource()).thenReturn(node);
 
     JedisCluster redis = mock(JedisCluster.class);
-    Map<String, JedisPool> poolMap =
-        new HashMap<String, JedisPool>() {
-          {
-            put("key1", pool);
-          }
-        };
+    Map<String, JedisPool> poolMap = new HashMap<>();
+    poolMap.put("key1", pool);
     when(redis.getClusterNodes()).thenReturn(poolMap);
 
     // ACT


### PR DESCRIPTION
Double brace initialization implicitly generates a new .class file, and the object holds a strong reference to the enclosing object.  It is better to initialize the objects normally.
We enable the CI check and fix existing code.