### PR TITLE
[config] remove optional in proto for ssl

### DIFF
--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -218,7 +218,7 @@ message BuildFarmServerConfig {
   
   // Absolute path to the PEM file containing both the required certificates and any
   // associated private key.
-  optional string ssl_certificate_path = 8;
+  string ssl_certificate_path = 8;
 
   // CAS write deadline
   google.protobuf.Duration cas_write_timeout = 9;


### PR DESCRIPTION
This is currently the only attribute that uses optional.  If the attribute is left out, it will not appear as an empty string.  
For consistency with other attributes, we can remove the optional.  This will make the existing code that checks for empty string correct.