### PR TITLE
allow build clients to send priority values larger than 1

### DIFF
--- a/src/main/java/build/buildfarm/instance/server/AbstractServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/server/AbstractServerInstance.java
@@ -1855,7 +1855,8 @@ public abstract class AbstractServerInstance implements Instance {
         .setExecEnabled(true)
         .setExecutionPriorityCapabilities(
             PriorityCapabilities.newBuilder()
-                .addPriorities(PriorityRange.newBuilder().setMinPriority(0).setMaxPriority(Integer.MAX_VALUE)))
+                .addPriorities(
+                    PriorityRange.newBuilder().setMinPriority(0).setMaxPriority(Integer.MAX_VALUE)))
         .build();
   }
 

--- a/src/main/java/build/buildfarm/instance/server/AbstractServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/server/AbstractServerInstance.java
@@ -1855,7 +1855,7 @@ public abstract class AbstractServerInstance implements Instance {
         .setExecEnabled(true)
         .setExecutionPriorityCapabilities(
             PriorityCapabilities.newBuilder()
-                .addPriorities(PriorityRange.newBuilder().setMinPriority(0).setMaxPriority(1)))
+                .addPriorities(PriorityRange.newBuilder().setMinPriority(0).setMaxPriority(Integer.MAX_VALUE)))
         .build();
   }
 


### PR DESCRIPTION
The priority queue implementation can handle values above 1.  We should adjust the client range to allow passing higher values.
Otherwise clients will see: `ERROR: --remote_execution_priority 10 is outside of server supported range 0-1.`