### PR TITLE
Revert "[metrics] Add action result metadata logging (#1056)"

### DIFF
--- a/src/main/java/build/buildfarm/metrics/AbstractMetricsPublisher.java
+++ b/src/main/java/build/buildfarm/metrics/AbstractMetricsPublisher.java
@@ -73,15 +73,10 @@ public abstract class AbstractMetricsPublisher implements MetricsPublisher {
   }
 
   @Override
-  public void publishRequestMetadata(RequestMetadata requestMetadata) {
-    throw new UnsupportedOperationException("Not Implemented.");
-  }
-
-  @Override
   public abstract void publishMetric(String metricName, Object metricValue);
 
   @VisibleForTesting
-  protected OperationRequestMetadata populateExecutionMetadata(
+  protected OperationRequestMetadata populateRequestMetadata(
       Operation operation, RequestMetadata requestMetadata) {
     try {
       actionsCounter.inc();
@@ -164,7 +159,7 @@ public abstract class AbstractMetricsPublisher implements MetricsPublisher {
     }
   }
 
-  protected static String formatExecutionMetadataToJson(
+  protected static String formatRequestMetadataToJson(
       OperationRequestMetadata operationRequestMetadata) throws InvalidProtocolBufferException {
     JsonFormat.TypeRegistry typeRegistry =
         JsonFormat.TypeRegistry.newBuilder()
@@ -179,20 +174,6 @@ public abstract class AbstractMetricsPublisher implements MetricsPublisher {
             .omittingInsignificantWhitespace()
             .print(operationRequestMetadata);
     logger.log(Level.FINE, "{}", formattedRequestMetadata);
-    return "EXECUTE_METADATA:" + formattedRequestMetadata;
-  }
-
-  protected static String formatActionResultMetadataToJson(RequestMetadata requestMetadata)
-      throws InvalidProtocolBufferException {
-    JsonFormat.TypeRegistry typeRegistry =
-        JsonFormat.TypeRegistry.newBuilder().add(PreconditionFailure.getDescriptor()).build();
-
-    String formattedRequestMetadata =
-        JsonFormat.printer()
-            .usingTypeRegistry(typeRegistry)
-            .omittingInsignificantWhitespace()
-            .print(requestMetadata);
-    logger.log(Level.FINE, "{}", formattedRequestMetadata);
-    return "ACTION_RESULT_METADATA:" + formattedRequestMetadata;
+    return formattedRequestMetadata;
   }
 }

--- a/src/main/java/build/buildfarm/metrics/MetricsPublisher.java
+++ b/src/main/java/build/buildfarm/metrics/MetricsPublisher.java
@@ -20,7 +20,5 @@ import com.google.longrunning.Operation;
 public interface MetricsPublisher {
   void publishRequestMetadata(Operation operation, RequestMetadata requestMetadata);
 
-  void publishRequestMetadata(RequestMetadata requestMetadata);
-
   void publishMetric(String metricName, Object metricValue);
 }

--- a/src/main/java/build/buildfarm/metrics/aws/AwsMetricsPublisher.java
+++ b/src/main/java/build/buildfarm/metrics/aws/AwsMetricsPublisher.java
@@ -70,8 +70,7 @@ public class AwsMetricsPublisher extends AbstractMetricsPublisher {
         snsClient.publishAsync(
             new PublishRequest(
                 snsTopicOperations,
-                formatExecutionMetadataToJson(
-                    populateExecutionMetadata(operation, requestMetadata))),
+                formatRequestMetadataToJson(populateRequestMetadata(operation, requestMetadata))),
             new AsyncHandler<PublishRequest, PublishResult>() {
               @Override
               public void onError(Exception e) {
@@ -85,34 +84,7 @@ public class AwsMetricsPublisher extends AbstractMetricsPublisher {
     } catch (Exception e) {
       logger.log(
           Level.WARNING,
-          String.format(
-              "Could not publish request metadata to SNS for %s.", requestMetadata.getTargetId()),
-          e);
-    }
-  }
-
-  @Override
-  public void publishRequestMetadata(RequestMetadata requestMetadata) {
-    try {
-      if (snsClient != null) {
-        snsClient.publishAsync(
-            new PublishRequest(
-                snsTopicOperations, formatActionResultMetadataToJson(requestMetadata)),
-            new AsyncHandler<PublishRequest, PublishResult>() {
-              @Override
-              public void onError(Exception e) {
-                logger.log(Level.WARNING, "Could not publish metrics data to SNS.", e);
-              }
-
-              @Override
-              public void onSuccess(PublishRequest request, PublishResult publishResult) {}
-            });
-      }
-    } catch (Exception e) {
-      logger.log(
-          Level.WARNING,
-          String.format(
-              "Could not publish request metadata to SNS for %s.", requestMetadata.getTargetId()),
+          String.format("Could not publish request metadata to SNS for %s.", operation.getName()),
           e);
     }
   }

--- a/src/main/java/build/buildfarm/metrics/log/LogMetricsPublisher.java
+++ b/src/main/java/build/buildfarm/metrics/log/LogMetricsPublisher.java
@@ -44,25 +44,11 @@ public class LogMetricsPublisher extends AbstractMetricsPublisher {
     try {
       logger.log(
           logLevel,
-          formatExecutionMetadataToJson(populateExecutionMetadata(operation, requestMetadata)));
+          formatRequestMetadataToJson(populateRequestMetadata(operation, requestMetadata)));
     } catch (Exception e) {
       logger.log(
           Level.WARNING,
-          String.format(
-              "Could not publish request metadata to LOG for %s.", requestMetadata.getTargetId()),
-          e);
-    }
-  }
-
-  @Override
-  public void publishRequestMetadata(RequestMetadata requestMetadata) {
-    try {
-      logger.log(logLevel, formatActionResultMetadataToJson(requestMetadata));
-    } catch (Exception e) {
-      logger.log(
-          Level.WARNING,
-          String.format(
-              "Could not publish request metadata to LOG for %s.", requestMetadata.getTargetId()),
+          String.format("Could not publish request metadata to LOG for %s.", operation.getName()),
           e);
     }
   }

--- a/src/main/java/build/buildfarm/server/ActionCacheService.java
+++ b/src/main/java/build/buildfarm/server/ActionCacheService.java
@@ -20,12 +20,10 @@ import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import build.bazel.remote.execution.v2.ActionCacheGrpc;
 import build.bazel.remote.execution.v2.ActionResult;
 import build.bazel.remote.execution.v2.GetActionResultRequest;
-import build.bazel.remote.execution.v2.RequestMetadata;
 import build.bazel.remote.execution.v2.UpdateActionResultRequest;
 import build.buildfarm.common.DigestUtil;
 import build.buildfarm.common.grpc.TracingMetadataUtils;
 import build.buildfarm.instance.Instance;
-import build.buildfarm.metrics.MetricsPublisher;
 import build.buildfarm.v1test.ActionCacheAccessPolicy;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -45,22 +43,19 @@ public class ActionCacheService extends ActionCacheGrpc.ActionCacheImplBase {
 
   private final Instance instance;
   private final boolean isWritable;
-  private final MetricsPublisher metricsPublisher;
 
-  public ActionCacheService(
-      Instance instance, ActionCacheAccessPolicy policy, MetricsPublisher metricsPublisher) {
+  public ActionCacheService(Instance instance, ActionCacheAccessPolicy policy) {
     this.instance = instance;
     this.isWritable = !policy.equals(ActionCacheAccessPolicy.READ_ONLY);
-    this.metricsPublisher = metricsPublisher;
   }
 
   @Override
   public void getActionResult(
       GetActionResultRequest request, StreamObserver<ActionResult> responseObserver) {
-    RequestMetadata requestMetadata = TracingMetadataUtils.fromCurrentContext();
     ListenableFuture<ActionResult> resultFuture =
         instance.getActionResult(
-            DigestUtil.asActionKey(request.getActionDigest()), requestMetadata);
+            DigestUtil.asActionKey(request.getActionDigest()),
+            TracingMetadataUtils.fromCurrentContext());
 
     addCallback(
         resultFuture,
@@ -103,7 +98,6 @@ public class ActionCacheService extends ActionCacheGrpc.ActionCacheImplBase {
         },
         directExecutor());
     actionResultsMetric.inc();
-    metricsPublisher.publishRequestMetadata(requestMetadata);
   }
 
   @Override

--- a/src/main/java/build/buildfarm/server/BuildFarmServer.java
+++ b/src/main/java/build/buildfarm/server/BuildFarmServer.java
@@ -110,9 +110,7 @@ public class BuildFarmServer extends LoggingMain {
     server =
         serverBuilder
             .addService(healthStatusManager.getHealthService())
-            .addService(
-                new ActionCacheService(
-                    instance, config.getAcPolicy(), getMetricsPublisher(config.getMetricsConfig())))
+            .addService(new ActionCacheService(instance, config.getAcPolicy()))
             .addService(new CapabilitiesService(instance))
             .addService(
                 new ContentAddressableStorageService(

--- a/src/test/java/build/buildfarm/metrics/MetricsPublisherTest.java
+++ b/src/test/java/build/buildfarm/metrics/MetricsPublisherTest.java
@@ -78,8 +78,8 @@ public class MetricsPublisherTest {
 
     AwsMetricsPublisher metricsPublisher = new AwsMetricsPublisher(metricsConfig);
     assertThat(
-            AbstractMetricsPublisher.formatExecutionMetadataToJson(
-                metricsPublisher.populateExecutionMetadata(operation, defaultRequestMetadata)))
+            AbstractMetricsPublisher.formatRequestMetadataToJson(
+                metricsPublisher.populateRequestMetadata(operation, defaultRequestMetadata)))
         .isNotNull();
 
     OperationRequestMetadata operationRequestMetadata =
@@ -94,13 +94,10 @@ public class MetricsPublisherTest {
             .build();
 
     assertThat(
-            AbstractMetricsPublisher.formatExecutionMetadataToJson(
-                metricsPublisher.populateExecutionMetadata(operation, defaultRequestMetadata)))
+            AbstractMetricsPublisher.formatRequestMetadataToJson(
+                metricsPublisher.populateRequestMetadata(operation, defaultRequestMetadata)))
         .isEqualTo(
-            "EXECUTE_METADATA:"
-                + JsonFormat.printer()
-                    .omittingInsignificantWhitespace()
-                    .print(operationRequestMetadata));
+            JsonFormat.printer().omittingInsignificantWhitespace().print(operationRequestMetadata));
   }
 
   @Test
@@ -110,7 +107,7 @@ public class MetricsPublisherTest {
 
     assertThat(
             new AwsMetricsPublisher(metricsConfig)
-                .populateExecutionMetadata(operation, defaultRequestMetadata))
+                .populateRequestMetadata(operation, defaultRequestMetadata))
         .isNotNull();
   }
 
@@ -121,7 +118,7 @@ public class MetricsPublisherTest {
 
     assertThat(
             new AwsMetricsPublisher(metricsConfig)
-                .populateExecutionMetadata(operation, defaultRequestMetadata))
+                .populateRequestMetadata(operation, defaultRequestMetadata))
         .isNotNull();
   }
 
@@ -139,7 +136,7 @@ public class MetricsPublisherTest {
 
     assertThat(
             new AwsMetricsPublisher(metricsConfig)
-                .populateExecutionMetadata(operation, defaultRequestMetadata))
+                .populateRequestMetadata(operation, defaultRequestMetadata))
         .isNotNull();
   }
 
@@ -150,7 +147,7 @@ public class MetricsPublisherTest {
 
     assertThat(
             new LogMetricsPublisher(MetricsConfig.getDefaultInstance())
-                .populateExecutionMetadata(operation, defaultRequestMetadata))
+                .populateRequestMetadata(operation, defaultRequestMetadata))
         .isNotNull();
   }
 }

--- a/src/test/java/build/buildfarm/server/ActionCacheServiceTest.java
+++ b/src/test/java/build/buildfarm/server/ActionCacheServiceTest.java
@@ -22,9 +22,7 @@ import static org.mockito.Mockito.verify;
 import build.bazel.remote.execution.v2.ActionResult;
 import build.bazel.remote.execution.v2.UpdateActionResultRequest;
 import build.buildfarm.instance.Instance;
-import build.buildfarm.metrics.log.LogMetricsPublisher;
 import build.buildfarm.v1test.ActionCacheAccessPolicy;
-import build.buildfarm.v1test.MetricsConfig;
 import io.grpc.stub.StreamObserver;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -40,10 +38,7 @@ public class ActionCacheServiceTest {
     // ARRANGE
     Instance instance = mock(Instance.class);
     ActionCacheService service =
-        new ActionCacheService(
-            instance,
-            ActionCacheAccessPolicy.READ_ONLY,
-            new LogMetricsPublisher(MetricsConfig.getDefaultInstance()));
+        new ActionCacheService(instance, ActionCacheAccessPolicy.READ_ONLY);
 
     // ACT
     StreamObserver<ActionResult> response = mock(StreamObserver.class);
@@ -62,10 +57,7 @@ public class ActionCacheServiceTest {
     // ARRANGE
     Instance instance = mock(Instance.class);
     ActionCacheService service =
-        new ActionCacheService(
-            instance,
-            ActionCacheAccessPolicy.READ_AND_WRITE,
-            new LogMetricsPublisher(MetricsConfig.getDefaultInstance()));
+        new ActionCacheService(instance, ActionCacheAccessPolicy.READ_AND_WRITE);
 
     // ACT
     StreamObserver<ActionResult> response = mock(StreamObserver.class);


### PR DESCRIPTION
This reverts commit 80d7d20115836be4500898320ea7bbd59005acd9.

It was realized that the original PR will introduce excessive amount of logging and therefore should be reverted.