### PR TITLE
[ci] gate on redis integration tests

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -67,6 +67,14 @@ tasks:
     shell_commands:
     - ./bazelw build //src/main/java/build/buildfarm/rpms/server:buildfarm-server-rpm //src/main/java/build/buildfarm/rpms/worker:buildfarm-worker-rpm
 
+  # This will run unit tests that integrate with redis.
+  # Outside of this step, similar functionality may be tested with mocks.
+  redis_unit_tests:
+    name: "Redis Unit Tests"
+    platform: ubuntu1804
+    shell_commands:
+    - ./.bazelci/redis_unit_tests.sh
+
   # We want to run the unit tests again inside of a docker container.
   # This is because test cases may behave different while in docker due to user permissions.
   # This is more of a sanity check between a defined docker file and running tests directly on the host.

--- a/.bazelci/redis_unit_tests.sh
+++ b/.bazelci/redis_unit_tests.sh
@@ -3,8 +3,6 @@
 # However this runs unit tests that interact directly with redis.
 
 # Run redis container
-docker stop buildfarm-redis > /dev/null 2>&1
-docker rm buildfarm-redis > /dev/null 2>&1
 docker run -d --rm --name buildfarm-redis --network host redis:5.0.9 --bind localhost
 
 # Run tests that rely on redis

--- a/.bazelci/redis_unit_tests.sh
+++ b/.bazelci/redis_unit_tests.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Typically our redis implementations are mocked.
+# However this runs unit tests that interact directly with redis.
+
+# Run redis container
+docker stop buildfarm-redis > /dev/null 2>&1
+docker rm buildfarm-redis > /dev/null 2>&1
+docker run -d --rm --name buildfarm-redis --network host redis:5.0.9 --bind localhost
+
+# Run tests that rely on redis
+./bazelw test --build_tests_only --define native-redis=true src/test/java/...

--- a/src/main/java/build/buildfarm/common/redis/QueueInterface.java
+++ b/src/main/java/build/buildfarm/common/redis/QueueInterface.java
@@ -22,7 +22,6 @@ import redis.clients.jedis.JedisCluster;
  * @brief A redis queue interface.
  */
 public abstract class QueueInterface {
-
   /**
    * @brief Push a value onto the queue with default priority of 1.
    * @details Adds the value into the backend rdered set.

--- a/src/main/java/build/buildfarm/common/redis/RedisQueue.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisQueue.java
@@ -42,6 +42,9 @@ public class RedisQueue extends QueueInterface {
    * @param name The global name of the queue.
    */
   public RedisQueue(String name) {
+    // In order for dequeue properly, the queue needs o have a hashtag.  Otherwise it will error
+    // with: "No way to dispatch this command to Redis Cluster because keys have different slots."
+    // when trying to brpoplpush. If no hashtag was given we provide a default.
     this.name = name;
   }
 

--- a/src/main/java/build/buildfarm/common/redis/RedisQueueFactory.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisQueueFactory.java
@@ -19,7 +19,6 @@ package build.buildfarm.common.redis;
  * @brief A redis queue factory.
  */
 public class RedisQueueFactory {
-
   public QueueInterface getQueue(String queueType, String name) {
     if (queueType == null) {
       return null;

--- a/src/main/java/build/buildfarm/common/redis/Timestamp.java
+++ b/src/main/java/build/buildfarm/common/redis/Timestamp.java
@@ -1,7 +1,6 @@
 package build.buildfarm.common.redis;
 
 public class Timestamp {
-
   public Long getMillis() {
     return System.currentTimeMillis();
   };

--- a/src/test/java/build/buildfarm/common/redis/BUILD
+++ b/src/test/java/build/buildfarm/common/redis/BUILD
@@ -36,9 +36,9 @@ java_test(
         exclude = NATIVE_REDIS_TESTS,
     ),
     classpath_resources = [":lua_resources"],
+    tags = ["exclusive"],
     test_class = "build.buildfarm.AllTests",
     deps = COMMON_DEPS,
-    tags = ["exclusive"],
 )
 
 java_test(

--- a/src/test/java/build/buildfarm/common/redis/BUILD
+++ b/src/test/java/build/buildfarm/common/redis/BUILD
@@ -34,13 +34,11 @@ java_test(
     srcs = glob(
         ["*.java"],
         exclude = NATIVE_REDIS_TESTS,
-    ) + select({
-        ":native-redis": NATIVE_REDIS_TESTS,
-        "//conditions:default": [],
-    }),
+    ),
     classpath_resources = [":lua_resources"],
     test_class = "build.buildfarm.AllTests",
     deps = COMMON_DEPS,
+    tags = ["exclusive"],
 )
 
 java_test(
@@ -51,7 +49,7 @@ java_test(
         "//conditions:default": ["RedisPriorityQueueMockTest.java"],
     }),
     classpath_resources = [":lua_resources"],
-    tags = ["priority_native"],
+    tags = ["exclusive"],
     test_class = "build.buildfarm.AllTests",
     deps = COMMON_DEPS,
 )
@@ -63,7 +61,7 @@ java_test(
         ":native-redis": ["RedisQueueTest.java"],
         "//conditions:default": ["RedisQueueMockTest.java"],
     }),
-    tags = ["queue_native"],
+    tags = ["exclusive"],
     test_class = "build.buildfarm.AllTests",
     deps = COMMON_DEPS,
 )
@@ -76,7 +74,7 @@ java_test(
         "//conditions:default": ["BalancedRedisQueueMockTest.java"],
     }),
     classpath_resources = [":lua_resources"],
-    tags = ["balanced_native"],
+    tags = ["exclusive"],
     test_class = "build.buildfarm.AllTests",
     deps = COMMON_DEPS,
 )

--- a/src/test/java/build/buildfarm/common/redis/RedisQueueTest.java
+++ b/src/test/java/build/buildfarm/common/redis/RedisQueueTest.java
@@ -179,8 +179,7 @@ public class RedisQueueTest {
   @Test
   public void sizeAdjustPushDequeue() throws Exception {
     // ARRANGE
-    RedisQueue queue = new RedisQueue("test");
-
+    RedisQueue queue = new RedisQueue("{hash}test");
     // ACT / ASSERT
     assertThat(queue.size(redis)).isEqualTo(0);
     queue.push(redis, "foo");


### PR DESCRIPTION
Unit tests that rely on redis are mocked and run in the CI.  However, there are additional tests that talk directly to redis that don't run in the CI. It would be helpful to start running these integration tests now to avoid unexpected issues. 
Considering we already run a full cluster with redis as an end-to-end integration test.  Using a redis container to run these additional unit tests seems acceptable.