### PR TITLE
Add priority queue 

### DIFF
--- a/generate_coverage.sh
+++ b/generate_coverage.sh
@@ -24,7 +24,7 @@ GATING_LINE_PERCENTAGE="40";
 GATING_FUNC_PERCENTAGE="40";
 
 # If the user does not pass a given target, this will be used instead.
-DEFAULT_TEST_TARGET="//src/test/...:all"
+DEFAULT_TEST_TARGET="//src/test/java/...:all"
 
 # Any test tags filters to apply when generating code coverage.
 DEFAULT_TEST_TAG_FILTERS="-redis"
@@ -145,7 +145,16 @@ if [ "${BUILDFARM_SKIP_COVERAGE_HOST:-false}" = false ]; then
     genhtml -f $traces
 
     command -v python >/dev/null 2>&1 || { echo >&2 'python could not be found, so the coverage report cannot be locally hosted.'; exit 1; }
-    python -m SimpleHTTPServer 8080
+
+    # Get python version
+    pythonVersion=`python -c 'import platform; major, minor, patch = platform.python_version_tuple(); print(major);'`
+
+    # Host code coverage based on python version
+    if [ $pythonVersion -eq 2 ];then
+        python -m SimpleHTTPServer 8080
+    else
+        python -m http.server 8080
+    fi
 else
     echo "Skipped coverage hosting."
 fi

