### PR TITLE
[metrics] Add operation Queued Time and Output Upload Time metrics

### DIFF
--- a/src/main/java/build/buildfarm/metrics/AbstractMetricsPublisher.java
+++ b/src/main/java/build/buildfarm/metrics/AbstractMetricsPublisher.java
@@ -25,6 +25,7 @@ import com.google.protobuf.util.JsonFormat;
 import com.google.rpc.PreconditionFailure;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Gauge;
+import io.prometheus.client.Summary;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -51,6 +52,10 @@ public abstract class AbstractMetricsPublisher implements MetricsPublisher {
           .labelNames("worker_name")
           .help("Operations per worker.")
           .register();
+  private static final Summary queuedTime =
+      Summary.build().name("queued_time_ms").help("Queued time in ms.").register();
+  private static final Summary outputUploadTime =
+      Summary.build().name("output_upload_time_ms").help("Output upload time in ms.").register();
 
   private final String clusterId;
 
@@ -103,6 +108,34 @@ public abstract class AbstractMetricsPublisher implements MetricsPublisher {
                       .getExecutionMetadata()
                       .getWorker())
               .inc();
+          queuedTime.observe(
+              (operationRequestMetadata
+                          .getExecuteResponse()
+                          .getResult()
+                          .getExecutionMetadata()
+                          .getExecutionStartTimestamp()
+                          .getNanos()
+                      - operationRequestMetadata
+                          .getExecuteResponse()
+                          .getResult()
+                          .getExecutionMetadata()
+                          .getQueuedTimestamp()
+                          .getNanos())
+                  / 1000000D);
+          outputUploadTime.observe(
+              (operationRequestMetadata
+                          .getExecuteResponse()
+                          .getResult()
+                          .getExecutionMetadata()
+                          .getOutputUploadCompletedTimestamp()
+                          .getNanos()
+                      - operationRequestMetadata
+                          .getExecuteResponse()
+                          .getResult()
+                          .getExecutionMetadata()
+                          .getOutputUploadStartTimestamp()
+                          .getNanos())
+                  / 1000000D);
         }
       }
       if (operation.getMetadata().is(ExecuteOperationMetadata.class)) {


### PR DESCRIPTION
These metrics are in addition to the existing ones tracking execution time and input fetch time. In combination, the additional metrics will give a more complete picture of the operation progress through the system.