### PR TITLE
[bfadmin] Add clusters api endpoint to discover all clusters

### DIFF
--- a/admin/main/src/main/java/tech/aurora/bfadmin/rest/AdminApi.java
+++ b/admin/main/src/main/java/tech/aurora/bfadmin/rest/AdminApi.java
@@ -31,9 +31,14 @@ public class AdminApi {
   @Value("${buildfarm.docker.name.regex}")
   private String containerRegex;
 
-  @RequestMapping("/clusters")
+  @RequestMapping("/clusters/info")
   public List<String> getAllClusters() {
     return adminService.getAllClusters();
+  }
+
+  @RequestMapping("/clusters/details")
+  public List<ClusterInfo> getAllClustersWithDetails() {
+    return adminService.getAllClustersWithDetails();
   }
 
   @RequestMapping("/cluster/info")

--- a/admin/main/src/main/java/tech/aurora/bfadmin/rest/AdminApi.java
+++ b/admin/main/src/main/java/tech/aurora/bfadmin/rest/AdminApi.java
@@ -12,6 +12,8 @@ import tech.aurora.bfadmin.model.ClusterDetails;
 import tech.aurora.bfadmin.model.ClusterInfo;
 import tech.aurora.bfadmin.service.AdminService;
 
+import java.util.List;
+
 @RestController
 @RequestMapping(value = "admin", method = RequestMethod.POST)
 public class AdminApi {
@@ -28,6 +30,11 @@ public class AdminApi {
 
   @Value("${buildfarm.docker.name.regex}")
   private String containerRegex;
+
+  @RequestMapping("/clusters")
+  public List<String> getAllClusters() {
+    return adminService.getAllClusters();
+  }
 
   @RequestMapping("/cluster/info")
   public ClusterInfo getClusterInfo() {

--- a/admin/main/src/main/java/tech/aurora/bfadmin/service/AdminService.java
+++ b/admin/main/src/main/java/tech/aurora/bfadmin/service/AdminService.java
@@ -7,9 +7,13 @@ import java.util.List;
 
 public interface AdminService {
 
+  List<ClusterInfo> getAllClustersWithDetails();
+
   List<String> getAllClusters();
 
   ClusterInfo getClusterInfo();
+
+  ClusterInfo getClusterInfo(String clusterId);
 
   ClusterDetails getClusterDetails();
 

--- a/admin/main/src/main/java/tech/aurora/bfadmin/service/AdminService.java
+++ b/admin/main/src/main/java/tech/aurora/bfadmin/service/AdminService.java
@@ -3,7 +3,11 @@ package tech.aurora.bfadmin.service;
 import tech.aurora.bfadmin.model.ClusterDetails;
 import tech.aurora.bfadmin.model.ClusterInfo;
 
+import java.util.List;
+
 public interface AdminService {
+
+  List<String> getAllClusters();
 
   ClusterInfo getClusterInfo();
 

--- a/admin/main/src/main/java/tech/aurora/bfadmin/service/impl/AdminServiceImpl.java
+++ b/admin/main/src/main/java/tech/aurora/bfadmin/service/impl/AdminServiceImpl.java
@@ -68,6 +68,18 @@ public class AdminServiceImpl implements AdminService {
   }
 
   @Override
+  public List<String> getAllClusters() {
+    List<String> clusters = new ArrayList<>();
+    for (AutoScalingGroup asg : autoScale.describeAutoScalingGroups(new DescribeAutoScalingGroupsRequest().withMaxRecords(100)).getAutoScalingGroups()) {
+      String clusterId = getAsgTagValue("buildfarm.cluster_id", asg.getTags());
+      if (!"".equals(clusterId) && !clusters.contains(clusterId)) {
+        clusters.add(clusterId);
+      }
+    }
+    return clusters;
+  }
+
+  @Override
   public ClusterInfo getClusterInfo() {
     ClusterInfo clusterInfo = new ClusterInfo();
     clusterInfo.setClusterId(clusterId);

--- a/admin/main/src/main/java/tech/aurora/bfadmin/service/impl/AdminServiceImpl.java
+++ b/admin/main/src/main/java/tech/aurora/bfadmin/service/impl/AdminServiceImpl.java
@@ -72,7 +72,7 @@ public class AdminServiceImpl implements AdminService {
     List<String> clusters = new ArrayList<>();
     for (AutoScalingGroup asg : autoScale.describeAutoScalingGroups(new DescribeAutoScalingGroupsRequest().withMaxRecords(100)).getAutoScalingGroups()) {
       String clusterId = getAsgTagValue("buildfarm.cluster_id", asg.getTags());
-      if (!"".equals(clusterId) && !clusters.contains(clusterId)) {
+      if (!clusterId.isEmpty() && !clusters.contains(clusterId)) {
         clusters.add(clusterId);
       }
     }
@@ -80,7 +80,21 @@ public class AdminServiceImpl implements AdminService {
   }
 
   @Override
+  public List<ClusterInfo> getAllClustersWithDetails() {
+    List<ClusterInfo> clusters = new ArrayList<>();
+    for (String clusterId : getAllClusters()) {
+      clusters.add(getClusterInfo(clusterId));
+    }
+    return clusters;
+  }
+
+  @Override
   public ClusterInfo getClusterInfo() {
+    return getClusterInfo(clusterId);
+  }
+
+  @Override
+  public ClusterInfo getClusterInfo(String clusterId) {
     ClusterInfo clusterInfo = new ClusterInfo();
     clusterInfo.setClusterId(clusterId);
     Asg serverAsg = new Asg();


### PR DESCRIPTION
Add 2 REST API endpoints:

- /clusters/info - to get names of all buildfarm clusters deployed in the AWS account.
- /clusters/details - to get all buildfarm clusters and deployment details (same information returned by /cluster/info endpoint)