### PR TITLE
[ci] extend formatter to support protobuf

### DIFF
--- a/.bazelci/format.sh
+++ b/.bazelci/format.sh
@@ -7,7 +7,7 @@ FORMAT_JAVA=true
 JAVA_FORMATTER_URL=https://github.com/google/google-java-format/releases/download/google-java-format-1.7/google-java-format-1.7-all-deps.jar
 LOCAL_FORMATTER="java_formatter.jar"
 
-FORMAT_PROTO=true
+FORMAT_PROTO=false
 CLANG_FORMAT=@llvm_toolchain//:bin/clang-format
 BAZEL_WRAPPER=bazelw
 

--- a/.bazelci/format.sh
+++ b/.bazelci/format.sh
@@ -3,8 +3,11 @@
 # This script will format all of the java source files.
 # Use the flag --check if you want the script to fail when formatting is not correct.
 
+FORMAT_JAVA=true
 JAVA_FORMATTER_URL=https://github.com/google/google-java-format/releases/download/google-java-format-1.7/google-java-format-1.7-all-deps.jar
 LOCAL_FORMATTER="java_formatter.jar"
+
+FORMAT_PROTO=false
 
 # Print an error such that it will surface in the context of buildkite
 print_error () {
@@ -14,39 +17,58 @@ print_error () {
     fi
 }
 
- # Download the formatter if we don't already have it.
-if [ ! -f "$LOCAL_FORMATTER" ] ; then
-    wget -O $LOCAL_FORMATTER $JAVA_FORMATTER_URL
-fi
-
- # Get all the files to format and format them
-files=$(find src/* -type f -name "*.java")
-
-# Check whether any formatting changes need to be made.
-# This is intended to be done by the CI.
-if [[ "$@" == "--check" ]]
-then
-    java -jar $LOCAL_FORMATTER --dry-run --set-exit-if-changed $files
+handle_format_error_check () {
     if [ $? -eq 0 ]
     then
-       echo "Files are correctly formatted."
-       exit 0
+        echo "Files are correctly formatted."
+        exit 0
     else
         print_error 'Run ./.bazelci/format.sh to resolve formatting issues.'
         exit 1
     fi
-fi
+}
 
-# The formatter is lax on certain whitespace decisons.
-# Therefore, we perform these adjustements before running the formatter.
-# This will make the formatting more consistent overall.
-for file in $files
-do
+run_java_formatter () {
+
+     # Download the formatter if we don't already have it.
+    if [ ! -f "$LOCAL_FORMATTER" ] ; then
+        wget -O $LOCAL_FORMATTER $JAVA_FORMATTER_URL
+    fi
+    
+     # Get all the files to format and format them
+    files=$(find src/* -type f -name "*.java")
+    
+    # Check whether any formatting changes need to be made.
+    # This is intended to be done by the CI.
+    if [[ "$@" == "--check" ]]
+    then
+        java -jar $LOCAL_FORMATTER --dry-run --set-exit-if-changed $files
+        handle_format_error_check
+    fi
+
+    # The formatter is lax on certain whitespace decisons.
+    # Therefore, we perform these adjustements before running the formatter.
+    # This will make the formatting more consistent overall.
+    for file in $files
+    do
 	# Remove whitespace lines after starting bracket '{'
 	# Ignore any issues if this does not succeed.
 	# The CI doesn't gate on this adjustment.
         awk -i inplace -v n=-2 'NR==n+1 && !NF{next} /\{/ {n=NR}1' $file > /dev/null 2>&1
-done
+    done
 
-# Fixes formatting issues
-java -jar $LOCAL_FORMATTER -i $files 
+    # Fixes formatting issues
+    java -jar $LOCAL_FORMATTER -i $files
+}
+
+run_proto_formatter () {
+echo "hi"
+}
+
+if [ "${FORMAT_JAVA:-false}" = true ]; then
+    run_java_formatter
+fi;
+
+if [ "${FORMAT_PROTO:-false}" = true ]; then
+    run_proto_formatter
+fi;

--- a/defs.bzl
+++ b/defs.bzl
@@ -10,6 +10,7 @@ load(
 )
 load("@io_grpc_grpc_java//:repositories.bzl", "grpc_java_repositories")
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+load("@com_grail_bazel_toolchain//toolchain:rules.bzl", "llvm_toolchain")
 
 IO_NETTY_MODULES = [
     "buffer",
@@ -118,6 +119,11 @@ def buildfarm_init(name = "buildfarm"):
     native.bind(
         name = "jar/redis/clients/jedis",
         actual = "@jedis//jar",
+    )
+
+    llvm_toolchain(
+        name = "llvm_toolchain",
+        llvm_version = "9.0.0",
     )
 
 def ensure_accurate_metadata():

--- a/defs.bzl
+++ b/defs.bzl
@@ -123,7 +123,7 @@ def buildfarm_init(name = "buildfarm"):
 
     llvm_toolchain(
         name = "llvm_toolchain",
-        llvm_version = "9.0.0",
+        llvm_version = "10.0.0",
     )
 
 def ensure_accurate_metadata():

--- a/deps.bzl
+++ b/deps.bzl
@@ -69,9 +69,9 @@ def archive_dependencies(third_party):
         # Used to format proto files
         {
             "name": "com_grail_bazel_toolchain",
-            "sha256": "b3dec631fe2be45b3a7a8a4161dd07fadc68825842e8d6305ed35bc8560968ca",
-            "strip_prefix": "bazel-toolchain-0.5.1",
-            "url": "https://github.com/grailbio/bazel-toolchain/archive/0.5.1.tar.gz",
+            "sha256": "54b54eedc71b93b278c44b6c056a737dc68545c6da75f63d0810676e1181f559",
+            "strip_prefix": "bazel-toolchain-76ce37e977a304acf8948eadabb82c516320e286",
+            "url": "https://github.com/grailbio/bazel-toolchain/archive/76ce37e977a304acf8948eadabb82c516320e286.tar.gz",
         },
 
         # Ideally we would use the 0.14.4 release of rules_docker,

--- a/deps.bzl
+++ b/deps.bzl
@@ -58,7 +58,6 @@ def archive_dependencies(third_party):
             "strip_prefix": "remote-apis-6345202a036a297b22b0a0e7531ef702d05f2130",
             "url": "https://github.com/bazelbuild/remote-apis/archive/6345202a036a297b22b0a0e7531ef702d05f2130.zip",
         },
-
         {
             "name": "rules_cc",
             "sha256": "34b2ebd4f4289ebbc27c7a0d854dcd510160109bb0194c0ba331c9656ffcb556",

--- a/deps.bzl
+++ b/deps.bzl
@@ -59,6 +59,14 @@ def archive_dependencies(third_party):
             "url": "https://github.com/bazelbuild/remote-apis/archive/6345202a036a297b22b0a0e7531ef702d05f2130.zip",
         },
 
+        # Used to format proto files
+        {
+            "name": "com_grail_bazel_toolchain",
+            "sha256": "b3dec631fe2be45b3a7a8a4161dd07fadc68825842e8d6305ed35bc8560968ca",
+            "strip_prefix": "bazel-toolchain-0.5.1",
+            "url": "https://github.com/grailbio/bazel-toolchain/archive/0.5.1.tar.gz",
+        },
+
         # Ideally we would use the 0.14.4 release of rules_docker,
         # but that version introduced new pypi and pkg dependncies on tar-related targets making the upgrade difficult.
         # Those dependencies were then removed afterward.  We pick a stable commit after 0.14.4 instead of cherry-picking in the different changes.

--- a/deps.bzl
+++ b/deps.bzl
@@ -59,6 +59,13 @@ def archive_dependencies(third_party):
             "url": "https://github.com/bazelbuild/remote-apis/archive/6345202a036a297b22b0a0e7531ef702d05f2130.zip",
         },
 
+        {
+            "name": "rules_cc",
+            "sha256": "34b2ebd4f4289ebbc27c7a0d854dcd510160109bb0194c0ba331c9656ffcb556",
+            "strip_prefix": "rules_cc-daf6ace7cfeacd6a83e9ff2ed659f416537b6c74",
+            "url": "https://github.com/bazelbuild/rules_cc/archive/daf6ace7cfeacd6a83e9ff2ed659f416537b6c74.tar.gz",
+        },
+
         # Used to format proto files
         {
             "name": "com_grail_bazel_toolchain",


### PR DESCRIPTION
protobuf files can be formatted with `clang-format`.  We extend `format.sh` to support this.  The gate is currently turned off.  We can turn it on later; I didn't wanted to format all of the protobuf files as part of the integration.