### PR TITLE
[admin] Fix buildfarm admin container uptime functionality

### DIFF
--- a/admin/main/src/main/java/tech/aurora/bfadmin/model/Ec2Instance.java
+++ b/admin/main/src/main/java/tech/aurora/bfadmin/model/Ec2Instance.java
@@ -39,7 +39,8 @@ public class Ec2Instance implements Serializable {
   }
 
   public String getContainerUptimeStr() {
-    if (getFormattedTimestamp(containerStartTime) > getFormattedTimestamp(uptime / 1000)) {
+    // Do not report container uptime if it hasn't been updated yet
+    if (getContainerUptimeInHours() > getUptimeInHours()) {
       return "N/A";
     } else {
       return getFormattedTimestamp(containerStartTime);


### PR DESCRIPTION
Fix comparison for the container uptime that was broken in the previous commit.