### PR TITLE
fix Bazel@HEAD

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -71,6 +71,7 @@ tasks:
   # Outside of this step, similar functionality may be tested with mocks.
   redis_unit_tests:
     name: "Redis Unit Tests"
+    bazel: "4.2.2"
     platform: ubuntu1804
     shell_commands:
     - ./.bazelci/redis_unit_tests.sh


### PR DESCRIPTION
https://github.com/bazelbuild/bazel-buildfarm/pull/1043 caused Bazel@HEAD to fail.
https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/2406#4aa14e8b-7b35-4592-b5d2-60b597c453e5

It's possible the reason is that Bazel built at HEAD doesn't have a version number.  This is how we fixed a similar issue in the past.