### PR TITLE
Provide real_input_directories configuration

### DIFF
--- a/examples/shard-worker.config.example
+++ b/examples/shard-worker.config.example
@@ -125,6 +125,20 @@ input_fetch_deadline: 60
 # multiple actions' executions.
 link_input_directories: true
 
+# A list of paths that will not be subject to the effects of the above
+# link_input_directories setting.
+# Relative to the input root, any directory in the input tree which matches
+# this path completely will have a real directory created for its inputs
+# for every action that executes on the worker. The example 'external' is
+# provided based on the characteristics of bazel's population of a top-level
+# external compendium which will exhibit poor directory caching performance.
+# This may also be used to provide writable directories as input roots for
+# actions which expect to be able to write to an input location and will fail
+# if they cannot.
+real_input_directories: "external"
+
+# real_input_directories: "path/to/uncached/directory"
+
 # an imposed action-key-invariant timeout used in the unspecified timeout case
 default_action_timeout: {
   seconds: 600

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -740,6 +740,7 @@ public class Worker extends LoggingMain {
         fileCache,
         owner,
         config.getLinkInputDirectories(),
+        config.getRealInputDirectoriesList(),
         removeDirectoryService,
         accessRecorder
         /* deadlineAfter=*/

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -653,6 +653,9 @@ message ShardWorkerConfig {
 
   // symlink cas input-only directories
   bool link_input_directories = 17;
+  
+  // a list of paths that will not be symlinked as input directories
+  repeated string real_input_directories = 41;
 
   // selected hash function
   build.bazel.remote.execution.v2.DigestFunction.Value digest_function = 18;
@@ -698,7 +701,6 @@ message ShardWorkerConfig {
 
   // a limit on time (in seconds) for input fetch stage to fetch inputs
   int32 input_fetch_deadline = 39;
-  
 }
 
 message ShardWorker {


### PR DESCRIPTION
Migrate the hardcoded 'external' path resolution to a configurable list
of paths that will, if provided as directories, be created as regular
directories, capable of being written to, and avoiding the directory
cache.