### PR TITLE
Let Redis listen only on localhost

### DIFF
--- a/.bazelci/integration_test.sh
+++ b/.bazelci/integration_test.sh
@@ -5,7 +5,7 @@
 # We ensure that the system can build a set of bazel targets.
 
 # Run redis container
-docker run -d --name buildfarm-redis -p 6379:6379 redis:5.0.9
+docker run -d --name buildfarm-redis --network host redis:5.0.9 --bind localhost
 
 # Build a container for buildfarm services
 docker build -t buildfarm .


### PR DESCRIPTION
Our vulnerability scanners have complained that they found an externally accessible Redis instance. I guess it's caused by this.

It wouldn't actually be accessible, because our GCP firewall prevents any incoming connections, but let's still fix it. :)