### PR TITLE
[metrics] Changing summary metrics to histogram in prometheus clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Buildfarm CI:<p>[![Build status](https://badge.buildkite.com/45f4fd4c0cfb95f7705156a4119641c6d5d6c310452d6e65a4.svg?branch=master)](https://buildkite.com/bazel/buildfarm-postsubmit)<p>
+Buildfarm CI:<p>[![Build status](https://badge.buildkite.com/45f4fd4c0cfb95f7705156a4119641c6d5d6c310452d6e65a4.svg?branch=main)](https://buildkite.com/bazel/buildfarm-postsubmit)<p>
 Nightly CI:<p>![Build status](https://badge.buildkite.com/d0c1471a98dd7d7123e6c21b57add0e8c2c0552042ea18f02c.svg)<p>
 Nightly Functionality Test:<p>![Build status](https://badge.buildkite.com/e0ac44ec0a8c3473d3d9490600366f1a73e8fa171d4913e9e3.svg)
 

--- a/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
@@ -1191,8 +1191,8 @@ public class RedisShardBackplane implements Backplane {
     return client.blockingCall(this::deprequeueOperation);
   }
 
-  private QueueEntry dispatchOperation(JedisCluster jedis, List<Platform.Property> provisions)
-      throws InterruptedException {
+  private @Nullable QueueEntry dispatchOperation(
+      JedisCluster jedis, List<Platform.Property> provisions) throws InterruptedException {
     String queueEntryJson = operationQueue.dequeue(jedis, provisions);
     if (queueEntryJson == null) {
       return null;

--- a/src/main/java/build/buildfarm/worker/InputFetcher.java
+++ b/src/main/java/build/buildfarm/worker/InputFetcher.java
@@ -162,7 +162,9 @@ public class InputFetcher implements Runnable {
     try {
       queuedOperation = workerContext.getQueuedOperation(operationContext.queueEntry);
       if (queuedOperation == null || !isQueuedOperationValid(queuedOperation)) {
-        logger.log(Level.SEVERE, format("invalid queued operation: %s", operationName));
+        if (queuedOperation != null) {
+          logger.log(Level.SEVERE, format("invalid queued operation: %s", operationName));
+        }
         owner.error().put(operationContext);
         return 0;
       }

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -271,6 +271,12 @@ class ShardWorkerContext implements WorkerContext {
     Digest queuedOperationDigest = queueEntry.getQueuedOperationDigest();
     ByteString queuedOperationBlob = getBlob(queuedOperationDigest);
     if (queuedOperationBlob == null) {
+      logger.log(
+          Level.WARNING,
+          format(
+              "missing queued operation: %s(%s)",
+              queueEntry.getExecuteEntry().getOperationName(),
+              DigestUtil.toString(queuedOperationDigest)));
       return null;
     }
     try {
@@ -308,7 +314,8 @@ class ShardWorkerContext implements WorkerContext {
     }
     listener.onWaitEnd();
 
-    if (DequeueMatchEvaluator.shouldKeepOperation(matchSettings, matchProvisions, queueEntry)) {
+    if (queueEntry == null
+        || DequeueMatchEvaluator.shouldKeepOperation(matchSettings, matchProvisions, queueEntry)) {
       listener.onEntry(queueEntry);
     } else {
       backplane.rejectOperation(queueEntry);


### PR DESCRIPTION
This change updates the following summary metrics to instead report as histograms:

io_bytes_read
missing_blobs
io_bytes_write
execution_time_ms
execution_stall_time_ms
input_fetch_time_ms
input_fetch_stall_time_ms

This change will make these metrics aggregatable across servers and workers allowing easier tracking in dashboards and alerting mechanisms.

This change resolves the following issue: https://github.com/bazelbuild/bazel-buildfarm/issues/868