### PR TITLE
Update buildfarm-http-proxy main class and docs; add --readonly flag …

### DIFF
--- a/_site/docs/architecture/content_addressable_storage.md
+++ b/_site/docs/architecture/content_addressable_storage.md
@@ -69,7 +69,7 @@ The HTTP/1 CAS proxy hosts a GRPC service definition for a configurable target H
 
 Since the HTTP/1 proxy is a separate process, there are no configuration options for it. Instead, run the proxy in a known location (address and port), and use a grpc configuration indicated above, pointing to its address and instance name. The proxy can be run with:
 
-`bazel run //src/main/java/build/buildfarm:buildfarm-http-proxy -- -p 8081 -c "http://your-http-endpoint"`
+`bazel run src/main/java/build/buildfarm/tools:buildfarm-http-proxy -- -p 8081 -c "http://your-http-endpoint" --noreadonly`
 
 And will result in a listening grpc service on port 8081 on all interfaces, relaying requests to the endpoint in question. Use `--help` to see more options.
 

--- a/src/main/java/build/buildfarm/proxy/http/HttpBlobStore.java
+++ b/src/main/java/build/buildfarm/proxy/http/HttpBlobStore.java
@@ -112,6 +112,7 @@ public final class HttpBlobStore implements SimpleBlobStore {
   private final URI uri;
   private final int timeoutMillis;
   private final boolean useTls;
+  private final boolean readOnly;
 
   private final Object closeLock = new Object();
 
@@ -178,6 +179,19 @@ public final class HttpBlobStore implements SimpleBlobStore {
       @Nullable final Credentials creds,
       @Nullable SocketAddress socketAddress)
       throws URISyntaxException, SSLException {
+        this(newEventLoopGroup, channelClass, uri, timeoutMillis, remoteMaxConnections, false, creds, socketAddress);
+  }
+
+  private HttpBlobStore(
+      Function<Integer, EventLoopGroup> newEventLoopGroup,
+      Class<? extends Channel> channelClass,
+      URI uri,
+      int timeoutMillis,
+      int remoteMaxConnections,
+      boolean readOnly,
+      @Nullable final Credentials creds,
+      @Nullable SocketAddress socketAddress)
+      throws URISyntaxException, SSLException {
     useTls = uri.getScheme().equals("https");
     if (uri.getPort() == -1) {
       int port = useTls ? 443 : 80;
@@ -240,6 +254,7 @@ public final class HttpBlobStore implements SimpleBlobStore {
     }
     this.creds = creds;
     this.timeoutMillis = timeoutMillis;
+    this.readOnly = readOnly;
   }
 
   @SuppressWarnings("FutureReturnValueIgnored")
@@ -521,57 +536,61 @@ public final class HttpBlobStore implements SimpleBlobStore {
   @SuppressWarnings({"FutureReturnValueIgnored", "ConstantConditions"})
   private void put(String key, long length, InputStream in, boolean casUpload)
       throws IOException, InterruptedException {
-    InputStream wrappedIn =
-        new FilterInputStream(in) {
-          @Override
-          public void close() {
-            // Ensure that the InputStream can't be closed somewhere in the Netty
-            // pipeline, so that we can support retries. The InputStream is closed in
-            // the finally block below.
+    if (!this.readOnly) {
+      InputStream wrappedIn =
+          new FilterInputStream(in) {
+            @Override
+            public void close() {
+              // Ensure that the InputStream can't be closed somewhere in the Netty
+              // pipeline, so that we can support retries. The InputStream is closed in
+              // the finally block below.
+            }
+          };
+      UploadCommand upload = new UploadCommand(uri, casUpload, key, wrappedIn, length);
+      Channel ch = null;
+      try {
+        ch = acquireUploadChannel();
+        ChannelFuture uploadFuture = ch.writeAndFlush(upload);
+        uploadFuture.sync();
+      } catch (Exception e) {
+        // e can be of type HttpException, because Netty uses Unsafe.throwException to re-throw a
+        // checked exception that hasn't been declared in the method signature.
+        if (e instanceof HttpException) {
+          HttpResponse response = ((HttpException) e).response();
+          if (authTokenExpired(response)) {
+            refreshCredentials();
+            // The error is due to an auth token having expired. Let's try again.
+            if (!reset(in)) {
+              // The InputStream can't be reset and thus we can't retry as most likely
+              // bytes have already been read from the InputStream.
+              throw e;
+            }
+            putAfterCredentialRefresh(upload);
+            return;
           }
-        };
-    UploadCommand upload = new UploadCommand(uri, casUpload, key, wrappedIn, length);
-    Channel ch = null;
-    try {
-      ch = acquireUploadChannel();
-      ChannelFuture uploadFuture = ch.writeAndFlush(upload);
-      uploadFuture.sync();
-    } catch (Exception e) {
-      // e can be of type HttpException, because Netty uses Unsafe.throwException to re-throw a
-      // checked exception that hasn't been declared in the method signature.
-      if (e instanceof HttpException) {
-        HttpResponse response = ((HttpException) e).response();
-        if (authTokenExpired(response)) {
-          refreshCredentials();
-          // The error is due to an auth token having expired. Let's try again.
-          if (!reset(in)) {
-            // The InputStream can't be reset and thus we can't retry as most likely
-            // bytes have already been read from the InputStream.
-            throw e;
-          }
-          putAfterCredentialRefresh(upload);
-          return;
         }
-      }
-      throw e;
-    } finally {
-      in.close();
-      if (ch != null) {
-        releaseUploadChannel(ch);
+        throw e;
+      } finally {
+        in.close();
+        if (ch != null) {
+          releaseUploadChannel(ch);
+        }
       }
     }
   }
 
   @SuppressWarnings({"FutureReturnValueIgnored", "ConstantConditions"})
   private void putAfterCredentialRefresh(UploadCommand cmd) throws InterruptedException {
-    Channel ch = null;
-    try {
-      ch = acquireUploadChannel();
-      ChannelFuture uploadFuture = ch.writeAndFlush(cmd);
-      uploadFuture.sync();
-    } finally {
-      if (ch != null) {
-        releaseUploadChannel(ch);
+    if (!this.readOnly) {
+      Channel ch = null;
+      try {
+        ch = acquireUploadChannel();
+        ChannelFuture uploadFuture = ch.writeAndFlush(cmd);
+        uploadFuture.sync();
+      } finally {
+        if (ch != null) {
+          releaseUploadChannel(ch);
+        }
       }
     }
   }

--- a/src/main/java/build/buildfarm/proxy/http/HttpBlobStore.java
+++ b/src/main/java/build/buildfarm/proxy/http/HttpBlobStore.java
@@ -179,7 +179,15 @@ public final class HttpBlobStore implements SimpleBlobStore {
       @Nullable final Credentials creds,
       @Nullable SocketAddress socketAddress)
       throws URISyntaxException, SSLException {
-        this(newEventLoopGroup, channelClass, uri, timeoutMillis, remoteMaxConnections, false, creds, socketAddress);
+    this(
+        newEventLoopGroup,
+        channelClass,
+        uri,
+        timeoutMillis,
+        remoteMaxConnections,
+        false,
+        creds,
+        socketAddress);
   }
 
   private HttpBlobStore(

--- a/src/main/java/build/buildfarm/proxy/http/HttpProxyOptions.java
+++ b/src/main/java/build/buildfarm/proxy/http/HttpProxyOptions.java
@@ -44,6 +44,13 @@ public class HttpProxyOptions extends OptionsBase {
   public String httpCache;
 
   @Option(
+      name = "readonly",
+      abbrev = 'r',
+      defaultValue = "true",
+      help = "Whether or not the http_cache is read-only. Defaults to true.")
+  public boolean readOnly;
+
+  @Option(
       name = "tree_default_page_size",
       defaultValue = "1024",
       help = "The default number of directories per tree page.")

--- a/src/main/java/build/buildfarm/tools/BUILD
+++ b/src/main/java/build/buildfarm/tools/BUILD
@@ -268,7 +268,7 @@ java_binary(
 
 java_binary(
     name = "buildfarm-http-proxy",
-    main_class = "build.buildfarm.tools.proxy.http.HttpProxy",
+    main_class = "build.buildfarm.proxy.http.HttpProxy",
     visibility = ["//visibility:public"],
     runtime_deps = ["//src/main/java/build/buildfarm/proxy/http"],
 )


### PR DESCRIPTION
…to prevent uploads back to the http store

This change fixes the target `src/main/java/build/buildfarm/tools:buildfarm-http-proxy` to point to the correct main class.  
We also update the site docs to refer to this target instead of an outdated target.  

For our use case, we also require it to be possible to force the proxied CAS to be read-only, which we add as a flag.  

@ShaneDelmore 