### PR TITLE
Add workaround for SIGBUS crash

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,6 @@
+common --enable_platform_specific_config
+
 build:fuse --define=fuse=true
+
+# Workaround for https://github.com/bazelbuild/bazel/issues/3236
+build:linux --sandbox_tmpfs_path=/tmp


### PR DESCRIPTION
I noticed that your tests are flakily crashing with a SIGBUS error.

Adding --sandbox_tmpfs_path=/tmp will prevent this error. Bazel CI usually injects it, but as you're using calling Bazel manually via shell scripts as part of your tests, this mechanism doesn't work, but we can just add it to the project-level bazelrc file.