### PR TITLE
[compression] initial integration of zstd-jni

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -81,6 +81,7 @@ def buildfarm_init(name = "buildfarm"):
                         "com.github.jnr:jnr-posix:3.0.53",
                         "com.github.pcj:google-options:1.0.0",
                         "com.github.serceman:jnr-fuse:0.5.5",
+                        "com.github.luben:zstd-jni:1.5.2-1",
                         "com.google.auth:google-auth-library-credentials:0.9.1",
                         "com.google.auth:google-auth-library-oauth2-http:0.9.1",
                         "com.google.code.findbugs:jsr305:3.0.1",

--- a/src/main/java/build/buildfarm/common/BUILD
+++ b/src/main/java/build/buildfarm/common/BUILD
@@ -28,5 +28,6 @@ java_library(
         "@maven//:org_apache_commons_commons_compress",
         "@maven//:org_threeten_threetenbp",
         "@remote_apis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
+        "@maven//:com_github_luben_zstd_jni",
     ],
 )

--- a/src/main/java/build/buildfarm/common/BUILD
+++ b/src/main/java/build/buildfarm/common/BUILD
@@ -16,6 +16,7 @@ java_library(
         "@maven//:com_github_jnr_jnr_constants",
         "@maven//:com_github_jnr_jnr_ffi",
         "@maven//:com_github_jnr_jnr_posix",
+        "@maven//:com_github_luben_zstd_jni",
         "@maven//:com_google_code_findbugs_jsr305",
         "@maven//:com_google_guava_failureaccess",
         "@maven//:com_google_guava_guava",
@@ -28,6 +29,5 @@ java_library(
         "@maven//:org_apache_commons_commons_compress",
         "@maven//:org_threeten_threetenbp",
         "@remote_apis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
-        "@maven//:com_github_luben_zstd_jni",
     ],
 )

--- a/src/main/java/build/buildfarm/common/CompressionUtils.java
+++ b/src/main/java/build/buildfarm/common/CompressionUtils.java
@@ -15,6 +15,7 @@
 package build.buildfarm.common;
 
 import com.github.luben.zstd.Zstd;
+import com.google.protobuf.ByteString;
 import java.util.Base64;
 
 /**
@@ -27,7 +28,8 @@ public class CompressionUtils {
    * @brief Compress a string with zstandard compression.
    * @details For optimal performance you should use byte buffers or streams. We provide a string
    *     interface due to the ubiquity of strings and as an easy way to test the underlying
-   *     implementation.
+   *     implementation. After the string information is zstd compressed they are encoded in base64
+   *     to avoid losing information between byte[] and String.
    * @param data The string to compress
    * @return The string in compressed format.
    * @note Suggested return identifier: compressedData
@@ -41,7 +43,8 @@ public class CompressionUtils {
    * @brief Decompress a zstandard compressed string.
    * @details For optimal performance you should use byte buffers or streams. We provide a string
    *     interface due to the ubiquity of strings and as an easy way to test the underlying
-   *     implementation.
+   *     implementation. After the string information is zstd compressed they are encoded in base64
+   *     to avoid losing information between byte[] and String.
    * @param data The string to decompress
    * @return The string in decompressed format.
    * @note Suggested return identifier: data
@@ -51,5 +54,30 @@ public class CompressionUtils {
     int size = (int) Zstd.decompressedSize(src);
     byte[] data = Zstd.decompress(src, size);
     return new String(data);
+  }
+
+  /**
+   * @brief Compress a bytestring with zstandard compression.
+   * @details creates a new bytestream.
+   * @param data The string to compress
+   * @return The string in compressed format.
+   * @note Suggested return identifier: compressedData
+   */
+  public static ByteString zstdCompress(ByteString data) {
+    byte[] compressed = Zstd.compress(data.toByteArray());
+    return ByteString.copyFrom(compressed);
+  }
+
+  /**
+   * @brief Decompress a zstandard compressed bytestring.
+   * @details creates a new bytestream.
+   * @param data The string to decompress
+   * @return The string in decompressed format.
+   * @note Suggested return identifier: data
+   */
+  public static ByteString zstdDecompress(ByteString compressedData) {
+    int size = (int) Zstd.decompressedSize(compressedData.toByteArray());
+    byte[] data = Zstd.decompress(compressedData.toByteArray(), size);
+    return ByteString.copyFrom(data);
   }
 }

