### PR TITLE
Make maxRequeueAttempts configurable

### DIFF
--- a/examples/shard-server.config.example
+++ b/examples/shard-server.config.example
@@ -49,6 +49,9 @@ instance {
     # a fallback to non-remote recovery, rather than a catastrophic
     # failure.
     max_blob_size: 4294967296
+
+    # Maximum number of requeue attempts for an operation
+    max_requeue_attempts: 5
     
     # Whether the instance should consult a denylist when looking up actions & invocations.
     # For cache-only systems users may want to disable this check.

--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -205,7 +205,7 @@ public class ShardInstance extends AbstractServerInstance {
   private final Random rand = new Random();
   private final Writes writes = new Writes(this::writeInstanceSupplier);
   private final int maxCpu;
-  private final int maxRequeueAttempts = 5; // TODO: get from config
+  private final int maxRequeueAttempts;
 
   private final ListeningExecutorService operationTransformService =
       listeningDecorator(newFixedThreadPool(24));
@@ -292,6 +292,7 @@ public class ShardInstance extends AbstractServerInstance {
         config.getRunOperationQueuer(),
         config.getMaxBlobSize(),
         config.getMaxCpu(),
+        config.getMaxRequeueAttempts(),
         config.getMaximumActionTimeout(),
         config.getUseDenyList(),
         onStop,
@@ -309,6 +310,7 @@ public class ShardInstance extends AbstractServerInstance {
       boolean runOperationQueuer,
       long maxBlobSize,
       int maxCpu,
+      int maxRequeueAttempts,
       Duration maxActionTimeout,
       boolean useDenyList,
       Runnable onStop,
@@ -328,6 +330,7 @@ public class ShardInstance extends AbstractServerInstance {
     this.onStop = onStop;
     this.maxBlobSize = maxBlobSize;
     this.maxCpu = maxCpu;
+    this.maxRequeueAttempts = maxRequeueAttempts;
     this.maxActionTimeout = maxActionTimeout;
     this.useDenyList = useDenyList;
     this.actionCacheFetchService = actionCacheFetchService;

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -544,6 +544,8 @@ message ShardInstanceConfig {
   
   // Whether the instance should consult a denylist when looking up actions & invocations.
   bool use_deny_list = 10;
+
+  int32 max_requeue_attempts = 11;
 }
 
 message ShardWorkerInstanceConfig {

--- a/src/test/java/build/buildfarm/instance/shard/ShardInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/shard/ShardInstanceTest.java
@@ -145,6 +145,7 @@ public class ShardInstanceTest {
             /* runOperationQueuer=*/ false,
             /* maxBlobSize=*/ 0,
             /* maxCpu=*/ 1,
+            /* maxRequeueAttempts=*/ 1,
             /* maxActionTimeout=*/ Duration.getDefaultInstance(),
             /* useDenyList=*/ true,
             mockOnStop,


### PR DESCRIPTION
Current default is hardcoded at 5. This could present a problem with very long timeout times, especially since bazel's default remote retry count is 5. Make this configurable to allow for more flexibility with addressing hung builds.