### PR TITLE
Allow BAZEL override for .bazelci/format.sh

### DIFF
--- a/.bazelci/format.sh
+++ b/.bazelci/format.sh
@@ -9,7 +9,9 @@ LOCAL_FORMATTER="java_formatter.jar"
 
 FORMAT_PROTO=true
 CLANG_FORMAT=@llvm_toolchain//:clang-format
-BAZEL_WRAPPER=bazel
+if [ -z "$BAZEL" ]; then
+  BAZEL=bazel
+fi
 
 FORMAT_BUILD=true
 BUILDIFIER=//:buildifier
@@ -72,17 +74,17 @@ run_proto_formatter () {
     # This is intended to be done by the CI.
     if [[ "$@" == "--check" ]]
     then
-        find . -name '*.proto' -exec $BAZEL_WRAPPER run $CLANG_FORMAT -- -i --dry-run --Werror {} +
+        find . -name '*.proto' -exec $BAZEL run $CLANG_FORMAT -- -i --dry-run --Werror {} +
         handle_format_error_check
         return
     fi
 
     # Fixes formatting issues
-    find . -name '*.proto' -exec $BAZEL_WRAPPER run $CLANG_FORMAT -- -i {} +
+    find . -name '*.proto' -exec $BAZEL run $CLANG_FORMAT -- -i {} +
 }
 
 run_buildifier () {
-    $BAZEL_WRAPPER run $BUILDIFIER -- -r > /dev/null 2>&1
+    $BAZEL run $BUILDIFIER -- -r > /dev/null 2>&1
 }
 
 if [ "${FORMAT_JAVA:-false}" = true ]; then


### PR DESCRIPTION
No need to call this a wrapper anymore