### PR TITLE
[bfadmin] Update REST services and rework implementation details

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -110,3 +110,9 @@ tasks:
     - export TEST_SHARD=true
     - export RUN_TEST=./.bazelci/run_abseil_test.sh
     - ./.bazelci/integration_test.sh
+
+  buildfarm_admin_test:
+    name: "BF Admin Test"
+    platform: ubuntu1804
+    shell_commands:
+    - ./.bazelci/test_bfadmin.sh

--- a/.bazelci/test_bfadmin.sh
+++ b/.bazelci/test_bfadmin.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# This script runs a basic buildfarm admin test
+cd admin/main;
+
+./mvnw clean package

--- a/admin/main/README.txt
+++ b/admin/main/README.txt
@@ -1,5 +1,13 @@
 # Buildfarm Admin
 
+## AWS Requirements
+
+All autoscaling groups and EC2 instances must be properly tagged:
+
+buildfarm.cluster_id=buildfarm-dev
+buildfarm.instance_type=[server|worker]
+buildfarm.worker_type=[cpu|gpu|other] (for workers only)
+
 ## Usage
 
 ### Build and Run Locally
@@ -12,5 +20,5 @@
 
 ```
 ./mvnw clean package docker:build -DdockerImageTags=1.0
-docker run -p 8080:8080 -v $HOME:/var/lib -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN bazelbuild/buildfarm-admin:1.0
+docker run -p 8080:8080 -v $HOME:/var/lib -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN bazelbuild/buildfarm-admin:latest
 ```

--- a/admin/main/pom.xml
+++ b/admin/main/pom.xml
@@ -95,6 +95,11 @@
 			<artifactId>lombok</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-ui</artifactId>
+			<version>1.5.2</version>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-json</artifactId>
 		</dependency>

--- a/admin/main/pom.xml
+++ b/admin/main/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>org.springframework</groupId>
 	<artifactId>bfadmin</artifactId>
-	<version>1.0</version>
+	<version>2.0</version>
 
 	<parent>
 		<groupId>org.springframework.boot</groupId>
@@ -22,32 +22,12 @@
 		</dependency>
 		<dependency>
 			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk-s3</artifactId>
-			<version>${awsSdkVersion}</version>
-		</dependency>
-		<dependency>
-			<groupId>com.amazonaws</groupId>
 			<artifactId>aws-java-sdk-core</artifactId>
 			<version>${awsSdkVersion}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.amazonaws</groupId>
 			<artifactId>aws-java-sdk-ec2</artifactId>
-			<version>${awsSdkVersion}</version>
-		</dependency>
-		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk-elasticloadbalancing</artifactId>
-			<version>${awsSdkVersion}</version>
-		</dependency>
-		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk-logs</artifactId>
-			<version>${awsSdkVersion}</version>
-		</dependency>
-		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk-ssm</artifactId>
 			<version>${awsSdkVersion}</version>
 		</dependency>
 		<dependency>

