### PR TITLE
make "bring your own container" feature opt-in for deployments

### DIFF
--- a/src/main/java/build/buildfarm/worker/Executor.java
+++ b/src/main/java/build/buildfarm/worker/Executor.java
@@ -447,7 +447,7 @@ class Executor {
     }
 
     // run the action under docker
-    if (!limits.containerSettings.containerImage.isEmpty()) {
+    if (limits.containerSettings.enabled) {
       DockerClient dockerClient = DockerClientBuilder.getInstance().build();
 
       // create settings

--- a/src/main/java/build/buildfarm/worker/resources/ContainerSettings.java
+++ b/src/main/java/build/buildfarm/worker/resources/ContainerSettings.java
@@ -27,6 +27,14 @@ import java.util.ArrayList;
  */
 public class ContainerSettings {
   /**
+   * @field enabled
+   * @brief Whether the action should run in the custom container.
+   * @details This will be enabled when specific exec_properties are used. Global buildfarm settings
+   *     may also effect whether the feature is available.
+   */
+  public boolean enabled = false;
+
+  /**
    * @field containerImage
    * @brief The container image to use.
    * @details In example format may look like:

--- a/src/main/java/build/buildfarm/worker/resources/ResourceDecider.java
+++ b/src/main/java/build/buildfarm/worker/resources/ResourceDecider.java
@@ -35,6 +35,8 @@ public final class ResourceDecider {
    * @param defaultMaxCores The unspecified maximum constraint for cores.
    * @param limitGlobalExecution Whether cpu limiting should be explicitly performed.
    * @param executeStageWidth The maximum amount of cores available for the operation.
+   * @param allowBringYourOwnContainer Whether or not the feature of "bringing your own containers"
+   *     is allowed.
    * @return Default resource limits.
    * @note Suggested return identifier: resourceLimits.
    */
@@ -44,7 +46,8 @@ public final class ResourceDecider {
       int defaultMaxCores,
       boolean onlyMulticoreTests,
       boolean limitGlobalExecution,
-      int executeStageWidth) {
+      int executeStageWidth,
+      boolean allowBringYourOwnContainer) {
     // Get all of the user suggested resource changes.
     ResourceLimits limits = ExecutionPropertiesParser.Parse(command);
 
@@ -56,7 +59,8 @@ public final class ResourceDecider {
         defaultMaxCores,
         onlyMulticoreTests,
         limitGlobalExecution,
-        executeStageWidth);
+        executeStageWidth,
+        allowBringYourOwnContainer);
 
     return limits;
   }
@@ -71,6 +75,8 @@ public final class ResourceDecider {
    * @param onlyMulticoreTests Only allow tests to be multicore.
    * @param limitGlobalExecution Whether cpu limiting should be explicitly performed.
    * @param executeStageWidth The maximum amount of cores available for the operation.
+   * @param allowBringYourOwnContainer Whether or not the feature of "bringing your own containers"
+   *     is allowed.
    */
   private static void adjustLimits(
       ResourceLimits limits,
@@ -79,7 +85,8 @@ public final class ResourceDecider {
       int defaultMaxCores,
       boolean onlyMulticoreTests,
       boolean limitGlobalExecution,
-      int executeStageWidth) {
+      int executeStageWidth,
+      boolean allowBringYourOwnContainer) {
     // store worker name
     limits.workerName = workerName;
 
@@ -164,27 +171,31 @@ public final class ResourceDecider {
       limits.description.add("configured execution policies skipped because of choosing sandbox");
     }
 
-    // Adjust flags for when a container image is chosen for the action.
-    adjustContainerFlags(limits);
+    // Decide whether the action will run in a container
+    if (allowBringYourOwnContainer && !limits.containerSettings.containerImage.isEmpty()) {
+      // enable container execution
+      limits.containerSettings.enabled = true;
+
+      // Adjust additional flags for when a container is being used.
+      adjustContainerFlags(limits);
+    }
 
     // we choose to resolve variables after the other variable values have been decided
     resolveEnvironmentVariables(limits);
   }
 
   private static void adjustContainerFlags(ResourceLimits limits) {
-    if (!limits.containerSettings.containerImage.isEmpty()) {
-      // Avoid using the existing execution policies when running actions under docker.
-      // The programs used in the execution policies likely won't exist in the container images.
-      limits.useExecutionPolicies = false;
-      limits.description.add("configured execution policies skipped because of choosing docker");
+    // Avoid using the existing execution policies when running actions under docker.
+    // The programs used in the execution policies likely won't exist in the container images.
+    limits.useExecutionPolicies = false;
+    limits.description.add("configured execution policies skipped because of choosing docker");
 
-      // avoid limiting resources as cgroups may not be available in the container.
-      // in fact, we will use docker's cgroup settings explicitly.
-      // TODO(thickey): use docker's cgroup settings given existing resource limitations.
-      limits.cpu.limit = false;
-      limits.mem.limit = false;
-      limits.description.add("resource limiting disabled because of choosing docker");
-    }
+    // avoid limiting resources as cgroups may not be available in the container.
+    // in fact, we will use docker's cgroup settings explicitly.
+    // TODO(thickey): use docker's cgroup settings given existing resource limitations.
+    limits.cpu.limit = false;
+    limits.mem.limit = false;
+    limits.description.add("resource limiting disabled because of choosing docker");
   }
 
   private static void adjustDebugFlags(Command command, ResourceLimits limits) {

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -121,6 +121,7 @@ class ShardWorkerContext implements WorkerContext {
   private final int defaultMaxCores;
   private final boolean limitGlobalExecution;
   private final boolean onlyMulticoreTests;
+  private final boolean allowBringYourOwnContainer;
   private final Map<String, QueueEntry> activeOperations = Maps.newConcurrentMap();
   private final Group executionsGroup = Group.getRoot().getChild("executions");
   private final Group operationsGroup = executionsGroup.getChild("operations");
@@ -157,6 +158,7 @@ class ShardWorkerContext implements WorkerContext {
       int defaultMaxCores,
       boolean limitGlobalExecution,
       boolean onlyMulticoreTests,
+      boolean allowBringYourOwnContainer,
       boolean errorOperationRemainingResources,
       CasWriter writer) {
     this.name = name;
@@ -178,6 +180,7 @@ class ShardWorkerContext implements WorkerContext {
     this.defaultMaxCores = defaultMaxCores;
     this.limitGlobalExecution = limitGlobalExecution;
     this.onlyMulticoreTests = onlyMulticoreTests;
+    this.allowBringYourOwnContainer = allowBringYourOwnContainer;
     this.errorOperationRemainingResources = errorOperationRemainingResources;
     this.writer = writer;
   }
@@ -808,7 +811,8 @@ class ShardWorkerContext implements WorkerContext {
         defaultMaxCores,
         onlyMulticoreTests,
         limitGlobalExecution,
-        getExecuteStageWidth());
+        getExecuteStageWidth(),
+        allowBringYourOwnContainer);
   }
 
   @Override

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -468,6 +468,7 @@ public class Worker extends LoggingMain {
             config.getDefaultMaxCores(),
             config.getLimitGlobalExecution(),
             config.getOnlyMulticoreTests(),
+            config.getAllowBringYourOwnContainer(),
             config.getErrorOperationRemainingResources(),
             writer);
 

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -710,6 +710,12 @@ message ShardWorkerConfig {
   // default_max_cores if not a test
   bool only_multicore_tests = 30;
 
+  // Some actions may need to run in a container specified by the client.  By
+  // using exec_properties clients can request the container for buildfarm to
+  // pull and use.  This feature is known as "bring your own container".  If the
+  // feature is disabled the corresponding exec_properties will be ignored.
+  bool allow_bring_your_own_container = 43;
+
   // user principal name for executions
   string exec_owner = 32;
 

--- a/src/test/java/build/buildfarm/worker/resources/ResourceDeciderTest.java
+++ b/src/test/java/build/buildfarm/worker/resources/ResourceDeciderTest.java
@@ -54,7 +54,8 @@ public class ResourceDeciderTest {
             /* defaultMaxCores=*/ 0,
             /* onlyMulticoreTests=*/ false,
             /* limitGlobalExecution=*/ false,
-            100);
+            /* executeStageWidth=*/ 100,
+            /* allowBringYourOwnContainer=*/ false);
 
     // ASSERT
     assertThat(limits.cpu.min).isEqualTo(7);
@@ -86,7 +87,8 @@ public class ResourceDeciderTest {
             defaultMaxCores,
             /* onlyMulticoreTests=*/ true,
             /* limitGlobalExecution=*/ false,
-            100);
+            /* executeStageWidth=*/ 100,
+            /* allowBringYourOwnContainer=*/ false);
 
     // ASSERT
     assertThat(limits.cpu.min).isEqualTo(1);
@@ -117,7 +119,8 @@ public class ResourceDeciderTest {
             /* defaultMaxCores=*/ 0,
             /* onlyMulticoreTests=*/ false,
             /* limitGlobalExecution=*/ false,
-            100);
+            /* executeStageWidth=*/ 100,
+            /* allowBringYourOwnContainer=*/ false);
 
     // ASSERT
     assertThat(limits.cpu.claimed).isGreaterThan(0);
@@ -147,7 +150,8 @@ public class ResourceDeciderTest {
             /* defaultMaxCores=*/ 0,
             /* onlyMulticoreTests=*/ false,
             /* limitGlobalExecution=*/ true,
-            100);
+            /* executeStageWidth=*/ 100,
+            /* allowBringYourOwnContainer=*/ false);
 
     // ASSERT
     assertThat(limits.cpu.limit).isTrue();
@@ -177,7 +181,8 @@ public class ResourceDeciderTest {
             /* defaultMaxCores=*/ 0,
             /* onlyMulticoreTests=*/ false,
             /* limitGlobalExecution=*/ false,
-            100);
+            /* executeStageWidth=*/ 100,
+            /* allowBringYourOwnContainer=*/ false);
 
     // ASSERT
     assertThat(limits.cpu.limit).isFalse();
@@ -207,7 +212,8 @@ public class ResourceDeciderTest {
             /* defaultMaxCores=*/ 0,
             /* onlyMulticoreTests=*/ false,
             /* limitGlobalExecution=*/ false,
-            100);
+            /* executeStageWidth=*/ 100,
+            /* allowBringYourOwnContainer=*/ false);
 
     // ASSERT
     assertThat(limits.cpu.claimed).isEqualTo(3);
