### PR TITLE
default_max_cores setting

### DIFF
--- a/examples/shard-worker.config.example
+++ b/examples/shard-worker.config.example
@@ -298,6 +298,19 @@ redis_shard_backplane_config: {
   #max_attempts: 10
 }
 
+# Constrain all executions to a pool of logical cores specified in execute_stage_width
+# The default (empty) does not limit the pool of logical cores available by executions
+#limit_global_execution: false
+
+# Constrain all executions to this logical core count unless otherwise specified via min/max-cores
+# The default (0) value does not limit executions within the global pool
+#default_max_cores: 1
+
+# Only permit tests to exceed the default_cores value for their min/max-cores range specification
+# This setting is meaningless without a non-zero default_cores
+# The default (false) value does not place restrictions on which executions can specify >1 min/max-cores
+#only_multicore_tests: false
+
 # Create exec trees containing directories that are owned by
 # this user
 # The default (empty) value does not change the owner

--- a/src/main/java/build/buildfarm/worker/resources/CpuLimits.java
+++ b/src/main/java/build/buildfarm/worker/resources/CpuLimits.java
@@ -43,7 +43,7 @@ public class CpuLimits {
    * @brief The minimum CPU cores required.
    * @details Client can suggest this though exec_properties.
    */
-  public int min = 0;
+  public int min = 1;
 
   /**
    * @field max

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -118,7 +118,7 @@ class ShardWorkerContext implements WorkerContext {
   private final Instance instance;
   private final Duration defaultActionTimeout;
   private final Duration maximumActionTimeout;
-  private final boolean limitExecution;
+  private final int defaultMaxCores;
   private final boolean limitGlobalExecution;
   private final boolean onlyMulticoreTests;
   private final Map<String, QueueEntry> activeOperations = Maps.newConcurrentMap();
@@ -154,7 +154,7 @@ class ShardWorkerContext implements WorkerContext {
       Instance instance,
       Duration defaultActionTimeout,
       Duration maximumActionTimeout,
-      boolean limitExecution,
+      int defaultMaxCores,
       boolean limitGlobalExecution,
       boolean onlyMulticoreTests,
       boolean errorOperationRemainingResources,
@@ -175,17 +175,11 @@ class ShardWorkerContext implements WorkerContext {
     this.instance = instance;
     this.defaultActionTimeout = defaultActionTimeout;
     this.maximumActionTimeout = maximumActionTimeout;
-    this.limitExecution = limitExecution;
+    this.defaultMaxCores = defaultMaxCores;
     this.limitGlobalExecution = limitGlobalExecution;
     this.onlyMulticoreTests = onlyMulticoreTests;
     this.errorOperationRemainingResources = errorOperationRemainingResources;
     this.writer = writer;
-    Preconditions.checkState(
-        !limitGlobalExecution || limitExecution,
-        "limit_global_execution is meaningless without limit_execution");
-    Preconditions.checkState(
-        !onlyMulticoreTests || limitExecution,
-        "only_multicore_tests is meaningless without limit_execution");
   }
 
   private static Retrier createBackplaneRetrier() {
@@ -775,7 +769,7 @@ class ShardWorkerContext implements WorkerContext {
 
   @Override
   public void createExecutionLimits() {
-    if (limitExecution) {
+    if (limitGlobalExecution || onlyMulticoreTests || defaultMaxCores > 0) {
       createOperationExecutionLimits();
     }
   }
@@ -829,7 +823,12 @@ class ShardWorkerContext implements WorkerContext {
 
   public ResourceLimits commandExecutionSettings(Command command) {
     return ResourceDecider.decideResourceLimitations(
-        command, name, onlyMulticoreTests, limitGlobalExecution, getExecuteStageWidth());
+        command,
+        name,
+        defaultMaxCores,
+        onlyMulticoreTests,
+        limitGlobalExecution,
+        getExecuteStageWidth());
   }
 
   @Override
@@ -838,7 +837,7 @@ class ShardWorkerContext implements WorkerContext {
       ImmutableList.Builder<String> arguments,
       Command command,
       Path workingDirectory) {
-    if (limitExecution) {
+    if (limitGlobalExecution || onlyMulticoreTests || defaultMaxCores > 0) {
       ResourceLimits limits = commandExecutionSettings(command);
       return limitSpecifiedExecution(limits, operationName, arguments, workingDirectory);
     }

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -465,7 +465,7 @@ public class Worker extends LoggingMain {
             instance,
             config.getDefaultActionTimeout(),
             config.getMaximumActionTimeout(),
-            config.getLimitExecution(),
+            config.getDefaultMaxCores(),
             config.getLimitGlobalExecution(),
             config.getOnlyMulticoreTests(),
             config.getErrorOperationRemainingResources(),

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -681,13 +681,15 @@ message ShardWorkerConfig {
   // with an action's platform for selection
   repeated ExecutionPolicy execution_policies = 25;
 
-  // support any execution limiting, whether global or specified
-  bool limit_execution = 31;
+  reserved 31, 33;
+
+  // default max-cores specification for executions, unlimited if not set
+  int32 default_max_cores = 42;
 
   // limit the available cores to execute_stage_width for unmetered execution if set
   bool limit_global_execution = 29;
 
-  // only allow test executions to be multicore (min-cores > 1), limiting both to 1 if not a test
+  // only allow test executions to respect min-cores > 1, limiting range to 1 -> default_max_cores if not a test
   bool only_multicore_tests = 30;
 
   // user principal name for executions

--- a/src/test/java/build/buildfarm/worker/resources/ResourceDeciderTest.java
+++ b/src/test/java/build/buildfarm/worker/resources/ResourceDeciderTest.java
@@ -48,7 +48,13 @@ public class ResourceDeciderTest {
 
     // ACT
     ResourceLimits limits =
-        ResourceDecider.decideResourceLimitations(command, "worker", false, false, 100);
+        ResourceDecider.decideResourceLimitations(
+            command,
+            "worker",
+            /* defaultMaxCores=*/ 0,
+            /* onlyMulticoreTests=*/ false,
+            /* limitGlobalExecution=*/ false,
+            100);
 
     // ASSERT
     assertThat(limits.cpu.min).isEqualTo(7);
