### PR TITLE
fix java_binary, container_image, and CI for memory worker

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -87,8 +87,9 @@ tasks:
     - ./.bazelci/integration_test.sh
     
   # Memory integration test is too slow.
-  # We can re-enable it, if memory instance is faster or we build less targets.
-  # It is preserved here for testing.
+  # We can re-enable it if memory instance becomes faster or we build less targets.
+  # It is preserved here for offline testing.
+  
   # integration_test_abseil:
   #   name: "Abseil Test (Memory)"
   #   platform: ubuntu1804
@@ -96,6 +97,7 @@ tasks:
   #   - export TEST_SHARD=false
   #   - export RUN_TEST=./.bazelci/run_abseil_test.sh
   #   - ./.bazelci/integration_test.sh
+  
   integration_test_abseil_shard:
     name: "Abseil Test (Shard)"
     platform: ubuntu1804

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -89,7 +89,7 @@ tasks:
     name: "Abseil Test (Memory)"
     platform: ubuntu1804
     shell_commands:
-    - export TEST_SHARD=true
+    - export TEST_SHARD=false
     - export RUN_TEST=./.bazelci/run_abseil_test.sh
     - ./.bazelci/integration_test.sh
   integration_test_abseil_shard:

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -75,7 +75,7 @@ tasks:
     name: "Integration Test (Memory)"
     platform: ubuntu1804
     shell_commands:
-    - export TEST_SHARD=true
+    - export TEST_SHARD=false
     - export RUN_TEST=./.bazelci/run_generative_cc_many_test.sh
   integration_test_many_shard:
     name: "Integration Test (Shard)"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -85,13 +85,17 @@ tasks:
     - export TEST_SHARD=true
     - export RUN_TEST=./.bazelci/run_generative_cc_many_test.sh
     - ./.bazelci/integration_test.sh
-  integration_test_abseil:
-    name: "Abseil Test (Memory)"
-    platform: ubuntu1804
-    shell_commands:
-    - export TEST_SHARD=false
-    - export RUN_TEST=./.bazelci/run_abseil_test.sh
-    - ./.bazelci/integration_test.sh
+    
+  # Memory integration test is too slow.
+  # We can re-enable it, if memory instance is faster or we build less targets.
+  # It is preserved here for testing.
+  # integration_test_abseil:
+  #   name: "Abseil Test (Memory)"
+  #   platform: ubuntu1804
+  #   shell_commands:
+  #   - export TEST_SHARD=false
+  #   - export RUN_TEST=./.bazelci/run_abseil_test.sh
+  #   - ./.bazelci/integration_test.sh
   integration_test_abseil_shard:
     name: "Abseil Test (Shard)"
     platform: ubuntu1804

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -77,6 +77,7 @@ tasks:
     shell_commands:
     - export TEST_SHARD=false
     - export RUN_TEST=./.bazelci/run_generative_cc_many_test.sh
+    - ./.bazelci/integration_test.sh
   integration_test_many_shard:
     name: "Integration Test (Shard)"
     platform: ubuntu1804

--- a/.bazelci/test_buildfarm_container.sh
+++ b/.bazelci/test_buildfarm_container.sh
@@ -5,7 +5,7 @@ cd buildfarm;
 
 #Various targets to be tested
 BUILDFARM_SERVER_TARGET="//src/main/java/build/buildfarm:buildfarm-server"
-BUILDFARM_WORKER_TARGET="//src/main/java/build/buildfarm:buildfarm-operationqueue-worker"
+BUILDFARM_WORKER_TARGET="//src/main/java/build/buildfarm:buildfarm-memory-worker"
 BUILDFARM_SHARD_WORKER_TAERGET="//src/main/java/build/buildfarm:buildfarm-shard-worker"
 
 #The configs used by the targets

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ bazel run //src/main/java/build/buildfarm:buildfarm-server <configfile> [<-p|--p
 Run via
 
 ```
-bazel run //src/main/java/build/buildfarm:buildfarm-operationqueue-worker <configfile> [--root ROOT] [--cas_cache_directory CAS_CACHE_DIRECTORY]
+bazel run //src/main/java/build/buildfarm:buildfarm-memory-worker <configfile> [--root ROOT] [--cas_cache_directory CAS_CACHE_DIRECTORY]
 ```
 
 - **`configfile`** has to be in Protocol Buffer text format, corresponding to a [WorkerConfig](https://github.com/bazelbuild/bazel-buildfarm/blob/master/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto#L459) definition.
@@ -72,7 +72,7 @@ bazel run //src/main/java/build/buildfarm:buildfarm-server -- --jvm_flag=-Djava.
 and
 
 ```
-bazel run //src/main/java/build/buildfarm:buildfarm-operationqueue-worker -- --jvm_flag=-Djava.util.logging.config.file=$PWD/examples/debug.logging.properties $PWD/examples/worker.config.example
+bazel run //src/main/java/build/buildfarm:buildfarm-memory-worker -- --jvm_flag=-Djava.util.logging.config.file=$PWD/examples/debug.logging.properties $PWD/examples/worker.config.example
 ```
 
 To attach a remote debugger, run the executable with the `--debug=<PORT>` flag. For example:

--- a/src/main/java/build/buildfarm/BUILD
+++ b/src/main/java/build/buildfarm/BUILD
@@ -79,9 +79,9 @@ container_image(
 )
 
 java_binary(
-    name = "buildfarm-operationqueue-worker",
+    name = "buildfarm-memory-worker",
     jvm_flags = ensure_accurate_metadata(),
-    main_class = "build.buildfarm.worker.operationqueue.Worker",
+    main_class = "build.buildfarm.worker.memory.Worker",
     visibility = ["//visibility:public"],
     runtime_deps = [
         "//src/main/java/build/buildfarm/worker/memory",
@@ -89,10 +89,10 @@ java_binary(
 )
 
 container_image(
-    name = "buildfarm-operationqueue-worker.container",
+    name = "buildfarm-memory-worker.container",
     base = "@java_image_base//image",
     cmd = [
-        "buildfarm-operationqueue-worker_deploy.jar",
+        "buildfarm-memory-worker_deploy.jar",
         "/config/worker.config",
     ],
     # leverage the implicit target of the buildfarm-server to get a fat jar.
@@ -100,7 +100,7 @@ container_image(
     # so we'd want some wrappy script. This seemed more straightforward.
     # https://docs.bazel.build/versions/master/be/java.html#java_binary_implicit_outputs
     files = [
-        ":buildfarm-operationqueue-worker_deploy.jar",
+        ":buildfarm-memory-worker_deploy.jar",
     ],
     tags = ["container"],
     visibility = ["//visibility:public"],


### PR DESCRIPTION
Addressing issue: https://github.com/bazelbuild/bazel-buildfarm/issues/864
 - fix `java_binary` name
 - fix `container_image` name
 - fix CI targets for memory integration test
 
 Documentation will be updated once landed