### PR TITLE
Prevent empty writes with RemoteCasWriter

### DIFF
--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -194,7 +194,9 @@ public class Worker extends LoggingMain {
 
   class RemoteCasWriter implements CasWriter {
     public void write(Digest digest, Path file) throws IOException, InterruptedException {
-      insertFileToCasMember(digest, file);
+      if (digest.getSizeBytes() > 0) {
+        insertFileToCasMember(digest, file);
+      }
     }
 
     private void insertFileToCasMember(Digest digest, Path file)


### PR DESCRIPTION
#1089 demonstrates an upload getting stuck when trying to upload an empty write in protected scopes to a remote worker CAS.

Skip this upload and return immediately if the digest is empty.