### PR TITLE
Use INVALID_ARGUMENT for putOperation and log

### DIFF
--- a/src/main/java/build/buildfarm/server/OperationQueueService.java
+++ b/src/main/java/build/buildfarm/server/OperationQueueService.java
@@ -149,7 +149,7 @@ public class OperationQueueService extends OperationQueueGrpc.OperationQueueImpl
 
     try {
       boolean ok = instance.putAndValidateOperation(operation);
-      Code code = ok ? Code.OK : Code.UNAVAILABLE;
+      Code code = ok ? Code.OK : Code.INVALID_ARGUMENT;
       responseObserver.onNext(com.google.rpc.Status.newBuilder().setCode(code.getNumber()).build());
       responseObserver.onCompleted();
     } catch (IllegalStateException e) {
@@ -173,7 +173,7 @@ public class OperationQueueService extends OperationQueueGrpc.OperationQueueImpl
     }
 
     boolean ok = instance.pollOperation(request.getOperationName(), request.getStage());
-    Code code = ok ? Code.OK : Code.UNAVAILABLE;
+    Code code = ok ? Code.OK : Code.INVALID_ARGUMENT;
     responseObserver.onNext(com.google.rpc.Status.newBuilder().setCode(code.getNumber()).build());
     responseObserver.onCompleted();
   }

--- a/src/test/java/build/buildfarm/server/BuildFarmServerTest.java
+++ b/src/test/java/build/buildfarm/server/BuildFarmServerTest.java
@@ -330,7 +330,7 @@ public class BuildFarmServerTest {
                         .setOperationName(executingOperation.getName())
                         .build())
                 .getCode())
-        .isEqualTo(Code.UNAVAILABLE.getNumber());
+        .isNotEqualTo(Code.OK.getNumber());
   }
 
   private Operation getOperation(String name) {


### PR DESCRIPTION
Specify INVALID_ARGUMENT, the best non-transient status code description
for the boolean understanding of putOperation and poll. Log if any
unexpected response occurs.