### PR TITLE
Run CAS indexer when worker is paused.

### DIFF
--- a/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
@@ -739,6 +739,7 @@ public class RedisShardBackplane implements Backplane {
     settings.hostNames = hostNames;
     settings.casQuery = config.getCasPrefix() + ":*";
     settings.scanAmount = 10000;
+    logger.info("Running CAS Indexer with settings: " + settings.toString());
     return client.call(jedis -> WorkerIndexer.removeWorkerIndexesFromCas(jedis, settings));
   }
 

--- a/src/main/java/build/buildfarm/server/AdminService.java
+++ b/src/main/java/build/buildfarm/server/AdminService.java
@@ -145,7 +145,7 @@ public class AdminService extends AdminGrpc.AdminImplBase {
       ReindexCasRequest request, StreamObserver<ReindexCasRequestResults> responseObserver) {
     try {
       CasIndexResults results = instance.reindexCas(request.getHostId());
-      logger.log(INFO, results.toMessage());
+      logger.log(INFO, "Indexer results: " + results.toMessage());
       responseObserver.onNext(
           ReindexCasRequestResults.newBuilder()
               .setRemovedHosts(results.removedHosts)
@@ -165,7 +165,7 @@ public class AdminService extends AdminGrpc.AdminImplBase {
     try {
       String arg = null;
       CasIndexResults results = instance.reindexCas(arg);
-      logger.log(INFO, results.toMessage());
+      logger.log(INFO, "Indexer results: " + results.toMessage());
       responseObserver.onNext(
           ReindexCasRequestResults.newBuilder()
               .setRemovedHosts(results.removedHosts)


### PR DESCRIPTION
After worker is paused and it's termination is imminent once all work is finished, we should run a CAS indexer to clean up the key mappings.