### PR TITLE
RPM packages for buildfarm server and worker

### DIFF
--- a/src/main/java/build/buildfarm/rpms/server/BUILD
+++ b/src/main/java/build/buildfarm/rpms/server/BUILD
@@ -1,0 +1,19 @@
+load("@rules_pkg//:rpm.bzl", "pkg_rpm")
+
+pkg_rpm(
+    name = "buildfarm-server-rpm",
+    data = [
+       "//examples:example_configs",
+       "//src/main/java/build/buildfarm:buildfarm-server_deploy.jar",
+       "//src/main/java/build/buildfarm:configs",
+       ":server-service"
+    ],
+    release = "0",
+    spec_file = "buildfarm-server.spec",
+    version = "0.1",
+)
+
+filegroup(
+    name = "server-service",
+    srcs = ["buildfarm-server.service"]
+)

--- a/src/main/java/build/buildfarm/rpms/server/BUILD
+++ b/src/main/java/build/buildfarm/rpms/server/BUILD
@@ -3,10 +3,10 @@ load("@rules_pkg//:rpm.bzl", "pkg_rpm")
 pkg_rpm(
     name = "buildfarm-server-rpm",
     data = [
-       "//examples:example_configs",
-       "//src/main/java/build/buildfarm:buildfarm-server_deploy.jar",
-       "//src/main/java/build/buildfarm:configs",
-       ":server-service"
+        ":server-service",
+        "//examples:example_configs",
+        "//src/main/java/build/buildfarm:buildfarm-server_deploy.jar",
+        "//src/main/java/build/buildfarm:configs",
     ],
     release = "0",
     spec_file = "buildfarm-server.spec",
@@ -15,5 +15,5 @@ pkg_rpm(
 
 filegroup(
     name = "server-service",
-    srcs = ["buildfarm-server.service"]
+    srcs = ["buildfarm-server.service"],
 )

--- a/src/main/java/build/buildfarm/rpms/server/BUILD
+++ b/src/main/java/build/buildfarm/rpms/server/BUILD
@@ -10,6 +10,7 @@ pkg_rpm(
     ],
     release = "0",
     spec_file = "buildfarm-server.spec",
+    tags = ["manual"],
     version = "1.10.0",
 )
 

--- a/src/main/java/build/buildfarm/rpms/server/BUILD
+++ b/src/main/java/build/buildfarm/rpms/server/BUILD
@@ -10,7 +10,7 @@ pkg_rpm(
     ],
     release = "0",
     spec_file = "buildfarm-server.spec",
-    version = "0.1",
+    version = "1.10.0",
 )
 
 filegroup(

--- a/src/main/java/build/buildfarm/rpms/server/buildfarm-server.service
+++ b/src/main/java/build/buildfarm/rpms/server/buildfarm-server.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=buildfarm server
+
+[Service]
+Type=simple
+User=root
+Group=root
+Restart=always
+WorkingDirectory=/usr/local/buildfarm-server
+ExecStart=/bin/sh -c 'exec /usr/bin/java -Djava.util.logging.config.file=/usr/local/buildfarm-server/logging.properties \
+          -jar /usr/local/buildfarm-server/buildfarm-server_deploy.jar \
+          /etc/buildfarm-server/config/server.config >>/var/log/buildfarm-server/server.log 2>&1'
+Restart=on-abort
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target

--- a/src/main/java/build/buildfarm/rpms/server/buildfarm-server.spec
+++ b/src/main/java/build/buildfarm/rpms/server/buildfarm-server.spec
@@ -2,6 +2,7 @@ Name:           buildfarm-server
 Version:        1.10.0
 Release:        0
 Summary:        Bazel Buildfarm Server
+URL:            https://github.com/bazelbuild/bazel-buildfarm
 
 License:        Apache License, v2.0
 

--- a/src/main/java/build/buildfarm/rpms/server/buildfarm-server.spec
+++ b/src/main/java/build/buildfarm/rpms/server/buildfarm-server.spec
@@ -1,0 +1,58 @@
+Name:           buildfarm-server
+Version:        0.1
+Release:        0
+Summary:        Bazel Buildfarm Server
+
+License:        Apache License, v2.0
+
+Requires:       java-11-openjdk
+BuildRequires:  systemd
+%{?systemd_requires}
+
+%description
+A Buildfarm server with an instance can be used strictly as an ActionCache and
+ContentAddressableStorage to improve build performance.
+
+%define debug_package %{nil}
+%define __jar_repack %{nil}
+
+%prep
+
+%build
+
+%install
+app_dir=%{buildroot}/usr/local/buildfarm-server
+config_dir=%{buildroot}/%{_sysconfdir}/buildfarm-server/config
+log_dir=%{buildroot}/var/log/buildfarm-server
+service_dir=%{buildroot}/%{_unitdir}
+
+mkdir -p $app_dir
+cp {buildfarm-server_deploy.jar} $app_dir
+cp {logging.properties} $app_dir
+mkdir -p $config_dir
+cp {server.config.example} $config_dir/server.config
+mkdir -p $log_dir
+mkdir -p $service_dir
+cp {buildfarm-server.service} $service_dir/%{name}.service
+
+%files
+/usr/local/buildfarm-server/buildfarm-server_deploy.jar
+%attr(644, root, root) /usr/local/buildfarm-server/logging.properties
+%attr(644, root, root) %{_unitdir}/%{name}.service
+%attr(644, root, root) %{_sysconfdir}/buildfarm-server/config/server.config
+%dir %attr(755, root, root)  /var/log/buildfarm-server
+
+%post
+%systemd_post %{name}.service
+%{_bindir}/systemctl enable %{name}.service
+%{_bindir}/systemctl start %{name}.service
+
+%preun
+%systemd_preun %{name}.service
+
+%postun
+rm -rf /etc/buildfarm-server
+rm -rf /usr/local/buildfarm-server
+rm -rf /var/log/buildfarm-server
+
+%systemd_postun_with_restart %{name}.service

--- a/src/main/java/build/buildfarm/rpms/server/buildfarm-server.spec
+++ b/src/main/java/build/buildfarm/rpms/server/buildfarm-server.spec
@@ -1,11 +1,11 @@
 Name:           buildfarm-server
-Version:        0.1
+Version:        1.10.0
 Release:        0
 Summary:        Bazel Buildfarm Server
 
 License:        Apache License, v2.0
 
-Requires:       java-11-openjdk
+Requires:       java-11-openjdk-headless
 BuildRequires:  systemd
 %{?systemd_requires}
 

--- a/src/main/java/build/buildfarm/rpms/worker/BUILD
+++ b/src/main/java/build/buildfarm/rpms/worker/BUILD
@@ -3,10 +3,10 @@ load("@rules_pkg//:rpm.bzl", "pkg_rpm")
 pkg_rpm(
     name = "buildfarm-worker-rpm",
     data = [
-       "//examples:example_configs",
-       "//src/main/java/build/buildfarm:buildfarm-shard-worker_deploy.jar",
-       "//src/main/java/build/buildfarm:configs",
-       ":worker-service"
+        ":worker-service",
+        "//examples:example_configs",
+        "//src/main/java/build/buildfarm:buildfarm-shard-worker_deploy.jar",
+        "//src/main/java/build/buildfarm:configs",
     ],
     release = "0",
     spec_file = "buildfarm-worker.spec",
@@ -15,5 +15,5 @@ pkg_rpm(
 
 filegroup(
     name = "worker-service",
-    srcs = ["buildfarm-worker.service"]
+    srcs = ["buildfarm-worker.service"],
 )

--- a/src/main/java/build/buildfarm/rpms/worker/BUILD
+++ b/src/main/java/build/buildfarm/rpms/worker/BUILD
@@ -1,0 +1,19 @@
+load("@rules_pkg//:rpm.bzl", "pkg_rpm")
+
+pkg_rpm(
+    name = "buildfarm-worker-rpm",
+    data = [
+       "//examples:example_configs",
+       "//src/main/java/build/buildfarm:buildfarm-shard-worker_deploy.jar",
+       "//src/main/java/build/buildfarm:configs",
+       ":worker-service"
+    ],
+    release = "0",
+    spec_file = "buildfarm-worker.spec",
+    version = "0.1",
+)
+
+filegroup(
+    name = "worker-service",
+    srcs = ["buildfarm-worker.service"]
+)

--- a/src/main/java/build/buildfarm/rpms/worker/BUILD
+++ b/src/main/java/build/buildfarm/rpms/worker/BUILD
@@ -10,6 +10,7 @@ pkg_rpm(
     ],
     release = "0",
     spec_file = "buildfarm-worker.spec",
+    tags = ["manual"],
     version = "1.10.0",
 )
 

--- a/src/main/java/build/buildfarm/rpms/worker/BUILD
+++ b/src/main/java/build/buildfarm/rpms/worker/BUILD
@@ -10,7 +10,7 @@ pkg_rpm(
     ],
     release = "0",
     spec_file = "buildfarm-worker.spec",
-    version = "0.1",
+    version = "1.10.0",
 )
 
 filegroup(

--- a/src/main/java/build/buildfarm/rpms/worker/buildfarm-worker.service
+++ b/src/main/java/build/buildfarm/rpms/worker/buildfarm-worker.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=buildfarm worker
+
+[Service]
+Type=simple
+User=root
+Group=root
+Restart=always
+WorkingDirectory=/usr/local/buildfarm-worker
+ExecStart=/bin/sh -c 'exec /usr/bin/java -Djava.util.logging.config.file=/usr/local/buildfarm-worker/logging.properties \
+          -jar /usr/local/buildfarm-worker/buildfarm-shard-worker_deploy.jar \
+          /etc/buildfarm-worker/config/worker.config >>/var/log/buildfarm-worker/worker.log 2>&1'
+Restart=on-abort
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target

--- a/src/main/java/build/buildfarm/rpms/worker/buildfarm-worker.spec
+++ b/src/main/java/build/buildfarm/rpms/worker/buildfarm-worker.spec
@@ -2,6 +2,7 @@ Name:           buildfarm-worker
 Version:        1.10.0
 Release:        0
 Summary:        Bazel Buildfarm Worker
+URL:            https://github.com/bazelbuild/bazel-buildfarm
 
 License:        Apache License, v2.0
 

--- a/src/main/java/build/buildfarm/rpms/worker/buildfarm-worker.spec
+++ b/src/main/java/build/buildfarm/rpms/worker/buildfarm-worker.spec
@@ -1,11 +1,11 @@
 Name:           buildfarm-worker
-Version:        0.1
+Version:        1.10.0
 Release:        0
 Summary:        Bazel Buildfarm Worker
 
 License:        Apache License, v2.0
 
-Requires:       java-11-openjdk
+Requires:       java-11-openjdk-headless
 BuildRequires:  systemd
 %{?systemd_requires}
 

--- a/src/main/java/build/buildfarm/rpms/worker/buildfarm-worker.spec
+++ b/src/main/java/build/buildfarm/rpms/worker/buildfarm-worker.spec
@@ -1,0 +1,59 @@
+Name:           buildfarm-worker
+Version:        0.1
+Release:        0
+Summary:        Bazel Buildfarm Worker
+
+License:        Apache License, v2.0
+
+Requires:       java-11-openjdk
+BuildRequires:  systemd
+%{?systemd_requires}
+
+%description
+Workers of all types throughout buildfarm are responsible for presenting execution
+roots to operations that they are matched with, fetching content from a CAS, executing
+those processes, and reporting the outputs and results of executions.
+
+%define debug_package %{nil}
+%define __jar_repack %{nil}
+
+%prep
+
+%build
+
+%install
+app_dir=%{buildroot}/usr/local/buildfarm-worker
+config_dir=%{buildroot}/%{_sysconfdir}/buildfarm-worker/config
+log_dir=%{buildroot}/var/log/buildfarm-worker
+service_dir=%{buildroot}/%{_unitdir}
+
+mkdir -p $app_dir
+cp {buildfarm-shard-worker_deploy.jar} $app_dir
+cp {logging.properties} $app_dir
+mkdir -p $config_dir
+cp {shard-worker.config.example} $config_dir/worker.config
+mkdir -p $log_dir
+mkdir -p $service_dir
+cp {buildfarm-worker.service} $service_dir/%{name}.service
+
+%files
+/usr/local/buildfarm-worker/buildfarm-shard-worker_deploy.jar
+%attr(644, root, root) /usr/local/buildfarm-worker/logging.properties
+%attr(644, root, root) %{_unitdir}/%{name}.service
+%attr(644, root, root) %{_sysconfdir}/buildfarm-worker/config/worker.config
+%dir %attr(755, root, root)  /var/log/buildfarm-worker
+
+%post
+%systemd_post %{name}.service
+%{_bindir}/systemctl enable %{name}.service
+%{_bindir}/systemctl start %{name}.service
+
+%preun
+%systemd_preun %{name}.service
+
+%postun
+rm -rf /usr/local/buildfarm-worker
+rm -rf /etc/buildfarm-worker
+rm -rf /var/log/buildfarm-worker
+
+%systemd_postun_with_restart %{name}.service


### PR DESCRIPTION
Add scripts(BUILD, *.service, *.spec) to generate RPM packages with systemd service for buildfarm-server and buildfarm-worker. Below are the paths for the files specified. 
issue  ->    #858 

_config_file_
- /etc/buildfarm-server/config/server.config
- /etc/buildfarm-worker/config/worker.config

_jar_
- /usr/local/buildfarm-server/buildfarm-server_deploy.jar
- /usr/local/buildfarm-worker/buildfarm-shard-worker_deploy.jar

_log_
- /var/log/buildfarm-server/server.log
- /var/log/buildfarm-worker/worker.log

_logging.properties_
- /usr/local/buildfarm-server/logging.properties
- /usr/local/buildfarm-worker/logging.properties

_systemd_
- /usr/lib/systemd/system/buildfarm-server.service
- /usr/lib/systemd/system/buildfarm-worker.service


**Install RPM:**
_buildfarm-worker_ 
- cd bazel-buildfarm
- systemd-analyze verify src/main/java/build/buildfarm/rpms/worker/buildfarm-worker.service
- rpmlint src/main/java/build/buildfarm/rpms/server/buildfarm-worker.spec
- bazel build src/main/java/build/buildfarm/rpms/worker:buildfarm-worker-rpm
- sudo rpm -e buildfarm-worker-0.1-0.x86_64
- sudo yum -y install bazel-bin/src/main/java/build/buildfarm/rpms/worker/buildfarm-worker-rpm.rpm  -v
- sudo systemctl status buildfarm-worker

_buildfarm-server_
- cd bazel-buildfarm
- systemd-analyze verify src/main/java/build/buildfarm/rpms/server/buildfarm-server.service
- rpmlint src/main/java/build/buildfarm/rpms/server/buildfarm-server.spec
- bazel build src/main/java/build/buildfarm/rpms/server:buildfarm-server-rpm
- sudo rpm -e buildfarm-server-0.1-0.x86_64 
- sudo yum -y install bazel-bin/src/main/java/build/buildfarm/rpms/server/buildfarm-server-rpm.rpm -v
- sudo systemctl status buildfarm-server

