### PR TITLE
[config] [breaking] Consolidate max_blob_size and max_entry_size_bytes configs

### DIFF
--- a/examples/shard-server.config.example
+++ b/examples/shard-server.config.example
@@ -48,7 +48,7 @@ instance {
     # a transient UNAVAILABLE response, which, in bazel's case, induces
     # a fallback to non-remote recovery, rather than a catastrophic
     # failure.
-    max_blob_size: 4294967296
+    max_entry_size_bytes: 2147483648 # 2 * 1024 * 1024 * 1024
 
     # Maximum number of requeue attempts for an operation
     max_requeue_attempts: 5

--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -186,7 +186,7 @@ public class ShardInstance extends AbstractServerInstance {
       Histogram.build().name("io_bytes_read").help("I/O (bytes)").register();
 
   private final Runnable onStop;
-  private final long maxBlobSize;
+  private final long maxEntrySizeBytes;
   private final Backplane backplane;
   private final ReadThroughActionCache readThroughActionCache;
   private final RemoteInputStreamFactory remoteInputStreamFactory;
@@ -290,7 +290,7 @@ public class ShardInstance extends AbstractServerInstance {
         config.getRunDispatchedMonitor(),
         config.getDispatchedMonitorIntervalSeconds(),
         config.getRunOperationQueuer(),
-        config.getMaxBlobSize(),
+        config.getMaxEntrySizeBytes(),
         config.getMaxCpu(),
         config.getMaxRequeueAttempts(),
         config.getMaximumActionTimeout(),
@@ -308,7 +308,7 @@ public class ShardInstance extends AbstractServerInstance {
       boolean runDispatchedMonitor,
       int dispatchedMonitorIntervalSeconds,
       boolean runOperationQueuer,
-      long maxBlobSize,
+      long maxEntrySizeBytes,
       int maxCpu,
       int maxRequeueAttempts,
       Duration maxActionTimeout,
@@ -328,7 +328,7 @@ public class ShardInstance extends AbstractServerInstance {
     this.readThroughActionCache = readThroughActionCache;
     this.workerStubs = workerStubs;
     this.onStop = onStop;
-    this.maxBlobSize = maxBlobSize;
+    this.maxEntrySizeBytes = maxEntrySizeBytes;
     this.maxCpu = maxCpu;
     this.maxRequeueAttempts = maxRequeueAttempts;
     this.maxActionTimeout = maxActionTimeout;
@@ -1049,8 +1049,8 @@ public class ShardInstance extends AbstractServerInstance {
     } catch (IOException e) {
       throw Status.fromThrowable(e).asRuntimeException();
     }
-    if (maxBlobSize > 0 && digest.getSizeBytes() > maxBlobSize) {
-      throw new EntryLimitException(digest.getSizeBytes(), maxBlobSize);
+    if (maxEntrySizeBytes > 0 && digest.getSizeBytes() > maxEntrySizeBytes) {
+      throw new EntryLimitException(digest.getSizeBytes(), maxEntrySizeBytes);
     }
     // FIXME small blob write to proto cache
     return writes.get(digest, uuid, requestMetadata);

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -536,7 +536,7 @@ message ShardInstanceConfig {
     RedisShardBackplaneConfig redis_shard_backplane_config = 4;
   }
 
-  int64 max_blob_size = 5;
+  int64 max_entry_size_bytes = 5;
   
   int32 max_cpu = 9;
 


### PR DESCRIPTION
Currently we have max_blob_size and max_entry_size_bytes configs, which accomplish the same thing - set the maximum blob size allowed. This causes confusion and can introduce operational issues if those configs are set to different values. This PR combines the two configs into a single max_entry_size_bytes.