@@ -56,10 +62,10 @@ public class ResourceDeciderTest {
   }
 
   // Function under test: decideResourceLimitations
-  // Reason for testing: test that cores are skipped
+  // Reason for testing: test that cores are defaulted
   // Failure explanation: cores were not decided as expected
   @Test
-  public void decideResourceLimitationsTestCoreSettingSkippedOnNontest() throws Exception {
+  public void decideResourceLimitationsTestCoreSettingDefaultedOnNontest() throws Exception {
     // ARRANGE
     Command command =
         Command.newBuilder()
@@ -72,17 +78,24 @@ public class ResourceDeciderTest {
             .build();
 
     // ACT
+    int defaultMaxCores = 3;
     ResourceLimits limits =
-        ResourceDecider.decideResourceLimitations(command, "worker", true, false, 100);
+        ResourceDecider.decideResourceLimitations(
+            command,
+            "worker",
+            defaultMaxCores,
+            /* onlyMulticoreTests=*/ true,
+            /* limitGlobalExecution=*/ false,
+            100);
 
     // ASSERT
     assertThat(limits.cpu.min).isEqualTo(1);
-    assertThat(limits.cpu.max).isEqualTo(1);
+    assertThat(limits.cpu.max).isEqualTo(defaultMaxCores);
   }
 
   // Function under test: decideResourceLimitations
-  // Reason for testing: test that claims remains 0 because of min-cores.
-  // Failure explanation: claims were not 0 as expected
+  // Reason for testing: test that claims are >0 despite min-cores == 0.
+  // Failure explanation: claims were not >0 as expected
   @Test
   public void decideResourceLimitationsEnsureClaimsOne() throws Exception {
     // ARRANGE
@@ -98,14 +111,20 @@ public class ResourceDeciderTest {
 
     // ACT
     ResourceLimits limits =
-        ResourceDecider.decideResourceLimitations(command, "worker", false, false, 100);
+        ResourceDecider.decideResourceLimitations(
+            command,
+            "worker",
+            /* defaultMaxCores=*/ 0,
+            /* onlyMulticoreTests=*/ false,
+            /* limitGlobalExecution=*/ false,
+            100);
 
     // ASSERT
-    assertThat(limits.cpu.claimed).isEqualTo(0);
+    assertThat(limits.cpu.claimed).isGreaterThan(0);
   }
 
   // Function under test: decideResourceLimitations
-  // Reason for testing: test that we limit cpu is globalLimitExecution is given.
+  // Reason for testing: test that we limit cpu if limitGlobalExecution is given.
   // Failure explanation: expected limit flag set.
   @Test
   public void decideResourceLimitationsEnsureLimitGlobalSet() throws Exception {
@@ -122,14 +141,20 @@ public class ResourceDeciderTest {
 
     // ACT
     ResourceLimits limits =
-        ResourceDecider.decideResourceLimitations(command, "worker", false, true, 100);
+        ResourceDecider.decideResourceLimitations(
+            command,
+            "worker",
+            /* defaultMaxCores=*/ 0,
+            /* onlyMulticoreTests=*/ false,
+            /* limitGlobalExecution=*/ true,
+            100);
 
     // ASSERT
     assertThat(limits.cpu.limit).isTrue();
   }
 
   // Function under test: decideResourceLimitations
-  // Reason for testing: test that we do not limit cpu is globalLimitExecution is false.
+  // Reason for testing: test that we do not limit cpu if globalLimitExecution is false.
   // Failure explanation: Did not expect limit flag set.
   @Test
   public void decideResourceLimitationsEnsureNoLimitNoGlobalSet() throws Exception {
@@ -146,7 +171,13 @@ public class ResourceDeciderTest {
 
     // ACT
     ResourceLimits limits =
-        ResourceDecider.decideResourceLimitations(command, "worker", false, false, 100);
+        ResourceDecider.decideResourceLimitations(
+            command,
+            "worker",
+            /* defaultMaxCores=*/ 0,
+            /* onlyMulticoreTests=*/ false,
+            /* limitGlobalExecution=*/ false,
+            100);
 
     // ASSERT
     assertThat(limits.cpu.limit).isFalse();
@@ -170,7 +201,13 @@ public class ResourceDeciderTest {
 
     // ACT
     ResourceLimits limits =
-        ResourceDecider.decideResourceLimitations(command, "worker", false, false, 100);
+        ResourceDecider.decideResourceLimitations(
+            command,
+            "worker",
+            /* defaultMaxCores=*/ 0,
+            /* onlyMulticoreTests=*/ false,
+            /* limitGlobalExecution=*/ false,
+            100);
 
     // ASSERT
     assertThat(limits.cpu.claimed).isEqualTo(3);
@@ -193,7 +230,13 @@ public class ResourceDeciderTest {
 
     // ACT
     ResourceLimits limits =
-        ResourceDecider.decideResourceLimitations(command, "worker", false, false, 100);
+        ResourceDecider.decideResourceLimitations(
+            command,
+            "worker",
+            /* defaultMaxCores=*/ 0,
+            /* onlyMulticoreTests=*/ false,
+            /* limitGlobalExecution=*/ false,
+            100);
 
     // ASSERT
     assertThat(limits.mem.min).isEqualTo(5);
@@ -211,7 +254,13 @@ public class ResourceDeciderTest {
 
     // ACT
     ResourceLimits limits =
-        ResourceDecider.decideResourceLimitations(command, "worker", true, false, 100);
+        ResourceDecider.decideResourceLimitations(
+            command,
+            "worker",
+            /* defaultMaxCores=*/ 0,
+            /* onlyMulticoreTests=*/ false,
+            /* limitGlobalExecution=*/ false,
+            100);
 
     // ASSERT
     assertThat(limits.extraEnvironmentVariables.isEmpty()).isTrue();
@@ -233,7 +282,13 @@ public class ResourceDeciderTest {
 
     // ACT
     ResourceLimits limits =
-        ResourceDecider.decideResourceLimitations(command, "worker", true, false, 100);
+        ResourceDecider.decideResourceLimitations(
+            command,
+            "worker",
+            /* defaultMaxCores=*/ 0,
+            /* onlyMulticoreTests=*/ false,
+            /* limitGlobalExecution=*/ false,
+            100);
 
     // ASSERT
     assertThat(limits.extraEnvironmentVariables.isEmpty()).isTrue();
@@ -258,7 +313,13 @@ public class ResourceDeciderTest {
 
     // ACT
     ResourceLimits limits =
-        ResourceDecider.decideResourceLimitations(command, "worker", true, false, 100);
+        ResourceDecider.decideResourceLimitations(
+            command,
+            "worker",
+            /* defaultMaxCores=*/ 0,
+            /* onlyMulticoreTests=*/ false,
+            /* limitGlobalExecution=*/ false,
+            100);
 
     // ASSERT
     assertThat(limits.extraEnvironmentVariables.size()).isEqualTo(1);
@@ -285,7 +346,13 @@ public class ResourceDeciderTest {
 
     // ACT
     ResourceLimits limits =
-        ResourceDecider.decideResourceLimitations(command, "worker", true, false, 100);
+        ResourceDecider.decideResourceLimitations(
+            command,
+            "worker",
+            /* defaultMaxCores=*/ 0,
+            /* onlyMulticoreTests=*/ false,
+            /* limitGlobalExecution=*/ false,
+            100);
 
     // ASSERT
     assertThat(limits.extraEnvironmentVariables.size()).isEqualTo(2);
@@ -314,7 +381,13 @@ public class ResourceDeciderTest {
 
     // ACT
     ResourceLimits limits =
-        ResourceDecider.decideResourceLimitations(command, "worker", true, false, 100);
+        ResourceDecider.decideResourceLimitations(
+            command,
+            "worker",
+            /* defaultMaxCores=*/ 0,
+            /* onlyMulticoreTests=*/ false,
+            /* limitGlobalExecution=*/ false,
+            100);
 
     // ASSERT
     assertThat(limits.extraEnvironmentVariables.size()).isEqualTo(0);
@@ -343,7 +416,13 @@ public class ResourceDeciderTest {
 
     // ACT
     ResourceLimits limits =
-        ResourceDecider.decideResourceLimitations(command, "worker", false, false, 100);
+        ResourceDecider.decideResourceLimitations(
+            command,
+            "worker",
+            /* defaultMaxCores=*/ 0,
+            /* onlyMulticoreTests=*/ false,
+            /* limitGlobalExecution=*/ false,
+            100);
 
     // ASSERT
     assertThat(limits.extraEnvironmentVariables.size()).isEqualTo(2);
@@ -370,7 +449,13 @@ public class ResourceDeciderTest {
 
     // ACT
     ResourceLimits limits =
-        ResourceDecider.decideResourceLimitations(command, "worker", true, false, 100);
+        ResourceDecider.decideResourceLimitations(
+            command,
+            "worker",
+            /* defaultMaxCores=*/ 0,
+            /* onlyMulticoreTests=*/ false,
+            /* limitGlobalExecution=*/ false,
+            100);
 
     // ASSERT
     assertThat(limits.extraEnvironmentVariables.size()).isEqualTo(1);
@@ -398,7 +483,13 @@ public class ResourceDeciderTest {
 
     // ACT
     ResourceLimits limits =
-        ResourceDecider.decideResourceLimitations(command, "worker", true, false, 100);
+        ResourceDecider.decideResourceLimitations(
+            command,
+            "worker",
+            /* defaultMaxCores=*/ 0,
+            /* onlyMulticoreTests=*/ false,
+            /* limitGlobalExecution=*/ false,
+            100);
 
     // ASSERT
     assertThat(limits.extraEnvironmentVariables.size()).isEqualTo(2);
@@ -426,7 +517,13 @@ public class ResourceDeciderTest {
 
     // ACT
     ResourceLimits limits =
-        ResourceDecider.decideResourceLimitations(command, "worker", true, false, 100);
+        ResourceDecider.decideResourceLimitations(
+            command,
+            "worker",
+            /* defaultMaxCores=*/ 0,
+            /* onlyMulticoreTests=*/ false,
+            /* limitGlobalExecution=*/ false,
+            100);
 
     // ASSERT
     assertThat(limits.extraEnvironmentVariables.size()).isEqualTo(1);
@@ -455,7 +552,13 @@ public class ResourceDeciderTest {
 
     // ACT
     ResourceLimits limits =
-        ResourceDecider.decideResourceLimitations(command, "worker", true, false, 100);
+        ResourceDecider.decideResourceLimitations(
+            command,
+            "worker",
+            /* defaultMaxCores=*/ 0,
+            /* onlyMulticoreTests=*/ false,
+            /* limitGlobalExecution=*/ false,
+            100);
 
     // ASSERT
     assertThat(limits.debugBeforeExecution).isTrue();
@@ -482,7 +585,13 @@ public class ResourceDeciderTest {
 
     // ACT
     ResourceLimits limits =
-        ResourceDecider.decideResourceLimitations(command, "worker", true, false, 100);
+        ResourceDecider.decideResourceLimitations(
+            command,
+            "worker",
+            /* defaultMaxCores=*/ 0,
+            /* onlyMulticoreTests=*/ false,
+            /* limitGlobalExecution=*/ false,
+            100);
 
     // ASSERT
     assertThat(limits.debugAfterExecution).isTrue();
@@ -509,7 +618,13 @@ public class ResourceDeciderTest {
 
     // ACT
     ResourceLimits limits =
-        ResourceDecider.decideResourceLimitations(command, "worker", true, false, 100);
+        ResourceDecider.decideResourceLimitations(
+            command,
+            "worker",
+            /* defaultMaxCores=*/ 0,
+            /* onlyMulticoreTests=*/ false,
+            /* limitGlobalExecution=*/ false,
+            100);
 
     // ASSERT
     assertThat(limits.debugBeforeExecution).isFalse();
@@ -525,7 +640,13 @@ public class ResourceDeciderTest {
 
     // ACT
     ResourceLimits limits =
-        ResourceDecider.decideResourceLimitations(command, "foo", true, false, 100);
+        ResourceDecider.decideResourceLimitations(
+            command,
+            "foo",
+            /* defaultMaxCores=*/ 0,
+            /* onlyMulticoreTests=*/ false,
+            /* limitGlobalExecution=*/ false,
+            100);
 
     // ASSERT
     assertThat(limits.workerName).isEqualTo("foo");

--- a/src/test/java/build/buildfarm/worker/shard/ShardWorkerContextTest.java
+++ b/src/test/java/build/buildfarm/worker/shard/ShardWorkerContextTest.java
@@ -98,7 +98,7 @@ public class ShardWorkerContextTest {
         /* deadlineAfterUnits=*/
         /* defaultActionTimeout=*/ Duration.getDefaultInstance(),
         /* maximumActionTimeout=*/ Duration.getDefaultInstance(),
-        /* limitExecution=*/ false,
+        /* defaultMaxCores=*/ 0,
         /* limitGlobalExecution=*/ false,
         /* onlyMulticoreTests=*/ false,
         /* errorOperationRemainingResources=*/ false,


### PR DESCRIPTION
Deprecated the legacy limit_execution option, which was a composite of
several valid specifications.
Provided a default value for max-cores without specification and used
for a range of non-tests in only_multicore_tests.
Cleaned up execution cpu limit decisions which could have resulted in 0
claims, and conditionalized some core limiting debug logging.
Removed test conditions that varied from onlyMulticoreTests default of
false where the check was immaterial