### PR TITLE
fix clang dependency to allow older versions of bazel

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -76,7 +76,7 @@ def archive_dependencies(third_party):
         # Used to format proto files
         {
             "name": "com_grail_bazel_toolchain",
-            "sha256": "a28285907868154a47ea4794bd4ecbbb35b31896493679b5808883ed3a6f09b5",
+            "sha256": "98e9fe7bcd2035164efa948ba91ea01ccbc4f933fd19f0320c9cbc536cfe22b7",
             "strip_prefix": "bazel-toolchain-f14a8a5de8f7e98a011a52163d4855572c07a1a3",
             "url": "https://github.com/grailbio/bazel-toolchain/archive/f14a8a5de8f7e98a011a52163d4855572c07a1a3.tar.gz",
         },

--- a/deps.bzl
+++ b/deps.bzl
@@ -76,7 +76,7 @@ def archive_dependencies(third_party):
         # Used to format proto files
         {
             "name": "com_grail_bazel_toolchain",
-            "sha256": "98e9fe7bcd2035164efa948ba91ea01ccbc4f933fd19f0320c9cbc536cfe22b7",
+            "sha256": "a28285907868154a47ea4794bd4ecbbb35b31896493679b5808883ed3a6f09b5",
             "strip_prefix": "bazel-toolchain-f14a8a5de8f7e98a011a52163d4855572c07a1a3",
             "url": "https://github.com/grailbio/bazel-toolchain/archive/f14a8a5de8f7e98a011a52163d4855572c07a1a3.tar.gz",
         },

--- a/deps.bzl
+++ b/deps.bzl
@@ -76,9 +76,9 @@ def archive_dependencies(third_party):
         # Used to format proto files
         {
             "name": "com_grail_bazel_toolchain",
-            "sha256": "148e871e785ae699e6adfbb07afea241ee668dbc0c530e72a47356885fce0cb7",
-            "strip_prefix": "bazel-toolchain-0.7",
-            "url": "https://github.com/grailbio/bazel-toolchain/archive/refs/tags/0.7.tar.gz",
+            "sha256": "98e9fe7bcd2035164efa948ba91ea01ccbc4f933fd19f0320c9cbc536cfe22b7",
+            "strip_prefix": "bazel-toolchain-f14a8a5de8f7e98a011a52163d4855572c07a1a3",
+            "url": "https://github.com/grailbio/bazel-toolchain/archive/f14a8a5de8f7e98a011a52163d4855572c07a1a3.tar.gz",
         },
         {
             "name": "io_bazel_rules_docker",


### PR DESCRIPTION
We recently [upgraded](https://github.com/bazelbuild/bazel-buildfarm/pull/1107) clang to get debian 11, and this caused project builds using bazel 4.2.2 to fail.  This was [fixed](https://github.com/grailbio/bazel-toolchain/pull/146) in the upstream project.  We will upgrade to fix our builds using an older version of bazel.