### PR TITLE
enable IO unit tests

### DIFF
--- a/src/test/java/build/buildfarm/common/io/BUILD
+++ b/src/test/java/build/buildfarm/common/io/BUILD
@@ -1,0 +1,20 @@
+java_test(
+    name = "tests",
+    srcs = glob(["*Test.java"]),
+    test_class = "build.buildfarm.AllTests",
+    deps = [
+        "//src/main/java/build/buildfarm/common",
+        "//src/main/java/build/buildfarm/common/grpc",
+        "//src/test/java/build/buildfarm:test_runner",
+        "@googleapis//:google_bytestream_bytestream_java_grpc",
+        "@googleapis//:google_bytestream_bytestream_java_proto",
+        "@maven//:com_google_protobuf_protobuf_java",
+        "@maven//:com_google_truth_truth",
+        "@maven//:io_grpc_grpc_api",
+        "@maven//:io_grpc_grpc_core",
+        "@maven//:io_grpc_grpc_stub",
+        "@maven//:io_grpc_grpc_testing",
+        "@maven//:org_mockito_mockito_core",
+        "@maven//:com_google_jimfs_jimfs",
+    ],
+)

--- a/src/test/java/build/buildfarm/common/io/BUILD
+++ b/src/test/java/build/buildfarm/common/io/BUILD
@@ -8,6 +8,7 @@ java_test(
         "//src/test/java/build/buildfarm:test_runner",
         "@googleapis//:google_bytestream_bytestream_java_grpc",
         "@googleapis//:google_bytestream_bytestream_java_proto",
+        "@maven//:com_google_jimfs_jimfs",
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:com_google_truth_truth",
         "@maven//:io_grpc_grpc_api",
@@ -15,6 +16,5 @@ java_test(
         "@maven//:io_grpc_grpc_stub",
         "@maven//:io_grpc_grpc_testing",
         "@maven//:org_mockito_mockito_core",
-        "@maven//:com_google_jimfs_jimfs",
     ],
 )

--- a/src/test/java/build/buildfarm/common/io/BUILD
+++ b/src/test/java/build/buildfarm/common/io/BUILD
@@ -1,6 +1,6 @@
 java_test(
     name = "tests",
-    srcs = glob(["*Test.java"]),
+    srcs = glob(["*.java"]),
     test_class = "build.buildfarm.AllTests",
     deps = [
         "//src/main/java/build/buildfarm/common",

--- a/src/test/java/build/buildfarm/common/io/UtilsTest.java
+++ b/src/test/java/build/buildfarm/common/io/UtilsTest.java
@@ -38,6 +38,7 @@ public class UtilsTest {
   public void setUp() throws IOException {
     root = Files.createTempDirectory("native-cas-test");
     fileStore = Files.getFileStore(root);
+    org.junit.Assume.assumeFalse(System.getProperty("os.name").contains("Win"));
   }
 
   @After


### PR DESCRIPTION
We are missing a BUILD file for these tests.

skipping windows for now, because java says `An illegal reflective access operation has occurred` which is indeed what our windows implementation does. 