### PR TITLE
derive execute_stage_width based on host resources

### DIFF
--- a/examples/shard-worker.config.example
+++ b/examples/shard-worker.config.example
@@ -107,7 +107,8 @@ cas: {
 #  }
 #}
 
-# the number of concurrently available slots in the execute phase
+# The number of concurrently available slots in the execute phase.
+# If a value of 0 is provided the system will derive a stage width equal to the available CPU cores.
 execute_stage_width: 1
 
 # the number of concurrently available slots in the input fetch phase

--- a/kubernetes/deployments/shard-worker.yaml
+++ b/kubernetes/deployments/shard-worker.yaml
@@ -17,6 +17,11 @@ spec:
       containers:
       - name: shard-worker
         image: buildfarm-shard-worker-image
+        resources:
+          limits:
+            cpu: "2"
+          requests:
+            cpu: "2"
         ports:
         - containerPort: 8981
         env:

--- a/src/main/java/build/buildfarm/common/config/ConfigAdjuster.java
+++ b/src/main/java/build/buildfarm/common/config/ConfigAdjuster.java
@@ -74,7 +74,7 @@ public class ConfigAdjuster {
           "grpc timeout not configured.  Setting to: " + defaultDuration.getSeconds() + "s");
     }
 
-    adjustExecuteStageWidth(builder);
+    builder.setExecuteStageWidth(adjustExecuteStageWidth(builder.getExecuteStageWidth()));
   }
 
   /**
@@ -96,7 +96,7 @@ public class ConfigAdjuster {
       builder.setCasCacheDirectory(options.casCacheDirectory);
     }
 
-    adjustExecuteStageWidth(builder);
+    builder.setExecuteStageWidth(adjustExecuteStageWidth(builder.getExecuteStageWidth()));
   }
 
   /**
@@ -141,41 +141,24 @@ public class ConfigAdjuster {
     }
   }
 
-  private static void adjustExecuteStageWidth(WorkerConfig.Builder builder) {
+  private static int adjustExecuteStageWidth(int currentWidth) {
 
     int availableCores = Runtime.getRuntime().availableProcessors();
-    if (builder.getExecuteStageWidth() <= 0) {
-      builder.setExecuteStageWidth(availableCores);
+    if (currentWidth <= 0) {
       logger.log(
           Level.INFO,
           "Execute stage width is not valid.  Setting to available cores: " + availableCores);
+      return availableCores;
     }
-    if (builder.getExecuteStageWidth() != availableCores) {
+    if (currentWidth != availableCores) {
       logger.log(
           Level.WARNING,
           "The configured 'execute stage width' does not optimally saturate available cores: "
-              + builder.getExecuteStageWidth()
+              + currentWidth
               + " > "
               + availableCores);
     }
-  }
 
-  private static void adjustExecuteStageWidth(ShardWorkerConfig.Builder builder) {
-
-    int availableCores = Runtime.getRuntime().availableProcessors();
-    if (builder.getExecuteStageWidth() <= 0) {
-      builder.setExecuteStageWidth(availableCores);
-      logger.log(
-          Level.INFO,
-          "Execute stage width is not valid.  Setting to available cores: " + availableCores);
-    }
-    if (builder.getExecuteStageWidth() != availableCores) {
-      logger.log(
-          Level.WARNING,
-          "The configured 'execute stage width' does not optimally saturate available cores: "
-              + builder.getExecuteStageWidth()
-              + " > "
-              + availableCores);
-    }
+    return currentWidth;
   }
 }

--- a/src/main/java/build/buildfarm/common/config/ConfigAdjuster.java
+++ b/src/main/java/build/buildfarm/common/config/ConfigAdjuster.java
@@ -73,6 +73,8 @@ public class ConfigAdjuster {
           Level.INFO,
           "grpc timeout not configured.  Setting to: " + defaultDuration.getSeconds() + "s");
     }
+
+    adjustExecuteStageWidth(builder);
   }
 
   /**
@@ -93,6 +95,8 @@ public class ConfigAdjuster {
       logger.log(Level.INFO, "casCacheDirectory from CLI: " + options.casCacheDirectory);
       builder.setCasCacheDirectory(options.casCacheDirectory);
     }
+
+    adjustExecuteStageWidth(builder);
   }
 
   /**
@@ -134,6 +138,44 @@ public class ConfigAdjuster {
       logger.log(
           Level.INFO,
           "Bytestream timeout not configured.  Setting to: " + defaultDuration.getSeconds() + "s");
+    }
+  }
+
+  private static void adjustExecuteStageWidth(WorkerConfig.Builder builder) {
+
+    int availableCores = Runtime.getRuntime().availableProcessors();
+    if (builder.getExecuteStageWidth() <= 0) {
+      builder.setExecuteStageWidth(availableCores);
+      logger.log(
+          Level.INFO,
+          "Execute stage width is not valid.  Setting to available cores: " + availableCores);
+    }
+    if (builder.getExecuteStageWidth() != availableCores) {
+      logger.log(
+          Level.WARNING,
+          "The configured 'execute stage width' does not optimally saturate available cores: "
+              + builder.getExecuteStageWidth()
+              + " > "
+              + availableCores);
+    }
+  }
+
+  private static void adjustExecuteStageWidth(ShardWorkerConfig.Builder builder) {
+
+    int availableCores = Runtime.getRuntime().availableProcessors();
+    if (builder.getExecuteStageWidth() <= 0) {
+      builder.setExecuteStageWidth(availableCores);
+      logger.log(
+          Level.INFO,
+          "Execute stage width is not valid.  Setting to available cores: " + availableCores);
+    }
+    if (builder.getExecuteStageWidth() != availableCores) {
+      logger.log(
+          Level.WARNING,
+          "The configured 'execute stage width' does not optimally saturate available cores: "
+              + builder.getExecuteStageWidth()
+              + " > "
+              + availableCores);
     }
   }
 }


### PR DESCRIPTION
### Summary:  
Users generally prefer their `execute_stage_width` to match the amount of CPU cores available.  When combined with `limit_execution` it properly saturates their CPU and maximizes parallelism.

Following this intuition, the diff provides 2 conveniences:  
 - Tells the user on startup if their configured stage width does not match their available CPUs.
 - Sets the stage width automatically if none is provided.
 
This helps remove any duplicate configuration that would normally occur across container deployments & worker configs.  It's also helpful for debugging a log as you know what the worker thinks its host resources are.

### Testing:  
tested this with k8s and saw the expected results.