### PR TITLE
[ci] pin buildifer

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,5 +1,5 @@
 ---
-buildifier: latest
+buildifier: 5.0.0
 tasks:
   
   # Linting jobs

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,5 +1,5 @@
 ---
-buildifier: 5.0.0
+buildifier: 4.2.5
 tasks:
   
   # Linting jobs

--- a/defs.bzl
+++ b/defs.bzl
@@ -61,7 +61,7 @@ ORG_SPRING_BOOT_MODULES = [
     "spring-boot",
 ]
 
-def buildfarm_init():
+def buildfarm_init(name = "buildfarm"):
     """
     Initialize the WORKSPACE for buildfarm-related targets
 

--- a/defs.bzl
+++ b/defs.bzl
@@ -61,7 +61,7 @@ ORG_SPRING_BOOT_MODULES = [
     "spring-boot",
 ]
 
-def buildfarm_init(name = "buildfarm"):
+def buildfarm_init():
     """
     Initialize the WORKSPACE for buildfarm-related targets
 

--- a/src/test/many/many-cc.bzl
+++ b/src/test/many/many-cc.bzl
@@ -5,7 +5,7 @@ Provide a simple C++ build graph as large as desired.
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("@bazel_skylib//rules:write_file.bzl", _write_file = "write_file")
 
-def write_file(name, out, lines, **kwargs):
+def write_file(name, out, lines):
     """
     Call the skylib write_file routine, ensuring that all lines end with a newline.
     """


### PR DESCRIPTION
oops, we have `buildifer` set to latest in CI.  New diffs will not pass until this is fixed.  Going to pin the version so the CI passes.