### PR TITLE
Consistently apply empty blob directory policy

### DIFF
--- a/src/main/java/build/buildfarm/instance/server/AbstractServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/server/AbstractServerInstance.java
@@ -837,7 +837,16 @@ public abstract class AbstractServerInstance implements Instance {
         String subDirectoryPath =
             directoryPath.isEmpty() ? directoryName : (directoryPath + "/" + directoryName);
         onInputDirectory.accept(subDirectoryPath);
-        if (!visited.contains(directoryDigest)) {
+        if (visited.contains(directoryDigest)) {
+          Directory subDirectory;
+          if (directoryDigest.getSizeBytes() == 0) {
+            subDirectory = Directory.getDefaultInstance();
+          } else {
+            subDirectory = directoriesIndex.get(directoryDigest);
+          }
+          enumerateActionInputDirectory(
+              subDirectoryPath, subDirectory, directoriesIndex, onInputFile, onInputDirectory);
+        } else {
           validateActionInputDirectoryDigest(
               subDirectoryPath,
               directoryDigest,
@@ -848,13 +857,6 @@ public abstract class AbstractServerInstance implements Instance {
               onInputDirectory,
               onInputDigest,
               preconditionFailure);
-        } else {
-          enumerateActionInputDirectory(
-              subDirectoryPath,
-              directoriesIndex.get(directoryDigest),
-              directoriesIndex,
-              onInputFile,
-              onInputDirectory);
         }
       }
     }

--- a/src/test/java/build/buildfarm/instance/server/BUILD
+++ b/src/test/java/build/buildfarm/instance/server/BUILD
@@ -17,6 +17,7 @@ java_test(
         "@maven//:com_google_guava_guava",
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:com_google_truth_truth",
+        "@maven//:io_grpc_grpc_api",
         "@maven//:io_grpc_grpc_stub",
         "@maven//:org_mockito_mockito_core",
         "@remote_apis//:build_bazel_remote_execution_v2_remote_execution_java_proto",


### PR DESCRIPTION
A pass through a directory hierarchy may encounter multiple empty blob
directories under the root for a consistent hash which does not appear
in the directories index - it may be empty or any other value upon
computation. This change ensures the secondary pass after visited
properly handles the empty digest consistent with the first behavior
which uses a default instance. This is a likely cause of NPEs in the
secondary pass, not guaranteed to be empty directories, but observably
caused by them in the unfixed test case.

Fixes #1101