### PR TITLE
[bfadmin] Upgrade log4j to 1.16.0 to address CVE-2021-45046

### DIFF
--- a/admin/main/pom.xml
+++ b/admin/main/pom.xml
@@ -132,7 +132,7 @@
 		<java.version>1.8</java.version>
 		<docker.image.prefix>bazelbuild/buildfarm-admin</docker.image.prefix>
 		<awsSdkVersion>1.11.970</awsSdkVersion>
-		<log4j2.version>2.15.0</log4j2.version>
+		<log4j2.version>2.16.0</log4j2.version>
 	</properties>
 
 	<build>


### PR DESCRIPTION
A follow up vulnerability was discovered in log4j. This PR fixes it by upgrading log4j to 1.16.0 (https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45046).