### PR TITLE
[static analysis burndown] remove unused variables

### DIFF
--- a/.bazelci/static_analysis_checks.xml
+++ b/.bazelci/static_analysis_checks.xml
@@ -46,7 +46,6 @@
     <exclude name="SystemPrintln"/>
     <exclude name="UnusedAssignment"/>
     <exclude name="UnusedFormalParameter"/>
-    <exclude name="UnusedLocalVariable"/>
     <exclude name="UseAssertEqualsInsteadOfAssertTrue"/>
     <exclude name="UseAssertNullInsteadOfAssertTrue"/>
     <exclude name="UseAssertSameInsteadOfAssertTrue"/>

--- a/src/main/java/build/buildfarm/Executor.java
+++ b/src/main/java/build/buildfarm/Executor.java
@@ -254,7 +254,6 @@ class Executor {
                 .setDigest(missingDigest)
                 .setData(ByteString.copyFrom(Files.readAllBytes(path)))
                 .build();
-        boolean foundBucket = false;
         int maxBucketSize = 0;
         long minBucketSize = Size.mbToBytes(2) + 1;
         int maxBucketIndex = 0;
@@ -335,7 +334,7 @@ class Executor {
             writtenBytes += len;
             first = false;
           }
-          WriteResponse response = writtenFuture.get();
+          writtenFuture.get();
           System.out.println(
               "Wrote long "
                   + DigestUtil.toString(missingDigest)

--- a/src/main/java/build/buildfarm/FindOperations.java
+++ b/src/main/java/build/buildfarm/FindOperations.java
@@ -53,7 +53,7 @@ class FindOperations {
 
     // get operations and print them
     ImmutableList.Builder<Operation> operations = new ImmutableList.Builder<>();
-    String token = instance.listOperations(100, "/operations", filterPredicate, operations);
+    instance.listOperations(100, "/operations", filterPredicate, operations);
     for (Operation operation : operations.build()) {
       System.out.println(operation.getName());
     }

--- a/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
+++ b/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
@@ -2184,8 +2184,6 @@ public abstract class CASFileCache implements ContentAddressableStorage {
         transformAsync(
             fetchFuture,
             (result) -> {
-              ImmutableList.Builder<Throwable> failures = ImmutableList.builder();
-              boolean failed = false;
               try {
                 disableAllWriteAccess(path);
               } catch (IOException e) {
@@ -2319,10 +2317,8 @@ public abstract class CASFileCache implements ContentAddressableStorage {
   private void copyExternalInput(Digest digest, CancellableOutputStream out)
       throws IOException, InterruptedException {
     logger.log(Level.FINE, format("downloading %s", DigestUtil.toString(digest)));
-    boolean complete = false;
     try (InputStream in = newExternalInput(digest, /* offset=*/ 0)) {
       ByteStreams.copy(in, out);
-      complete = true;
     } catch (IOException e) {
       out.cancel();
       logger.log(

--- a/src/main/java/build/buildfarm/common/io/Utils.java
+++ b/src/main/java/build/buildfarm/common/io/Utils.java
@@ -172,7 +172,7 @@ public class Utils {
       direntPtr = libc.readdir(DIR);
     }
 
-    int return_value = libc.closedir(DIR);
+    libc.closedir(DIR);
     return dirents;
   }
 
@@ -465,7 +465,6 @@ public class Utils {
 
   public static @Nullable UserPrincipal getUser(String userName, FileSystem fileSystem)
       throws IOException {
-    final @Nullable UserPrincipal user;
     if (Strings.isNullOrEmpty(userName)) {
       return null;
     }

--- a/src/main/java/build/buildfarm/instance/server/AbstractServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/server/AbstractServerInstance.java
@@ -932,14 +932,12 @@ public abstract class AbstractServerInstance implements Instance {
       PreconditionFailure.Builder preconditionFailure,
       RequestMetadata requestMetadata)
       throws StatusException, InterruptedException {
-    final ListenableFuture<Void> validatedFuture;
     if (!queuedOperation.hasAction()) {
       preconditionFailure
           .addViolationsBuilder()
           .setType(VIOLATION_TYPE_MISSING)
           .setSubject("blobs/" + DigestUtil.toString(actionDigest))
           .setDescription(MISSING_ACTION);
-      validatedFuture = Futures.immediateFuture(null);
     } else {
       ImmutableSet.Builder<Digest> inputDigestsBuilder = ImmutableSet.builder();
       validateAction(
@@ -1247,9 +1245,8 @@ public abstract class AbstractServerInstance implements Instance {
       RequestMetadata requestMetadata,
       Watcher watcher)
       throws InterruptedException {
-    Action action;
     try {
-      action = validateActionDigest("execute", actionDigest, requestMetadata);
+      validateActionDigest("execute", actionDigest, requestMetadata);
     } catch (StatusException e) {
       com.google.rpc.Status status = StatusProto.fromThrowable(e);
       if (status == null) {

--- a/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
@@ -1021,8 +1021,6 @@ public class RedisShardBackplane implements Backplane {
 
   @Override
   public boolean putOperation(Operation operation, ExecutionStage.Value stage) throws IOException {
-    // FIXME queue and prequeue should no longer be passed to here
-    boolean prequeue = stage == ExecutionStage.Value.UNKNOWN && !operation.getDone();
     boolean queue = stage == ExecutionStage.Value.QUEUED;
     boolean complete = !queue && operation.getDone();
     boolean publish = !queue && stage != ExecutionStage.Value.UNKNOWN;

--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -2041,7 +2041,6 @@ public class ShardInstance extends AbstractServerInstance {
     }
     Digest actionDigest = metadata.getActionDigest();
     SettableFuture<Void> queueFuture = SettableFuture.create();
-    long startTransformUSecs = stopwatch.elapsed(MICROSECONDS);
     logger.log(
         Level.FINE,
         format(

--- a/src/main/java/build/buildfarm/instance/stub/StubInstance.java
+++ b/src/main/java/build/buildfarm/instance/stub/StubInstance.java
@@ -82,7 +82,6 @@ import build.buildfarm.v1test.QueueEntry;
 import build.buildfarm.v1test.ReindexCasRequest;
 import build.buildfarm.v1test.ReindexCasRequestResults;
 import build.buildfarm.v1test.ShutDownWorkerGracefullyRequest;
-import build.buildfarm.v1test.ShutDownWorkerGracefullyRequestResults;
 import build.buildfarm.v1test.ShutDownWorkerGrpc;
 import build.buildfarm.v1test.ShutDownWorkerGrpc.ShutDownWorkerBlockingStub;
 import build.buildfarm.v1test.TakeOperationRequest;
@@ -870,11 +869,10 @@ public class StubInstance implements Instance {
   @Override
   public void deregisterWorker(String workerName) {
     throwIfStopped();
-    ShutDownWorkerGracefullyRequestResults proto =
-        adminBlockingStub
-            .get()
-            .shutDownWorkerGracefully(
-                ShutDownWorkerGracefullyRequest.newBuilder().setWorkerName(workerName).build());
+    adminBlockingStub
+        .get()
+        .shutDownWorkerGracefully(
+            ShutDownWorkerGracefullyRequest.newBuilder().setWorkerName(workerName).build());
   }
 
   @Override

--- a/src/main/java/build/buildfarm/operations/finder/EnrichedOperationBuilder.java
+++ b/src/main/java/build/buildfarm/operations/finder/EnrichedOperationBuilder.java
@@ -134,27 +134,22 @@ public class EnrichedOperationBuilder {
    */
   private static Digest operationToActionDigest(Operation operation) {
     ExecuteOperationMetadata metadata;
-    RequestMetadata requestMetadata;
 
     try {
       if (operation.getMetadata().is(QueuedOperationMetadata.class)) {
         QueuedOperationMetadata queuedOperationMetadata =
             operation.getMetadata().unpack(QueuedOperationMetadata.class);
         metadata = queuedOperationMetadata.getExecuteOperationMetadata();
-        requestMetadata = queuedOperationMetadata.getRequestMetadata();
       } else if (operation.getMetadata().is(ExecutingOperationMetadata.class)) {
         ExecutingOperationMetadata executingMetadata =
             operation.getMetadata().unpack(ExecutingOperationMetadata.class);
         metadata = executingMetadata.getExecuteOperationMetadata();
-        requestMetadata = executingMetadata.getRequestMetadata();
       } else if (operation.getMetadata().is(CompletedOperationMetadata.class)) {
         CompletedOperationMetadata completedMetadata =
             operation.getMetadata().unpack(CompletedOperationMetadata.class);
         metadata = completedMetadata.getExecuteOperationMetadata();
-        requestMetadata = completedMetadata.getRequestMetadata();
       } else {
         metadata = operation.getMetadata().unpack(ExecuteOperationMetadata.class);
-        requestMetadata = null;
       }
 
     } catch (InvalidProtocolBufferException e) {

--- a/src/main/java/build/buildfarm/proxy/http/ContentAddressableStorageService.java
+++ b/src/main/java/build/buildfarm/proxy/http/ContentAddressableStorageService.java
@@ -79,7 +79,6 @@ public class ContentAddressableStorageService
   public void batchUpdateBlobs(
       BatchUpdateBlobsRequest batchRequest,
       StreamObserver<BatchUpdateBlobsResponse> responseObserver) {
-    ImmutableList.Builder<ByteString> validBlobsBuilder = new ImmutableList.Builder<>();
     ImmutableList.Builder<BatchUpdateBlobsResponse.Response> responses =
         new ImmutableList.Builder<>();
     Function<com.google.rpc.Code, com.google.rpc.Status> statusForCode =

--- a/src/main/java/build/buildfarm/worker/ByteStringWriteReader.java
+++ b/src/main/java/build/buildfarm/worker/ByteStringWriteReader.java
@@ -43,7 +43,6 @@ public class ByteStringWriteReader implements Runnable {
   }
 
   public void run() {
-    boolean closed = false;
     byte[] buffer = new byte[1024 * 16];
     int len;
     write.getFuture().addListener(this::complete, directExecutor());

--- a/src/main/java/build/buildfarm/worker/UploadManifest.java
+++ b/src/main/java/build/buildfarm/worker/UploadManifest.java
@@ -158,6 +158,11 @@ public class UploadManifest {
 
   private void addFile(Path file, CASInsertionPolicy policy) throws IOException {
     Digest digest = digestUtil.compute(file);
+    result
+        .addOutputFilesBuilder()
+        .setPath(execRoot.relativize(file).toString())
+        .setIsExecutable(Files.isExecutable(file))
+        .setDigest(digest);
     digestToFile.put(digest, file);
   }
 

--- a/src/main/java/build/buildfarm/worker/UploadManifest.java
+++ b/src/main/java/build/buildfarm/worker/UploadManifest.java
@@ -20,7 +20,6 @@ import static build.buildfarm.worker.Utils.statIfFound;
 import build.bazel.remote.execution.v2.ActionResult;
 import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.Directory;
-import build.bazel.remote.execution.v2.OutputFile;
 import build.bazel.remote.execution.v2.Tree;
 import build.buildfarm.common.DigestUtil;
 import build.buildfarm.common.io.Dirent;
@@ -159,12 +158,6 @@ public class UploadManifest {
 
   private void addFile(Path file, CASInsertionPolicy policy) throws IOException {
     Digest digest = digestUtil.compute(file);
-    OutputFile.Builder builder =
-        result
-            .addOutputFilesBuilder()
-            .setPath(execRoot.relativize(file).toString())
-            .setIsExecutable(Files.isExecutable(file))
-            .setDigest(digest);
     digestToFile.put(digest, file);
   }
 

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -532,6 +532,12 @@ class ShardWorkerContext implements WorkerContext {
       return;
     }
 
+    resultBuilder
+        .addOutputFilesBuilder()
+        .setPath(outputFile)
+        .setDigest(digest)
+        .setIsExecutable(Files.isExecutable(outputPath));
+
     try {
       insertFile(digest, outputPath);
     } catch (EntryLimitException e) {

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -29,7 +29,6 @@ import build.bazel.remote.execution.v2.Directory;
 import build.bazel.remote.execution.v2.DirectoryNode;
 import build.bazel.remote.execution.v2.ExecutionStage;
 import build.bazel.remote.execution.v2.FileNode;
-import build.bazel.remote.execution.v2.OutputFile;
 import build.bazel.remote.execution.v2.Platform;
 import build.bazel.remote.execution.v2.Tree;
 import build.buildfarm.backplane.Backplane;
@@ -533,12 +532,6 @@ class ShardWorkerContext implements WorkerContext {
       return;
     }
 
-    OutputFile.Builder outputFileBuilder =
-        resultBuilder
-            .addOutputFilesBuilder()
-            .setPath(outputFile)
-            .setDigest(digest)
-            .setIsExecutable(Files.isExecutable(outputPath));
     try {
       insertFile(digest, outputPath);
     } catch (EntryLimitException e) {

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -193,7 +193,6 @@ public class Worker extends LoggingMain {
         throws IOException, InterruptedException, ExecutionException {
       // create a write for inserting into another CAS member.
       String workerName = getRandomWorker();
-      Instance casMember = workerStub(workerName);
       Write write = getCasMemberWrite(digest, workerName);
 
       streamIntoWriteFuture(in, write, digest).get();

--- a/src/test/java/build/buildfarm/cas/cfc/CASFileCacheTest.java
+++ b/src/test/java/build/buildfarm/cas/cfc/CASFileCacheTest.java
@@ -365,7 +365,6 @@ class CASFileCacheTest {
     Path invalidDigest = root.resolve("00").resolve("digest");
     ByteString validBlob = ByteString.copyFromUtf8("valid");
     Digest validDigest = DIGEST_UTIL.compute(ByteString.copyFromUtf8("valid"));
-    String validHash = validDigest.getHash();
     Path invalidExec = fileCache.getPath(CASFileCache.getFileName(validDigest, false) + "_regular");
 
     Files.write(tooFewComponents, ImmutableList.of("Too Few Components"), StandardCharsets.UTF_8);

--- a/src/test/java/build/buildfarm/cas/cfc/DirectoriesIndexTest.java
+++ b/src/test/java/build/buildfarm/cas/cfc/DirectoriesIndexTest.java
@@ -65,8 +65,6 @@ public class DirectoriesIndexTest {
     // create directory and file
     ByteString coolBlob = ByteString.copyFromUtf8("cool content");
     Digest digest = DIGEST_UTIL.compute(coolBlob);
-    String dirName = "cool_dir";
-    Path path = entryPathStrategy.getPath(dirName);
     ImmutableList.Builder<String> entriesBuilder = new ImmutableList.Builder<>();
     entriesBuilder.add(digest.getHash());
 

--- a/src/test/java/build/buildfarm/common/grpc/StubWriteOutputStreamTest.java
+++ b/src/test/java/build/buildfarm/common/grpc/StubWriteOutputStreamTest.java
@@ -175,7 +175,6 @@ public class StubWriteOutputStreamTest {
             Functions.identity(),
             /* expectedSize=*/ StubWriteOutputStream.UNLIMITED_EXPECTED_SIZE,
             /* autoflush=*/ true);
-    ByteString content = ByteString.copyFromUtf8("Hello, World");
 
     boolean callbackTimedOut = false;
     try (OutputStream out =

--- a/src/test/java/build/buildfarm/common/redis/BalancedRedisQueueMockTest.java
+++ b/src/test/java/build/buildfarm/common/redis/BalancedRedisQueueMockTest.java
@@ -148,7 +148,7 @@ public class BalancedRedisQueueMockTest {
     BalancedRedisQueue queue = new BalancedRedisQueue("queue_name", ImmutableList.of());
 
     // ACT
-    RedisQueue internalQueue = queue.getCurrentPopQueue();
+    queue.getCurrentPopQueue();
   }
 
   // Function under test: getCurrentPopQueueIndex
@@ -160,7 +160,7 @@ public class BalancedRedisQueueMockTest {
     BalancedRedisQueue queue = new BalancedRedisQueue("queue_name", ImmutableList.of());
 
     // ACT
-    int index = queue.getCurrentPopQueueIndex();
+    queue.getCurrentPopQueueIndex();
   }
 
   // Function under test: getInternalQueue
@@ -172,7 +172,7 @@ public class BalancedRedisQueueMockTest {
     BalancedRedisQueue queue = new BalancedRedisQueue("queue_name", ImmutableList.of());
 
     // ACT
-    RedisQueue internalQueue = queue.getInternalQueue(0);
+    queue.getInternalQueue(0);
   }
 
   // Function under test: getDequeueName

--- a/src/test/java/build/buildfarm/common/redis/BalancedRedisQueueTest.java
+++ b/src/test/java/build/buildfarm/common/redis/BalancedRedisQueueTest.java
@@ -58,7 +58,7 @@ public class BalancedRedisQueueTest {
   @Test
   public void balancedRedisQueueCreateHashesConstructsWithoutError() throws Exception {
     // ACT
-    BalancedRedisQueue queue = new BalancedRedisQueue("test", ImmutableList.of());
+    new BalancedRedisQueue("test", ImmutableList.of());
   }
 
   // Function under test: push

--- a/src/test/java/build/buildfarm/common/redis/ProvisionedRedisQueueTest.java
+++ b/src/test/java/build/buildfarm/common/redis/ProvisionedRedisQueueTest.java
@@ -47,8 +47,7 @@ public class ProvisionedRedisQueueTest {
   // Failure explanation: the object cannot be constructed
   @Test
   public void provisionedRedisQueueCanConstruct() throws Exception {
-    ProvisionedRedisQueue queue =
-        new ProvisionedRedisQueue("name", ImmutableList.of(), HashMultimap.create());
+    new ProvisionedRedisQueue("name", ImmutableList.of(), HashMultimap.create());
   }
 
   // Function under test: ProvisionedRedisQueue
@@ -56,8 +55,7 @@ public class ProvisionedRedisQueueTest {
   // Failure explanation: the object cannot be constructed
   @Test
   public void provisionedRedisQueueCanConstructOverload() throws Exception {
-    ProvisionedRedisQueue queue =
-        new ProvisionedRedisQueue("name", ImmutableList.of(), HashMultimap.create(), true);
+    new ProvisionedRedisQueue("name", ImmutableList.of(), HashMultimap.create(), true);
   }
 
   // Function under test: explainEligibility

--- a/src/test/java/build/buildfarm/common/redis/RedisMapMockTest.java
+++ b/src/test/java/build/buildfarm/common/redis/RedisMapMockTest.java
@@ -41,7 +41,7 @@ public class RedisMapMockTest {
   @Test
   public void redisMapConstructsWithoutError() throws Exception {
     // ARRANGE
-    RedisMap map = new RedisMap("test");
+    new RedisMap("test");
   }
 
   // Function under test: insert

--- a/src/test/java/build/buildfarm/common/redis/RedisNodeHashesMockTest.java
+++ b/src/test/java/build/buildfarm/common/redis/RedisNodeHashesMockTest.java
@@ -87,7 +87,7 @@ public class RedisNodeHashesMockTest {
   // Failure explanation: the object cannot be constructed
   @Test
   public void getEvenlyDistributedHashesCanConstruct() throws Exception {
-    RedisNodeHashes converter = new RedisNodeHashes();
+    new RedisNodeHashes();
   }
 
   // Function under test: getEvenlyDistributedHashesWithPrefix

--- a/src/test/java/build/buildfarm/common/redis/RedisQueueMockTest.java
+++ b/src/test/java/build/buildfarm/common/redis/RedisQueueMockTest.java
@@ -56,7 +56,7 @@ public class RedisQueueMockTest {
   @Test
   public void redisQueueConstructsWithoutError() throws Exception {
     // ACT
-    RedisQueue queue = new RedisQueue("test");
+    new RedisQueue("test");
   }
 
   // Function under test: push
@@ -217,7 +217,7 @@ public class RedisQueueMockTest {
         new Thread(
             () -> {
               try {
-                String val = queue.dequeue(redis, 100000);
+                queue.dequeue(redis, 100000);
               } catch (Exception e) {
               }
             });

--- a/src/test/java/build/buildfarm/common/redis/RedisQueueTest.java
+++ b/src/test/java/build/buildfarm/common/redis/RedisQueueTest.java
@@ -56,7 +56,7 @@ public class RedisQueueTest {
   @Test
   public void redisQueueConstructsWithoutError() throws Exception {
     // ACT
-    RedisQueue queue = new RedisQueue("test");
+    new RedisQueue("test");
   }
 
   // Function under test: push

--- a/src/test/java/build/buildfarm/common/redis/RedisSlotToHashTest.java
+++ b/src/test/java/build/buildfarm/common/redis/RedisSlotToHashTest.java
@@ -58,7 +58,7 @@ public class RedisSlotToHashTest {
   // Failure explanation: the object cannot be constructed
   @Test
   public void correlateEnsureConstruction() throws Exception {
-    RedisSlotToHash slotToHash = new RedisSlotToHash();
+    new RedisSlotToHash();
   }
 
   // Function under test: correlateRange

--- a/src/test/java/build/buildfarm/instance/memory/MemoryInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/memory/MemoryInstanceTest.java
@@ -454,7 +454,6 @@ public class MemoryInstanceTest {
     Digest actionDigestWithExcessiveTimeout = createAction(Action.newBuilder().setTimeout(timeout));
 
     Watcher watcher = mock(Watcher.class);
-    IllegalStateException timeoutInvalid = null;
     instance.execute(
         actionDigestWithExcessiveTimeout,
         /* skipCacheLookup=*/ true,

--- a/src/test/java/build/buildfarm/instance/shard/RedisShardBackplaneTest.java
+++ b/src/test/java/build/buildfarm/instance/shard/RedisShardBackplaneTest.java
@@ -241,8 +241,6 @@ public class RedisShardBackplaneTest {
             config, "invocation-blacklist-test", o -> o, o -> o, mockJedisClusterFactory);
     backplane.start("startTime/test:0000");
 
-    final String opName = "op";
-
     assertThat(
             backplane.isBlacklisted(
                 RequestMetadata.newBuilder()

--- a/src/test/java/build/buildfarm/instance/shard/ShardInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/shard/ShardInstanceTest.java
@@ -50,7 +50,6 @@ import build.bazel.remote.execution.v2.DirectoryNode;
 import build.bazel.remote.execution.v2.ExecuteOperationMetadata;
 import build.bazel.remote.execution.v2.ExecuteResponse;
 import build.bazel.remote.execution.v2.ExecutionPolicy;
-import build.bazel.remote.execution.v2.FileNode;
 import build.bazel.remote.execution.v2.OutputFile;
 import build.bazel.remote.execution.v2.RequestMetadata;
 import build.bazel.remote.execution.v2.ResultsCachePolicy;
@@ -325,14 +324,6 @@ public class ShardInstanceTest {
 
   @Test
   public void queueActionFailsQueueEligibility() throws Exception {
-    ByteString foo = ByteString.copyFromUtf8("foo");
-    Digest fooDigest = DIGEST_UTIL.compute(ByteString.copyFromUtf8("foo"));
-    // no need to provide foo, just want to make a non-default directory
-    Directory subdir =
-        Directory.newBuilder()
-            .addFiles(FileNode.newBuilder().setName("foo").setDigest(fooDigest))
-            .build();
-    Digest subdirDigest = DIGEST_UTIL.compute(foo);
     Directory inputRoot = Directory.newBuilder().build();
     ByteString inputRootContent = inputRoot.toByteString();
     Digest inputRootDigest = DIGEST_UTIL.compute(inputRootContent);
@@ -454,12 +445,6 @@ public class ShardInstanceTest {
   @Test
   public void queueDirectoryMissingErrorsOperation() throws Exception {
     ByteString foo = ByteString.copyFromUtf8("foo");
-    Digest fooDigest = DIGEST_UTIL.compute(ByteString.copyFromUtf8("foo"));
-    // no need to provide foo, just want to make a non-default directory
-    Directory subdir =
-        Directory.newBuilder()
-            .addFiles(FileNode.newBuilder().setName("foo").setDigest(fooDigest))
-            .build();
     Digest subdirDigest = DIGEST_UTIL.compute(foo);
     Directory inputRoot =
         Directory.newBuilder()
@@ -616,17 +601,6 @@ public class ShardInstanceTest {
     when(mockBackplane.propertiesEligibleForQueue(Matchers.anyList())).thenReturn(true);
 
     when(mockBackplane.canQueue()).thenReturn(true);
-
-    ActionResult actionResult =
-        ActionResult.newBuilder()
-            .addOutputFiles(
-                OutputFile.newBuilder()
-                    .setPath("output/path")
-                    .setDigest(
-                        Digest.newBuilder()
-                            .setHash("find-missing-blobs-causes-resource-exhausted")
-                            .setSizeBytes(1)))
-            .build();
 
     when(mockBackplane.getActionResult(eq(actionKey)))
         .thenThrow(new IOException(Status.UNAVAILABLE.asException()));

--- a/src/test/java/build/buildfarm/instance/stub/StubInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/stub/StubInstanceTest.java
@@ -292,7 +292,6 @@ public class StubInstanceTest {
   public void completedWriteBeforeCloseThrowsOnNextInteraction()
       throws IOException, InterruptedException {
     String resourceName = "early-completed-output-stream-test";
-    AtomicReference<ByteString> writtenContent = new AtomicReference<>();
     serviceRegistry.addService(
         new ByteStreamImplBase() {
           boolean completed = false;

--- a/src/test/java/build/buildfarm/server/BuildFarmServerTest.java
+++ b/src/test/java/build/buildfarm/server/BuildFarmServerTest.java
@@ -61,7 +61,6 @@ import com.google.bytestream.ByteStreamProto.WriteResponse;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.hash.HashCode;
-import com.google.common.util.concurrent.SettableFuture;
 import com.google.longrunning.CancelOperationRequest;
 import com.google.longrunning.GetOperationRequest;
 import com.google.longrunning.ListOperationsRequest;
@@ -440,7 +439,6 @@ public class BuildFarmServerTest {
 
     assertThat(getBlob(digest)).isNull();
 
-    SettableFuture<Void> partialFuture = SettableFuture.create();
     FutureWriteResponseObserver futureResponder = new FutureWriteResponseObserver();
     StreamObserver<WriteRequest> requestObserver =
         ByteStreamGrpc.newStub(inProcessChannel).write(futureResponder);

--- a/src/test/java/build/buildfarm/server/ExecutionServiceTest.java
+++ b/src/test/java/build/buildfarm/server/ExecutionServiceTest.java
@@ -30,7 +30,6 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.longrunning.Operation;
 import io.grpc.stub.ServerCallStreamObserver;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.function.Consumer;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -49,7 +48,6 @@ public class ExecutionServiceTest {
   @Test
   public void keepaliveIsCancelledWithContext() throws Exception {
     ScheduledExecutorService keepaliveScheduler = newSingleThreadScheduledExecutor();
-    Consumer<String> snsMetricsPublisher = requestMetadata -> {};
     ExecutionService service =
         new ExecutionService(
             instances,

--- a/src/test/java/build/buildfarm/worker/FuseCASTest.java
+++ b/src/test/java/build/buildfarm/worker/FuseCASTest.java
@@ -403,7 +403,6 @@ public class FuseCASTest {
     ByteString data = ByteString.copyFromUtf8("Hello, World\n");
     Pointer buf = pointerFromByteString(data);
     fuseCAS.write("/foo", buf, data.size(), /* offset=*/ 0, fi);
-    FileStat fileStat = createFileStat();
 
     byte[] readData = new byte[5];
     u8[] array = Struct.arrayOf(Runtime.getSystemRuntime(), u8.class, readData.length);

--- a/src/test/java/build/buildfarm/worker/InputFetchStageTest.java
+++ b/src/test/java/build/buildfarm/worker/InputFetchStageTest.java
@@ -26,10 +26,8 @@ import build.buildfarm.v1test.ExecuteEntry;
 import build.buildfarm.v1test.QueueEntry;
 import build.buildfarm.v1test.QueuedOperation;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import io.grpc.Deadline;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 import org.junit.Test;
@@ -74,9 +72,6 @@ public class InputFetchStageTest {
 
   @Test
   public void invalidQueuedOperationFails() throws InterruptedException {
-    Map<String, QueuedOperation> queuedOperations = Maps.newHashMap();
-    List<QueueEntry> queue = Lists.newArrayList();
-
     Poller poller = mock(Poller.class);
 
     QueueEntry badEntry =

--- a/src/test/java/build/buildfarm/worker/OutputDirectoryTest.java
+++ b/src/test/java/build/buildfarm/worker/OutputDirectoryTest.java
@@ -91,8 +91,7 @@ public class OutputDirectoryTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void duplicateDirectorySeparatorIsInvalid() {
-    OutputDirectory outputDirectory =
-        OutputDirectory.parse(ImmutableList.of(), ImmutableList.of("a//b"), ImmutableList.of());
+    OutputDirectory.parse(ImmutableList.of(), ImmutableList.of("a//b"), ImmutableList.of());
   }
 
   @Test

--- a/src/test/java/build/buildfarm/worker/memory/UploadOutputsTest.java
+++ b/src/test/java/build/buildfarm/worker/memory/UploadOutputsTest.java
@@ -183,7 +183,6 @@ public class UploadOutputsTest {
   public void uploadOutputsIgnoresMissingOutputDirectories()
       throws IOException, StatusException, InterruptedException {
     uploadOutputs(ImmutableList.<String>of(), ImmutableList.<String>of("foo"));
-    Tree emptyTree = Tree.newBuilder().setRoot(Directory.getDefaultInstance()).build();
     verify(mockUploader, never()).uploadBlobs(any());
   }
 


### PR DESCRIPTION
This is similar to the dead code removal from before but captures local variables unused in scope.  
Enable static analysis and fix code.