--- a/src/main/java/build/buildfarm/common/CompressionUtils.java
+++ b/src/main/java/build/buildfarm/common/CompressionUtils.java
@@ -25,8 +25,9 @@ import java.util.Base64;
 public class CompressionUtils {
   /**
    * @brief Compress a string with zstandard compression.
-   * @details This is usually done with byte buffers. It's not going to give ideal performance, but
-   *     it's useful for String manipulation testing the underlying implementation.
+   * @details For optimal performance you should use byte buffers or streams. We provide a string
+   *     interface due to the ubiquity of strings and as an easy way to test the underlying
+   *     implementation.
    * @param data The string to compress
    * @return The string in compressed format.
    * @note Suggested return identifier: compressedData
@@ -38,8 +39,9 @@ public class CompressionUtils {
 
   /**
    * @brief Decompress a zstandard compressed string.
-   * @details This is usually done with byte buffers. It's not going to give ideal performance, but
-   *     it's useful for String manipulation testing the underlying implementation.
+   * @details For optimal performance you should use byte buffers or streams. We provide a string
+   *     interface due to the ubiquity of strings and as an easy way to test the underlying
+   *     implementation.
    * @param data The string to decompress
    * @return The string in decompressed format.
    * @note Suggested return identifier: data

--- a/src/main/java/build/buildfarm/common/CompressionUtils.java
+++ b/src/main/java/build/buildfarm/common/CompressionUtils.java
@@ -16,6 +16,7 @@ package build.buildfarm.common;
 
 import com.github.luben.zstd.Zstd;
 import java.util.Base64;
+import java.nio.charset.StandardCharsets;
 
 /**
  * @class CompressionUtils

--- a/src/main/java/build/buildfarm/common/CompressionUtils.java
+++ b/src/main/java/build/buildfarm/common/CompressionUtils.java
@@ -16,7 +16,6 @@ package build.buildfarm.common;
 
 import com.github.luben.zstd.Zstd;
 import java.util.Base64;
-import java.nio.charset.StandardCharsets;
 
 /**
  * @class CompressionUtils

--- a/src/main/java/build/buildfarm/common/CompressionUtils.java
+++ b/src/main/java/build/buildfarm/common/CompressionUtils.java
@@ -1,0 +1,53 @@
+// Copyright 2022 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.common;
+
+import com.github.luben.zstd.Zstd;
+import java.util.Base64;
+
+/**
+ * @class CompressionUtils
+ * @brief Utilities for compressing data
+ * @details These utilities are used to convert between lossless compression formats
+ */
+public class CompressionUtils {
+  /**
+   * @brief Compress a string with zstandard compression.
+   * @details Usually done with byte buffers. Not for performance, but testing underlying
+   *     implementation.
+   * @param data The string to compress
+   * @return The string in compressed format.
+   * @note Suggested return identifier: compressedData
+   */
+  public static String zstdCompress(String data) {
+    byte[] compressed = Zstd.compress(data.getBytes());
+    return Base64.getEncoder().encodeToString(compressed);
+  }
+
+  /**
+   * @brief Decompress a zstandard compressed string.
+   * @details Usually done with byte buffers. Not for performance, but testing underlying
+   *     implementation.
+   * @param data The string to decompress
+   * @return The string in decompressed format.
+   * @note Suggested return identifier: data
+   */
+  public static String zstdDecompress(String compressedData) {
+    byte[] src = Base64.getDecoder().decode(compressedData);
+    int size = (int) Zstd.decompressedSize(src);
+    byte[] data = Zstd.decompress(src, size);
+    return new String(data);
+  }
+}

--- a/src/main/java/build/buildfarm/common/CompressionUtils.java
+++ b/src/main/java/build/buildfarm/common/CompressionUtils.java
@@ -25,8 +25,8 @@ import java.util.Base64;
 public class CompressionUtils {
   /**
    * @brief Compress a string with zstandard compression.
-   * @details Usually done with byte buffers. Not for performance, but testing underlying
-   *     implementation.
+   * @details This is usually done with byte buffers. It's not going to give ideal performance, but
+   *     it's useful for String manipulation testing the underlying implementation.
    * @param data The string to compress
    * @return The string in compressed format.
    * @note Suggested return identifier: compressedData
@@ -38,8 +38,8 @@ public class CompressionUtils {
 
   /**
    * @brief Decompress a zstandard compressed string.
-   * @details Usually done with byte buffers. Not for performance, but testing underlying
-   *     implementation.
+   * @details This is usually done with byte buffers. It's not going to give ideal performance, but
+   *     it's useful for String manipulation testing the underlying implementation.
    * @param data The string to decompress
    * @return The string in decompressed format.
    * @note Suggested return identifier: data

--- a/src/test/java/build/buildfarm/common/CompressionUtilsTest.java
+++ b/src/test/java/build/buildfarm/common/CompressionUtilsTest.java
@@ -70,4 +70,22 @@ public class CompressionUtilsTest {
     // ASSERT
     assertThat(data).isEqualTo(result);
   }
+
+  // Function under test: zstdCompress
+  // Reason for testing: Test command line compatibility.
+  // Failure explanation: The results are not the same as running standard CLI tools.
+  @Test
+  public void cliCompatibility() throws Exception {
+    // ARRANGE
+    String data = "Hello World";
+
+    // ACT
+    String result = CompressionUtils.zstdCompress(data);
+
+    // ASSERT
+    // This should be equivalent to the following command:
+    // echo -n "Hello World" > /tmp/out.txt; zstd --stdout --no-check /tmp/out.txt | base64
+    // The temporary file is required to create a matching frame header.
+    assertThat(result).isEqualTo("KLUv/SALWQAASGVsbG8gV29ybGQ=");
+  }
 }

--- a/src/test/java/build/buildfarm/common/CompressionUtilsTest.java
+++ b/src/test/java/build/buildfarm/common/CompressionUtilsTest.java
@@ -19,7 +19,6 @@ import static com.google.common.truth.Truth.assertThat;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import java.nio.charset.StandardCharsets;
 
 /**
  * @class CompressionUtilsTest
@@ -70,21 +69,5 @@ public class CompressionUtilsTest {
 
     // ASSERT
     assertThat(data).isEqualTo(result);
-  }
-  
-  // Function under test: zstdCompress
-  // Reason for testing: Test command line compatibility.
-  // Failure explanation: The results are not the same as running standard CLI tools.
-  @Test
-  public void cliCompatibility() throws Exception {
-    // ARRANGE
-    String data = "a";
-
-    // ACT
-    // echo -n "Hello World" | zstd --stdout | base64
-    String result = CompressionUtils.zstdCompress(data);
-
-    // ASSERT
-    assertThat(result).isEqualTo("KLUv/QRYWQAASGVsbG8gV29ybGTCWyQZ");
   }
 }

--- a/src/test/java/build/buildfarm/common/CompressionUtilsTest.java
+++ b/src/test/java/build/buildfarm/common/CompressionUtilsTest.java
@@ -1,0 +1,73 @@
+// Copyright 2022 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.common;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * @class CompressionUtilsTest
+ * @brief tests compression utility functions.
+ */
+@RunWith(JUnit4.class)
+public class CompressionUtilsTest {
+  // Function under test: zstdCompress
+  // Reason for testing: compression creates new data
+  // Failure explanation: compression either failed or did not change data.
+  @Test
+  public void compressionCreatesNewData() throws Exception {
+    // ARRANGE
+    String data = "Hello World";
+
+    // ACT
+    String result = CompressionUtils.zstdCompress(data);
+
+    // ASSERT
+    assertThat(data).isNotEqualTo(result);
+  }
+
+  // Function under test: zstdCompress, zstdDecompress
+  // Reason for testing: compression to decompression is idempotent.
+  // Failure explanation: compression & decompression are not acting idempotent.
+  @Test
+  public void compressionDecompressionIdempotent() throws Exception {
+    // ARRANGE
+    String data = "Hello World";
+
+    // ACT
+    String result = CompressionUtils.zstdDecompress(CompressionUtils.zstdCompress(data));
+
+    // ASSERT
+    assertThat(data).isEqualTo(result);
+  }
+
+  // Function under test: zstdCompress, zstdDecompress
+  // Reason for testing: empty string can be compressed & uncompressed.
+  // Failure explanation: empty string is failure edge case.
+  @Test
+  public void emptyStringIdempotent() throws Exception {
+    // ARRANGE
+    String data = "";
+
+    // ACT
+    String result = CompressionUtils.zstdDecompress(CompressionUtils.zstdCompress(data));
+
+    // ASSERT
+    assertThat(data).isEqualTo(result);
+  }
+}

--- a/src/test/java/build/buildfarm/common/CompressionUtilsTest.java
+++ b/src/test/java/build/buildfarm/common/CompressionUtilsTest.java
@@ -19,6 +19,7 @@ import static com.google.common.truth.Truth.assertThat;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import java.nio.charset.StandardCharsets;
 
 /**
  * @class CompressionUtilsTest
@@ -69,5 +70,21 @@ public class CompressionUtilsTest {
 
     // ASSERT
     assertThat(data).isEqualTo(result);
+  }
+  
+  // Function under test: zstdCompress
+  // Reason for testing: Test command line compatibility.
+  // Failure explanation: The results are not the same as running standard CLI tools.
+  @Test
+  public void cliCompatibility() throws Exception {
+    // ARRANGE
+    String data = "a";
+
+    // ACT
+    // echo -n "Hello World" | zstd --stdout | base64
+    String result = CompressionUtils.zstdCompress(data);
+
+    // ASSERT
+    assertThat(result).isEqualTo("KLUv/QRYWQAASGVsbG8gV29ybGTCWyQZ");
   }
 }

--- a/src/test/java/build/buildfarm/common/CompressionUtilsTest.java
+++ b/src/test/java/build/buildfarm/common/CompressionUtilsTest.java
@@ -16,6 +16,8 @@ package build.buildfarm.common;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.protobuf.ByteString;
+import java.util.Base64;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -87,5 +89,73 @@ public class CompressionUtilsTest {
     // echo -n "Hello World" > /tmp/out.txt; zstd --stdout --no-check /tmp/out.txt | base64
     // The temporary file is required to create a matching frame header.
     assertThat(result).isEqualTo("KLUv/SALWQAASGVsbG8gV29ybGQ=");
+  }
+
+  // Function under test: zstdCompress
+  // Reason for testing: compression creates new data
+  // Failure explanation: compression either failed or did not change data.
+  @Test
+  public void byteStringCompressionCreatesNewData() throws Exception {
+    // ARRANGE
+    String data = "Hello World";
+
+    // ACT
+    ByteString result = CompressionUtils.zstdCompress(ByteString.copyFromUtf8(data));
+
+    // ASSERT
+    assertThat(data).isNotEqualTo(result.toStringUtf8());
+  }
+
+  // Function under test: zstdCompress, zstdDecompress
+  // Reason for testing: compression to decompression is idempotent.
+  // Failure explanation: compression & decompression are not acting idempotent.
+  @Test
+  public void byteStringCompressionDecompressionIdempotent() throws Exception {
+    // ARRANGE
+    String data = "Hello World";
+
+    // ACT
+    ByteString result =
+        CompressionUtils.zstdDecompress(
+            CompressionUtils.zstdCompress(ByteString.copyFromUtf8(data)));
+
+    // ASSERT
+    assertThat(data).isEqualTo(result.toStringUtf8());
+  }
+
+  // Function under test: zstdCompress, zstdDecompress
+  // Reason for testing: empty string can be compressed & uncompressed.
+  // Failure explanation: empty string is failure edge case.
+  @Test
+  public void byteStringEmptyStringIdempotent() throws Exception {
+    // ARRANGE
+    String data = "";
+
+    // ACT
+    ByteString result =
+        CompressionUtils.zstdDecompress(
+            CompressionUtils.zstdCompress(ByteString.copyFromUtf8(data)));
+
+    // ASSERT
+    assertThat(data).isEqualTo(result.toStringUtf8());
+  }
+
+  // Function under test: zstdCompress
+  // Reason for testing: Test command line compatibility.
+  // Failure explanation: The results are not the same as running standard CLI tools.
+  @Test
+  public void byteStringCliCompatibility() throws Exception {
+    // ARRANGE
+    String data = "Hello World";
+
+    // ACT
+    ByteString result = CompressionUtils.zstdCompress(ByteString.copyFromUtf8(data));
+
+    // ASSERT
+    // This should be equivalent to the following command:
+    // echo -n "Hello World" > /tmp/out.txt; zstd --stdout --no-check /tmp/out.txt | base64
+    // The temporary file is required to create a matching frame header.
+    assertThat(Base64.getEncoder().encodeToString(result.toByteArray()))
+        .isEqualTo("KLUv/SALWQAASGVsbG8gV29ybGQ=");
   }
 }


### PR DESCRIPTION
We integrate and test the **zstd-jni** library for future support of [--experimental_remote_cache_compression](https://bazel.build/reference/command-line-reference#flag--experimental_remote_cache_compression).  
Type support is provided for **String** & **ByteString** initially.  Additional interfaces will be added based on implementation requirements.  

Tracking issue: https://github.com/bazelbuild/bazel-buildfarm/issues/956
Additional reference: https://github.com/bazelbuild/bazel-buildfarm/compare/main...shirchen:shirchen/compression?expand=1