### PR TITLE
[debug] show the worker name when debugging actions

### DIFF
--- a/src/main/java/build/buildfarm/worker/resources/ResourceDecider.java
+++ b/src/main/java/build/buildfarm/worker/resources/ResourceDecider.java
@@ -30,6 +30,7 @@ public final class ResourceDecider {
    * @details Platform properties from specified exec_properties are taken into account as well as
    *     global buildfarm configuration.
    * @param command The command to decide resource limitations for.
+   * @param workerName The name of the worker taking on the action.
    * @param onlyMulticoreTests Only allow tests to be multicore.
    * @param limitGlobalExecution Whether cpu limiting should be explicitly performed.
    * @param executeStageWidth The maximum amount of cores available for the operation.
@@ -38,6 +39,7 @@ public final class ResourceDecider {
    */
   public static ResourceLimits decideResourceLimitations(
       Command command,
+      String workerName,
       boolean onlyMulticoreTests,
       boolean limitGlobalExecution,
       int executeStageWidth) {
@@ -45,7 +47,8 @@ public final class ResourceDecider {
     ResourceLimits limits = ExecutionPropertiesParser.Parse(command);
 
     // Further modify the resource limits based on user selection and buildfarm constraints.
-    adjustLimits(limits, command, onlyMulticoreTests, limitGlobalExecution, executeStageWidth);
+    adjustLimits(
+        limits, command, workerName, onlyMulticoreTests, limitGlobalExecution, executeStageWidth);
 
     return limits;
   }
@@ -55,16 +58,21 @@ public final class ResourceDecider {
    * @details Existing limits configuration and buildfarm configuration are taken into account.
    * @param limits Existing limits chosen by the user's exec_properties.
    * @param command The command to decide resource limitations for.
+   * @param workerName The name of the worker taking on the action.
    * @param onlyMulticoreTests Only allow tests to be multicore.
    * @param limitGlobalExecution Whether cpu limiting should be explicitly performed.
    * @param executeStageWidth The maximum amount of cores available for the operation.
    */
-  public static void adjustLimits(
+  private static void adjustLimits(
       ResourceLimits limits,
       Command command,
+      String workerName,
       boolean onlyMulticoreTests,
       boolean limitGlobalExecution,
       int executeStageWidth) {
+    // store worker name
+    limits.workerName = workerName;
+
     // force limits on non-test actions
     if (onlyMulticoreTests && !CommandUtils.isTest(command)) {
       limits.cpu.min = 1;

--- a/src/main/java/build/buildfarm/worker/resources/ResourceLimits.java
+++ b/src/main/java/build/buildfarm/worker/resources/ResourceLimits.java
@@ -30,6 +30,13 @@ import java.util.Map;
  */
 public class ResourceLimits {
   /**
+   * @field workerName
+   * @brief The name of the worker used for executing an action.
+   * @details This can be helpful for correlating actions to the underlying worker agent.
+   */
+  public String workerName = "";
+
+  /**
    * @field useLinuxSandbox
    * @brief Whether to use bazel's linux sandbox as an execution wrapper.
    * @details Other resource limits will be translated into the appropriate CLI arguments for the

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -839,10 +839,7 @@ class ShardWorkerContext implements WorkerContext {
       Command command,
       Path workingDirectory) {
     if (limitExecution) {
-      ResourceLimits limits =
-          ResourceDecider.decideResourceLimitations(
-              command, onlyMulticoreTests, limitGlobalExecution, getExecuteStageWidth());
-
+      ResourceLimits limits = commandExecutionSettings(command);
       return limitSpecifiedExecution(limits, operationName, arguments, workingDirectory);
     }
     return new IOResource() {

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -829,7 +829,7 @@ class ShardWorkerContext implements WorkerContext {
 
   public ResourceLimits commandExecutionSettings(Command command) {
     return ResourceDecider.decideResourceLimitations(
-        command, onlyMulticoreTests, limitGlobalExecution, getExecuteStageWidth());
+        command, name, onlyMulticoreTests, limitGlobalExecution, getExecuteStageWidth());
   }
 
   @Override

--- a/src/test/java/build/buildfarm/worker/resources/ResourceDeciderTest.java
+++ b/src/test/java/build/buildfarm/worker/resources/ResourceDeciderTest.java
@@ -47,7 +47,8 @@ public class ResourceDeciderTest {
             .build();
 
     // ACT
-    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, false, false, 100);
+    ResourceLimits limits =
+        ResourceDecider.decideResourceLimitations(command, "worker", false, false, 100);
 
     // ASSERT
     assertThat(limits.cpu.min).isEqualTo(7);
@@ -71,7 +72,8 @@ public class ResourceDeciderTest {
             .build();
 
     // ACT
-    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, true, false, 100);
+    ResourceLimits limits =
+        ResourceDecider.decideResourceLimitations(command, "worker", true, false, 100);
 
     // ASSERT
     assertThat(limits.cpu.min).isEqualTo(1);
@@ -95,7 +97,8 @@ public class ResourceDeciderTest {
             .build();
 
     // ACT
-    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, false, false, 100);
+    ResourceLimits limits =
+        ResourceDecider.decideResourceLimitations(command, "worker", false, false, 100);
 
     // ASSERT
     assertThat(limits.cpu.claimed).isEqualTo(0);
@@ -118,7 +121,8 @@ public class ResourceDeciderTest {
             .build();
 
     // ACT
-    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, false, true, 100);
+    ResourceLimits limits =
+        ResourceDecider.decideResourceLimitations(command, "worker", false, true, 100);
 
     // ASSERT
     assertThat(limits.cpu.limit).isTrue();
@@ -141,7 +145,8 @@ public class ResourceDeciderTest {
             .build();
 
     // ACT
-    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, false, false, 100);
+    ResourceLimits limits =
+        ResourceDecider.decideResourceLimitations(command, "worker", false, false, 100);
 
     // ASSERT
     assertThat(limits.cpu.limit).isFalse();
@@ -164,7 +169,8 @@ public class ResourceDeciderTest {
             .build();
 
     // ACT
-    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, false, false, 100);
+    ResourceLimits limits =
+        ResourceDecider.decideResourceLimitations(command, "worker", false, false, 100);
 
     // ASSERT
     assertThat(limits.cpu.claimed).isEqualTo(3);
@@ -186,7 +192,8 @@ public class ResourceDeciderTest {
             .build();
 
     // ACT
-    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, false, false, 100);
+    ResourceLimits limits =
+        ResourceDecider.decideResourceLimitations(command, "worker", false, false, 100);
 
     // ASSERT
     assertThat(limits.mem.min).isEqualTo(5);
@@ -203,7 +210,8 @@ public class ResourceDeciderTest {
     Command command = Command.newBuilder().build();
 
     // ACT
-    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, true, false, 100);
+    ResourceLimits limits =
+        ResourceDecider.decideResourceLimitations(command, "worker", true, false, 100);
 
     // ASSERT
     assertThat(limits.extraEnvironmentVariables.isEmpty()).isTrue();
@@ -224,7 +232,8 @@ public class ResourceDeciderTest {
             .build();
 
     // ACT
-    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, true, false, 100);
+    ResourceLimits limits =
+        ResourceDecider.decideResourceLimitations(command, "worker", true, false, 100);
 
     // ASSERT
     assertThat(limits.extraEnvironmentVariables.isEmpty()).isTrue();
@@ -248,7 +257,8 @@ public class ResourceDeciderTest {
             .build();
 
     // ACT
-    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, true, false, 100);
+    ResourceLimits limits =
+        ResourceDecider.decideResourceLimitations(command, "worker", true, false, 100);
 
     // ASSERT
     assertThat(limits.extraEnvironmentVariables.size()).isEqualTo(1);
@@ -274,7 +284,8 @@ public class ResourceDeciderTest {
             .build();
 
     // ACT
-    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, true, false, 100);
+    ResourceLimits limits =
+        ResourceDecider.decideResourceLimitations(command, "worker", true, false, 100);
 
     // ASSERT
     assertThat(limits.extraEnvironmentVariables.size()).isEqualTo(2);
@@ -302,7 +313,8 @@ public class ResourceDeciderTest {
             .build();
 
     // ACT
-    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, true, false, 100);
+    ResourceLimits limits =
+        ResourceDecider.decideResourceLimitations(command, "worker", true, false, 100);
 
     // ASSERT
     assertThat(limits.extraEnvironmentVariables.size()).isEqualTo(0);
@@ -330,7 +342,8 @@ public class ResourceDeciderTest {
             .build();
 
     // ACT
-    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, false, false, 100);
+    ResourceLimits limits =
+        ResourceDecider.decideResourceLimitations(command, "worker", false, false, 100);
 
     // ASSERT
     assertThat(limits.extraEnvironmentVariables.size()).isEqualTo(2);
@@ -356,7 +369,8 @@ public class ResourceDeciderTest {
             .build();
 
     // ACT
-    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, true, false, 100);
+    ResourceLimits limits =
+        ResourceDecider.decideResourceLimitations(command, "worker", true, false, 100);
 
     // ASSERT
     assertThat(limits.extraEnvironmentVariables.size()).isEqualTo(1);
@@ -383,7 +397,8 @@ public class ResourceDeciderTest {
             .build();
 
     // ACT
-    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, true, false, 100);
+    ResourceLimits limits =
+        ResourceDecider.decideResourceLimitations(command, "worker", true, false, 100);
 
     // ASSERT
     assertThat(limits.extraEnvironmentVariables.size()).isEqualTo(2);
@@ -410,7 +425,8 @@ public class ResourceDeciderTest {
             .build();
 
     // ACT
-    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, true, false, 100);
+    ResourceLimits limits =
+        ResourceDecider.decideResourceLimitations(command, "worker", true, false, 100);
 
     // ASSERT
     assertThat(limits.extraEnvironmentVariables.size()).isEqualTo(1);
@@ -438,7 +454,8 @@ public class ResourceDeciderTest {
             .build();
 
     // ACT
-    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, true, false, 100);
+    ResourceLimits limits =
+        ResourceDecider.decideResourceLimitations(command, "worker", true, false, 100);
 
     // ASSERT
     assertThat(limits.debugBeforeExecution).isTrue();
@@ -464,7 +481,8 @@ public class ResourceDeciderTest {
             .build();
 
     // ACT
-    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, true, false, 100);
+    ResourceLimits limits =
+        ResourceDecider.decideResourceLimitations(command, "worker", true, false, 100);
 
     // ASSERT
     assertThat(limits.debugAfterExecution).isTrue();
@@ -490,9 +508,27 @@ public class ResourceDeciderTest {
             .build();
 
     // ACT
-    ResourceLimits limits = ResourceDecider.decideResourceLimitations(command, true, false, 100);
+    ResourceLimits limits =
+        ResourceDecider.decideResourceLimitations(command, "worker", true, false, 100);
 
     // ASSERT
     assertThat(limits.debugBeforeExecution).isFalse();
+  }
+
+  // Function under test: decideResourceLimitations
+  // Reason for testing: The worker name is captured
+  // Failure explanation: The worker name is not being captured in the returned value.
+  @Test
+  public void decideResourceLimitationsTestWorkerName() throws Exception {
+    // ARRANGE
+    Command command = Command.newBuilder().build();
+
+    // ACT
+    ResourceLimits limits =
+        ResourceDecider.decideResourceLimitations(command, "foo", true, false, 100);
+
+    // ASSERT
+    assertThat(limits.workerName).isEqualTo("foo");
+    ;
   }
 }

--- a/src/test/java/build/buildfarm/worker/resources/ResourceDeciderTest.java
+++ b/src/test/java/build/buildfarm/worker/resources/ResourceDeciderTest.java
@@ -529,6 +529,5 @@ public class ResourceDeciderTest {
 
     // ASSERT
     assertThat(limits.workerName).isEqualTo("foo");
-    ;
   }
 }


### PR DESCRIPTION
It's important to know which worker has executed the action.  This makes the worker name available while debugging actions.