### PR TITLE
[dev] bundle cgroups with worker image

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -46,6 +46,8 @@ tasks:
     - "..."
   macos:
     name: "Unit Tests"
+    build_flags:
+    - "--build_tag_filters=-container"
     build_targets:
     - "..."
     test_targets:


### PR DESCRIPTION
fixes warning discussed in https://github.com/bazelbuild/bazel-buildfarm/pull/1013 by making cgexec available in the container