### PR TITLE
[deployment] [testing] fix java_image for buildfarm-shard-worker

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -100,13 +100,17 @@ java_image(
 
 java_image(
     name = "buildfarm-shard-worker",
+    args = ["/app/build_buildfarm/examples/shard-worker.config.example"],
     base = "@ubuntu-bionic//image",
     classpath_resources = [
         "//src/main/java/build/buildfarm:configs",
     ],
-    entrypoint = [
-        "/app/buildfarm/tini",
-        "--",
+    data = [
+        "//examples:example_configs",
+        "//src/main/java/build/buildfarm:configs",
+    ],
+    jvm_flags = [
+        "-Djava.util.logging.config.file=/app/build_buildfarm/src/main/java/build/buildfarm/logging.properties",
     ],
     main_class = "build.buildfarm.worker.shard.Worker",
     tags = ["container"],


### PR DESCRIPTION
similar to https://github.com/bazelbuild/bazel-buildfarm/pull/968, the shard-worker container cannot be directly run from bazel.  This fixes it, so that it can be spawned that way.