@@ -236,7 +242,8 @@ public class ResourceDeciderTest {
             /* defaultMaxCores=*/ 0,
             /* onlyMulticoreTests=*/ false,
             /* limitGlobalExecution=*/ false,
-            100);
+            /* executeStageWidth=*/ 100,
+            /* allowBringYourOwnContainer=*/ false);
 
     // ASSERT
     assertThat(limits.mem.min).isEqualTo(5);
@@ -260,7 +267,8 @@ public class ResourceDeciderTest {
             /* defaultMaxCores=*/ 0,
             /* onlyMulticoreTests=*/ false,
             /* limitGlobalExecution=*/ false,
-            100);
+            /* executeStageWidth=*/ 100,
+            /* allowBringYourOwnContainer=*/ false);
 
     // ASSERT
     assertThat(limits.extraEnvironmentVariables.isEmpty()).isTrue();
@@ -288,7 +296,8 @@ public class ResourceDeciderTest {
             /* defaultMaxCores=*/ 0,
             /* onlyMulticoreTests=*/ false,
             /* limitGlobalExecution=*/ false,
-            100);
+            /* executeStageWidth=*/ 100,
+            /* allowBringYourOwnContainer=*/ false);
 
     // ASSERT
     assertThat(limits.extraEnvironmentVariables.isEmpty()).isTrue();
