### PR TITLE
[bugfix] resolve stuck action example

### DIFF
--- a/src/main/java/build/buildfarm/worker/Executor.java
+++ b/src/main/java/build/buildfarm/worker/Executor.java
@@ -303,7 +303,6 @@ class Executor {
         operationContext.toBuilder().setOperation(operation).build();
     boolean claimed = owner.output().claim(reportOperationContext);
     operationContext.poller.pause();
-
     if (claimed) {
       try {
         owner.output().put(reportOperationContext);

--- a/src/main/java/build/buildfarm/worker/Executor.java
+++ b/src/main/java/build/buildfarm/worker/Executor.java
@@ -555,6 +555,7 @@ class Executor {
       return ExecutionDebugger.performAfterExecutionDebug(
           processBuilder, exitCode, limits, executionStatistics, resultBuilder);
     }
+
     return statusCode;
   }
 }

--- a/src/main/java/build/buildfarm/worker/Executor.java
+++ b/src/main/java/build/buildfarm/worker/Executor.java
@@ -257,7 +257,6 @@ class Executor {
       // based on the exit code observed from the main process. The test runner may kill any stray
       // processes. Tests should not leak processes in this fashion.
       // Based on configuration, we will decide whether remaining resources should be an error.
-
       if (workerContext.shouldErrorOperationOnRemainingResources()
           && resource.isReferenced()
           && statusCode == Code.OK) {
@@ -300,11 +299,9 @@ class Executor {
             operationName, resultBuilder.getExitCode()));
 
     operationContext.executeResponse.getStatusBuilder().setCode(statusCode.getNumber());
-
     OperationContext reportOperationContext =
         operationContext.toBuilder().setOperation(operation).build();
     boolean claimed = owner.output().claim(reportOperationContext);
-
     operationContext.poller.pause();
 
     if (claimed) {
@@ -312,7 +309,6 @@ class Executor {
         owner.output().put(reportOperationContext);
       } catch (InterruptedException e) {
         owner.output().release();
-
         throw e;
       }
     } else {


### PR DESCRIPTION
https://github.com/bazelbuild/bazel-buildfarm/issues/578 shows an example of a unit test that works locally, but hangs on buildfarm.  The issue is that although the process ends, `ByteStringWriteReader.getData()` throws an `InterruptedException` and we were only handling the `IOException`.  We resolve this issue by refactoring the way stdout/stderr is extracted and ensure the example test still completes successfully.  

I'm not sure if this is the core issue related to action hangs, but by not handling the  `InterruptedException` I think we skip logic related to handling the poller which might be causing deadlocks in the future. 

With this change:
1. https://github.com/bazelbuild/bazel-buildfarm/issues/578 unit test will pass successfully.  
2. Infinite loop programs will still timeout and fail as expected (they get re-queued but will fail on requeue amount) 

