### PR TITLE
Propagate IOException without delegate on newInput

### DIFF
--- a/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
+++ b/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
@@ -517,8 +517,11 @@ public abstract class CASFileCache implements ContentAddressableStorage {
     try {
       return newLocalInput(digest, offset);
     } catch (NoSuchFileException e) {
-      return newInputFallback(digest, offset);
+      if (delegate == null) {
+        throw e;
+      }
     }
+    return newInputFallback(digest, offset);
   }
 
   @Override


### PR DESCRIPTION
The failover (local->remote) input stream factory relies on the specific
NoSuchFileException presentation by the CAS in order to trigger a remote
(other shard member) download for the worker context getBlob.
newInputFallback must not be called when delegate is null, or it will
incur an NPE from the precondition validation.

Fixes #954 