@@ -319,7 +328,8 @@ public class ResourceDeciderTest {
             /* defaultMaxCores=*/ 0,
             /* onlyMulticoreTests=*/ false,
             /* limitGlobalExecution=*/ false,
-            100);
+            /* executeStageWidth=*/ 100,
+            /* allowBringYourOwnContainer=*/ false);
 
     // ASSERT
     assertThat(limits.extraEnvironmentVariables.size()).isEqualTo(1);
@@ -352,7 +362,8 @@ public class ResourceDeciderTest {
             /* defaultMaxCores=*/ 0,
             /* onlyMulticoreTests=*/ false,
             /* limitGlobalExecution=*/ false,
-            100);
+            /* executeStageWidth=*/ 100,
+            /* allowBringYourOwnContainer=*/ false);
 
     // ASSERT
     assertThat(limits.extraEnvironmentVariables.size()).isEqualTo(2);
@@ -387,7 +398,8 @@ public class ResourceDeciderTest {
             /* defaultMaxCores=*/ 0,
             /* onlyMulticoreTests=*/ false,
             /* limitGlobalExecution=*/ false,
-            100);
+            /* executeStageWidth=*/ 100,
+            /* allowBringYourOwnContainer=*/ false);
 
     // ASSERT
     assertThat(limits.extraEnvironmentVariables.size()).isEqualTo(0);
@@ -422,7 +434,8 @@ public class ResourceDeciderTest {
             /* defaultMaxCores=*/ 0,
             /* onlyMulticoreTests=*/ false,
             /* limitGlobalExecution=*/ false,
-            100);
+            /* executeStageWidth=*/ 100,
+            /* allowBringYourOwnContainer=*/ false);
 
     // ASSERT
     assertThat(limits.extraEnvironmentVariables.size()).isEqualTo(2);
