### PR TITLE
fix_container_restart_time

### DIFF
--- a/admin/main/src/main/java/tech/aurora/bfadmin/model/Ec2Instance.java
+++ b/admin/main/src/main/java/tech/aurora/bfadmin/model/Ec2Instance.java
@@ -39,7 +39,11 @@ public class Ec2Instance implements Serializable {
   }
 
   public String getContainerUptimeStr() {
-    return getFormattedTimestamp(containerStartTime);
+    if (getFormattedTimestamp(containerStartTime) > getFormattedTimestamp(uptime / 1000)) {
+      return "N/A";
+    } else {
+      return getFormattedTimestamp(containerStartTime);
+    }
   }
 
   public Long getUptimeInHours() {


### PR DESCRIPTION
When a server/worker comes on line, we write a key entry to Redis that records the start up time for that container. The key is based on the IP address of the host. Since IP addresses are recycled and we do not clean up old keys (we probably should have a TTL set on them), they keys stay indefinitely. While this is not really and issue, what happens when the IP address is reused is that the container start time in buildfarm admin will temporarily show the old value, which will be incorrect, until the key is updated with the new value (could be a few minutes). This bug can be simply fixed by comparing the host uptime to the container uptime. If the container uptime is greater than host uptime, we should show N/A.