### PR TITLE
[bfadmin] Fix buildfarm admin get client uptime service

### DIFF
--- a/admin/main/src/main/resources/proto/buildfarm.proto
+++ b/admin/main/src/main/resources/proto/buildfarm.proto
@@ -141,6 +141,7 @@ message Host {
 
 message GetClientStartTimeRequest {
     string instance_name = 1;
+    repeated string host_name = 2;
 }
 
 message GetClientStartTimeResult {

--- a/src/main/java/build/buildfarm/backplane/Backplane.java
+++ b/src/main/java/build/buildfarm/backplane/Backplane.java
@@ -29,6 +29,7 @@ import build.buildfarm.operations.FindOperationsResults;
 import build.buildfarm.v1test.BackplaneStatus;
 import build.buildfarm.v1test.DispatchedOperation;
 import build.buildfarm.v1test.ExecuteEntry;
+import build.buildfarm.v1test.GetClientStartTimeRequest;
 import build.buildfarm.v1test.GetClientStartTimeResult;
 import build.buildfarm.v1test.QueueEntry;
 import build.buildfarm.v1test.ShardWorker;
@@ -307,5 +308,5 @@ public interface Backplane {
   Boolean propertiesEligibleForQueue(List<Platform.Property> provisions);
 
   @ThreadSafe
-  GetClientStartTimeResult getClientStartTime() throws IOException;
+  GetClientStartTimeResult getClientStartTime(GetClientStartTimeRequest request) throws IOException;
 }

--- a/src/main/java/build/buildfarm/instance/Instance.java
+++ b/src/main/java/build/buildfarm/instance/Instance.java
@@ -31,6 +31,7 @@ import build.buildfarm.common.EntryLimitException;
 import build.buildfarm.common.Watcher;
 import build.buildfarm.common.Write;
 import build.buildfarm.v1test.BackplaneStatus;
+import build.buildfarm.v1test.GetClientStartTimeRequest;
 import build.buildfarm.v1test.GetClientStartTimeResult;
 import build.buildfarm.v1test.PrepareWorkerForGracefulShutDownRequestResults;
 import build.buildfarm.v1test.Tree;
@@ -142,7 +143,7 @@ public interface Instance {
 
   PrepareWorkerForGracefulShutDownRequestResults shutDownWorkerGracefully();
 
-  GetClientStartTimeResult getClientStartTime();
+  GetClientStartTimeResult getClientStartTime(GetClientStartTimeRequest request);
 
   CasIndexResults reindexCas(@Nullable String hostName);
 

--- a/src/main/java/build/buildfarm/instance/memory/MemoryInstance.java
+++ b/src/main/java/build/buildfarm/instance/memory/MemoryInstance.java
@@ -65,6 +65,7 @@ import build.buildfarm.v1test.ActionCacheConfig;
 import build.buildfarm.v1test.BackplaneStatus;
 import build.buildfarm.v1test.ExecuteEntry;
 import build.buildfarm.v1test.FilesystemACConfig;
+import build.buildfarm.v1test.GetClientStartTimeRequest;
 import build.buildfarm.v1test.GetClientStartTimeResult;
 import build.buildfarm.v1test.GrpcACConfig;
 import build.buildfarm.v1test.MemoryInstanceConfig;
@@ -1038,7 +1039,7 @@ public class MemoryInstance extends AbstractServerInstance {
   }
 
   @Override
-  public GetClientStartTimeResult getClientStartTime() {
+  public GetClientStartTimeResult getClientStartTime(GetClientStartTimeRequest request) {
     throw new UnsupportedOperationException();
   }
 

--- a/src/main/java/build/buildfarm/instance/server/AbstractServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/server/AbstractServerInstance.java
@@ -75,6 +75,7 @@ import build.buildfarm.operations.EnrichedOperation;
 import build.buildfarm.operations.FindOperationsResults;
 import build.buildfarm.v1test.CompletedOperationMetadata;
 import build.buildfarm.v1test.ExecutingOperationMetadata;
+import build.buildfarm.v1test.GetClientStartTimeRequest;
 import build.buildfarm.v1test.GetClientStartTimeResult;
 import build.buildfarm.v1test.PrepareWorkerForGracefulShutDownRequestResults;
 import build.buildfarm.v1test.QueuedOperation;
@@ -1864,7 +1865,7 @@ public abstract class AbstractServerInstance implements Instance {
   }
 
   @Override
-  public abstract GetClientStartTimeResult getClientStartTime();
+  public abstract GetClientStartTimeResult getClientStartTime(GetClientStartTimeRequest request);
 
   @Override
   public abstract CasIndexResults reindexCas(String hostName);

--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -76,6 +76,7 @@ import build.buildfarm.instance.server.AbstractServerInstance;
 import build.buildfarm.operations.FindOperationsResults;
 import build.buildfarm.v1test.BackplaneStatus;
 import build.buildfarm.v1test.ExecuteEntry;
+import build.buildfarm.v1test.GetClientStartTimeRequest;
 import build.buildfarm.v1test.GetClientStartTimeResult;
 import build.buildfarm.v1test.OperationIteratorToken;
 import build.buildfarm.v1test.ProfiledQueuedOperationMetadata;
@@ -2459,9 +2460,9 @@ public class ShardInstance extends AbstractServerInstance {
   }
 
   @Override
-  public GetClientStartTimeResult getClientStartTime() {
+  public GetClientStartTimeResult getClientStartTime(GetClientStartTimeRequest request) {
     try {
-      return backplane.getClientStartTime();
+      return backplane.getClientStartTime(request);
     } catch (IOException e) {
       throw Status.fromThrowable(e).asRuntimeException();
     }

--- a/src/main/java/build/buildfarm/instance/stub/StubInstance.java
+++ b/src/main/java/build/buildfarm/instance/stub/StubInstance.java
@@ -74,6 +74,7 @@ import build.buildfarm.v1test.AdminGrpc;
 import build.buildfarm.v1test.AdminGrpc.AdminBlockingStub;
 import build.buildfarm.v1test.BackplaneStatus;
 import build.buildfarm.v1test.BackplaneStatusRequest;
+import build.buildfarm.v1test.GetClientStartTimeRequest;
 import build.buildfarm.v1test.GetClientStartTimeResult;
 import build.buildfarm.v1test.OperationQueueGrpc;
 import build.buildfarm.v1test.OperationQueueGrpc.OperationQueueBlockingStub;
@@ -873,7 +874,7 @@ public class StubInstance implements Instance {
   }
 
   @Override
-  public GetClientStartTimeResult getClientStartTime() {
+  public GetClientStartTimeResult getClientStartTime(GetClientStartTimeRequest request) {
     throw new UnsupportedOperationException();
   }
 

--- a/src/main/java/build/buildfarm/server/AdminService.java
+++ b/src/main/java/build/buildfarm/server/AdminService.java
@@ -109,7 +109,7 @@ public class AdminService extends AdminGrpc.AdminImplBase {
       GetClientStartTimeRequest request,
       StreamObserver<GetClientStartTimeResult> responseObserver) {
     try {
-      GetClientStartTimeResult result = instance.getClientStartTime();
+      GetClientStartTimeResult result = instance.getClientStartTime(request);
       responseObserver.onNext(result);
       responseObserver.onCompleted();
     } catch (Exception e) {

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerInstance.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerInstance.java
@@ -40,6 +40,7 @@ import build.buildfarm.operations.FindOperationsResults;
 import build.buildfarm.v1test.BackplaneStatus;
 import build.buildfarm.v1test.CompletedOperationMetadata;
 import build.buildfarm.v1test.ExecutingOperationMetadata;
+import build.buildfarm.v1test.GetClientStartTimeRequest;
 import build.buildfarm.v1test.GetClientStartTimeResult;
 import build.buildfarm.v1test.QueueEntry;
 import build.buildfarm.v1test.QueuedOperationMetadata;
@@ -362,9 +363,9 @@ public class ShardWorkerInstance extends AbstractServerInstance {
   }
 
   @Override
-  public GetClientStartTimeResult getClientStartTime() {
+  public GetClientStartTimeResult getClientStartTime(GetClientStartTimeRequest request) {
     try {
-      return backplane.getClientStartTime();
+      return backplane.getClientStartTime(request);
     } catch (IOException e) {
       throw Status.fromThrowable(e).asRuntimeException();
     }

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -139,6 +139,7 @@ message Host {
 
 message GetClientStartTimeRequest {
   string instance_name = 1;
+  repeated string host_name = 2;
 }
 
 message GetClientStartTimeResult {

--- a/src/test/java/build/buildfarm/instance/server/AbstractServerInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/server/AbstractServerInstanceTest.java
@@ -54,6 +54,7 @@ import build.buildfarm.common.Write;
 import build.buildfarm.instance.MatchListener;
 import build.buildfarm.operations.FindOperationsResults;
 import build.buildfarm.v1test.BackplaneStatus;
+import build.buildfarm.v1test.GetClientStartTimeRequest;
 import build.buildfarm.v1test.GetClientStartTimeResult;
 import build.buildfarm.v1test.PrepareWorkerForGracefulShutDownRequestResults;
 import build.buildfarm.v1test.WorkerListMessage;
@@ -160,7 +161,7 @@ public class AbstractServerInstanceTest {
     }
 
     @Override
-    public GetClientStartTimeResult getClientStartTime() {
+    public GetClientStartTimeResult getClientStartTime(GetClientStartTimeRequest request) {
       throw new UnsupportedOperationException();
     }
 


### PR DESCRIPTION
Current implementation introduces significant performance issues with a large number of keys. This change addresses these issues by providing the list of keys to the uptime service.