### PR TITLE
[shutdown] avoid execution workers hanging on failed pipeline creation

### DIFF
--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -817,7 +817,7 @@ public class Worker extends LoggingMain {
   private void blockUntilShutdown() throws InterruptedException {
     // should really be waiting for either server or pipeline shutdown
     try {
-      if (pipeline.hasStages()) {
+      if (pipeline.hasStages() || hasExecutionCapability) {
         pipeline.join();
       } else {
         logger.log(INFO, "No pipeline stages.  Block until interruption.");


### PR DESCRIPTION
During worker startup we might fail to connect to redis.  This failure prevents a pipeline from being created.  The lack of a pipeline tells the worker avoid shutdown under the impression that we might be a storage-only worker.  We need a better model for worker lifetime.  For now, I want to avoid this problem on execution workers.  This gives execution workers the same behavior before storage workers were introduced.