### PR TITLE
[static analysis burndown] enable gates from previous intellij fixes

### DIFF
--- a/.bazelci/static_analysis_checks.xml
+++ b/.bazelci/static_analysis_checks.xml
@@ -40,7 +40,6 @@
     <exclude name="ReplaceVectorWithList"/>
     <exclude name="SwitchStmtsShouldHaveDefault"/>
     <exclude name="SystemPrintln"/>
-    <exclude name="UnusedFormalParameter"/>
     <exclude name="UseAssertEqualsInsteadOfAssertTrue"/>
     <exclude name="UseAssertNullInsteadOfAssertTrue"/>
     <exclude name="UseAssertSameInsteadOfAssertTrue"/>
@@ -71,11 +70,8 @@
     <exclude name="ExtendsObject"/>
     <exclude name="FieldDeclarationsShouldBeAtStartOfClass"/>
     <exclude name="FieldNamingConventions"/>
-    <exclude name="ForLoopShouldBeWhileLoop"/>
-    <exclude name="ForLoopsMustUseBraces"/>
     <exclude name="FormalParameterNamingConventions"/>
     <exclude name="GenericsNaming"/>
-    <exclude name="IdenticalCatchBranches"/>
     <exclude name="LinguisticNaming"/>
     <exclude name="LocalHomeNamingConvention"/>
     <exclude name="LocalInterfaceSessionNamingConvention"/>
@@ -95,7 +91,6 @@
     <exclude name="SuspiciousConstantFieldName"/>
     <exclude name="TooManyStaticImports"/>
     <exclude name="UnnecessaryAnnotationValueElement"/>
-    <exclude name="UnnecessaryCast"/>
     <exclude name="UnnecessaryConstructor"/>
     <exclude name="UnnecessaryFullyQualifiedName"/>
     <exclude name="UselessParentheses"/>


### PR DESCRIPTION
Here are some static analysis gates we can now enable from the recent intellij fixes (#890, #891)