### PR TITLE
presubmit.yml: specify a bazel version for `rpm_builds`

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -60,6 +60,7 @@ tasks:
     - "..."
   rpm_builds:
     name: "Rpm Builds"
+    bazel: "4.2.2"
     platform: centos7
     shell_commands:
     - ./bazelw build //src/main/java/build/buildfarm/rpms/server:buildfarm-server-rpm //src/main/java/build/buildfarm/rpms/worker:buildfarm-worker-rpm


### PR DESCRIPTION
The rpm build test fails in Bazel downstream because it requires a release version of Bazel.
Specifying a Bazel version number for `rpm_builds` will skip this test in Bazel downstream.

Fixes https://github.com/bazelbuild/bazel-buildfarm/issues/915