### PR TITLE
[bfadmin] Fix CVE-2021-43466 vulnerability in thymeleaf

### DIFF
--- a/admin/main/README.txt
+++ b/admin/main/README.txt
@@ -22,3 +22,9 @@ buildfarm.worker_type=[cpu|gpu|other] (for workers only)
 ./mvnw clean package docker:build -DdockerImageTags=1.0
 docker run -p 8080:8080 -v $HOME:/var/lib -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN bazelbuild/buildfarm-admin:latest
 ```
+
+### Run dependency check using OWASP plugin
+
+```
+./mvnw org.owasp:dependency-check-maven:check
+```

--- a/admin/main/pom.xml
+++ b/admin/main/pom.xml
@@ -133,6 +133,7 @@
 		<docker.image.prefix>bazelbuild/buildfarm-admin</docker.image.prefix>
 		<awsSdkVersion>1.11.970</awsSdkVersion>
 		<log4j2.version>2.16.0</log4j2.version>
+		<thymeleaf.version>3.0.14.RELEASE</thymeleaf.version>
 	</properties>
 
 	<build>
@@ -222,6 +223,21 @@
 					<source>8</source>
 					<target>8</target>
 				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.owasp</groupId>
+				<artifactId>dependency-check-maven</artifactId>
+				<version>6.5.0</version>
+				<configuration>
+					<failBuildOnCVSS>8</failBuildOnCVSS>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>check</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
This PR adds a OWASP maven plugin to detect future dependency vulnerabilities and fixes a critical CVE-2021-43466 vulnerability in thymeleaf.