### PR TITLE
Increase jedis client timeout to 10 seconds

### DIFF
--- a/src/main/java/build/buildfarm/instance/shard/JedisClusterFactory.java
+++ b/src/main/java/build/buildfarm/instance/shard/JedisClusterFactory.java
@@ -146,8 +146,8 @@ public class JedisClusterFactory {
     return () ->
         new JedisCluster(
             new HostAndPort(redisUri.getHost(), redisUri.getPort()),
-            /* connectionTimeout=*/ Integer.max(2000, timeout),
-            /* soTimeout=*/ Integer.max(2000, timeout),
+            /* connectionTimeout=*/ Integer.max(10000, timeout),
+            /* soTimeout=*/ Integer.max(10000, timeout),
             Integer.max(5, maxAttempts),
             password,
             poolConfig);


### PR DESCRIPTION
Current timeout of 2s is not sufficient enough for some calls, for example, the new get client start time one. Increasing to 10s to make sure some of the longer running calls (which are expected to be due to the number of keys they need to load) will complete in time.