--- a/admin/main/src/main/java/tech/aurora/bfadmin/controller/AdminController.java
+++ b/admin/main/src/main/java/tech/aurora/bfadmin/controller/AdminController.java
@@ -44,7 +44,7 @@ public class AdminController {
   @RequestMapping("/dashboard")
   public String getDashboard(Model model) {
     model.addAttribute("clusterInfo", clusterInfo);
-    model.addAttribute("clusterDetails", adminService.getClusterDetails(clusterId));
+    model.addAttribute("clusterDetails", adminService.getClusterDetails());
     model.addAttribute("awsRegion", region);
     return "dashboard";
   }
@@ -53,7 +53,7 @@ public class AdminController {
   public void init() {
     logger.info("Initializing aws sdk for region {}", region);
     ec2 = AmazonEC2ClientBuilder.standard().withRegion(region).build();
-    clusterInfo = adminService.getClusterInfo(clusterId);
+    clusterInfo = adminService.getClusterInfo();
     logger.info("Found Buildfarm deployment in AWS account: clusterInfo [ number of servers: {}, number of worker groups: {}, grpc endpoint: {}:{}",
             clusterInfo.getServers().getAsg().getInstances().size(), clusterInfo.getWorkers().size(), deploymentDomain, deploymentPort);
   }

--- a/admin/main/src/main/java/tech/aurora/bfadmin/controller/AdminController.java
+++ b/admin/main/src/main/java/tech/aurora/bfadmin/controller/AdminController.java
@@ -2,10 +2,10 @@ package tech.aurora.bfadmin.controller;
 
 import com.amazonaws.services.ec2.AmazonEC2;
 import com.amazonaws.services.ec2.AmazonEC2ClientBuilder;
-import com.amazonaws.services.ec2.model.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import tech.aurora.bfadmin.model.ClusterInfo;
 import tech.aurora.bfadmin.service.AdminService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
@@ -13,7 +13,6 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import javax.annotation.PostConstruct;
-import java.util.List;
 
 @Controller
 public class AdminController {
@@ -22,34 +21,20 @@ public class AdminController {
   @Autowired
   AdminService adminService;
 
-  @Value("${cluster.id}")
+  @Value("${buildfarm.cluster.name}")
   private String clusterId;
 
   @Value("${deployment.domain}")
   private String deploymentDomain;
 
-  @Value("${deployment.port}")
+  @Value("${buildfarm.public.port}")
   private int deploymentPort;
-
-  @Value("${deployment.tag.instance.type.server}")
-  private String serverTagValue;
-
-  @Value("${deployment.tag.instance.type.cpuworker}")
-  private String cpuWorkerTagValue;
-
-  @Value("${deployment.tag.instance.type.gpuworker}")
-  private String gpuWorkerTagValue;
-
-  @Value("${deployment.tag.cluster.name}")
-  private String clusterTagName;
 
   @Value("${aws.region}")
   private String region;
 
   private AmazonEC2 ec2;
-  private String workerAsg;
-  private String gpuWorkerAsg;
-  private String serverAsg;
+  private ClusterInfo clusterInfo;
 
   @RequestMapping("/")
   public String getMainApp() {
@@ -58,13 +43,9 @@ public class AdminController {
   
   @RequestMapping("/dashboard")
   public String getDashboard(Model model) {
-    model.addAttribute("workers", adminService.getInstances(workerAsg, 0, deploymentDomain, deploymentPort));
-    model.addAttribute("gpuWorkers", adminService.getInstances(gpuWorkerAsg, 0, deploymentDomain, deploymentPort));
-    model.addAttribute("servers", adminService.getInstances(serverAsg, 0, deploymentDomain, deploymentPort));
-    model.addAttribute("serversAutoScalingGroup", serverAsg);
-    model.addAttribute("workersAutoScalingGroup", workerAsg);
-    model.addAttribute("gpuWorkersAutoScalingGroup", gpuWorkerAsg);
-    model.addAttribute("clusterId", clusterId);
+    model.addAttribute("clusterInfo", clusterInfo);
+    model.addAttribute("clusterDetails", adminService.getClusterDetails(clusterId));
+    model.addAttribute("awsRegion", region);
     return "dashboard";
   }
 
@@ -72,50 +53,12 @@ public class AdminController {
   public void init() {
     logger.info("Initializing aws sdk for region {}", region);
     ec2 = AmazonEC2ClientBuilder.standard().withRegion(region).build();
-
-    Instance serverInfo = getInstanceByTag("buildfarm.instance_type", serverTagValue);
-    if (serverInfo != null) {
-      this.serverAsg = getTagValue("aws:autoscaling:groupName", serverInfo.getTags());
-    }
-    Instance workerInfo = getInstanceByTag("buildfarm.worker_type", cpuWorkerTagValue);
-    if (workerInfo != null) {
-      this.workerAsg = getTagValue("aws:autoscaling:groupName", workerInfo.getTags());
-    }
-    Instance gpuWorkerInfo = getInstanceByTag("buildfarm.worker_type", gpuWorkerTagValue);
-    if (gpuWorkerInfo != null) {
-      this.gpuWorkerAsg = getTagValue("aws:autoscaling:groupName", gpuWorkerInfo.getTags());
-    }
-    logger.info("Found Buildfarm deployment in AWS account: " +
-                    "clusterId: {}, worker asg: {}, gpu worker asg: {}, server asg: {}, grpc endpoint: {}:{}",
-            clusterId, workerAsg, gpuWorkerAsg, serverAsg, deploymentDomain, deploymentPort);
+    clusterInfo = adminService.getClusterInfo(clusterId);
+    logger.info("Found Buildfarm deployment in AWS account: clusterInfo [ number of servers: {}, number of worker groups: {}, grpc endpoint: {}:{}",
+            clusterInfo.getServers().getAsg().getInstances().size(), clusterInfo.getWorkers().size(), deploymentDomain, deploymentPort);
   }
 
   public String getBaseClusterId() {
     return clusterId.replace("buildfarm-", "");
-  }
-
-  private Instance getInstanceByTag(String tagName, String tagValue) {
-    DescribeInstancesResult instancesResult = ec2.describeInstances(
-            new DescribeInstancesRequest().withFilters(
-                    new Filter().withName("instance-state-name").withValues("running"),
-                    new Filter().withName("tag:" + clusterTagName).withValues(clusterId),
-                    new Filter().withName("tag:" + tagName).withValues(tagValue)));
-    for (Reservation r : instancesResult.getReservations()) {
-      for (Instance e : r.getInstances()) {
-        if (e != null) {
-          return e;
-        }
-      }
-    }
-    return null;
-  }
-
-  private String getTagValue(String tagName, List<Tag> tags) {
-    for (Tag tag : tags) {
-      if (tagName.equalsIgnoreCase(tag.getKey())) {
-        return tag.getValue();
-      }
-    }
-    return "";
   }
 }

--- a/admin/main/src/main/java/tech/aurora/bfadmin/model/Asg.java
+++ b/admin/main/src/main/java/tech/aurora/bfadmin/model/Asg.java
@@ -1,0 +1,26 @@
+package tech.aurora.bfadmin.model;
+
+import com.amazonaws.services.autoscaling.model.AutoScalingGroup;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class Asg implements Serializable {
+  private static final long serialVersionUID = 4343106139005494435L;
+  private static final Logger logger = LoggerFactory.getLogger(Asg.class);
+
+  private AutoScalingGroup asg;
+  private String groupType;
+  private String workerType;
+
+  public String getWorkerType() {
+    return workerType != null ? workerType.toUpperCase() : "";
+  }
+}

--- a/admin/main/src/main/java/tech/aurora/bfadmin/model/ClusterDetails.java
+++ b/admin/main/src/main/java/tech/aurora/bfadmin/model/ClusterDetails.java
@@ -1,0 +1,29 @@
+package tech.aurora.bfadmin.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ClusterDetails implements Serializable {
+  private static final long serialVersionUID = 4343106139005494435L;
+  private static final Logger logger = LoggerFactory.getLogger(ClusterDetails.class);
+
+  private String clusterId;
+  private List<Instance> servers;
+  private List<Instance> workers;
+
+  public List<Instance> getWorkers() {
+    Collections.sort(workers, Comparator.comparing(Instance::getWorkerType).thenComparing(Instance::getUptimeInHours, Comparator.reverseOrder()));
+    return workers;
+  }
+}

--- a/admin/main/src/main/java/tech/aurora/bfadmin/model/ClusterInfo.java
+++ b/admin/main/src/main/java/tech/aurora/bfadmin/model/ClusterInfo.java
@@ -1,0 +1,22 @@
+package tech.aurora.bfadmin.model;
+
+import java.io.Serializable;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ClusterInfo implements Serializable {
+  private static final long serialVersionUID = 4343106139005494435L;
+  private static final Logger logger = LoggerFactory.getLogger(ClusterInfo.class);
+
+  private String clusterId;
+  private Asg servers;
+  private List<Asg> workers;
+}

--- a/admin/main/src/main/java/tech/aurora/bfadmin/rest/AdminApi.java
+++ b/admin/main/src/main/java/tech/aurora/bfadmin/rest/AdminApi.java
@@ -7,7 +7,12 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import tech.aurora.bfadmin.model.ClusterDetails;
+import tech.aurora.bfadmin.model.ClusterInfo;
 import tech.aurora.bfadmin.service.AdminService;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @RestController
 @RequestMapping("admin")
@@ -20,26 +25,26 @@ public class AdminApi {
   @Value("${deployment.domain}")
   private String deploymentDomain;
 
-  @Value("${deployment.port}")
+  @Value("${buildfarm.public.port}")
   private int deploymentPort;
 
-  @Value("${buildfarm.run.docker.regex}")
+  @Value("${buildfarm.docker.name.regex}")
   private String containerRegex;
 
-  @RequestMapping("/restart/worker/{instanceId}")
-  public int restartWorker(@PathVariable String instanceId) {
-    if (instanceId.contains("ip")) {
-      instanceId = adminService.getInstanceIdByPrivateDnsName(instanceId);
-      logger.info("Retrieved instance id {}", instanceId);
-    }
-    return adminService.stopDockerContainer(instanceId, containerRegex, deploymentDomain, deploymentPort);
+  @RequestMapping("/cluster/info")
+  public ClusterInfo getClusterInfo(@PathVariable String clusterId) {
+    return adminService.getClusterInfo(clusterId);
   }
 
-  @RequestMapping("/restart/server/{instanceId}")
-  public int restartScheduler(@PathVariable String instanceId) {
+  @RequestMapping("/cluster/details")
+  public ClusterDetails getClusterDetails(@PathVariable String clusterId) {
+    return adminService.getClusterDetails(clusterId);
+  }
+
+  @RequestMapping("/restart/{instanceId}")
+  public int restartContainer(@PathVariable String instanceId) {
     if (instanceId.contains("ip")) {
       instanceId = adminService.getInstanceIdByPrivateDnsName(instanceId);
-      logger.info("Retrieved instance id {}", instanceId);
     }
     return adminService.stopDockerContainer(instanceId, containerRegex, deploymentDomain, deploymentPort);
   }
@@ -48,14 +53,13 @@ public class AdminApi {
   public int terminateInstance(@PathVariable String instanceId) {
     if (instanceId.contains("ip")) {
       instanceId = adminService.getInstanceIdByPrivateDnsName(instanceId);
-      logger.info("Retrieved instance id {}", instanceId);
     }
     return adminService.terminateInstance(instanceId, deploymentDomain, deploymentPort);
   }
 
-  @RequestMapping("/scale/{autoScaleGroup}/{numInstances}")
-  public String scaleWorkers(@PathVariable String autoScaleGroup,
+  @RequestMapping("/scale/{asgName}/{numInstances}")
+  public String scaleGroup(@PathVariable String asgName,
       @PathVariable Integer numInstances) {
-    return adminService.scaleGroup(autoScaleGroup, numInstances);
+    return adminService.scaleGroup(asgName, numInstances);
   }
 }

--- a/admin/main/src/main/java/tech/aurora/bfadmin/rest/AdminApi.java
+++ b/admin/main/src/main/java/tech/aurora/bfadmin/rest/AdminApi.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 import tech.aurora.bfadmin.model.ClusterDetails;
 import tech.aurora.bfadmin.model.ClusterInfo;
@@ -15,7 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @RestController
-@RequestMapping("admin")
+@RequestMapping(value = "admin", method = RequestMethod.POST)
 public class AdminApi {
   private static final Logger logger = LoggerFactory.getLogger(AdminApi.class);
   

--- a/admin/main/src/main/java/tech/aurora/bfadmin/rest/AdminApi.java
+++ b/admin/main/src/main/java/tech/aurora/bfadmin/rest/AdminApi.java
@@ -33,13 +33,13 @@ public class AdminApi {
   private String containerRegex;
 
   @RequestMapping("/cluster/info")
-  public ClusterInfo getClusterInfo(@PathVariable String clusterId) {
-    return adminService.getClusterInfo(clusterId);
+  public ClusterInfo getClusterInfo() {
+    return adminService.getClusterInfo();
   }
 
   @RequestMapping("/cluster/details")
-  public ClusterDetails getClusterDetails(@PathVariable String clusterId) {
-    return adminService.getClusterDetails(clusterId);
+  public ClusterDetails getClusterDetails() {
+    return adminService.getClusterDetails();
   }
 
   @RequestMapping("/restart/{instanceId}")

--- a/admin/main/src/main/java/tech/aurora/bfadmin/service/AdminService.java
+++ b/admin/main/src/main/java/tech/aurora/bfadmin/service/AdminService.java
@@ -1,28 +1,21 @@
 package tech.aurora.bfadmin.service;
 
-import com.amazonaws.services.autoscaling.model.AutoScalingGroup;
-import tech.aurora.bfadmin.model.Ec2Instance;
+import tech.aurora.bfadmin.model.ClusterDetails;
+import tech.aurora.bfadmin.model.ClusterInfo;
+import tech.aurora.bfadmin.model.Instance;
 import java.util.List;
 
 public interface AdminService {
 
-  List<Ec2Instance> getInstances(String asgName, int ageInMinutes, String grpcEndpoint, int grpcPort);
+  ClusterInfo getClusterInfo(String clusterId);
 
-  String scaleGroup(String autoScaleGroup, Integer desiredInstances);
+  ClusterDetails getClusterDetails(String clusterId);
+
+  String scaleGroup(String asgName, Integer desiredInstances);
 
   int terminateInstance(String instanceId, String grpcEndpoint, int grpcPort);
 
-  void gracefullyShutDownWorker(String workerName, String grpcEndpoint, int grpcPort);
-
   String getInstanceIdByPrivateDnsName(String dnsName);
 
-  String resizeGroup(String autoScaleGroup, Integer minInstances, Integer maxInstances);
-
-  AutoScalingGroup describeAutoScalingGroup(String autoScaleGroup);
-
   int stopDockerContainer(String instanceId, String containerType, String grpcEndpoint, int grpcPort);
-
-  String scaleOnDemandTargetPercentage(String autoScaleGroup, Integer onDemandTargetPercentage, Integer minPercentage);
-
-  String setOnDemandTargetPercentage(String autoScaleGroup, Integer onDemandTargetPercentage, Integer minPercentage);
 }

--- a/admin/main/src/main/java/tech/aurora/bfadmin/service/AdminService.java
+++ b/admin/main/src/main/java/tech/aurora/bfadmin/service/AdminService.java
@@ -7,9 +7,9 @@ import java.util.List;
 
 public interface AdminService {
 
-  ClusterInfo getClusterInfo(String clusterId);
+  ClusterInfo getClusterInfo();
 
-  ClusterDetails getClusterDetails(String clusterId);
+  ClusterDetails getClusterDetails();
 
   String scaleGroup(String asgName, Integer desiredInstances);
 

--- a/admin/main/src/main/java/tech/aurora/bfadmin/service/impl/AdminServiceImpl.java
+++ b/admin/main/src/main/java/tech/aurora/bfadmin/service/impl/AdminServiceImpl.java
@@ -42,6 +42,9 @@ import javax.annotation.PostConstruct;
 public class AdminServiceImpl implements AdminService {
   private static final Logger logger = LoggerFactory.getLogger(AdminServiceImpl.class);
 
+  @Value("${buildfarm.cluster.name}")
+  private String clusterId;
+
   @Value("${buildfarm.worker.port}")
   private int workerPort;
 
@@ -65,7 +68,7 @@ public class AdminServiceImpl implements AdminService {
   }
 
   @Override
-  public ClusterInfo getClusterInfo(String clusterId) {
+  public ClusterInfo getClusterInfo() {
     ClusterInfo clusterInfo = new ClusterInfo();
     clusterInfo.setClusterId(clusterId);
     Asg serverAsg = new Asg();
@@ -85,7 +88,7 @@ public class AdminServiceImpl implements AdminService {
   }
 
   @Override
-  public ClusterDetails getClusterDetails(String clusterId) {
+  public ClusterDetails getClusterDetails() {
     ClusterDetails clusterDetails = new ClusterDetails();
     clusterDetails.setClusterId(clusterId);
     clusterDetails.setServers(getInstances(clusterId,"server"));

--- a/admin/main/src/main/java/tech/aurora/bfadmin/service/impl/AdminServiceImpl.java
+++ b/admin/main/src/main/java/tech/aurora/bfadmin/service/impl/AdminServiceImpl.java
@@ -3,10 +3,6 @@ package tech.aurora.bfadmin.service.impl;
 import build.buildfarm.v1test.AdminGrpc;
 import build.buildfarm.v1test.GetClientStartTimeRequest;
 import build.buildfarm.v1test.GetClientStartTimeResult;
-import build.buildfarm.v1test.GetHostsRequest;
-import build.buildfarm.v1test.GetHostsResult;
-import build.buildfarm.v1test.Host;
-import build.buildfarm.v1test.ShutDownWorkerGracefullyRequest;
 import build.buildfarm.v1test.StopContainerRequest;
 import build.buildfarm.v1test.TerminateHostRequest;
 import com.amazonaws.services.autoscaling.AmazonAutoScaling;
@@ -14,8 +10,7 @@ import com.amazonaws.services.autoscaling.AmazonAutoScalingClientBuilder;
 import com.amazonaws.services.autoscaling.model.AutoScalingGroup;
 import com.amazonaws.services.autoscaling.model.DescribeAutoScalingGroupsRequest;
 import com.amazonaws.services.autoscaling.model.DescribeAutoScalingGroupsResult;
-import com.amazonaws.services.autoscaling.model.InstancesDistribution;
-import com.amazonaws.services.autoscaling.model.MixedInstancesPolicy;
+import com.amazonaws.services.autoscaling.model.TagDescription;
 import com.amazonaws.services.autoscaling.model.UpdateAutoScalingGroupRequest;
 import com.amazonaws.services.autoscaling.model.UpdateAutoScalingGroupResult;
 import com.amazonaws.services.ec2.AmazonEC2;
@@ -23,17 +18,18 @@ import com.amazonaws.services.ec2.AmazonEC2ClientBuilder;
 import com.amazonaws.services.ec2.model.DescribeInstancesRequest;
 import com.amazonaws.services.ec2.model.DescribeInstancesResult;
 import com.amazonaws.services.ec2.model.Filter;
-import com.amazonaws.services.ec2.model.Instance;
 import com.amazonaws.services.ec2.model.Reservation;
-import com.google.protobuf.util.Timestamps;
+import com.amazonaws.services.ec2.model.Tag;
 import com.google.rpc.Status;
-import tech.aurora.bfadmin.model.Ec2Instance;
+import tech.aurora.bfadmin.model.Asg;
+import tech.aurora.bfadmin.model.ClusterDetails;
+import tech.aurora.bfadmin.model.ClusterInfo;
+import tech.aurora.bfadmin.model.Instance;
 import tech.aurora.bfadmin.service.AdminService;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,14 +42,17 @@ import javax.annotation.PostConstruct;
 public class AdminServiceImpl implements AdminService {
   private static final Logger logger = LoggerFactory.getLogger(AdminServiceImpl.class);
 
-  @Value("${buildfarm.server.port}")
-  private int serverPort;
-
   @Value("${buildfarm.worker.port}")
   private int workerPort;
 
   @Value("${aws.region}")
   private String region;
+
+  @Value("${deployment.domain}")
+  private String deploymentDomain;
+
+  @Value("${buildfarm.public.port}")
+  private int deploymentPort;
 
   private AmazonEC2 ec2;
   private AmazonAutoScaling autoScale;
@@ -66,33 +65,32 @@ public class AdminServiceImpl implements AdminService {
   }
 
   @Override
-  public List<Ec2Instance> getInstances(String asgName, int ageInMinutes, String grpcEndpoint, int grpcPort) {
-    List<Ec2Instance> instances = new ArrayList<>();
-    ManagedChannel channel = ManagedChannelBuilder.forAddress(grpcEndpoint, grpcPort).usePlaintext().build();
-    try {
-      AdminGrpc.AdminBlockingStub stub = AdminGrpc.newBlockingStub(channel);
-      GetHostsRequest request = GetHostsRequest.newBuilder().setFilter(asgName).setAgeInMinutes(ageInMinutes).setStatus("running").build();
-      GetHostsResult result = stub.getHosts(request);
-      for (Host host : result.getHostsList()) {
-        instances.add(new Ec2Instance(
-          host.getHostNum(),
-          host.getHostId(),
-          host.getIpAddress(),
-          new Date(Timestamps.toMillis(host.getLaunchTime())),
-          host.getState(),
-          host.getDnsName(),
-          host.getLaunchTime().getSeconds() * 1000,
-          getContainerUptime(host.getIpAddress(), asgName, stub), 
-          host.getNumCores(),
-          host.getType(),
-          host.getLifecycle()));
-      }
-    } catch (Exception e) {
-      logger.error("Could not load instances. Is {} cluster up and running?", grpcEndpoint, e);
-    } finally {
-      channel.shutdown();
+  public ClusterInfo getClusterInfo(String clusterId) {
+    ClusterInfo clusterInfo = new ClusterInfo();
+    clusterInfo.setClusterId(clusterId);
+    Asg serverAsg = new Asg();
+    serverAsg.setGroupType("server");
+    serverAsg.setAsg(getAutoScalingGroup(getAsgNamesFromHosts(clusterId, "server").get(0)));
+    clusterInfo.setServers(serverAsg);
+    List<Asg> workerAsgs = new ArrayList<>();
+    for (String asgName : getAsgNamesFromHosts(clusterId, "worker")) {
+      Asg workerAsg = new Asg();
+      workerAsg.setGroupType("worker");
+      workerAsg.setAsg(getAutoScalingGroup(asgName));
+      workerAsg.setWorkerType(getAsgTagValue("buildfarm.worker_type", workerAsg.getAsg().getTags()));
+      workerAsgs.add(workerAsg);
     }
-    return instances;
+    clusterInfo.setWorkers(workerAsgs);
+    return clusterInfo;
+  }
+
+  @Override
+  public ClusterDetails getClusterDetails(String clusterId) {
+    ClusterDetails clusterDetails = new ClusterDetails();
+    clusterDetails.setClusterId(clusterId);
+    clusterDetails.setServers(getInstances(clusterId,"server"));
+    clusterDetails.setWorkers(getInstances(clusterId,"worker"));
+    return clusterDetails;
   }
 
   @Override
@@ -118,23 +116,13 @@ public class AdminServiceImpl implements AdminService {
   }
 
   @Override
-  public void gracefullyShutDownWorker(String workerName, String grpcEndpoint, int grpcPort) {
-    ManagedChannel channel = ManagedChannelBuilder.forAddress(grpcEndpoint, grpcPort).usePlaintext().build();
-    AdminGrpc.AdminBlockingStub stub = AdminGrpc.newBlockingStub(channel);
-    ShutDownWorkerGracefullyRequest request = ShutDownWorkerGracefullyRequest.newBuilder().setWorkerName(workerName).build();
-    stub.shutDownWorkerGracefully(request);
-    channel.shutdown();
-    logger.info("Initiated graceful worker shutdown for worker {} using {}:{}", grpcEndpoint, grpcPort);
-  }
-
-  @Override
   public String getInstanceIdByPrivateDnsName(String dnsName) {
     Filter filter = new Filter().withName("private-dns-name").withValues(dnsName);
     DescribeInstancesRequest describeInstancesRequest =
       new DescribeInstancesRequest().withFilters(filter);
     DescribeInstancesResult instancesResult = ec2.describeInstances(describeInstancesRequest);
     for (Reservation r : instancesResult.getReservations()) {
-      for (Instance e : r.getInstances()) {
+      for (com.amazonaws.services.ec2.model.Instance e : r.getInstances()) {
         if (e.getPrivateDnsName() != null && e.getPrivateDnsName().equals(dnsName)) {
           return e.getInstanceId();
         }
@@ -144,60 +132,74 @@ public class AdminServiceImpl implements AdminService {
   }
 
   @Override
-  public String scaleGroup(String autoScaleGroup, Integer desiredInstances) {
-    logger.info("Scaling group {} to {} instances", autoScaleGroup, desiredInstances);
+  public String scaleGroup(String asgName, Integer desiredInstances) {
+    logger.info("Scaling group {} to {} instances", asgName, desiredInstances);
     UpdateAutoScalingGroupRequest request = new UpdateAutoScalingGroupRequest()
-      .withAutoScalingGroupName(autoScaleGroup).withDesiredCapacity(desiredInstances);
+      .withAutoScalingGroupName(asgName).withDesiredCapacity(desiredInstances);
     UpdateAutoScalingGroupResult response = autoScale.updateAutoScalingGroup(request);
     return response.toString();
   }
 
-  @Override
-  public String resizeGroup(String autoScaleGroup, Integer minInstances, Integer maxInstances) {
-    logger.info("Resizing group {} to min: {}, max: {} instances", autoScaleGroup, minInstances,
-      maxInstances);
-    UpdateAutoScalingGroupRequest request =
-      new UpdateAutoScalingGroupRequest().withAutoScalingGroupName(autoScaleGroup);
-    if (minInstances != null && minInstances > 0) {
-      request.setMinSize(minInstances);
+  private List<Instance> getInstances(String clusterId, String type) {
+    List<Instance> instances = new ArrayList<>();
+    ManagedChannel channel = ManagedChannelBuilder.forAddress(deploymentDomain, deploymentPort).usePlaintext().build();
+    AdminGrpc.AdminBlockingStub stub = AdminGrpc.newBlockingStub(channel);
+    for (com.amazonaws.services.ec2.model.Instance e : getEc2Instances(clusterId, type)) {
+      Instance instance = new Instance();
+      instance.setEc2Instance(e);
+      instance.setClusterId(clusterId);
+      if ("worker".equals(type)) {
+        instance.setWorkerType(getTagValue("buildfarm.worker_type", e.getTags()));
+      }
+      instance.setGroupType(type);
+      instance.setContainerStartTime(getContainerUptime(e.getPrivateIpAddress(), getTagValue("aws:autoscaling:groupName", e.getTags()), stub));
+      instances.add(instance);
     }
-    if (maxInstances != null && maxInstances > 0) {
-      request.setMaxSize(maxInstances);
+    if (channel != null) {
+      channel.shutdown();
     }
-    UpdateAutoScalingGroupResult response = autoScale.updateAutoScalingGroup(request);
-    return response.toString();
+    return instances;
   }
 
-  @Override
-  public String scaleOnDemandTargetPercentage(String autoScaleGroup, Integer onDemandTargetPercentage, Integer minPercentage) {
-    AutoScalingGroup asg = describeAutoScalingGroup(autoScaleGroup);
-    MixedInstancesPolicy mixedInstancesPolicy = asg.getMixedInstancesPolicy();
-    InstancesDistribution instancesDistribution = mixedInstancesPolicy.getInstancesDistribution();
-    return setOnDemandTargetPercentage(autoScaleGroup, instancesDistribution.getOnDemandPercentageAboveBaseCapacity() + onDemandTargetPercentage, minPercentage);
-  }
-
-  @Override
-  public String setOnDemandTargetPercentage(String autoScaleGroup, Integer onDemandTargetPercentage, Integer minPercentage) {
-    if (onDemandTargetPercentage < minPercentage) {
-      onDemandTargetPercentage = minPercentage;
-    } else if (onDemandTargetPercentage > 100) {
-      onDemandTargetPercentage = 100;
-    }
-    logger.info("Updating group {} on demand target to: {}%", autoScaleGroup, onDemandTargetPercentage);
-    UpdateAutoScalingGroupRequest request =
-      new UpdateAutoScalingGroupRequest()
-        .withAutoScalingGroupName(autoScaleGroup)
-        .withMixedInstancesPolicy(new MixedInstancesPolicy().withInstancesDistribution(new InstancesDistribution().withOnDemandPercentageAboveBaseCapacity(onDemandTargetPercentage)));
-    UpdateAutoScalingGroupResult response = autoScale.updateAutoScalingGroup(request);
-    return response.toString();
-  }
-
-  @Override
-  public AutoScalingGroup describeAutoScalingGroup(String autoScaleGroup) {
+  private AutoScalingGroup getAutoScalingGroup(String asgName) {
     DescribeAutoScalingGroupsRequest request = new DescribeAutoScalingGroupsRequest()
-      .withAutoScalingGroupNames(Arrays.asList(autoScaleGroup));
+      .withAutoScalingGroupNames(Arrays.asList(asgName));
     DescribeAutoScalingGroupsResult response = autoScale.describeAutoScalingGroups(request);
     return response.getAutoScalingGroups().get(0);
+  }
+
+  private List<com.amazonaws.services.ec2.model.Instance> getEc2Instances(String clusterId, String type) {
+    List<com.amazonaws.services.ec2.model.Instance> instances = new ArrayList<>();
+    DescribeInstancesResult instancesResult = ec2.describeInstances(
+            new DescribeInstancesRequest().withFilters(
+                    new Filter().withName("instance-state-name").withValues("running"),
+                    new Filter().withName("tag:buildfarm.cluster_id").withValues(clusterId),
+                    new Filter().withName("tag:buildfarm.instance_type").withValues(type)));
+    for (Reservation r : instancesResult.getReservations()) {
+      for (com.amazonaws.services.ec2.model.Instance e : r.getInstances()) {
+        if (e != null) {
+          instances.add(e);
+        }
+      }
+    }
+    return instances;
+  }
+
+  private List<String> getAsgNamesFromHosts(String clusterId, String type) {
+    List<String> asgNames = new ArrayList<>();
+    DescribeInstancesResult instancesResult = ec2.describeInstances(
+            new DescribeInstancesRequest().withFilters(
+                    new Filter().withName("instance-state-name").withValues("running"),
+                    new Filter().withName("tag:buildfarm.cluster_id").withValues(clusterId),
+                    new Filter().withName("tag:buildfarm.instance_type").withValues(type)));
+    for (com.amazonaws.services.ec2.model.Instance e : getEc2Instances(clusterId, type)) {
+      for (Tag tag : e.getTags()) {
+        if ("aws:autoscaling:groupName".equalsIgnoreCase(tag.getKey()) && !asgNames.contains(tag.getValue())) {
+          asgNames.add(tag.getValue());
+        }
+      }
+    }
+    return asgNames;
   }
 
   private Long getContainerUptime(String hostname, String asgName, AdminGrpc.AdminBlockingStub stub) {
@@ -208,5 +210,23 @@ public class AdminServiceImpl implements AdminService {
     } else {
       return 0L;
     }
+  }
+
+  private String getTagValue(String tagName, List<Tag> tags) {
+    for (Tag tag : tags) {
+      if (tagName.equalsIgnoreCase(tag.getKey())) {
+        return tag.getValue();
+      }
+    }
+    return "";
+  }
+
+  private String getAsgTagValue(String tagName, List<TagDescription> tags) {
+    for (TagDescription tag : tags) {
+      if (tagName.equalsIgnoreCase(tag.getKey())) {
+        return tag.getValue();
+      }
+    }
+    return "";
   }
 }

--- a/admin/main/src/main/resources/application.properties
+++ b/admin/main/src/main/resources/application.properties
@@ -11,3 +11,7 @@ deployment.domain=localhost
 
 # AWS
 aws.region=us-east-1
+
+# API Docs
+springdoc.swagger-ui.path=/restapi.html
+springdoc.swagger-ui.operationsSorter=method

--- a/admin/main/src/main/resources/application.properties
+++ b/admin/main/src/main/resources/application.properties
@@ -1,25 +1,13 @@
-# General
-spring.application.name=Buildfarm Admin
-cluster.id=buildfarm-dev
+# Buildfarm Installation
 buildfarm.server.port=8980
 buildfarm.worker.port=8981
+buildfarm.public.port=80
+buildfarm.cluster.name=buildfarm-dev
+buildfarm.docker.name.regex=k8s_buildfarm
 
-# Web Server
+# Buildfarm Admin Deployment
 server.port=8080
-
-# EC2 Run Commands
-buildfarm.run.cmd.document=AWS-RunShellScript
-buildfarm.run.docker.server=buildfarm-server
-buildfarm.run.docker.worker=buildfarm-worker
-buildfarm.run.docker.regex=k8s_buildfarm
-
-# Customized per deployment
-deployment.tag.instance.type.server=server
-deployment.tag.instance.type.cpuworker=cpu
-deployment.tag.instance.type.gpuworker=gpu
 deployment.domain=localhost
-deployment.port=8980
-deployment.tag.cluster.name=buildfarm.cluster_id
 
 # AWS
 aws.region=us-east-1

--- a/admin/main/src/main/resources/templates/dashboard.html
+++ b/admin/main/src/main/resources/templates/dashboard.html
@@ -13,11 +13,11 @@
 			<!-- Begin Page Content -->
 			<div class="container-fluid">
 				<!-- Page Heading -->
-				<h1 class="h3 mb-2 text-gray-800">Dashboard - <span id="clusterId" th:text="${clusterId}"></span></h1>
+				<h1 class="h3 mb-2 text-gray-800">Dashboard - <span id="clusterId" th:text="${clusterDetails.clusterId}"></span></h1>
 				<p class="mb-4"></p>
 				<div class="card shadow mb-4">
 					<div class="card-header py-3">
-						<h6 class="m-0 font-weight-bold text-primary">CPU Workers</h6>
+						<h6 class="m-0 font-weight-bold text-primary">Workers</h6>
 					</div>
 					<div class="card-body">
 						<div class="table-responsive">
@@ -31,83 +31,34 @@
 									<th>Container Up</th>
 									<th>Instance Type</th>
 									<th>Lifecycle</th>
+									<th>Worker Type</th>
 									<th></th>
 									<th></th>
 								</tr>
 								</thead>
 								<tbody>
-								<tr th:each="instance : ${workers}">
+								<tr th:each="instance : ${clusterDetails.workers}">
 									<td>
-										<a th:href="@{'https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#Instances:search=' + ${instance.instanceId}}"
+										<a th:href="@{'https://console.aws.amazon.com/ec2/v2/home?region=' + ${awsRegion} + '#Instances:search=' + ${instance.ec2Instance.instanceId}}"
 										   th:target="_blank">
-											<span th:text="${instance.instanceId}"></span>
+											<span th:text="${instance.ec2Instance.instanceId}"></span>
 										</a>
 									</td>
-									<td><span th:text="${instance.privateIp}"></span></td>
+									<td><span th:text="${instance.ec2Instance.privateIpAddress}"></span></td>
 									<td><span th:text="${instance.formattedLaunchTime}"></span></td>
 									<td><span th:text="${instance.uptimeStr}"></span></td>
 									<td><span th:text="${instance.containerUptimeStr}"></span></td>
-									<td><span th:text="${instance.instanceType}"></span></td>
+									<td><span th:text="${instance.ec2Instance.instanceType}"></span></td>
 									<td><span th:text="${instance.lifecycle}"></span></td>
+									<td><span th:text="${instance.workerType}"></span></td>
 									<td>
 											<span><a
-													th:href="@{'/admin/restart/worker/' + ${instance.instanceId}}"
+													th:href="@{'/admin/restart/' + ${instance.ec2Instance.instanceId}}"
 													class="btn btn-danger btn-sm actionable-btn">Reboot</a></span>
 									</td>
 									<td>
 											<span><a
-													th:href="@{'/admin/terminate/' + ${instance.instanceId}}"
-													class="btn btn-danger btn-sm actionable-btn">Terminate</a></span>
-									</td>
-								</tr>
-								</tbody>
-							</table>
-						</div>
-					</div>
-				</div>
-				<p class="mb-4"></p>
-				<div class="card shadow mb-4">
-					<div class="card-header py-3">
-						<h6 class="m-0 font-weight-bold text-primary">GPU Workers</h6>
-					</div>
-					<div class="card-body">
-						<div class="table-responsive">
-							<table class="table table-bordered" id="dataTableGpuWorkers" width="100%" cellspacing="0">
-								<thead>
-								<tr>
-									<th>Instance ID</th>
-									<th>IP Address</th>
-									<th>Launched On</th>
-									<th>Instance Up</th>
-									<th>Container Up</th>
-									<th>Instance Type</th>
-									<th>Lifecycle</th>
-									<th></th>
-									<th></th>
-								</tr>
-								</thead>
-								<tbody>
-								<tr th:each="instance : ${gpuWorkers}">
-									<td>
-										<a th:href="@{'https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#Instances:search=' + ${instance.instanceId}}"
-										   th:target="_blank">
-											<span th:text="${instance.instanceId}"></span>
-										</a>
-									</td>
-									<td><span th:text="${instance.privateIp}"></span></td>
-									<td><span th:text="${instance.formattedLaunchTime}"></span></td>
-									<td><span th:text="${instance.uptimeStr}"></span></td>
-									<td><span th:text="${instance.containerUptimeStr}"></span></td>
-									<td><span th:text="${instance.instanceType}"></span></td>
-									<td><span th:text="${instance.lifecycle}"></span></td>
-									<td>
-											<span><a
-													th:href="@{'/admin/restart/worker/' + ${instance.instanceId}}"
-													class="btn btn-danger btn-sm actionable-btn">Reboot</a></span>
-									</td>
-									<td>
-											<span><a
-													th:href="@{'/admin/terminate/' + ${instance.instanceId}}"
+													th:href="@{'/admin/terminate/' + ${instance.ec2Instance.instanceId}}"
 													class="btn btn-danger btn-sm actionable-btn">Terminate</a></span>
 									</td>
 								</tr>
@@ -138,27 +89,27 @@
 								</tr>
 								</thead>
 								<tbody>
-								<tr th:each="instance : ${servers}">
+								<tr th:each="instance : ${clusterDetails.servers}">
 									<td>
-										<a th:href="@{'https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#Instances:search=' + ${instance.instanceId}}"
+										<a th:href="@{'https://console.aws.amazon.com/ec2/v2/home?region=' + ${awsRegion} + '#Instances:search=' + ${instance.ec2Instance.instanceId}}"
 										   th:target="_blank">
-											<span th:text="${instance.instanceId}"></span>
+											<span th:text="${instance.ec2Instance.instanceId}"></span>
 										</a>
 									</td>
-									<td><span th:text="${instance.privateIp}"></span></td>
+									<td><span th:text="${instance.ec2Instance.privateIpAddress}"></span></td>
 									<td><span th:text="${instance.formattedLaunchTime}"></span></td>
 									<td><span th:text="${instance.uptimeStr}"></span></td>
 									<td><span th:text="${instance.containerUptimeStr}"></span></td>
-									<td><span th:text="${instance.instanceType}"></span></td>
+									<td><span th:text="${instance.ec2Instance.instanceType}"></span></td>
 									<td><span th:text="${instance.lifecycle}"></span></td>
 									<td>
 											<span><a
-													th:href="@{'/admin/restart/server/' + ${instance.instanceId}}"
+													th:href="@{'/admin/restart/' + ${instance.ec2Instance.instanceId}}"
 													class="btn btn-danger btn-sm actionable-btn">Reboot</a></span>
 									</td>
 									<td>
 											<span><a
-													th:href="@{'/admin/terminate/' + ${instance.instanceId}}"
+													th:href="@{'/admin/terminate/' + ${instance.ec2Instance.instanceId}}"
 													class="btn btn-danger btn-sm actionable-btn">Terminate</a></span>
 									</td>
 								</tr>
@@ -169,54 +120,31 @@
 				</div>
 
 				<div class="row">
-					<div class="col-lg-4">
+					<div class="col-lg-4" th:each="workerAsg : ${clusterInfo.workers}">
 						<div class="card shadow mb-4">
 							<!-- Card Header -->
 							<div class="card-header py-3 d-flex flex-row align-items-center justify-content-between">
-								<h6 class="m-0 font-weight-bold text-primary">CPU Workers Autoscaling Group</h6>
+								<h6 class="m-0 font-weight-bold text-primary">Workers Autoscaling Group (<span th:text="${workerAsg.workerType}"></span>)</h6>
 							</div>
 							<!-- Card Body -->
 							<div class="card-body actionable-container">
-								<p class="card-text">Set desired number of CPU workers.</p>
+								<p class="card-text">Set desired number of workers.</p>
 								<div class="form-group">
-									<label for="numWorkers">Number of CPU Workers</label>
+									<label for="numWorkers">Number of Workers</label>
 									<select
 											class="form-control actionable-value" id="numWorkers">
 										<option>Select</option>
-										<option th:each="i : ${#numbers.sequence( 0, 150, 1)}"><p th:text="${ i }" th:remove="tag"></p></option>
+										<option th:each="i : ${#numbers.sequence( 0, 100, 1)}"><p th:text="${ i }" th:remove="tag"></p></option>
 									</select>
 								</div>
 								<a
-										th:href="@{'/admin/scale/' + ${workersAutoScalingGroup} + '/'}"
-										class="btn btn-primary actionable-btn-with-value">Scale CPU Workers
+										th:href="@{'/admin/scale/' + ${workerAsg.asg.autoScalingGroupName} + '/'}"
+										class="btn btn-primary actionable-btn-with-value">Scale Workers
 									Group</a>
 							</div>
 						</div>
 					</div>
-					<div class="col-lg-4">
-						<div class="card shadow mb-4">
-							<!-- Card Header -->
-							<div class="card-header py-3 d-flex flex-row align-items-center justify-content-between">
-								<h6 class="m-0 font-weight-bold text-primary">GPU Workers Autoscaling Group</h6>
-							</div>
-							<!-- Card Body -->
-							<div class="card-body actionable-container">
-								<p class="card-text">Set desired number of GPU workers.</p>
-								<div class="form-group">
-									<label for="numWorkers">Number of GPU Workers</label>
-									<select
-											class="form-control actionable-value" id="numGpuWorkers">
-										<option>Select</option>
-										<option th:each="i : ${#numbers.sequence( 0, 30, 1)}"><p th:text="${ i }" th:remove="tag"></p></option>
-									</select>
-								</div>
-								<a
-										th:href="@{'/admin/scale/' + ${gpuWorkersAutoScalingGroup} + '/'}"
-										class="btn btn-primary actionable-btn-with-value">Scale GPU Workers
-									Group</a>
-							</div>
-						</div>
-					</div>
+
 					<div class="col-lg-4">
 						<div class="card shadow mb-4">
 							<!-- Card Header -->
@@ -231,11 +159,11 @@
 									<select
 											class="form-control actionable-value" id="numServers">
 										<option>Select</option>
-										<option th:each="i : ${#numbers.sequence( 0, 20, 1)}"><p th:text="${ i }" th:remove="tag"></p></option>
+										<option th:each="i : ${#numbers.sequence( 0, 100, 1)}"><p th:text="${ i }" th:remove="tag"></p></option>
 									</select>
 								</div>
 								<a
-										th:href="@{'/admin/scale/' + ${serversAutoScalingGroup} + '/'}"
+										th:href="@{'/admin/scale/' + ${clusterInfo.servers.asg.autoScalingGroupName} + '/'}"
 										class="btn btn-primary actionable-btn-with-value">Scale Servers
 									Group</a>
 							</div>


### PR DESCRIPTION
This PR introduces the following changes to Buildfarm Admin:

- Update worker retrieval functionality to support arbitrary worker names/queues vs cpu/gpu specific implementation
- Update UI to group all workers under the same list and add worker type column
- Simplify controller implementation 
- Add missing REST endpoints for cluster information and details
- Refactor to remove unused code and configuration properties (some configuration properties were renamed so an update may be needed to current deployments)
- Add Swagger API docs at http://localhost:8080/restapi.html