--- a/src/main/java/build/buildfarm/BUILD
+++ b/src/main/java/build/buildfarm/BUILD
@@ -6,6 +6,12 @@ package(
 )
 
 filegroup(
+    name = "lua_file",
+    srcs = ["zpoplpush.lua"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
     name = "configs",
     srcs = ["logging.properties"],
     visibility = ["//visibility:public"],
@@ -22,6 +28,7 @@ java_binary(
     name = "buildfarm-server",
     classpath_resources = [
         ":configs",
+        ":lua_file",
     ],
     jvm_flags = ensure_accurate_metadata(),
     main_class = "build.buildfarm.server.BuildFarmServer",

--- a/src/main/java/build/buildfarm/BUILD
+++ b/src/main/java/build/buildfarm/BUILD
@@ -6,7 +6,7 @@ package(
 )
 
 filegroup(
-    name = "lua_file",
+    name = "lua_resources",
     srcs = ["zpoplpush.lua"],
     visibility = ["//visibility:public"],
 )
@@ -28,7 +28,7 @@ java_binary(
     name = "buildfarm-server",
     classpath_resources = [
         ":configs",
-        ":lua_file",
+        ":lua_resources",
     ],
     jvm_flags = ensure_accurate_metadata(),
     main_class = "build.buildfarm.server.BuildFarmServer",

--- a/src/main/java/build/buildfarm/common/redis/BalancedRedisQueue.java
+++ b/src/main/java/build/buildfarm/common/redis/BalancedRedisQueue.java
@@ -96,11 +96,18 @@ public class BalancedRedisQueue {
    * @note Overloaded.
    */
   public BalancedRedisQueue(String name, List<String> hashtags) {
-    this.originalHashtag = RedisHashtags.existingHash(name);
-    this.name = RedisHashtags.unhashedName(name);
-    this.type = "regular";
-    this.maxQueueSize = -1; // infinite size
-    createHashedQueues(this.name, hashtags, this.type);
+    this(name, hashtags, -1, "regular");
+  }
+
+  /**
+   * @brief Constructor.
+   * @details Construct a named redis queue with an established redis cluster.
+   * @param name The global name of the queue.
+   * @param hashtags Hashtags to distribute queue data.
+   * @note Overloaded.
+   */
+  public BalancedRedisQueue(String name, List<String> hashtags, String queueType) {
+    this(name, hashtags, -1, queueType);
   }
 
   /**
@@ -112,9 +119,23 @@ public class BalancedRedisQueue {
    * @note Overloaded.
    */
   public BalancedRedisQueue(String name, List<String> hashtags, int maxQueueSize) {
+    this(name, hashtags, maxQueueSize, "regular");
+  }
+
+  /**
+   * @brief Constructor.
+   * @details Construct a named redis queue with an established redis cluster.
+   * @param name The global name of the queue.
+   * @param hashtags Hashtags to distribute queue data.
+   * @param maxQueueSize The maximum amount of elements that should be added to the queue.
+   * @param queueTYpe Type of the queue
+   * @note Overloaded.
+   */
+  public BalancedRedisQueue(
+      String name, List<String> hashtags, int maxQueueSize, String queueType) {
     this.originalHashtag = RedisHashtags.existingHash(name);
     this.name = RedisHashtags.unhashedName(name);
-    this.type = "regular";
+    this.type = queueType;
     this.maxQueueSize = maxQueueSize;
     createHashedQueues(this.name, hashtags, this.type);
   }

--- a/src/main/java/build/buildfarm/common/redis/BalancedRedisQueue.java
+++ b/src/main/java/build/buildfarm/common/redis/BalancedRedisQueue.java
@@ -72,8 +72,6 @@ public class BalancedRedisQueue {
    */
   private final List<QueueInterface> queues = new ArrayList<>();
 
-  // private final List<QueueInterface> queuesTest;
-
   /**
    * @field currentPushQueue
    * @brief The current queue to act push on.

--- a/src/main/java/build/buildfarm/common/redis/BalancedRedisQueue.java
+++ b/src/main/java/build/buildfarm/common/redis/BalancedRedisQueue.java
@@ -42,6 +42,7 @@ public class BalancedRedisQueue {
    *     Hashtags are added to this base name. This name will not contain a redis hashtag.
    */
   private final String name;
+
   private final String type;
 
   /**
@@ -71,7 +72,7 @@ public class BalancedRedisQueue {
    */
   private final List<QueueInterface> queues = new ArrayList<>();
 
-  //private final List<QueueInterface> queuesTest;
+  // private final List<QueueInterface> queuesTest;
 
   /**
    * @field currentPushQueue
@@ -102,7 +103,6 @@ public class BalancedRedisQueue {
     this.type = "regular";
     this.maxQueueSize = -1; // infinite size
     createHashedQueues(this.name, hashtags, this.type);
-
   }
 
   /**
@@ -131,10 +131,10 @@ public class BalancedRedisQueue {
   }
 
   /**
-  * @brief Push a value onto the queue.
-  * @details Adds the value into one of the internal backend redis queues.
-  * @param val The value to push onto the queue.
-  */
+   * @brief Push a value onto the queue.
+   * @details Adds the value into one of the internal backend redis queues.
+   * @param val The value to push onto the queue.
+   */
   public void push(JedisCluster jedis, String val, double priority) {
     queues.get(roundRobinPushIndex()).push(jedis, val, priority);
   }
@@ -369,7 +369,9 @@ public class BalancedRedisQueue {
     // to the same redis slot.
     if (hashtags.isEmpty()) {
       if (!originalHashtag.isEmpty()) {
-        queues.add(new RedisQueueFactory().getQueue(type, RedisHashtags.hashedName(name, originalHashtag)));
+        queues.add(
+            new RedisQueueFactory()
+                .getQueue(type, RedisHashtags.hashedName(name, originalHashtag)));
       } else {
         queues.add(new RedisQueueFactory().getQueue(type, RedisHashtags.hashedName(name, "06S")));
       }

--- a/src/main/java/build/buildfarm/common/redis/QueueInterface.java
+++ b/src/main/java/build/buildfarm/common/redis/QueueInterface.java
@@ -14,8 +14,8 @@
 
 package build.buildfarm.common.redis;
 
-import redis.clients.jedis.JedisCluster;
 import build.buildfarm.common.StringVisitor;
+import redis.clients.jedis.JedisCluster;
 
 /**
  * @class QueueInterface
@@ -28,7 +28,7 @@ import build.buildfarm.common.StringVisitor;
  */
 public abstract class QueueInterface {
 
-  //void push(JedisCluster jedis, String val, double priority);
+  // void push(JedisCluster jedis, String val, double priority);
 
   /**
    * @brief Push a value onto the queue with default priority of 1.
@@ -122,5 +122,4 @@ public abstract class QueueInterface {
    * @param visitor A visitor for each visited element in the queue.
    */
   abstract void visitDequeue(JedisCluster jedis, StringVisitor visitor);
-
 }

--- a/src/main/java/build/buildfarm/common/redis/QueueInterface.java
+++ b/src/main/java/build/buildfarm/common/redis/QueueInterface.java
@@ -28,8 +28,6 @@ import redis.clients.jedis.JedisCluster;
  */
 public abstract class QueueInterface {
 
-  // void push(JedisCluster jedis, String val, double priority);
-
   /**
    * @brief Push a value onto the queue with default priority of 1.
    * @details Adds the value into the backend rdered set.

--- a/src/main/java/build/buildfarm/common/redis/QueueInterface.java
+++ b/src/main/java/build/buildfarm/common/redis/QueueInterface.java
@@ -1,4 +1,4 @@
-// Copyright 2020 The Bazel Authors. All rights reserved.
+// Copyright 2020-2022 The Bazel Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,11 +20,6 @@ import redis.clients.jedis.JedisCluster;
 /**
  * @class QueueInterface
  * @brief A redis queue interface.
- * @details A redis queue is an implementation of a queue data structure which internally uses redis
- *     to store and distribute the data. Its important to know that the lifetime of the queue
- *     persists before and after the queue data structure is created (since it exists in redis).
- *     Therefore, two redis queues with the same name, would in fact be the same underlying redis
- *     queue.
  */
 public abstract class QueueInterface {
 

--- a/src/main/java/build/buildfarm/common/redis/RedisPriorityQueue.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisPriorityQueue.java
@@ -251,7 +251,7 @@ public class RedisPriorityQueue extends QueueInterface {
    * @brief Adds additional functionality to the jedis client.
    * @details Load the custom lua script so we can have zpoplpush.
    */
-  private String getLuaScript(JedisCluster jedis, String filename) {
+  private String getLuaScript(String filename) {
     InputStream luaInputStream = this.getClass().getClassLoader().getResourceAsStream(filename);
     if (luaInputStream == null) {
       throw new IllegalArgumentException(filename + " is not found");

--- a/src/main/java/build/buildfarm/common/redis/RedisPriorityQueue.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisPriorityQueue.java
@@ -91,7 +91,7 @@ public class RedisPriorityQueue {
    * @note Suggested return identifier: wasRemoved.
    */
   public boolean removeAll(JedisCluster jedis, String val) {
-    return jedis.lrem(name, 0, val) != 0;
+    return jedis.zrem(name, val) != 0;
   }
 
   /**
@@ -129,9 +129,7 @@ public class RedisPriorityQueue {
     List<String> args = Arrays.asList(name, getDequeueName());
     Object obj_val = jedis.eval(getLuaScript(jedis, "zpoplpush.lua"), keys, args);
     String val = String.valueOf(obj_val);
-    System.out.println("Here is your value:" + val);
     if (val != null && !val.isEmpty()) {
-      System.out.println("It's not null");
       return val;
     }
     if (Thread.currentThread().isInterrupted()) {
@@ -168,7 +166,7 @@ public class RedisPriorityQueue {
    * @note Suggested return identifier: length.
    */
   public long size(JedisCluster jedis) {
-    return jedis.llen(name);
+    return jedis.zcard(name);
   }
 
   /**
@@ -230,8 +228,6 @@ public class RedisPriorityQueue {
         new BufferedReader(new InputStreamReader(luaInputStream))
           .lines()
           .collect(Collectors.joining("\n"));
-    //String sha = jedis.scriptLoad(luaScript, name);
-    //System.out.println("Script sha:" + sha);
     return luaScript;
   }
 }

--- a/src/main/java/build/buildfarm/common/redis/RedisPriorityQueue.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisPriorityQueue.java
@@ -256,10 +256,8 @@ public class RedisPriorityQueue extends QueueInterface {
     if (luaInputStream == null) {
       throw new IllegalArgumentException(filename + " is not found");
     }
-    String luaScript =
-        new BufferedReader(new InputStreamReader(luaInputStream))
+    return new BufferedReader(new InputStreamReader(luaInputStream))
             .lines()
-            .collect(Collectors.joining("\n"));
-    return luaScript;
+            .collect(Collectors.joining("\n"))
   }
 }

--- a/src/main/java/build/buildfarm/common/redis/RedisPriorityQueue.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisPriorityQueue.java
@@ -258,6 +258,6 @@ public class RedisPriorityQueue extends QueueInterface {
     }
     return new BufferedReader(new InputStreamReader(luaInputStream))
             .lines()
-            .collect(Collectors.joining("\n"))
+            .collect(Collectors.joining("\n"));
   }
 }

--- a/src/main/java/build/buildfarm/common/redis/RedisPriorityQueue.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisPriorityQueue.java
@@ -42,6 +42,7 @@ public class RedisPriorityQueue extends QueueInterface {
    */
   private final String name;
 
+  private final String script;
   private Timestamp time;
   private final List<String> keys;
 
@@ -54,6 +55,7 @@ public class RedisPriorityQueue extends QueueInterface {
     this.name = name;
     this.time = new Timestamp();
     this.keys = Arrays.asList(name);
+    this.script = getLuaScript("zpoplpush.lua");
   }
 
   /**
@@ -67,6 +69,7 @@ public class RedisPriorityQueue extends QueueInterface {
     this.name = name;
     this.time = time;
     this.keys = Arrays.asList(name);
+    this.script = getLuaScript("zpoplpush.lua");
   }
 
   /**
@@ -127,7 +130,7 @@ public class RedisPriorityQueue extends QueueInterface {
   public String dequeue(JedisCluster jedis, int timeout_s) throws InterruptedException {
     List<String> args = Arrays.asList(name, getDequeueName(), "true");
     for (int i = 0; i < timeout_s; ++i) {
-      Object obj_val = jedis.eval(getLuaScript(jedis, "zpoplpush.lua"), keys, args);
+      Object obj_val = jedis.eval(script, keys, args);
       String val = String.valueOf(obj_val);
       if (val != null && !val.isEmpty() && !val.equals("null")) {
         return val;
@@ -146,7 +149,7 @@ public class RedisPriorityQueue extends QueueInterface {
   @Override
   public String nonBlockingDequeue(JedisCluster jedis) throws InterruptedException {
     List<String> args = Arrays.asList(name, getDequeueName());
-    Object obj_val = jedis.eval(getLuaScript(jedis, "zpoplpush.lua"), keys, args);
+    Object obj_val = jedis.eval(script, keys, args);
     String val = String.valueOf(obj_val);
     if (val != null && !val.isEmpty() && !val.equals("null")) {
       return val;

--- a/src/main/java/build/buildfarm/common/redis/RedisPriorityQueue.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisPriorityQueue.java
@@ -257,7 +257,7 @@ public class RedisPriorityQueue extends QueueInterface {
       throw new IllegalArgumentException(filename + " is not found");
     }
     return new BufferedReader(new InputStreamReader(luaInputStream))
-            .lines()
-            .collect(Collectors.joining("\n"));
+        .lines()
+        .collect(Collectors.joining("\n"));
   }
 }

--- a/src/main/java/build/buildfarm/common/redis/RedisPriorityQueue.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisPriorityQueue.java
@@ -14,21 +14,15 @@
 
 package build.buildfarm.common.redis;
 
-import java.time.Clock;
 import build.buildfarm.common.StringVisitor;
-import java.util.List;
-import redis.clients.jedis.JedisCluster;
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
-import java.util.HashSet;
 import java.util.stream.Collectors;
-import java.util.Arrays;
-import java.util.ArrayList;
+import redis.clients.jedis.JedisCluster;
 
 /**
  * @class RedisQueue
@@ -39,7 +33,7 @@ import java.util.ArrayList;
  *     Therefore, two redis queues with the same name, would in fact be the same underlying redis
  *     queue.
  */
-public class RedisPriorityQueue extends QueueInterface{
+public class RedisPriorityQueue extends QueueInterface {
   /**
    * @field name
    * @brief The unique name of the queue.
@@ -47,6 +41,7 @@ public class RedisPriorityQueue extends QueueInterface{
    *     had the same name, they would be instances of the same underlying redis queue.
    */
   private final String name;
+
   private Timestamp time;
   private final List<String> keys;
 
@@ -61,10 +56,10 @@ public class RedisPriorityQueue extends QueueInterface{
     this.keys = Arrays.asList(name);
   }
 
-    /**
+  /**
    * @brief Constructor.
-   * @details Construct a named redis queue with an established redis cluster. Used to ease
-   *      the testing of the order of the queued actions
+   * @details Construct a named redis queue with an established redis cluster. Used to ease the
+   *     testing of the order of the queued actions
    * @param name The global name of the queue.
    * @param time Timestamp of the operation.
    */
@@ -257,17 +252,14 @@ public class RedisPriorityQueue extends QueueInterface{
    * @details Load the custom lua script so we can have zpoplpush.
    */
   private String getLuaScript(JedisCluster jedis, String filename) {
-    InputStream luaInputStream =
-        this.getClass()
-          .getClassLoader()
-          .getResourceAsStream(filename);
+    InputStream luaInputStream = this.getClass().getClassLoader().getResourceAsStream(filename);
     if (luaInputStream == null) {
-        throw new IllegalArgumentException(filename + " is not found");
+      throw new IllegalArgumentException(filename + " is not found");
     }
     String luaScript =
         new BufferedReader(new InputStreamReader(luaInputStream))
-          .lines()
-          .collect(Collectors.joining("\n"));
+            .lines()
+            .collect(Collectors.joining("\n"));
     return luaScript;
   }
 }

--- a/src/main/java/build/buildfarm/common/redis/RedisPriorityQueue.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisPriorityQueue.java
@@ -1,0 +1,237 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.common.redis;
+
+import build.buildfarm.common.StringVisitor;
+import java.util.List;
+import redis.clients.jedis.JedisCluster;
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.Arrays;
+import java.util.ArrayList;
+
+/**
+ * @class RedisQueue
+ * @brief A redis queue.
+ * @details A redis queue is an implementation of a queue data structure which internally uses redis
+ *     to store and distribute the data. Its important to know that the lifetime of the queue
+ *     persists before and after the queue data structure is created (since it exists in redis).
+ *     Therefore, two redis queues with the same name, would in fact be the same underlying redis
+ *     queue.
+ */
+public class RedisPriorityQueue {
+  /**
+   * @field name
+   * @brief The unique name of the queue.
+   * @details The name is used by the redis cluster client to access the queue data. If two queues
+   *     had the same name, they would be instances of the same underlying redis queue.
+   */
+  private final String name;
+
+  /**
+   * @brief Constructor.
+   * @details Construct a named redis queue with an established redis cluster.
+   * @param name The global name of the queue.
+   */
+  public RedisPriorityQueue(String name) {
+    this.name = name;
+  }
+
+  /**
+   * @brief Push a value onto the queue with specified priority.
+   * @details Adds the value into the backend redis ordered set.
+   * @param val The value to push onto the priority queue.
+   */
+  public void push(JedisCluster jedis, String val, double priority) {
+    jedis.zadd(name, priority, val);
+  }
+
+  /**
+   * @brief Push a value onto the queue with default priority of 1.
+   * @details Adds the value into the backend rdered set.
+   * @param val The value to push onto the priority queue.
+   */
+  public void push(JedisCluster jedis, String val) {
+    push(jedis, val, 1);
+  }
+
+  /**
+   * @brief Remove element from dequeue.
+   * @details Removes an element from the dequeue and specifies whether it was removed.
+   * @param val The value to remove.
+   * @return Whether or not the value was removed.
+   * @note Suggested return identifier: wasRemoved.
+   */
+  public boolean removeFromDequeue(JedisCluster jedis, String val) {
+    return jedis.lrem(getDequeueName(), -1, val) != 0;
+  }
+
+  /**
+   * @brief Remove all elements that match from queue.
+   * @details Removes all matching elements from the queue and specifies whether it was removed.
+   * @param val The value to remove.
+   * @return Whether or not the value was removed.
+   * @note Suggested return identifier: wasRemoved.
+   */
+  public boolean removeAll(JedisCluster jedis, String val) {
+    return jedis.lrem(name, 0, val) != 0;
+  }
+
+  /**
+   * @brief Pop element into internal dequeue and return value.
+   * @details This pops the element from one queue atomically into an internal list called the
+   *     dequeue. It will wait until the timeout has expired. Null is returned if the timeout has
+   *     expired.
+   * @param timeout_s Timeout to wait if there is no item to dequeue. (units: seconds (s))
+   * @return The value of the transfered element. null if the thread was interrupted.
+   * @note Overloaded.
+   * @note Suggested return identifier: val.
+   */
+  public String dequeue(JedisCluster jedis, int timeout_s) throws InterruptedException {
+    List<String> keys = Arrays.asList(name);
+    List<String> args = Arrays.asList(name, getDequeueName());
+    for (int i = 0; i < timeout_s; ++i) {
+      Object obj_val = jedis.eval(getLuaScript(jedis, "zpoplpush.lua"), keys, args);
+      String val = String.valueOf(obj_val);
+      if (val != null && !val.isEmpty()) {
+        return val;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * @brief Pop element into internal dequeue and return value.
+   * @details This pops the element from one queue atomically into an internal list called the
+   *     dequeue. It does not block and null is returned if there is nothing to dequeue.
+   * @return The value of the transfered element. null if nothing was dequeued.
+   * @note Suggested return identifier: val.
+   */
+  public String nonBlockingDequeue(JedisCluster jedis) throws InterruptedException {
+    List<String> keys = Arrays.asList(name);
+    List<String> args = Arrays.asList(name, getDequeueName());
+    Object obj_val = jedis.eval(getLuaScript(jedis, "zpoplpush.lua"), keys, args);
+    String val = String.valueOf(obj_val);
+    System.out.println("Here is your value:" + val);
+    if (val != null && !val.isEmpty()) {
+      System.out.println("It's not null");
+      return val;
+    }
+    if (Thread.currentThread().isInterrupted()) {
+      throw new InterruptedException();
+    }
+    return null;
+  }
+
+  /**
+   * @brief Get name.
+   * @details Get the name of the queue. this is the redis key used for the list.
+   * @return The name of the queue.
+   * @note Suggested return identifier: name.
+   */
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * @brief Get dequeue name.
+   * @details Get the name of the internal dequeue used by the queue. this is the redis key used for
+   *     the list.
+   * @return The name of the queue.
+   * @note Suggested return identifier: name.
+   */
+  public String getDequeueName() {
+    return name + "_dequeue";
+  }
+
+  /**
+   * @brief Get size.
+   * @details Checks the current length of the queue.
+   * @return The current length of the queue.
+   * @note Suggested return identifier: length.
+   */
+  public long size(JedisCluster jedis) {
+    return jedis.llen(name);
+  }
+
+  /**
+   * @brief Visit each element in the queue.
+   * @details Enacts a visitor over each element in the queue.
+   * @param visitor A visitor for each visited element in the queue.
+   * @note Overloaded.
+   */
+  public void visit(JedisCluster jedis, StringVisitor visitor) {
+    visit(jedis, name, visitor);
+  }
+
+  /**
+   * @brief Visit each element in the dequeue.
+   * @details Enacts a visitor over each element in the dequeue.
+   * @param visitor A visitor for each visited element in the queue.
+   */
+  public void visitDequeue(JedisCluster jedis, StringVisitor visitor) {
+    visit(jedis, getDequeueName(), visitor);
+  }
+
+  /**
+   * @brief Visit each element in the queue via queue name.
+   * @details Enacts a visitor over each element in the queue.
+   * @param queueName The name of the queue to visit.
+   * @param visitor A visitor for each visited element in the queue.
+   * @note Overloaded.
+   */
+  private void visit(JedisCluster jedis, String queueName, StringVisitor visitor) {
+    int listPageSize = 10000;
+
+    int index = 0;
+    int nextIndex = listPageSize;
+    List<String> entries;
+
+    do {
+      entries = jedis.lrange(queueName, index, nextIndex - 1);
+      for (String entry : entries) {
+        visitor.visit(entry);
+      }
+      index = nextIndex;
+      nextIndex += entries.size();
+    } while (entries.size() == listPageSize);
+  }
+
+  /**
+   * @brief Adds additional functionality to the jedis client.
+   * @details Load the custom lua script so we can have zpoplpush.
+   */
+  private String getLuaScript(JedisCluster jedis, String filename) {
+    InputStream luaInputStream =
+        this.getClass()
+          .getClassLoader()
+          .getResourceAsStream(filename);
+    if (luaInputStream == null) {
+        throw new IllegalArgumentException(filename + " is not found");
+    }
+    String luaScript =
+        new BufferedReader(new InputStreamReader(luaInputStream))
+          .lines()
+          .collect(Collectors.joining("\n"));
+    //String sha = jedis.scriptLoad(luaScript, name);
+    //System.out.println("Script sha:" + sha);
+    return luaScript;
+  }
+}

--- a/src/main/java/build/buildfarm/common/redis/RedisQueue.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisQueue.java
@@ -51,7 +51,7 @@ public class RedisQueue extends QueueInterface {
    * @param val The value to push onto the queue.
    */
   public void push(JedisCluster jedis, String val) {
-    jedis.lpush(name, val);
+    push(jedis, val, 1);
   }
 
   /**

--- a/src/main/java/build/buildfarm/common/redis/RedisQueue.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisQueue.java
@@ -60,7 +60,7 @@ public class RedisQueue extends QueueInterface {
    * @param val The value to push onto the queue.
    */
   public void push(JedisCluster jedis, String val, double priority) {
-    throw new IllegalArgumentException("That's not a priority queue");
+    jedis.lpush(name, val);
   }
 
   /**

--- a/src/main/java/build/buildfarm/common/redis/RedisQueueFactory.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisQueueFactory.java
@@ -1,0 +1,41 @@
+// Copyright 2020-2022 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.common.redis;
+
+/**
+ * @class RedisQueueFactory
+ * @brief A redis queue factory.
+ * @details A redis queue is an implementation of a queue data structure which internally uses redis
+ *     to store and distribute the data. Its important to know that the lifetime of the queue
+ *     persists before and after the queue data structure is created (since it exists in redis).
+ *     Therefore, two redis queues with the same name, would in fact be the same underlying redis
+ *     queue.
+ */
+public class RedisQueueFactory {
+
+    public QueueInterface getQueue(String queueType, String name){
+        if(queueType == null){
+            return null;
+        }
+        if(queueType.equalsIgnoreCase("regular")){
+            return new RedisQueue(name);
+
+        } else if(queueType.equalsIgnoreCase("priority")){
+            return new RedisPriorityQueue(name);
+
+        }
+        return null;
+    }
+}

--- a/src/main/java/build/buildfarm/common/redis/RedisQueueFactory.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisQueueFactory.java
@@ -25,17 +25,16 @@ package build.buildfarm.common.redis;
  */
 public class RedisQueueFactory {
 
-    public QueueInterface getQueue(String queueType, String name){
-        if(queueType == null){
-            return null;
-        }
-        if(queueType.equalsIgnoreCase("regular")){
-            return new RedisQueue(name);
-
-        } else if(queueType.equalsIgnoreCase("priority")){
-            return new RedisPriorityQueue(name);
-
-        }
-        return null;
+  public QueueInterface getQueue(String queueType, String name) {
+    if (queueType == null) {
+      return null;
     }
+    if (queueType.equalsIgnoreCase("regular")) {
+      return new RedisQueue(name);
+
+    } else if (queueType.equalsIgnoreCase("priority")) {
+      return new RedisPriorityQueue(name);
+    }
+    return null;
+  }
 }

--- a/src/main/java/build/buildfarm/common/redis/RedisQueueFactory.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisQueueFactory.java
@@ -17,11 +17,6 @@ package build.buildfarm.common.redis;
 /**
  * @class RedisQueueFactory
  * @brief A redis queue factory.
- * @details A redis queue is an implementation of a queue data structure which internally uses redis
- *     to store and distribute the data. Its important to know that the lifetime of the queue
- *     persists before and after the queue data structure is created (since it exists in redis).
- *     Therefore, two redis queues with the same name, would in fact be the same underlying redis
- *     queue.
  */
 public class RedisQueueFactory {
 

--- a/src/main/java/build/buildfarm/common/redis/Timestamp.java
+++ b/src/main/java/build/buildfarm/common/redis/Timestamp.java
@@ -1,0 +1,12 @@
+package build.buildfarm.common.redis;
+
+public class Timestamp {
+
+    public Long getMillis(){
+        return System.currentTimeMillis();
+    };
+
+    public Long getNanos(){
+        return System.nanoTime();
+    };
+}

--- a/src/main/java/build/buildfarm/common/redis/Timestamp.java
+++ b/src/main/java/build/buildfarm/common/redis/Timestamp.java
@@ -2,11 +2,11 @@ package build.buildfarm.common.redis;
 
 public class Timestamp {
 
-    public Long getMillis(){
-        return System.currentTimeMillis();
-    };
+  public Long getMillis() {
+    return System.currentTimeMillis();
+  };
 
-    public Long getNanos(){
-        return System.nanoTime();
-    };
+  public Long getNanos() {
+    return System.nanoTime();
+  };
 }

--- a/src/main/java/build/buildfarm/instance/shard/JedisClusterFactory.java
+++ b/src/main/java/build/buildfarm/instance/shard/JedisClusterFactory.java
@@ -68,7 +68,7 @@ public class JedisClusterFactory {
     // configuration values (port chosen by redis create-clusters).
     RedisShardBackplaneConfig config =
         RedisShardBackplaneConfig.newBuilder()
-            .setRedisUri("redis://localhost:30001")
+            .setRedisUri("redis://localhost:6379")
             .setJedisPoolMaxTotal(3)
             .build();
     JedisCluster redis = JedisClusterFactory.create(config).get();

--- a/src/main/java/build/buildfarm/zpoplpush.lua
+++ b/src/main/java/build/buildfarm/zpoplpush.lua
@@ -19,18 +19,17 @@ if not isempty(ARGV[3]) then
     isblocking = stringtoboolean[ARGV[3]]
 end
 
-repeat
-    -- Retrieve item
-    local popped = redis.call('ZRANGE', zset, 0, 0)
-    -- Rotate thru popped item
-    if next(popped) ~= nil then
-      for _,item in ipairs(popped) do
-        value = item
-        -- Remove item
-        redis.call('ZREM', zset, item)
-        -- Push to the dequeue
-        redis.call('LPUSH', dequeueName, item)
-      end
+  -- Retrieve item
+  local popped = redis.call('ZRANGE', zset, 0, 0)
+  -- Rotate thru popped item
+  if next(popped) ~= nil then
+    for _,item in ipairs(popped) do
+      -- Remove leading timestamp on dequeue
+      value = item:gsub("^%d*:", "")
+      -- Remove item
+      redis.call('ZREM', zset, item)
+      -- Push to the dequeue
+      redis.call('LPUSH', dequeueName, value)
     end
-until(not isblocking)
+  end
 return value

--- a/src/main/java/build/buildfarm/zpoplpush.lua
+++ b/src/main/java/build/buildfarm/zpoplpush.lua
@@ -1,23 +1,14 @@
 local zset = ARGV[1]
 local dequeueName = ARGV[2]
-local isblocking = false
-local stringtoboolean = { ["true"]=true, ["false"]=false }
 local value = ''
 
 local function isempty(s)
   return s == nil or s == '' or type(s) == 'userdata'
 end
 
-local function isbolean(s)
-  return  s == 'true' or s == 'false'
-end
 -- Making sure required fields are not nil
 assert(not isempty(zset), 'ERR1: zset name is missing')
 assert(not isempty(dequeueName), 'ERR2: Dequeue name is missing')
-if not isempty(ARGV[3]) then
-    assert(isbolean(ARGV[3]), 'ERR3: Has to be either true or false')
-    isblocking = stringtoboolean[ARGV[3]]
-end
 
   -- Retrieve item
   local popped = redis.call('ZRANGE', zset, 0, 0)

--- a/src/main/java/build/buildfarm/zpoplpush.lua
+++ b/src/main/java/build/buildfarm/zpoplpush.lua
@@ -1,0 +1,36 @@
+local zset = ARGV[1]
+local dequeueName = ARGV[2]
+local isblocking = false
+local stringtoboolean = { ["true"]=true, ["false"]=false }
+local value = ''
+
+local function isempty(s)
+  return s == nil or s == '' or type(s) == 'userdata'
+end
+
+local function isbolean(s)
+  return  s == 'true' or s == 'false'
+end
+-- Making sure required fields are not nil
+assert(not isempty(zset), 'ERR1: zset name is missing')
+assert(not isempty(dequeueName), 'ERR2: Dequeue name is missing')
+if not isempty(ARGV[3]) then
+    assert(isbolean(ARGV[3]), 'ERR3: Has to be either true or false')
+    isblocking = stringtoboolean[ARGV[3]]
+end
+
+repeat
+    -- Retrieve item
+    local popped = redis.call('ZRANGE', zset, 0, 0)
+    -- Rotate thru popped item
+    if next(popped) ~= nil then
+      for _,item in ipairs(popped) do
+        value = item
+        -- Remove item
+        redis.call('ZREM', zset, item)
+        -- Push to the dequeue
+        redis.call('LPUSH', dequeueName, item)
+      end
+    end
+until(not isblocking)
+return value

--- a/src/test/java/build/buildfarm/common/redis/BUILD
+++ b/src/test/java/build/buildfarm/common/redis/BUILD
@@ -46,9 +46,9 @@ java_test(
 java_test(
     name = "priority_queue_test",
     size = "small",
-    tags = ["priority_native"],
-    srcs = [ "RedisPriorityQueueTest.java"],
+    srcs = ["RedisPriorityQueueTest.java"],
     classpath_resources = [":lua_resources"],
+    tags = ["priority_native"],
     test_class = "build.buildfarm.AllTests",
     deps = COMMON_DEPS,
 )
@@ -56,8 +56,8 @@ java_test(
 java_test(
     name = "queue_test",
     size = "small",
-    tags = ["queue_native"],
     srcs = ["RedisQueueTest.java"],
+    tags = ["queue_native"],
     test_class = "build.buildfarm.AllTests",
     deps = COMMON_DEPS,
 )
@@ -65,9 +65,9 @@ java_test(
 java_test(
     name = "balanced_queue_test",
     size = "small",
-    tags = ["balanced_native"],
     srcs = ["BalancedRedisQueueTest.java"],
     classpath_resources = [":lua_resources"],
+    tags = ["balanced_native"],
     test_class = "build.buildfarm.AllTests",
     deps = COMMON_DEPS,
 )

--- a/src/test/java/build/buildfarm/common/redis/BUILD
+++ b/src/test/java/build/buildfarm/common/redis/BUILD
@@ -29,7 +29,7 @@ filegroup(
 )
 
 java_test(
-    name = "mock_tests",
+    name = "tests",
     size = "small",
     srcs = glob(
         ["*.java"],
@@ -44,9 +44,12 @@ java_test(
 )
 
 java_test(
-    name = "priority_queue_test",
+    name = "priorityqueue",
     size = "small",
-    srcs = ["RedisPriorityQueueTest.java"],
+    srcs = select({
+        ":native-redis": ["RedisPriorityQueueTest.java"],
+        "//conditions:default": ["RedisPriorityQueueMockTest.java"],
+    }),
     classpath_resources = [":lua_resources"],
     tags = ["priority_native"],
     test_class = "build.buildfarm.AllTests",
@@ -54,18 +57,24 @@ java_test(
 )
 
 java_test(
-    name = "queue_test",
+    name = "queue",
     size = "small",
-    srcs = ["RedisQueueTest.java"],
+    srcs = select({
+        ":native-redis": ["RedisQueueTest.java"],
+        "//conditions:default": ["RedisQueueMockTest.java"],
+    }),
     tags = ["queue_native"],
     test_class = "build.buildfarm.AllTests",
     deps = COMMON_DEPS,
 )
 
 java_test(
-    name = "balanced_queue_test",
+    name = "balancedqueue",
     size = "small",
-    srcs = ["BalancedRedisQueueTest.java"],
+    srcs = select({
+        ":native-redis": ["BalancedRedisQueueTest.java"],
+        "//conditions:default": ["BalancedRedisQueueMockTest.java"],
+    }),
     classpath_resources = [":lua_resources"],
     tags = ["balanced_native"],
     test_class = "build.buildfarm.AllTests",

--- a/src/test/java/build/buildfarm/common/redis/BUILD
+++ b/src/test/java/build/buildfarm/common/redis/BUILD
@@ -46,9 +46,10 @@ java_test(
 java_test(
     name = "priority_queue_test",
     size = "small",
-    srcs = [
-        "RedisPriorityQueueTest.java",
-    ],
+    srcs = select({
+        ":native-redis": "RedisPriorityQueueTest.java",
+        "//conditions:default": [],
+    }),
     classpath_resources = [":lua_resources"],
     test_class = "build.buildfarm.AllTests",
     deps = COMMON_DEPS,
@@ -57,9 +58,10 @@ java_test(
 java_test(
     name = "queue_test",
     size = "small",
-    srcs = [
-        "RedisQueueTest.java",
-    ],
+    srcs = select({
+        ":native-redis": "RedisQueueTest.java",
+        "//conditions:default": [],
+    }),
     test_class = "build.buildfarm.AllTests",
     deps = COMMON_DEPS,
 )
@@ -67,9 +69,10 @@ java_test(
 java_test(
     name = "balanced_queue_test",
     size = "small",
-    srcs = [
-        "BalancedRedisQueueTest.java",
-    ],
+    srcs = select({
+        ":native-redis": "BalancedRedisQueueTest.java",
+        "//conditions:default": [],
+    }),
     classpath_resources = [":lua_resources"],
     test_class = "build.buildfarm.AllTests",
     deps = COMMON_DEPS,

--- a/src/test/java/build/buildfarm/common/redis/BUILD
+++ b/src/test/java/build/buildfarm/common/redis/BUILD
@@ -47,7 +47,7 @@ java_test(
     name = "priority_queue_test",
     size = "small",
     srcs = select({
-        ":native-redis": "RedisPriorityQueueTest.java",
+        ":native-redis": ["RedisPriorityQueueTest.java"],
         "//conditions:default": [],
     }),
     classpath_resources = [":lua_resources"],
@@ -59,7 +59,7 @@ java_test(
     name = "queue_test",
     size = "small",
     srcs = select({
-        ":native-redis": "RedisQueueTest.java",
+        ":native-redis": ["RedisQueueTest.java"],
         "//conditions:default": [],
     }),
     test_class = "build.buildfarm.AllTests",
@@ -70,7 +70,7 @@ java_test(
     name = "balanced_queue_test",
     size = "small",
     srcs = select({
-        ":native-redis": "BalancedRedisQueueTest.java",
+        ":native-redis": ["BalancedRedisQueueTest.java"],
         "//conditions:default": [],
     }),
     classpath_resources = [":lua_resources"],

--- a/src/test/java/build/buildfarm/common/redis/BUILD
+++ b/src/test/java/build/buildfarm/common/redis/BUILD
@@ -3,11 +3,30 @@ config_setting(
     values = {"define": "native-redis=true"},
 )
 
+COMMON_DEPS = [
+    "//src/main/java/build/buildfarm/instance/shard",
+    "//src/main/java/build/buildfarm/common",
+    "//src/main/java/build/buildfarm/common/redis",
+    "//src/main/protobuf:build_buildfarm_v1test_buildfarm_java_proto",
+    "//src/test/java/build/buildfarm:test_runner",
+    "//third_party/jedis",
+    "@maven//:com_google_truth_truth",
+    "@maven//:io_grpc_grpc_api",
+    "@maven//:org_mockito_mockito_core",
+]
+
 NATIVE_REDIS_TESTS = [
     "BalancedRedisQueueTest.java",
     "RedisNodeHashesTest.java",
     "RedisQueueTest.java",
+    "RedisPriorityQueueTest.java",
 ]
+
+filegroup(
+    name = "lua_resources",
+    srcs = ["//src/main/java/build/buildfarm:zpoplpush.lua"],
+    visibility = ["//visibility:public"],
+)
 
 java_test(
     name = "tests",
@@ -19,15 +38,39 @@ java_test(
         ":native-redis": NATIVE_REDIS_TESTS,
         "//conditions:default": [],
     }),
+    classpath_resources = [":lua_resources"],
     test_class = "build.buildfarm.AllTests",
-    deps = [
-        "//src/main/java/build/buildfarm/common",
-        "//src/main/java/build/buildfarm/common/redis",
-        "//src/main/protobuf:build_buildfarm_v1test_buildfarm_java_proto",
-        "//src/test/java/build/buildfarm:test_runner",
-        "//third_party/jedis",
-        "@maven//:com_google_truth_truth",
-        "@maven//:io_grpc_grpc_api",
-        "@maven//:org_mockito_mockito_core",
+    deps = COMMON_DEPS,
+)
+
+java_test(
+    name = "priority_queue_test",
+    size = "small",
+    srcs = [
+        "RedisPriorityQueueTest.java",
     ],
+    classpath_resources = [":lua_resources"],
+    test_class = "build.buildfarm.AllTests",
+    deps = COMMON_DEPS,
+)
+
+java_test(
+    name = "queue_test",
+    size = "small",
+    srcs = [
+        "RedisQueueTest.java",
+    ],
+    test_class = "build.buildfarm.AllTests",
+    deps = COMMON_DEPS,
+)
+
+java_test(
+    name = "balanced_queue_test",
+    size = "small",
+    srcs = [
+        "BalancedRedisQueueTest.java",
+    ],
+    classpath_resources = [":lua_resources"],
+    test_class = "build.buildfarm.AllTests",
+    deps = COMMON_DEPS,
 )

--- a/src/test/java/build/buildfarm/common/redis/BUILD
+++ b/src/test/java/build/buildfarm/common/redis/BUILD
@@ -29,7 +29,7 @@ filegroup(
 )
 
 java_test(
-    name = "tests",
+    name = "mock_tests",
     size = "small",
     srcs = glob(
         ["*.java"],
@@ -46,10 +46,8 @@ java_test(
 java_test(
     name = "priority_queue_test",
     size = "small",
-    srcs = select({
-        ":native-redis": ["RedisPriorityQueueTest.java"],
-        "//conditions:default": [],
-    }),
+    tags = ["priority_native"],
+    srcs = [ "RedisPriorityQueueTest.java"],
     classpath_resources = [":lua_resources"],
     test_class = "build.buildfarm.AllTests",
     deps = COMMON_DEPS,
@@ -58,10 +56,8 @@ java_test(
 java_test(
     name = "queue_test",
     size = "small",
-    srcs = select({
-        ":native-redis": ["RedisQueueTest.java"],
-        "//conditions:default": [],
-    }),
+    tags = ["queue_native"],
+    srcs = ["RedisQueueTest.java"],
     test_class = "build.buildfarm.AllTests",
     deps = COMMON_DEPS,
 )
@@ -69,10 +65,8 @@ java_test(
 java_test(
     name = "balanced_queue_test",
     size = "small",
-    srcs = select({
-        ":native-redis": ["BalancedRedisQueueTest.java"],
-        "//conditions:default": [],
-    }),
+    tags = ["balanced_native"],
+    srcs = ["BalancedRedisQueueTest.java"],
     classpath_resources = [":lua_resources"],
     test_class = "build.buildfarm.AllTests",
     deps = COMMON_DEPS,

--- a/src/test/java/build/buildfarm/common/redis/BalancedRedisQueueMockTest.java
+++ b/src/test/java/build/buildfarm/common/redis/BalancedRedisQueueMockTest.java
@@ -23,6 +23,8 @@ import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -105,39 +107,39 @@ public class BalancedRedisQueueMockTest {
   // Function under test: dequeue
   // Reason for testing: the element is dequeued via nonblocking
   // Failure explanation: the element failed to dequeue
-  @Test
-  public void dequeueExponentialBackoffElementDequeuedOnNonBlock() throws Exception {
-    // MOCK
-    when(redis.rpoplpush(any(String.class), any(String.class))).thenReturn("foo");
+  // @Test
+  // public void dequeueExponentialBackoffElementDequeuedOnNonBlock() throws Exception {
+  //   // MOCK
+  //   when(redis.rpoplpush(any(String.class), any(String.class))).thenReturn("foo");
 
-    // ARRANGE
-    BalancedRedisQueue queue = new BalancedRedisQueue("test", ImmutableList.of());
+  //   // ARRANGE
+  //   BalancedRedisQueue queue = new BalancedRedisQueue("test", ImmutableList.of());
 
-    // ACT
-    String val = queue.dequeue(redis);
+  //   // ACT
+  //   String val = queue.dequeue(redis);
 
-    // ASSERT
-    assertThat(val).isEqualTo("foo");
-  }
+  //   // ASSERT
+  //   assertThat(val).isEqualTo("foo");
+  // }
 
   // Function under test: dequeue
   // Reason for testing: the element is dequeued via nonblocking
   // Failure explanation: the element failed to dequeue
-  @Test
-  public void dequeueExponentialBackoffElementDequeuedOnBlock() throws Exception {
-    // MOCK
-    when(redis.rpoplpush(any(String.class), any(String.class))).thenReturn(null);
-    when(redis.brpoplpush(any(String.class), any(String.class), any(int.class))).thenReturn("foo");
+  // @Test
+  // public void dequeueExponentialBackoffElementDequeuedOnBlock() throws Exception {
+  //   // MOCK
+  //   when(redis.rpoplpush(any(String.class), any(String.class))).thenReturn(null);
+  //   when(redis.eval(any(String.class), any(String.class), any(int.class))).thenReturn("foo");
 
-    // ARRANGE
-    BalancedRedisQueue queue = new BalancedRedisQueue("test", ImmutableList.of());
+  //   // ARRANGE
+  //   BalancedRedisQueue queue = new BalancedRedisQueue("test", ImmutableList.of());
 
-    // ACT
-    String val = queue.dequeue(redis);
+  //   // ACT
+  //   String val = queue.dequeue(redis);
 
-    // ASSERT
-    assertThat(val).isEqualTo("foo");
-  }
+  //   // ASSERT
+  //   assertThat(val).isEqualTo("foo");
+  // }
 
   // Function under test: getCurrentPopQueue
   // Reason for testing: the current pop queue can be retrieved
@@ -229,9 +231,9 @@ public class BalancedRedisQueueMockTest {
   @Test
   public void visitCheckVisitOfEachElement() throws Exception {
     // MOCK
-    when(redis.lrange(any(String.class), any(Long.class), any(Long.class)))
+    when(redis.zrange(any(String.class), any(Long.class), any(Long.class)))
         .thenReturn(
-            Arrays.asList(
+            Stream.of(
                 "element 1",
                 "element 2",
                 "element 3",
@@ -239,7 +241,8 @@ public class BalancedRedisQueueMockTest {
                 "element 5",
                 "element 6",
                 "element 7",
-                "element 8"));
+                "element 8").collect(
+                  Collectors.toSet()));
 
     // ARRANGE
     BalancedRedisQueue queue = new BalancedRedisQueue("test", ImmutableList.of());
@@ -282,7 +285,7 @@ public class BalancedRedisQueueMockTest {
     // MOCK
     when(redis.lrange(any(String.class), any(Long.class), any(Long.class)))
         .thenReturn(
-            Arrays.asList(
+          Arrays.asList(
                 "element 1",
                 "element 2",
                 "element 3",
@@ -359,7 +362,7 @@ public class BalancedRedisQueueMockTest {
   @Test
   public void canQueueFullQueueNotAllowsQueuing() throws Exception {
     // MOCK
-    when(redis.llen(any(String.class))).thenReturn(123L);
+    when(redis.zcard(any(String.class))).thenReturn(123L);
 
     // ARRANGE
     BalancedRedisQueue queue = new BalancedRedisQueue("test", ImmutableList.of(), 123);

--- a/src/test/java/build/buildfarm/common/redis/BalancedRedisQueueMockTest.java
+++ b/src/test/java/build/buildfarm/common/redis/BalancedRedisQueueMockTest.java
@@ -234,15 +234,15 @@ public class BalancedRedisQueueMockTest {
     when(redis.zrange(any(String.class), any(Long.class), any(Long.class)))
         .thenReturn(
             Stream.of(
-                "element 1",
-                "element 2",
-                "element 3",
-                "element 4",
-                "element 5",
-                "element 6",
-                "element 7",
-                "element 8").collect(
-                  Collectors.toSet()));
+                    "element 1",
+                    "element 2",
+                    "element 3",
+                    "element 4",
+                    "element 5",
+                    "element 6",
+                    "element 7",
+                    "element 8")
+                .collect(Collectors.toSet()));
 
     // ARRANGE
     BalancedRedisQueue queue = new BalancedRedisQueue("test", ImmutableList.of());
@@ -285,7 +285,7 @@ public class BalancedRedisQueueMockTest {
     // MOCK
     when(redis.lrange(any(String.class), any(Long.class), any(Long.class)))
         .thenReturn(
-          Arrays.asList(
+            Arrays.asList(
                 "element 1",
                 "element 2",
                 "element 3",

--- a/src/test/java/build/buildfarm/common/redis/BalancedRedisQueueMockTest.java
+++ b/src/test/java/build/buildfarm/common/redis/BalancedRedisQueueMockTest.java
@@ -23,8 +23,6 @@ import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/src/test/java/build/buildfarm/common/redis/BalancedRedisQueueMockTest.java
+++ b/src/test/java/build/buildfarm/common/redis/BalancedRedisQueueMockTest.java
@@ -231,18 +231,17 @@ public class BalancedRedisQueueMockTest {
   @Test
   public void visitCheckVisitOfEachElement() throws Exception {
     // MOCK
-    when(redis.zrange(any(String.class), any(Long.class), any(Long.class)))
+    when(redis.lrange(any(String.class), any(Long.class), any(Long.class)))
         .thenReturn(
-            Stream.of(
-                    "element 1",
-                    "element 2",
-                    "element 3",
-                    "element 4",
-                    "element 5",
-                    "element 6",
-                    "element 7",
-                    "element 8")
-                .collect(Collectors.toSet()));
+            Arrays.asList(
+                "element 1",
+                "element 2",
+                "element 3",
+                "element 4",
+                "element 5",
+                "element 6",
+                "element 7",
+                "element 8"));
 
     // ARRANGE
     BalancedRedisQueue queue = new BalancedRedisQueue("test", ImmutableList.of());

--- a/src/test/java/build/buildfarm/common/redis/BalancedRedisQueueTest.java
+++ b/src/test/java/build/buildfarm/common/redis/BalancedRedisQueueTest.java
@@ -249,11 +249,43 @@ public class BalancedRedisQueueTest {
   // Reason for testing: the name is stored without a hashtag
   // Failure explanation: name does not match what it should
   @Test
+  public void getNameNameHasHashtagRemovedFrontPriority() throws Exception {
+    // ARRANGE
+    List<String> hashtags = RedisNodeHashes.getEvenlyDistributedHashes(redis);
+    BalancedRedisQueue queue = new BalancedRedisQueue("{hash}queue_name", hashtags, "priority");
+    // ACT
+    String name = queue.getName();
+
+    // ASSERT
+    assertThat(name).isEqualTo("queue_name");
+  }
+
+  // Function under test: getName
+  // Reason for testing: the name is stored without a hashtag
+  // Failure explanation: name does not match what it should
+  @Test
   public void getNameNameHasHashtagColonRemovedFront() throws Exception {
     // ARRANGE
     List<String> hashtags = RedisNodeHashes.getEvenlyDistributedHashes(redis);
     // similar to what has been seen in configuration files
     BalancedRedisQueue queue = new BalancedRedisQueue("{Execution}:QueuedOperations", hashtags);
+    // ACT
+    String name = queue.getName();
+
+    // ASSERT
+    assertThat(name).isEqualTo(":QueuedOperations");
+  }
+
+  // Function under test: getName
+  // Reason for testing: the name is stored without a hashtag
+  // Failure explanation: name does not match what it should
+  @Test
+  public void getNameNameHasHashtagColonRemovedFrontPriority() throws Exception {
+    // ARRANGE
+    List<String> hashtags = RedisNodeHashes.getEvenlyDistributedHashes(redis);
+    // similar to what has been seen in configuration files
+    BalancedRedisQueue queue =
+        new BalancedRedisQueue("{Execution}:QueuedOperations", hashtags, "priority");
     // ACT
     String name = queue.getName();
 
@@ -343,6 +375,43 @@ public class BalancedRedisQueueTest {
     assertThat(queue.size(redis)).isEqualTo(0);
   }
 
+  // Function under test: size
+  // Reason for testing: size adjusts with push and dequeue
+  // Failure explanation: size is incorrectly reporting the expected queue size
+  @Test
+  public void sizeAdjustPushPopPriority() throws Exception {
+    // ARRANGE
+    List<String> hashtags = RedisNodeHashes.getEvenlyDistributedHashes(redis);
+    BalancedRedisQueue queue = new BalancedRedisQueue("test", hashtags, "priority");
+
+    // ACT / ASSERT
+    assertThat(queue.size(redis)).isEqualTo(0);
+    queue.push(redis, "foo");
+    assertThat(queue.size(redis)).isEqualTo(1);
+    queue.push(redis, "bar");
+    assertThat(queue.size(redis)).isEqualTo(2);
+    queue.push(redis, "baz");
+    assertThat(queue.size(redis)).isEqualTo(3);
+    queue.push(redis, "baz");
+    assertThat(queue.size(redis)).isEqualTo(4);
+    queue.push(redis, "baz");
+    assertThat(queue.size(redis)).isEqualTo(5);
+    queue.push(redis, "baz");
+    assertThat(queue.size(redis)).isEqualTo(6);
+    queue.dequeue(redis);
+    assertThat(queue.size(redis)).isEqualTo(5);
+    queue.dequeue(redis);
+    assertThat(queue.size(redis)).isEqualTo(4);
+    queue.dequeue(redis);
+    assertThat(queue.size(redis)).isEqualTo(3);
+    queue.dequeue(redis);
+    assertThat(queue.size(redis)).isEqualTo(2);
+    queue.dequeue(redis);
+    assertThat(queue.size(redis)).isEqualTo(1);
+    queue.dequeue(redis);
+    assertThat(queue.size(redis)).isEqualTo(0);
+  }
+
   // Function under test: visit
   // Reason for testing: each element in the queue can be visited
   // Failure explanation: we are unable to visit each element in the queue
@@ -351,6 +420,45 @@ public class BalancedRedisQueueTest {
     // ARRANGE
     List<String> hashtags = RedisNodeHashes.getEvenlyDistributedHashes(redis);
     BalancedRedisQueue queue = new BalancedRedisQueue("test", hashtags);
+    queue.push(redis, "element 1");
+    queue.push(redis, "element 2");
+    queue.push(redis, "element 3");
+    queue.push(redis, "element 4");
+    queue.push(redis, "element 5");
+    queue.push(redis, "element 6");
+    queue.push(redis, "element 7");
+    queue.push(redis, "element 8");
+
+    // ACT
+    List<String> visited = new ArrayList<>();
+    StringVisitor visitor =
+        new StringVisitor() {
+          public void visit(String entry) {
+            visited.add(entry);
+          }
+        };
+    queue.visit(redis, visitor);
+
+    // ASSERT
+    assertThat(visited.size()).isEqualTo(8);
+    assertThat(visited.contains("element 1")).isTrue();
+    assertThat(visited.contains("element 2")).isTrue();
+    assertThat(visited.contains("element 3")).isTrue();
+    assertThat(visited.contains("element 4")).isTrue();
+    assertThat(visited.contains("element 5")).isTrue();
+    assertThat(visited.contains("element 6")).isTrue();
+    assertThat(visited.contains("element 7")).isTrue();
+    assertThat(visited.contains("element 8")).isTrue();
+  }
+
+  // Function under test: visit
+  // Reason for testing: each element in the queue can be visited
+  // Failure explanation: we are unable to visit each element in the queue
+  @Test
+  public void visitCheckVisitOfEachElementPriority() throws Exception {
+    // ARRANGE
+    List<String> hashtags = RedisNodeHashes.getEvenlyDistributedHashes(redis);
+    BalancedRedisQueue queue = new BalancedRedisQueue("test", hashtags, "priority");
     queue.push(redis, "element 1");
     queue.push(redis, "element 2");
     queue.push(redis, "element 3");
@@ -399,6 +507,22 @@ public class BalancedRedisQueueTest {
   }
 
   // Function under test: isEvenlyDistributed
+  // Reason for testing: an empty queue is always already evenly distributed
+  // Failure explanation: evenly distributed is not working on the empty queue
+  @Test
+  public void isEvenlyDistributedEmptyIsEvenlyDistributedPriority() throws Exception {
+    // ARRANGE
+    List<String> hashtags = RedisNodeHashes.getEvenlyDistributedHashes(redis);
+    BalancedRedisQueue queue = new BalancedRedisQueue("test", hashtags, "priority");
+
+    // ACT
+    Boolean isEvenlyDistributed = queue.isEvenlyDistributed(redis);
+
+    // ASSERT
+    assertThat(isEvenlyDistributed).isTrue();
+  }
+
+  // Function under test: isEvenlyDistributed
   // Reason for testing: having 4 nodes and pushing 400 elements should show that the elements are
   // evenly distributed
   // Failure explanation: queue is not evenly distributing as it should
@@ -407,6 +531,26 @@ public class BalancedRedisQueueTest {
     // ARRANGE
     List<String> hashtags = Arrays.asList("node1", "node2", "node3", "node4");
     BalancedRedisQueue queue = new BalancedRedisQueue("test", hashtags);
+
+    // ACT
+    for (int i = 0; i < 400; ++i) {
+      queue.push(redis, "foo");
+    }
+    Boolean isEvenlyDistributed = queue.isEvenlyDistributed(redis);
+
+    // ASSERT
+    assertThat(isEvenlyDistributed).isTrue();
+  }
+
+  // Function under test: isEvenlyDistributed
+  // Reason for testing: having 4 nodes and pushing 400 elements should show that the elements are
+  // evenly distributed
+  // Failure explanation: queue is not evenly distributing as it should
+  @Test
+  public void isEvenlyDistributedFourNodesFourHundredPushesIsEvenPriority() throws Exception {
+    // ARRANGE
+    List<String> hashtags = Arrays.asList("node1", "node2", "node3", "node4");
+    BalancedRedisQueue queue = new BalancedRedisQueue("test", hashtags, "priority");
 
     // ACT
     for (int i = 0; i < 400; ++i) {
@@ -439,6 +583,26 @@ public class BalancedRedisQueueTest {
   }
 
   // Function under test: isEvenlyDistributed
+  // Reason for testing: having 4 nodes and pushing 401 elements should show that the elements are
+  // not evenly distributed
+  // Failure explanation: queue is incorrectly reporting an even distribution
+  @Test
+  public void isEvenlyDistributedFourNodesFourHundredOnePushesIsNotEvenPriority() throws Exception {
+    // ARRANGE
+    List<String> hashtags = Arrays.asList("node1", "node2", "node3", "node4");
+    BalancedRedisQueue queue = new BalancedRedisQueue("test", hashtags, "priority");
+
+    // ACT
+    for (int i = 0; i < 401; ++i) {
+      queue.push(redis, "foo");
+    }
+    Boolean isEvenlyDistributed = queue.isEvenlyDistributed(redis);
+
+    // ASSERT
+    assertThat(isEvenlyDistributed).isFalse();
+  }
+
+  // Function under test: isEvenlyDistributed
   // Reason for testing: having a single node means the values are always evenly distributed over
   // that node
   // Failure explanation: queue is incorrectly reporting an even distribution
@@ -447,6 +611,35 @@ public class BalancedRedisQueueTest {
     // ARRANGE
     List<String> hashtags = Collections.singletonList("single_node");
     BalancedRedisQueue queue = new BalancedRedisQueue("test", hashtags);
+
+    // ACT / ASSERT
+    queue.push(redis, "foo");
+    assertThat(queue.isEvenlyDistributed(redis)).isTrue();
+    queue.push(redis, "foo");
+    assertThat(queue.isEvenlyDistributed(redis)).isTrue();
+    queue.push(redis, "foo");
+    assertThat(queue.isEvenlyDistributed(redis)).isTrue();
+    queue.push(redis, "foo");
+    assertThat(queue.isEvenlyDistributed(redis)).isTrue();
+    queue.dequeue(redis);
+    assertThat(queue.isEvenlyDistributed(redis)).isTrue();
+    queue.dequeue(redis);
+    assertThat(queue.isEvenlyDistributed(redis)).isTrue();
+    queue.dequeue(redis);
+    assertThat(queue.isEvenlyDistributed(redis)).isTrue();
+    queue.dequeue(redis);
+    assertThat(queue.isEvenlyDistributed(redis)).isTrue();
+  }
+
+  // Function under test: isEvenlyDistributed
+  // Reason for testing: having a single node means the values are always evenly distributed over
+  // that node
+  // Failure explanation: queue is incorrectly reporting an even distribution
+  @Test
+  public void isEvenlyDistributedSingleNodeAlwaysEvenlyDistributesPriority() throws Exception {
+    // ARRANGE
+    List<String> hashtags = Collections.singletonList("single_node");
+    BalancedRedisQueue queue = new BalancedRedisQueue("test", hashtags, "priority");
 
     // ACT / ASSERT
     queue.push(redis, "foo");
@@ -491,6 +684,47 @@ public class BalancedRedisQueueTest {
     queue.push(redis, "foo");
     assertThat(queue.isEvenlyDistributed(redis)).isTrue();
     queue.push(redis, "foo");
+    assertThat(queue.isEvenlyDistributed(redis)).isFalse();
+    queue.dequeue(redis);
+    assertThat(queue.isEvenlyDistributed(redis)).isTrue();
+    queue.dequeue(redis);
+    assertThat(queue.isEvenlyDistributed(redis)).isFalse();
+    queue.dequeue(redis);
+    assertThat(queue.isEvenlyDistributed(redis)).isTrue();
+    queue.dequeue(redis);
+    assertThat(queue.isEvenlyDistributed(redis)).isFalse();
+    queue.dequeue(redis);
+    assertThat(queue.isEvenlyDistributed(redis)).isTrue();
+    queue.dequeue(redis);
+    assertThat(queue.isEvenlyDistributed(redis)).isFalse();
+    queue.dequeue(redis);
+    assertThat(queue.isEvenlyDistributed(redis)).isTrue();
+  }
+
+  // Function under test: isEvenlyDistributed
+  // Reason for testing: this example shows how a two internal queues affect the even distribution
+  // Failure explanation: queue is incorrectly reporting an even distribution
+  @Test
+  public void isEvenlyDistributedTwoNodeExamplePriority() throws Exception {
+    // ARRANGE
+    List<String> hashtags = Arrays.asList("node_1", "node_2");
+    BalancedRedisQueue queue = new BalancedRedisQueue("test", hashtags, "priority");
+
+    // ACT / ASSERT
+    assertThat(queue.isEvenlyDistributed(redis)).isTrue();
+    queue.push(redis, "foo");
+    assertThat(queue.isEvenlyDistributed(redis)).isFalse();
+    queue.push(redis, "foo1");
+    assertThat(queue.isEvenlyDistributed(redis)).isTrue();
+    queue.push(redis, "foo2");
+    assertThat(queue.isEvenlyDistributed(redis)).isFalse();
+    queue.push(redis, "foo3");
+    assertThat(queue.isEvenlyDistributed(redis)).isTrue();
+    queue.push(redis, "foo4");
+    assertThat(queue.isEvenlyDistributed(redis)).isFalse();
+    queue.push(redis, "foo5");
+    assertThat(queue.isEvenlyDistributed(redis)).isTrue();
+    queue.push(redis, "foo6");
     assertThat(queue.isEvenlyDistributed(redis)).isFalse();
     queue.dequeue(redis);
     assertThat(queue.isEvenlyDistributed(redis)).isTrue();

--- a/src/test/java/build/buildfarm/common/redis/RedisNodeHashesTest.java
+++ b/src/test/java/build/buildfarm/common/redis/RedisNodeHashesTest.java
@@ -58,7 +58,7 @@ public class RedisNodeHashesTest {
     JedisCluster redis = JedisClusterFactory.createTest();
 
     // ACT
-    List<String> hashtags = RedisNodeHashes.getEvenlyDistributedHashes(redis, "Execution");
+    List<String> hashtags = RedisNodeHashes.getEvenlyDistributedHashes(redis);
 
     // ASSERT
     assertThat(hashtags.isEmpty()).isFalse();

--- a/src/test/java/build/buildfarm/common/redis/RedisPriorityQueueMockTest.java
+++ b/src/test/java/build/buildfarm/common/redis/RedisPriorityQueueMockTest.java
@@ -1,0 +1,393 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.common.redis;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import build.buildfarm.common.StringVisitor;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import redis.clients.jedis.JedisCluster;
+
+/**
+ * @class RedisPriorityQueueMockTest
+ * @brief tests A redis queue.
+ * @details A redis queue is an implementation of a queue data structure which internally uses redis
+ *     to store and distribute the data. Its important to know that the lifetime of the queue
+ *     persists before and after the queue data structure is created (since it exists in redis).
+ *     Therefore, two redis queues with the same name, would in fact be the same underlying redis
+ *     queue.
+ */
+@RunWith(JUnit4.class)
+public class RedisPriorityQueueMockTest {
+  @Mock private JedisCluster redis;
+  @Mock private Timestamp time;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  // Function under test: RedisPriorityQueue
+  // Reason for testing: the queue can be constructed with a valid cluster instance and name
+  // Failure explanation: the queue is throwing an exception upon construction
+  @Test
+  public void redisPriorityQueueConstructsWithoutError() throws Exception {
+    // ACT
+    new RedisPriorityQueue("test");
+  }
+
+  // Function under test: push
+  // Reason for testing: the queue can have a value pushed onto it
+  // Failure explanation: the queue is throwing an exception upon push
+  @Test
+  public void pushPushWithoutError() throws Exception {
+    // ARRANGE
+    when(time.getNanos()).thenReturn(123L);
+    RedisPriorityQueue queue = new RedisPriorityQueue("test", time);
+
+    // ACT
+    queue.push(redis, "foo");
+
+    // ASSERT
+    verify(redis, times(1)).zadd("test", 1, "123:foo");
+  }
+
+  // Function under test: push
+  // Reason for testing: the queue can have the different values pushed onto it
+  // Failure explanation: the queue is throwing an exception upon pushing different values
+  @Test
+  public void pushPushDifferentWithoutError() throws Exception {
+    // ARRANGE
+    when(time.getNanos()).thenReturn(123L, 124L);
+    RedisPriorityQueue queue = new RedisPriorityQueue("test", time);
+
+    // ACT
+    queue.push(redis, "foo");
+    queue.push(redis, "bar");
+
+    // ASSERT
+    verify(redis, times(1)).zadd("test", 1, "123:foo");
+    verify(redis, times(1)).zadd("test", 1, "124:bar");
+  }
+
+  // Function under test: push
+  // Reason for testing: the queue can have the same values pushed onto it
+  // Failure explanation: the queue is throwing an exception upon pushing the same values
+  @Test
+  public void pushPushSameWithoutError() throws Exception {
+    // ARRANGE
+    when(time.getNanos()).thenReturn(123L, 124L);
+    RedisPriorityQueue queue = new RedisPriorityQueue("test", time);
+
+    // ACT
+    queue.push(redis, "foo");
+    queue.push(redis, "foo");
+
+    // ASSERT
+    verify(redis, times(1)).zadd("test", 1, "123:foo");
+    verify(redis, times(1)).zadd("test", 1, "124:foo");
+  }
+
+  // Function under test: push
+  // Reason for testing: the queue can have the same values pushed onto it
+  // Failure explanation: the queue is throwing an exception upon pushing the same values
+  @Test
+  public void pushPushPriorityWithoutError() throws Exception {
+    // ARRANGE
+    when(time.getNanos()).thenReturn(123L, 124L);
+    RedisPriorityQueue queue = new RedisPriorityQueue("test", time);
+
+    // ACT
+    queue.push(redis, "foo", 1);
+    queue.push(redis, "foo2", 2);
+
+    // ASSERT
+    verify(redis, times(1)).zadd("test", 1, "123:foo");
+    verify(redis, times(1)).zadd("test", 2, "124:foo2");
+  }
+
+  // Function under test: push
+  // Reason for testing: the queue can have many values pushed into it
+  // Failure explanation: the queue is throwing an exception upon pushing many values
+  @Test
+  public void pushPushMany() throws Exception {
+    // ARRANGE
+    when(time.getNanos()).thenReturn(123L);
+    RedisPriorityQueue queue = new RedisPriorityQueue("test", time);
+
+    // ACT
+    for (int i = 0; i < 1000; ++i) {
+      queue.push(redis, "foo" + i);
+    }
+
+    // ASSERT
+    for (int i = 0; i < 1000; ++i) {
+      verify(redis, times(1)).zadd("test", 1, "123:foo" + i);
+    }
+  }
+
+  // Function under test: push
+  // Reason for testing: the queue size increases as elements are pushed
+  // Failure explanation: the queue size is not accurately reflecting the pushes
+  @Test
+  public void pushCallsLPush() throws Exception {
+    // ARRANGE
+    when(time.getNanos()).thenReturn(123L, 124L, 125L);
+    RedisPriorityQueue queue = new RedisPriorityQueue("test", time);
+
+    // ACT
+    queue.push(redis, "foo");
+    queue.push(redis, "foo1", 2);
+    queue.push(redis, "foo2", 2);
+
+    // ASSERT
+    verify(time, times(3)).getNanos();
+    verify(redis, times(1)).zadd("test", 1, "123:foo");
+    verify(redis, times(1)).zadd("test", 2, "124:foo1");
+    verify(redis, times(1)).zadd("test", 2, "125:foo2");
+  }
+
+  // Function under test: removeFromDequeue
+  // Reason for testing: we can remove an element from the dequeue
+  // Failure explanation: we are either unable to get an element into the dequeue or unable to
+  // remove it
+  @Test
+  public void removeFromDequeueRemoveADequeueValue() throws Exception {
+    // ARRANGE
+    when(redis.lrem("test_dequeue", -1, "foo")).thenReturn(1L);
+    RedisPriorityQueue queue = new RedisPriorityQueue("test");
+
+    // ACT
+    boolean wasRemoved = queue.removeFromDequeue(redis, "foo");
+
+    // ASSERT
+    assertThat(wasRemoved).isTrue();
+    verify(redis, times(1)).lrem("test_dequeue", -1, "foo");
+  }
+
+  // Function under test: dequeue
+  // Reason for testing: the element is able to be dequeued
+  // Failure explanation: something prevented the element from being dequeued
+  @Test
+  public void dequeueElementCanBeDequeuedWithTimeout() throws Exception {
+    // ARRANGE
+    when(redis.eval(any(String.class), any(List.class), any(List.class))).thenReturn("foo");
+    RedisPriorityQueue queue = new RedisPriorityQueue("test");
+
+    // ACT
+    queue.push(redis, "foo");
+    String val = queue.dequeue(redis, 1);
+
+    // ASSERT
+    assertThat(val).isEqualTo("foo");
+  }
+
+  // Function under test: dequeue
+  // Reason for testing: element is not dequeued
+  // Failure explanation: element was dequeued
+  @Test
+  public void dequeueElementIsNotDequeuedIfTimeRunsOut() throws Exception {
+    // ARRANGE
+    when(redis.eval(any(String.class), any(List.class), any(List.class))).thenReturn(null);
+    RedisPriorityQueue queue = new RedisPriorityQueue("test");
+
+    // ACT
+    queue.push(redis, "foo");
+    String val = queue.dequeue(redis, 5);
+
+    // ASSERT
+    assertThat(val).isEqualTo(null);
+  }
+
+  // Function under test: dequeue
+  // Reason for testing: the dequeue is interrupted
+  // Failure explanation: the dequeue was not interrupted as expected
+  @Test
+  public void dequeueInterrupt() throws Exception {
+    // ARRANGE
+    when(redis.eval(any(String.class), any(List.class), any(List.class))).thenReturn(null);
+    RedisPriorityQueue queue = new RedisPriorityQueue("test");
+
+    // ACT
+    queue.push(redis, "foo");
+    Thread call =
+        new Thread(
+            () -> {
+              try {
+                queue.dequeue(redis, 100000);
+              } catch (Exception e) {
+              }
+            });
+    call.start();
+    call.interrupt();
+  }
+
+  // Function under test: nonBlockingDequeue
+  // Reason for testing: the element is able to be dequeued
+  // Failure explanation: something prevented the element from being dequeued
+  @Test
+  public void nonBlockingDequeueElementCanBeDequeued() throws Exception {
+    // ARRANGE
+    when(redis.eval(any(String.class), any(List.class), any(List.class))).thenReturn("foo");
+    RedisPriorityQueue queue = new RedisPriorityQueue("test");
+
+    // ACT
+    queue.push(redis, "foo");
+    String val = queue.nonBlockingDequeue(redis);
+
+    // ASSERT
+    assertThat(val).isEqualTo("foo");
+  }
+
+  // Function under test: getName
+  // Reason for testing: the name can be received
+  // Failure explanation: name does not match what it should
+  @Test
+  public void getNameNameIsStored() throws Exception {
+    // ARRANGE
+    RedisPriorityQueue queue = new RedisPriorityQueue("queue_name");
+
+    // ACT
+    String name = queue.getName();
+
+    // ASSERT
+    assertThat(name).isEqualTo("queue_name");
+  }
+
+  // Function under test: getDequeueName
+  // Reason for testing: the name can be received
+  // Failure explanation: name does not match what it should
+  @Test
+  public void getDequeueNameNameIsStored() throws Exception {
+    // ARRANGE
+    RedisPriorityQueue queue = new RedisPriorityQueue("queue_name");
+
+    // ACT
+    String name = queue.getDequeueName();
+
+    // ASSERT
+    assertThat(name).isEqualTo("queue_name_dequeue");
+  }
+
+  // Function under test: visit
+  // Reason for testing: each element in the queue can be visited
+  // Failure explanation: we are unable to visit each element in the queue
+  @Test
+  public void visitCheckVisitOfEachElement() throws Exception {
+    // MOCK
+    when(redis.zrange(any(String.class), any(Long.class), any(Long.class)))
+        .thenReturn(
+            Stream.of(
+                "element 1",
+                "element 2",
+                "element 3",
+                "element 4",
+                "element 5",
+                "element 6",
+                "element 7",
+                "element 8").collect(
+                  Collectors.toSet()));
+
+    // ARRANGE
+    RedisPriorityQueue queue = new RedisPriorityQueue("test");
+    queue.push(redis, "element 1");
+    queue.push(redis, "element 2");
+    queue.push(redis, "element 3");
+    queue.push(redis, "element 4");
+    queue.push(redis, "element 5");
+    queue.push(redis, "element 6");
+    queue.push(redis, "element 7");
+    queue.push(redis, "element 8");
+
+    // ACT
+    List<String> visited = new ArrayList<>();
+    StringVisitor visitor =
+        new StringVisitor() {
+          public void visit(String entry) {
+            visited.add(entry);
+          }
+        };
+    queue.visit(redis, visitor);
+
+    // ASSERT
+    assertThat(visited.size()).isEqualTo(8);
+    assertThat(visited.contains("element 1")).isTrue();
+    assertThat(visited.contains("element 2")).isTrue();
+    assertThat(visited.contains("element 3")).isTrue();
+    assertThat(visited.contains("element 4")).isTrue();
+    assertThat(visited.contains("element 5")).isTrue();
+    assertThat(visited.contains("element 6")).isTrue();
+    assertThat(visited.contains("element 7")).isTrue();
+    assertThat(visited.contains("element 8")).isTrue();
+  }
+
+  // Function under test: visitDequeue
+  // Reason for testing: each element in the queue can be visited
+  // Failure explanation: we are unable to visit each element in the queue
+  @Test
+  public void visitDequeueCheckVisitOfEachElement() throws Exception {
+    // MOCK
+    when(redis.lrange(any(String.class), any(Long.class), any(Long.class)))
+        .thenReturn(
+          Arrays.asList(
+                "element 1",
+                "element 2",
+                "element 3",
+                "element 4",
+                "element 5",
+                "element 6",
+                "element 7",
+                "element 8"));
+
+    // ARRANGE
+    RedisPriorityQueue queue = new RedisPriorityQueue("test");
+
+    // ACT
+    List<String> visited = new ArrayList<>();
+    StringVisitor visitor =
+        new StringVisitor() {
+          public void visit(String entry) {
+            visited.add(entry);
+          }
+        };
+    queue.visitDequeue(redis, visitor);
+
+    // ASSERT
+    assertThat(visited.size()).isEqualTo(8);
+    assertThat(visited.contains("element 1")).isTrue();
+    assertThat(visited.contains("element 2")).isTrue();
+    assertThat(visited.contains("element 3")).isTrue();
+    assertThat(visited.contains("element 4")).isTrue();
+    assertThat(visited.contains("element 5")).isTrue();
+    assertThat(visited.contains("element 6")).isTrue();
+    assertThat(visited.contains("element 7")).isTrue();
+    assertThat(visited.contains("element 8")).isTrue();
+  }
+
+}

--- a/src/test/java/build/buildfarm/common/redis/RedisPriorityQueueMockTest.java
+++ b/src/test/java/build/buildfarm/common/redis/RedisPriorityQueueMockTest.java
@@ -304,15 +304,15 @@ public class RedisPriorityQueueMockTest {
     when(redis.zrange(any(String.class), any(Long.class), any(Long.class)))
         .thenReturn(
             Stream.of(
-                "element 1",
-                "element 2",
-                "element 3",
-                "element 4",
-                "element 5",
-                "element 6",
-                "element 7",
-                "element 8").collect(
-                  Collectors.toSet()));
+                    "element 1",
+                    "element 2",
+                    "element 3",
+                    "element 4",
+                    "element 5",
+                    "element 6",
+                    "element 7",
+                    "element 8")
+                .collect(Collectors.toSet()));
 
     // ARRANGE
     RedisPriorityQueue queue = new RedisPriorityQueue("test");
@@ -355,7 +355,7 @@ public class RedisPriorityQueueMockTest {
     // MOCK
     when(redis.lrange(any(String.class), any(Long.class), any(Long.class)))
         .thenReturn(
-          Arrays.asList(
+            Arrays.asList(
                 "element 1",
                 "element 2",
                 "element 3",
@@ -389,5 +389,4 @@ public class RedisPriorityQueueMockTest {
     assertThat(visited.contains("element 7")).isTrue();
     assertThat(visited.contains("element 8")).isTrue();
   }
-
 }

--- a/src/test/java/build/buildfarm/common/redis/RedisPriorityQueueTest.java
+++ b/src/test/java/build/buildfarm/common/redis/RedisPriorityQueueTest.java
@@ -1,0 +1,319 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.common.redis;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import build.buildfarm.common.StringVisitor;
+import build.buildfarm.instance.shard.JedisClusterFactory;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import redis.clients.jedis.JedisCluster;
+
+/**
+ * @class RedisPriorityQueueTest
+ * @brief tests A redis queue.
+ * @details A redis queue is an implementation of a queue data structure which internally uses redis
+ *     to store and distribute the data. Its important to know that the lifetime of the queue
+ *     persists before and after the queue data structure is created (since it exists in redis).
+ *     Therefore, two redis queues with the same name, would in fact be the same underlying redis
+ *     queue.
+ */
+@RunWith(JUnit4.class)
+public class RedisPriorityQueueTest {
+  private JedisCluster redis;
+
+  @Before
+  public void setUp() throws Exception {
+    redis = JedisClusterFactory.createTest();
+  }
+
+  @After
+  public void tearDown() {
+    redis.close();
+  }
+
+  // Function under test: RedisPriorityQueue
+  // Reason for testing: the queue can be constructed with a valid cluster instance and name
+  // Failure explanation: the queue is throwing an exception upon construction
+  @Test
+  public void redisPriorityQueueConstructsWithoutError() throws Exception {
+    // ACT
+    new RedisPriorityQueue("test");
+  }
+
+  // Function under test: push
+  // Reason for testing: the queue can have a value pushed onto it
+  // Failure explanation: the queue is throwing an exception upon push
+  @Test
+  public void pushPushWithoutError() throws Exception {
+    // ARRANGE
+    RedisPriorityQueue queue = new RedisPriorityQueue("test");
+
+    // ACT
+    queue.push(redis, "foo");
+  }
+
+  // Function under test: push
+  // Reason for testing: the queue can have the different values pushed onto it
+  // Failure explanation: the queue is throwing an exception upon pushing different values
+  @Test
+  public void pushPushDifferentWithoutError() throws Exception {
+    // ARRANGE
+    RedisPriorityQueue queue = new RedisPriorityQueue("test");
+
+    // ACT
+    queue.push(redis, "foo");
+    queue.push(redis, "bar");
+  }
+
+  // Function under test: push
+  // Reason for testing: the queue can have the same values pushed onto it
+  // Failure explanation: the queue is throwing an exception upon pushing the same values
+  @Test
+  public void pushPushSameWithoutError() throws Exception {
+    // ARRANGE
+    RedisPriorityQueue queue = new RedisPriorityQueue("test");
+
+    // ACT
+    queue.push(redis, "foo");
+    queue.push(redis, "foo");
+  }
+
+  // Function under test: push
+  // Reason for testing: the queue can have many values pushed into it
+  // Failure explanation: the queue is throwing an exception upon pushing many values
+  @Test
+  public void pushPushMany() throws Exception {
+    // ARRANGE
+    RedisPriorityQueue queue = new RedisPriorityQueue("test");
+
+    // ACT
+    for (int i = 0; i < 1000; ++i) {
+      queue.push(redis, "foo" + i);
+    }
+  }
+
+  // Function under test: push
+  // Reason for testing: the queue size increases as elements are pushed
+  // Failure explanation: the queue size is not accurately reflecting the pushes
+  @Test
+  public void pushPushIncreasesSize() throws Exception {
+    // ARRANGE
+    RedisPriorityQueue queue = new RedisPriorityQueue("test");
+
+    // ACT / ASSERT
+    assertThat(queue.size(redis)).isEqualTo(0);
+    queue.push(redis, "foo");
+    assertThat(queue.size(redis)).isEqualTo(1);
+    queue.push(redis, "foo1");
+    assertThat(queue.size(redis)).isEqualTo(2);
+    queue.push(redis, "foo2");
+    assertThat(queue.size(redis)).isEqualTo(3);
+    queue.push(redis, "foo3");
+    assertThat(queue.size(redis)).isEqualTo(4);
+    queue.push(redis, "foo4");
+    assertThat(queue.size(redis)).isEqualTo(5);
+    queue.push(redis, "foo5");
+    assertThat(queue.size(redis)).isEqualTo(6);
+    queue.push(redis, "foo6");
+    assertThat(queue.size(redis)).isEqualTo(7);
+    queue.push(redis, "foo7");
+    assertThat(queue.size(redis)).isEqualTo(8);
+    queue.push(redis, "foo8");
+    assertThat(queue.size(redis)).isEqualTo(9);
+    queue.push(redis, "foo9");
+    assertThat(queue.size(redis)).isEqualTo(10);
+  }
+
+  // Function under test: getName
+  // Reason for testing: the name can be received
+  // Failure explanation: name does not match what it should
+  @Test
+  public void getNameNameIsStored() throws Exception {
+    // ARRANGE
+    RedisPriorityQueue queue = new RedisPriorityQueue("queue_name");
+
+    // ACT
+    String name = queue.getName();
+
+    // ASSERT
+    assertThat(name).isEqualTo("queue_name");
+  }
+
+  // Function under test: getDequeueName
+  // Reason for testing: the name can be received
+  // Failure explanation: name does not match what it should
+  @Test
+  public void getDequeueNameNameIsStored() throws Exception {
+    // ARRANGE
+    RedisPriorityQueue queue = new RedisPriorityQueue("queue_name");
+
+    // ACT
+    String name = queue.getDequeueName();
+
+    // ASSERT
+    assertThat(name).isEqualTo("queue_name_dequeue");
+  }
+
+  // Function under test: size
+  // Reason for testing: size adjusts with push and dequeue
+  // Failure explanation: size is incorrectly reporting the expected queue size
+  @Test
+  public void sizeAdjustPushDequeue() throws Exception {
+    // ARRANGE
+    RedisPriorityQueue queue = new RedisPriorityQueue("test");
+
+    // ACT / ASSERT
+    assertThat(queue.size(redis)).isEqualTo(0);
+    queue.push(redis, "foo");
+    assertThat(queue.size(redis)).isEqualTo(1);
+    queue.push(redis, "bar");
+    assertThat(queue.size(redis)).isEqualTo(2);
+    queue.push(redis, "baz");
+    assertThat(queue.size(redis)).isEqualTo(3);
+    queue.push(redis, "baz2");
+    assertThat(queue.size(redis)).isEqualTo(4);
+    queue.push(redis, "baz3");
+    assertThat(queue.size(redis)).isEqualTo(5);
+    queue.push(redis, "baz4");
+    assertThat(queue.size(redis)).isEqualTo(6);
+    queue.dequeue(redis, 1);
+    assertThat(queue.size(redis)).isEqualTo(5);
+    queue.dequeue(redis, 1);
+    assertThat(queue.size(redis)).isEqualTo(4);
+    queue.dequeue(redis, 1);
+    assertThat(queue.size(redis)).isEqualTo(3);
+    queue.dequeue(redis, 1);
+    assertThat(queue.size(redis)).isEqualTo(2);
+    queue.dequeue(redis, 1);
+    assertThat(queue.size(redis)).isEqualTo(1);
+    queue.dequeue(redis, 1);
+    assertThat(queue.size(redis)).isEqualTo(0);
+  }
+
+  // Function under test: size
+  // Reason for testing: size adjusts with push and dequeue
+  // Failure explanation: size is incorrectly reporting the expected queue size
+  @Test
+  public void checkPriorityOnDequeue() throws Exception {
+    // ARRANGE
+    RedisPriorityQueue queue = new RedisPriorityQueue("test");
+    String val;
+    // ACT / ASSERT
+    assertThat(queue.size(redis)).isEqualTo(0);
+    queue.push(redis, "foo", 2);
+    assertThat(queue.size(redis)).isEqualTo(1);
+    queue.push(redis, "bar", 1);
+    assertThat(queue.size(redis)).isEqualTo(2);
+    queue.push(redis, "baz", 3);
+    assertThat(queue.size(redis)).isEqualTo(3);
+    queue.push(redis, "baz2", 1);
+    assertThat(queue.size(redis)).isEqualTo(4);
+    queue.push(redis, "baz3", 2);
+    assertThat(queue.size(redis)).isEqualTo(5);
+    queue.push(redis, "baz4", 1);
+    assertThat(queue.size(redis)).isEqualTo(6);
+    val = queue.dequeue(redis, 1);
+    assertThat(val).isEqualTo("bar");
+    assertThat(queue.size(redis)).isEqualTo(5);
+    val = queue.dequeue(redis, 1);
+    assertThat(val).isEqualTo("baz2");
+    assertThat(queue.size(redis)).isEqualTo(4);
+    val = queue.dequeue(redis, 1);
+    assertThat(val).isEqualTo("baz4");
+    assertThat(queue.size(redis)).isEqualTo(3);
+    val = queue.dequeue(redis, 1);
+    assertThat(val).isEqualTo("foo");
+    assertThat(queue.size(redis)).isEqualTo(2);
+    val = queue.dequeue(redis, 1);
+    assertThat(val).isEqualTo("baz3");
+    assertThat(queue.size(redis)).isEqualTo(1);
+    val = queue.dequeue(redis, 1);
+    assertThat(val).isEqualTo("baz");
+    assertThat(queue.size(redis)).isEqualTo(0);
+  }
+
+  // Function under test: visit
+  // Reason for testing: each element in the queue can be visited
+  // Failure explanation: we are unable to visit each element in the queue
+  @Test
+  public void visitCheckVisitOfEachElement() throws Exception {
+    // ARRANGE
+    RedisPriorityQueue queue = new RedisPriorityQueue("test");
+    queue.push(redis, "element 1");
+    queue.push(redis, "element 2");
+    queue.push(redis, "element 3");
+    queue.push(redis, "element 4");
+    queue.push(redis, "element 5");
+    queue.push(redis, "element 6");
+    queue.push(redis, "element 7");
+    queue.push(redis, "element 8");
+
+    // ACT
+    List<String> visited = new ArrayList<>();
+    StringVisitor visitor =
+        new StringVisitor() {
+          public void visit(String entry) {
+            visited.add(entry);
+          }
+        };
+    queue.visit(redis, visitor);
+
+    // ASSERT
+    assertThat(visited.size()).isEqualTo(8);
+    assertThat(visited.contains("element 1")).isTrue();
+    assertThat(visited.contains("element 2")).isTrue();
+    assertThat(visited.contains("element 3")).isTrue();
+    assertThat(visited.contains("element 4")).isTrue();
+    assertThat(visited.contains("element 5")).isTrue();
+    assertThat(visited.contains("element 6")).isTrue();
+    assertThat(visited.contains("element 7")).isTrue();
+    assertThat(visited.contains("element 8")).isTrue();
+  }
+
+  // Function under test: visit
+  // Reason for testing: add and visit many elements
+  // Failure explanation: we are unable to visit all the elements when there are many of them
+  @Test
+  public void visitVisitManyOverPageSize() throws Exception {
+    // ARRANGE
+    RedisPriorityQueue queue = new RedisPriorityQueue("test");
+    for (int i = 0; i < 2500; ++i) {
+      queue.push(redis, "foo" + i);
+    }
+
+    // ACT
+    List<String> visited = new ArrayList<>();
+    StringVisitor visitor =
+        new StringVisitor() {
+          public void visit(String entry) {
+            visited.add(entry);
+          }
+        };
+    queue.visit(redis, visitor);
+
+    // ASSERT
+    assertThat(visited.size()).isEqualTo(2500);
+    for (int i = 0; i < 2500; ++i) {
+      assertThat(visited.contains("foo" + i)).isTrue();
+    }
+  }
+}


### PR DESCRIPTION
Added priority queue implemented with the help of [ordered sets](https://redis.io/commands/zadd) in the lua script
Not entirely sure how blocking operations work, so I'm open for suggestions (There are some left overs in the lua script)
Fixed all non-mock tests, also added new ones
Made a QueueInterface(with RedisQueueFactory) which will pick one of the  two types of queues (regular or priority). At the moment it's hard codded to use 'regular' (old behaviour). 
Later will add an option to set it through 'server.config/worker.config'