### PR TITLE
[deployment] [testing] fix java_image for buildfarm-server

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -88,6 +88,11 @@ java_image(
     runtime_deps = [
         "//src/main/java/build/buildfarm/server",
     ],
+    jvm_flags = [
+        "-Djava.util.logging.config.file=/app/build_buildfarm/src/main/java/build/buildfarm/logging.properties"
+    ],
+    args = ["/app/build_buildfarm/examples/shard-server.config.example"],
+    data = ["//src/main/java/build/buildfarm:configs", "//examples:example_configs"],
 )
 
 java_image(

--- a/BUILD
+++ b/BUILD
@@ -79,20 +79,23 @@ sh_binary(
 # Docker images for buildfarm components
 java_image(
     name = "buildfarm-server",
+    args = ["/app/build_buildfarm/examples/shard-server.config.example"],
     base = "@amazon_corretto_java_image_base//image",
     classpath_resources = [
         "//src/main/java/build/buildfarm:configs",
+    ],
+    data = [
+        "//examples:example_configs",
+        "//src/main/java/build/buildfarm:configs",
+    ],
+    jvm_flags = [
+        "-Djava.util.logging.config.file=/app/build_buildfarm/src/main/java/build/buildfarm/logging.properties",
     ],
     main_class = "build.buildfarm.server.BuildFarmServer",
     tags = ["container"],
     runtime_deps = [
         "//src/main/java/build/buildfarm/server",
     ],
-    jvm_flags = [
-        "-Djava.util.logging.config.file=/app/build_buildfarm/src/main/java/build/buildfarm/logging.properties"
-    ],
-    args = ["/app/build_buildfarm/examples/shard-server.config.example"],
-    data = ["//src/main/java/build/buildfarm:configs", "//examples:example_configs"],
 )
 
 java_image(


### PR DESCRIPTION
The `buildfarm-server` java_image cannot be run from bazel:
```
./bazelw run :buildfarm-server
INFO: Found 1 target...
Target //:buildfarm-server up-to-date:
  bazel-bin/buildfarm-server-layer.tar
INFO: Elapsed time: 0.525s, Critical Path: 0.33s
INFO: 9 processes: 4 internal, 5 linux-sandbox.
INFO: Build completed successfully, 9 total actions
INFO: Build completed successfully, 9 total actions
f5002e36a6ac: Loading layer [==================================================>]  60.43MB/60.43MB
Loaded image ID: sha256:90f047ccd409154a1b4719d5603bcfd32a6ef8704013e907dd4bd1af8eab2911
Tagging 90f047ccd409154a1b4719d5603bcfd32a6ef8704013e907dd4bd1af8eab2911 as bazel:buildfarm-server
error: 1:1: Expected identifier. Found ''
```

After this change, we can run it:
```
./bazelw run :buildfarm-server
INFO: Found 1 target...
Target //:buildfarm-server up-to-date:
  bazel-bin/buildfarm-server-layer.tar
INFO: Elapsed time: 0.062s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Build completed successfully, 1 total action
Loaded image ID: sha256:4a692997f49183418dc5165688ee3fe7c1d593fb4bbf896e1f31bcc2cd21e5c1
Tagging 4a692997f49183418dc5165688ee3fe7c1d593fb4bbf896e1f31bcc2cd21e5c1 as bazel:buildfarm-server
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
[INFO   ] build.buildfarm.instance.shard.ShardInstance getGrpcTimeout - grpc timeout not configured.  Setting to: 60s  
[INFO   ] build.buildfarm.server.BuildFarmServer <init> - buildfarm-server-d2b03071-67db-415c-b56f-acc577ff13ea initialized  
[INFO   ] build.buildfarm.instance.shard.DispatchedMonitor run - DispatchedMonitor: Running  
[INFO   ] build.buildfarm.metrics.prometheus.PrometheusPublisher startHttpServer - Prometheus port is not configured. HTTP Server will not be started
```

related: https://stackoverflow.com/questions/68977552/bazel-java-image