### PR TITLE
[config] set ensure_outputs_present globally

### DIFF
--- a/examples/shard-server.config.example
+++ b/examples/shard-server.config.example
@@ -41,6 +41,10 @@ instance {
     # The operation queuer is exclusive and should run on
     # multiple instances concurrently.
     run_operation_queuer: true
+    
+    # When checking the action cache, decide whether all outputs are also present in the CAS.
+    # If any output is missing, a cache miss is returned to the client.
+    ensure_outputs_present: false
 
     # The maximum size of a single blob accepted via a
     # ByteStream#write or ContentAddressableStorage#batchUpdateBlobs

--- a/src/main/java/build/buildfarm/instance/memory/MemoryInstance.java
+++ b/src/main/java/build/buildfarm/instance/memory/MemoryInstance.java
@@ -239,7 +239,8 @@ public class MemoryInstance extends AbstractServerInstance {
             config.getActionCacheConfig(), contentAddressableStorage, digestUtil),
         outstandingOperations,
         MemoryInstance.createCompletedOperationMap(contentAddressableStorage, digestUtil),
-        /*activeBlobWrites=*/ new ConcurrentHashMap<>());
+        /*activeBlobWrites=*/ new ConcurrentHashMap<>(),
+        false);
     this.config = config;
     this.watchers = watchers;
     this.outstandingOperations = outstandingOperations;

--- a/src/main/java/build/buildfarm/instance/server/AbstractServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/server/AbstractServerInstance.java
@@ -332,8 +332,15 @@ public abstract class AbstractServerInstance implements Instance {
   private static boolean shouldEnsureOutputsPresent(
       boolean ensureOutputsPresent, RequestMetadata requestMetadata) {
 
-    // We will ensure outputs are present if the system is globally configured to check.
-    // Otherwise we will determine if dynamically from optional URI parameters.
+    // The 'ensure outputs present' setting means that the AC will only return results to the client
+    // when all of the action output blobs are present in the CAS.  If any one blob is missing, the
+    // system will return a cache miss.  Although this is a more expensive check to perform, some
+    // users may want to enable this feature. It may be useful if you cannot rely on requestMetadata
+    // of incoming messages (perhaps due to a proxy). Or other build systems may not be reliable
+    // without this extra check.
+
+    // We perform the outputs present check if the system is globally configured to check for it.
+    // Otherwise the behavior is determined dynamically from optional URI parameters.
     if (ensureOutputsPresent) {
       return true;
     }

--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -309,7 +309,8 @@ public class ShardInstance extends AbstractServerInstance {
         config.getUseDenyList(),
         onStop,
         WorkerStubs.create(digestUtil, getGrpcTimeout(config)),
-        actionCacheFetchService);
+        actionCacheFetchService,
+        config.getEnsureOutputsPresent());
   }
 
   public ShardInstance(
@@ -327,7 +328,8 @@ public class ShardInstance extends AbstractServerInstance {
       boolean useDenyList,
       Runnable onStop,
       LoadingCache<String, Instance> workerStubs,
-      ListeningExecutorService actionCacheFetchService) {
+      ListeningExecutorService actionCacheFetchService,
+      boolean ensureOutputsPresent) {
     super(
         name,
         digestUtil,
@@ -335,7 +337,8 @@ public class ShardInstance extends AbstractServerInstance {
         /* actionCache=*/ readThroughActionCache,
         /* outstandingOperations=*/ null,
         /* completedOperations=*/ null,
-        /* activeBlobWrites=*/ null);
+        /* activeBlobWrites=*/ null,
+        ensureOutputsPresent);
     this.backplane = backplane;
     this.readThroughActionCache = readThroughActionCache;
     this.workerStubs = workerStubs;

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerInstance.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerInstance.java
@@ -71,7 +71,7 @@ public class ShardWorkerInstance extends AbstractServerInstance {
       DigestUtil digestUtil,
       Backplane backplane,
       ContentAddressableStorage contentAddressableStorage) {
-    super(name, digestUtil, contentAddressableStorage, null, null, null, null);
+    super(name, digestUtil, contentAddressableStorage, null, null, null, null, false);
     this.backplane = backplane;
   }
 

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -547,6 +547,8 @@ message ShardInstanceConfig {
   oneof backplane {
     RedisShardBackplaneConfig redis_shard_backplane_config = 4;
   }
+  
+  bool ensure_outputs_present = 12;
 
   int64 max_entry_size_bytes = 5;
   

--- a/src/test/java/build/buildfarm/instance/server/AbstractServerInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/server/AbstractServerInstanceTest.java
@@ -97,7 +97,8 @@ public class AbstractServerInstanceTest {
           actionCache,
           /* outstandingOperations=*/ null,
           /* completedOperations=*/ null,
-          /* activeBlobWrites=*/ null);
+          /* activeBlobWrites=*/ null,
+          false);
     }
 
     DummyServerInstance() {

--- a/src/test/java/build/buildfarm/instance/shard/ShardInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/shard/ShardInstanceTest.java
@@ -150,7 +150,8 @@ public class ShardInstanceTest {
             /* useDenyList=*/ true,
             mockOnStop,
             CacheBuilder.newBuilder().build(mockInstanceLoader),
-            /* actionCacheFetchService=*/ listeningDecorator(newSingleThreadExecutor()));
+            /* actionCacheFetchService=*/ listeningDecorator(newSingleThreadExecutor()),
+            false);
     instance.start("startTime/test:0000");
   }
 


### PR DESCRIPTION
This was discussed for easier testing.  We also have a scons build system that was retrofitted to use REAPI and it can't handle missing blobs.  So we may also use it for that scenario.

no breaking change.  forwards compatible.