@@ -455,7 +468,8 @@ public class ResourceDeciderTest {
             /* defaultMaxCores=*/ 0,
             /* onlyMulticoreTests=*/ false,
             /* limitGlobalExecution=*/ false,
-            100);
+            /* executeStageWidth=*/ 100,
+            /* allowBringYourOwnContainer=*/ false);
 
     // ASSERT
     assertThat(limits.extraEnvironmentVariables.size()).isEqualTo(1);
@@ -489,7 +503,8 @@ public class ResourceDeciderTest {
             /* defaultMaxCores=*/ 0,
             /* onlyMulticoreTests=*/ false,
             /* limitGlobalExecution=*/ false,
-            100);
+            /* executeStageWidth=*/ 100,
+            /* allowBringYourOwnContainer=*/ false);
 
     // ASSERT
     assertThat(limits.extraEnvironmentVariables.size()).isEqualTo(2);
@@ -523,7 +538,8 @@ public class ResourceDeciderTest {
             /* defaultMaxCores=*/ 0,
             /* onlyMulticoreTests=*/ false,
             /* limitGlobalExecution=*/ false,
-            100);
+            /* executeStageWidth=*/ 100,
+            /* allowBringYourOwnContainer=*/ false);
 
     // ASSERT
     assertThat(limits.extraEnvironmentVariables.size()).isEqualTo(1);
@@ -558,7 +574,8 @@ public class ResourceDeciderTest {
             /* defaultMaxCores=*/ 0,
             /* onlyMulticoreTests=*/ false,
             /* limitGlobalExecution=*/ false,
-            100);
+            /* executeStageWidth=*/ 100,
+            /* allowBringYourOwnContainer=*/ false);
 
     // ASSERT
     assertThat(limits.debugBeforeExecution).isTrue();
@@ -591,7 +608,8 @@ public class ResourceDeciderTest {
             /* defaultMaxCores=*/ 0,
             /* onlyMulticoreTests=*/ false,
             /* limitGlobalExecution=*/ false,
-            100);
+            /* executeStageWidth=*/ 100,
+            /* allowBringYourOwnContainer=*/ false);
 
     // ASSERT
     assertThat(limits.debugAfterExecution).isTrue();
@@ -624,7 +642,8 @@ public class ResourceDeciderTest {
             /* defaultMaxCores=*/ 0,
             /* onlyMulticoreTests=*/ false,
             /* limitGlobalExecution=*/ false,
-            100);
+            /* executeStageWidth=*/ 100,
+            /* allowBringYourOwnContainer=*/ false);
 
     // ASSERT
     assertThat(limits.debugBeforeExecution).isFalse();
@@ -646,7 +665,8 @@ public class ResourceDeciderTest {
             /* defaultMaxCores=*/ 0,
             /* onlyMulticoreTests=*/ false,
             /* limitGlobalExecution=*/ false,
-            100);
+            /* executeStageWidth=*/ 100,
+            /* allowBringYourOwnContainer=*/ false);
 
     // ASSERT
     assertThat(limits.workerName).isEqualTo("foo");

--- a/src/test/java/build/buildfarm/worker/shard/ShardWorkerContextTest.java
+++ b/src/test/java/build/buildfarm/worker/shard/ShardWorkerContextTest.java
@@ -101,6 +101,7 @@ public class ShardWorkerContextTest {
         /* defaultMaxCores=*/ 0,
         /* limitGlobalExecution=*/ false,
         /* onlyMulticoreTests=*/ false,
+        /* allowBringYourOwnContainer=*/ false,
         /* errorOperationRemainingResources=*/ false,
         writer);
   }


### PR DESCRIPTION
Actions that pass `container-image` in their exec_properties will result in buildfarm using docker during execution.  This may be undesirable for buildfarm deployments.  We make the feature opt-in to prevent undesired use.  

Excerpt from user:  

> I’m attempting to validate that our buildfarm can upgrade from 1.5 -> 1.12.   Buildfarm now seems to be inspecting our exec_properties for key “container-image” and doing something new with it in an incompatible way.  Is there a way to disable the built in buildfarm docker executor?
> 
> We may want to use the builtin docker execution if it works well but ideally I’d like to handle that separate from the upgrade.   In buildfarm 1.5 we handle running in docker with our own execution policy wrapper that handles the container-image property.  Hypothetically someone could be using this property for something other than docker too, it may be desirable to disable the presence of it from it attempting to run in docker.
