### PR TITLE
Switch storage workers to server blockUntilShutdown

### DIFF
--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -823,7 +823,7 @@ public class Worker extends LoggingMain {
         pipeline.join();
       } else {
         logger.log(INFO, "No pipeline stages.  Block until interruption.");
-        while (!Thread.interrupted()) {}
+        server.blockUntilShutdown();
       }
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();


### PR DESCRIPTION
fixes issue: https://github.com/bazelbuild/bazel-buildfarm/issues/1097