### PR TITLE
[refactor] distributed state in backplane

### DIFF
--- a/src/main/java/build/buildfarm/instance/shard/DistributedState.java
+++ b/src/main/java/build/buildfarm/instance/shard/DistributedState.java
@@ -70,7 +70,7 @@ public class DistributedState {
 
   /**
    * @field dispatchingOperations
-   * @brief Operations that are in the process of being dispached from the operation queue.
+   * @brief Operations that are in the process of being dispatched from the operation queue.
    * @details We keep track of them in the distributed state to avoid them getting lost if a
    *     particular machine goes down.
    */

--- a/src/main/java/build/buildfarm/instance/shard/DistributedState.java
+++ b/src/main/java/build/buildfarm/instance/shard/DistributedState.java
@@ -14,17 +14,11 @@
 
 package build.buildfarm.instance.shard;
 
-import build.buildfarm.common.function.InterruptingRunnable;
 import build.buildfarm.common.redis.BalancedRedisQueue;
-import build.buildfarm.common.redis.ProvisionedRedisQueue;
-import build.buildfarm.common.redis.RedisClient;
 import build.buildfarm.common.redis.RedisHashMap;
-import build.buildfarm.common.redis.RedisHashtags;
 import build.buildfarm.common.redis.RedisMap;
-import build.buildfarm.common.redis.RedisNodeHashes;
 
 public class DistributedState {
-    
 
   public RedisMap actionCache;
   public RedisMap blockedActions;
@@ -37,5 +31,4 @@ public class DistributedState {
   public OperationQueue operationQueue;
   public CasWorkerMap casWorkerMap;
   public RedisHashMap workers;
-  
 }

--- a/src/main/java/build/buildfarm/instance/shard/DistributedState.java
+++ b/src/main/java/build/buildfarm/instance/shard/DistributedState.java
@@ -18,17 +18,95 @@ import build.buildfarm.common.redis.BalancedRedisQueue;
 import build.buildfarm.common.redis.RedisHashMap;
 import build.buildfarm.common.redis.RedisMap;
 
+/**
+ * @class DistributedState
+ * @brief The backplane contains distributed state that is shared across the entire cluster. We use
+ *     containerized wrappers to abstract over any backend system managing state.
+ * @details Traditionally redis has been chosen for distributed state management, but alternative
+ *     backends can be chosen by choosing customized containers.
+ */
 public class DistributedState {
+  /**
+   * @field workers
+   * @brief All of the workers register themselves to the cluster.
+   * @details This is done to keep track of which machines are online and known by the rest of the
+   *     cluster.
+   */
+  public RedisHashMap workers;
 
+  /**
+   * @field prequeue
+   * @brief Where execution requests are initially placed once recieved from the frontend.
+   * @details This is to allow the frontend to quickly place requests and use its resources to take
+   *     on more requests.
+   */
+  public BalancedRedisQueue prequeue;
+
+  /**
+   * @field actionCache
+   * @brief The implementation of an action cache.
+   * @details See
+   *     https://github.com/bazelbuild/remote-apis/blob/3b4b6402103539d66fcdd1a4d945f660742665ca/build/bazel/remote/execution/v2/remote_execution.proto#L144
+   *     for the remote API definition of an action cache.
+   */
   public RedisMap actionCache;
-  public RedisMap blockedActions;
-  public RedisMap blockedInvocations;
+
+  /**
+   * @field operationQueue
+   * @brief The queue that holds operations that are ready to be executed by the worker pool.
+   * @details The operation queue is actually made of multiple queues based on platform properties.
+   *     There is a matching algorithm that decides how servers place items onto it, and how workers
+   *     pop requests off of it.
+   */
+  public OperationQueue operationQueue;
+
+  /**
+   * @field processingOperations
+   * @brief Operations that are being processed from the prequeue to the operation queue.
+   * @details We keep track of them in the distributed state to avoid them getting lost if a
+   *     particular machine goes down.
+   */
   public RedisMap processingOperations;
+
+  /**
+   * @field dispatchingOperations
+   * @brief Operations that are in the process of being dispached from the operation queue.
+   * @details We keep track of them in the distributed state to avoid them getting lost if a
+   *     particular machine goes down.
+   */
   public RedisMap dispatchingOperations;
+
+  /**
+   * @field dispatchedOperations
+   * @brief Operations that currently being executed.
+   * @details We keep track of them here so they can be re-executed if the progress of the execution
+   *     is lost.
+   */
   public RedisHashMap dispatchedOperations;
 
-  public BalancedRedisQueue prequeue;
-  public OperationQueue operationQueue;
+  /**
+   * @field casWorkerMap
+   * @brief This map keeps track of which workers have which CAS blobs.
+   * @details Its the worker's responsibility to share this information to others. We do this to
+   *     inform other machines where to find CAS data.
+   */
   public CasWorkerMap casWorkerMap;
-  public RedisHashMap workers;
+
+  /**
+   * @field blockedInvocations
+   * @brief Invocations that the cluster has decided it no longer wants to execute in the future.
+   * @details The requests tied to these invocations will be denied and the client will not get
+   *     their action request executed. The use-case is blocking a particular user or client from
+   *     continuing their requests.
+   */
+  public RedisMap blockedInvocations;
+
+  /**
+   * @field blockedActions
+   * @brief Actions that the cluster has decided it no longer wants to execute in the future.
+   * @details The requests tied to these actions will be denied and the client will not get their
+   *     action request executed. The use case is blocking a certain action hash they we didn't like
+   *     and will refuse to run again.
+   */
+  public RedisMap blockedActions;
 }

--- a/src/main/java/build/buildfarm/instance/shard/DistributedState.java
+++ b/src/main/java/build/buildfarm/instance/shard/DistributedState.java
@@ -1,0 +1,41 @@
+// Copyright 2022 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.instance.shard;
+
+import build.buildfarm.common.function.InterruptingRunnable;
+import build.buildfarm.common.redis.BalancedRedisQueue;
+import build.buildfarm.common.redis.ProvisionedRedisQueue;
+import build.buildfarm.common.redis.RedisClient;
+import build.buildfarm.common.redis.RedisHashMap;
+import build.buildfarm.common.redis.RedisHashtags;
+import build.buildfarm.common.redis.RedisMap;
+import build.buildfarm.common.redis.RedisNodeHashes;
+
+public class DistributedState {
+    
+
+  public RedisMap actionCache;
+  public RedisMap blockedActions;
+  public RedisMap blockedInvocations;
+  public RedisMap processingOperations;
+  public RedisMap dispatchingOperations;
+  public RedisHashMap dispatchedOperations;
+
+  public BalancedRedisQueue prequeue;
+  public OperationQueue operationQueue;
+  public CasWorkerMap casWorkerMap;
+  public RedisHashMap workers;
+  
+}

--- a/src/main/java/build/buildfarm/instance/shard/DistributedStateCreator.java
+++ b/src/main/java/build/buildfarm/instance/shard/DistributedStateCreator.java
@@ -1,0 +1,169 @@
+// Copyright 2022 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.instance.shard;
+
+import build.bazel.remote.execution.v2.Platform;
+import build.buildfarm.common.redis.BalancedRedisQueue;
+import build.buildfarm.common.redis.ProvisionedRedisQueue;
+import build.buildfarm.common.redis.RedisClient;
+import build.buildfarm.common.redis.RedisHashMap;
+import build.buildfarm.common.redis.RedisHashtags;
+import build.buildfarm.common.redis.RedisMap;
+import build.buildfarm.common.redis.RedisNodeHashes;
+import build.buildfarm.v1test.ProvisionedQueue;
+import build.buildfarm.v1test.QueueType;
+import build.buildfarm.v1test.RedisShardBackplaneConfig;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.LinkedHashMultimap;
+import com.google.common.collect.SetMultimap;
+import java.io.IOException;
+import java.util.List;
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+
+public class DistributedStateCreator {
+  public static DistributedState create(RedisClient client, RedisShardBackplaneConfig config)
+      throws IOException {
+    DistributedState state = new DistributedState();
+
+    // Create containers that make up the backplane
+    state.casWorkerMap = createCasWorkerMap(config);
+    state.actionCache = createActionCache(config);
+    state.prequeue = createPrequeue(client, config);
+    state.operationQueue = createOperationQueue(client, config);
+    state.blockedActions = new RedisMap(config.getActionBlacklistPrefix());
+    state.blockedInvocations = new RedisMap(config.getInvocationBlacklistPrefix());
+    state.processingOperations = new RedisMap(config.getProcessingPrefix());
+    state.dispatchingOperations = new RedisMap(config.getDispatchingPrefix());
+    state.dispatchedOperations = new RedisHashMap(config.getDispatchedOperationsHashName());
+    state.workers = new RedisHashMap(config.getWorkersHashName());
+
+    return state;
+  }
+
+  private static CasWorkerMap createCasWorkerMap(RedisShardBackplaneConfig config) {
+    if (config.getCacheCas()) {
+      RedissonClient redissonClient = createRedissonClient();
+      return new RedissonCasWorkerMap(redissonClient, config.getCasPrefix(), config.getCasExpire());
+    } else {
+      return new JedisCasWorkerMap(config.getCasPrefix(), config.getCasExpire());
+    }
+  }
+
+  private static RedisMap createActionCache(RedisShardBackplaneConfig config) {
+    return new RedisMap(config.getActionCachePrefix());
+  }
+
+  private static RedissonClient createRedissonClient() {
+    Config redissonConfig = new Config();
+    return Redisson.create(redissonConfig);
+  }
+
+  private static BalancedRedisQueue createPrequeue(
+      RedisClient client, RedisShardBackplaneConfig config) throws IOException {
+    // Construct the prequeue so that elements are balanced across all redis nodes.
+    return new BalancedRedisQueue(
+        getPreQueuedOperationsListName(config),
+        getQueueHashes(client, getPreQueuedOperationsListName(config)),
+        config.getMaxPreQueueDepth(),
+        queueTypeToSr(config));
+  }
+
+  private static OperationQueue createOperationQueue(
+      RedisClient client, RedisShardBackplaneConfig config) throws IOException {
+    // Construct an operation queue based on configuration.
+    // An operation queue consists of multiple provisioned queues in which the order dictates the
+    // eligibility and placement of operations.
+    // Therefore, it is recommended to have a final provision queue with no actual platform
+    // requirements.  This will ensure that all operations are eligible for the final queue.
+    ImmutableList.Builder<ProvisionedRedisQueue> provisionedQueues = new ImmutableList.Builder<>();
+    for (ProvisionedQueue queueConfig : config.getProvisionedQueues().getQueuesList()) {
+      ProvisionedRedisQueue provisionedQueue =
+          new ProvisionedRedisQueue(
+              getQueueName(queueConfig, config),
+              queueTypeToSr(config),
+              getQueueHashes(client, getQueueName(queueConfig, config)),
+              toMultimap(queueConfig.getPlatform().getPropertiesList()),
+              queueConfig.getAllowUnmatched());
+      provisionedQueues.add(provisionedQueue);
+    }
+    // If there is no configuration for provisioned queues, we might consider that an error.
+    // After all, the operation queue is made up of n provisioned queues, and if there were no
+    // provisioned queues provided, we can not properly construct the operation queue.
+    // In this case however, we will automatically provide a default queue will full eligibility on
+    // all operations.
+    // This will ensure the expected behavior for the paradigm in which all work is put on the same
+    // queue.
+    if (config.getProvisionedQueues().getQueuesList().isEmpty()) {
+      SetMultimap defaultProvisions = LinkedHashMultimap.create();
+      defaultProvisions.put(
+          ProvisionedRedisQueue.WILDCARD_VALUE, ProvisionedRedisQueue.WILDCARD_VALUE);
+      ProvisionedRedisQueue defaultQueue =
+          new ProvisionedRedisQueue(
+              getQueuedOperationsListName(config),
+              queueTypeToSr(config),
+              getQueueHashes(client, getQueuedOperationsListName(config)),
+              defaultProvisions);
+      provisionedQueues.add(defaultQueue);
+    }
+
+    return new OperationQueue(provisionedQueues.build(), config.getMaxQueueDepth());
+  }
+
+  static List<String> getQueueHashes(RedisClient client, String queueName) throws IOException {
+    return client.call(
+        jedis ->
+            RedisNodeHashes.getEvenlyDistributedHashesWithPrefix(
+                jedis, RedisHashtags.existingHash(queueName)));
+  }
+
+  private static SetMultimap<String, String> toMultimap(List<Platform.Property> provisions) {
+    SetMultimap<String, String> set = LinkedHashMultimap.create();
+    for (Platform.Property property : provisions) {
+      set.put(property.getName(), property.getValue());
+    }
+    return set;
+  }
+
+  private static String queueTypeToSr(RedisShardBackplaneConfig config) {
+    QueueType queue = config.getRedisQueueType();
+    return queue.toString().toLowerCase();
+  }
+
+  private static String getQueuedOperationsListName(RedisShardBackplaneConfig config) {
+    String name = config.getQueuedOperationsListName();
+    String queue_type = queueTypeToSr(config);
+    return createFullQueueName(name, queue_type);
+  }
+
+  private static String getPreQueuedOperationsListName(RedisShardBackplaneConfig config) {
+    String name = config.getPreQueuedOperationsListName();
+    String queue_type = queueTypeToSr(config);
+    return createFullQueueName(name, queue_type);
+  }
+
+  private static String getQueueName(ProvisionedQueue pconfig, RedisShardBackplaneConfig rconfig) {
+    String name = pconfig.getName();
+    String queue_type = queueTypeToSr(rconfig);
+    return createFullQueueName(name, queue_type);
+  }
+
+  private static String createFullQueueName(String base, String type) {
+    // To maintain forwards compatibility, we do not append the type to the regular queue
+    // implementation.
+    return ((!type.equals("regular")) ? base + "_" + type : base);
+  }
+}


### PR DESCRIPTION
Move distributed state containers and their creation to modules outside the backplane.  
This is to continue the effort on simplifying the backplane and allowing different backends