### PR TITLE
Add TLS support for buildfarm server

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,3 +8,4 @@
 
 Uber Technologies Inc.
 Aurora Innovation, Inc.
+VMware, Inc.

--- a/src/main/java/build/buildfarm/server/BuildFarmServer.java
+++ b/src/main/java/build/buildfarm/server/BuildFarmServer.java
@@ -1,5 +1,5 @@
-//“Copyright 2021 VMware, Inc.”
-//SPDX-License-Identifier: Apache-2.0
+// “Copyright 2021 VMware, Inc.”
+// SPDX-License-Identifier: Apache-2.0
 // Copyright 2017 The Bazel Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -94,8 +94,8 @@ public class BuildFarmServer extends LoggingMain {
 
     ServerInterceptor headersInterceptor = new ServerHeadersInterceptor();
     if (config.getSslCertificatePath() != "") {
-	File ssl_certificate_path = new File(config.getSslCertificatePath());
-	serverBuilder.useTransportSecurity(ssl_certificate_path, ssl_certificate_path);
+      File ssl_certificate_path = new File(config.getSslCertificatePath());
+      serverBuilder.useTransportSecurity(ssl_certificate_path, ssl_certificate_path);
     }
     server =
         serverBuilder

--- a/src/main/java/build/buildfarm/server/BuildFarmServer.java
+++ b/src/main/java/build/buildfarm/server/BuildFarmServer.java
@@ -39,6 +39,7 @@ import io.grpc.protobuf.services.ProtoReflectionService;
 import io.grpc.services.HealthStatusManager;
 import io.grpc.util.TransmitStatusRuntimeExceptionInterceptor;
 import io.prometheus.client.Counter;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -90,7 +91,10 @@ public class BuildFarmServer extends LoggingMain {
     healthStatusManager = new HealthStatusManager();
 
     ServerInterceptor headersInterceptor = new ServerHeadersInterceptor();
-
+    if (config.getSslCertificatePath() != "") {
+	File ssl_certificate_path = new File(config.getSslCertificatePath());
+	serverBuilder.useTransportSecurity(ssl_certificate_path, ssl_certificate_path);
+    }
     server =
         serverBuilder
             .addService(healthStatusManager.getHealthService())

--- a/src/main/java/build/buildfarm/server/BuildFarmServer.java
+++ b/src/main/java/build/buildfarm/server/BuildFarmServer.java
@@ -1,5 +1,3 @@
-// “Copyright 2021 VMware, Inc.”
-// SPDX-License-Identifier: Apache-2.0
 // Copyright 2017 The Bazel Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/build/buildfarm/server/BuildFarmServer.java
+++ b/src/main/java/build/buildfarm/server/BuildFarmServer.java
@@ -1,3 +1,5 @@
+//“Copyright 2021 VMware, Inc.”
+//SPDX-License-Identifier: Apache-2.0
 // Copyright 2017 The Bazel Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -213,6 +213,11 @@ message BuildFarmServerConfig {
   PrometheusConfig prometheus_config = 7;
   
   BuildEventConfig build_event_config = 8;
+  // Absolute path to the PEM file containing both the required certificates and any
+
+  // associated private key.
+
+  optional string ssl_certificate_path = 9;
 }
 
 message MetricsConfig {

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -1,5 +1,5 @@
-//“Copyright 2021 VMware, Inc.” 
-//SPDX-License-Identifier: Apache-2.0
+// “Copyright 2021 VMware, Inc.” 
+// SPDX-License-Identifier: Apache-2.0
 syntax = "proto3";
 
 package build.buildfarm.v1test;

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -1,3 +1,5 @@
+//“Copyright 2021 VMware, Inc.” 
+//SPDX-License-Identifier: Apache-2.0
 syntax = "proto3";
 
 package build.buildfarm.v1test;
@@ -213,10 +215,9 @@ message BuildFarmServerConfig {
   PrometheusConfig prometheus_config = 7;
   
   BuildEventConfig build_event_config = 8;
+  
   // Absolute path to the PEM file containing both the required certificates and any
-
   // associated private key.
-
   optional string ssl_certificate_path = 9;
 }
 

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -1,5 +1,3 @@
-// “Copyright 2021 VMware, Inc.” 
-// SPDX-License-Identifier: Apache-2.0
 syntax = "proto3";
 
 package build.buildfarm.v1test;


### PR DESCRIPTION
It was added an optional TLS support for BuildFarm server. If a ssl_certificate_path is populated with path to a PEM file, the code will use a gRPC**s** otherwise it will default to gRPC (plain-text). It was added a new field in the .proto file to accommodate the new changes.