### PR TITLE
[bfadmin] Fixes log4j vulnerability

### DIFF
--- a/admin/main/pom.xml
+++ b/admin/main/pom.xml
@@ -132,6 +132,7 @@
 		<java.version>1.8</java.version>
 		<docker.image.prefix>bazelbuild/buildfarm-admin</docker.image.prefix>
 		<awsSdkVersion>1.11.970</awsSdkVersion>
+		<log4j2.version>2.15.0</log4j2.version>
 	</properties>
 
 	<build>


### PR DESCRIPTION
This PR upgrades log4j to 2.15.0 to address the https://nvd.nist.gov/vuln/detail/CVE-2021-44228 vulnerability in buildfarm admin.