### PR TITLE
set allow_unmatched: True in worker example config.  Improve error message.

### DIFF
--- a/examples/shard-worker.config.example
+++ b/examples/shard-worker.config.example
@@ -289,6 +289,7 @@ redis_shard_backplane_config: {
           value: "*"
         }
       }
+      allow_unmatched: True
     }
   }
 

--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -1455,7 +1455,7 @@ public class ShardInstance extends AbstractServerInstance {
           .setSubject(INVALID_PLATFORM)
           .setDescription(
               format(
-                  "properties are not valid for queue eligibility: %s",
+                  "properties are not valid for queue eligibility: %s.  If you think your queue should still accept these poperties without them being specified in queue configuration, consider configuring the queue with `allow_unmatched: True`",
                   platform.getPropertiesList()));
     }
 

--- a/src/test/java/build/buildfarm/instance/shard/ShardInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/shard/ShardInstanceTest.java
@@ -365,7 +365,8 @@ public class ShardInstanceTest {
                 Violation.newBuilder()
                     .setType(VIOLATION_TYPE_INVALID)
                     .setSubject(INVALID_PLATFORM)
-                    .setDescription("properties are not valid for queue eligibility: []"))
+                    .setDescription(
+                        "properties are not valid for queue eligibility: [].  If you think your queue should still accept these poperties without them being specified in queue configuration, consider configuring the queue with `allow_unmatched: True`"))
             .build();
     ExecuteResponse executeResponse =
         ExecuteResponse.newBuilder()


### PR DESCRIPTION
The server example has `allow_unmatched: True` by default, but the worker does not.  The inconsistency will confuse users.  
see: https://buildteamworld.slack.com/archives/C9C4H1SN7/p1650405057441019

we'll adjust the example config and provide a more helpful error message.