### PR TITLE
Adjust histogram buckets

### DIFF
--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -194,7 +194,11 @@ public class ShardInstance extends AbstractServerInstance {
       Gauge.build().name("queue_size").labelNames("queue_name").help("Queue size.").register();
 
   private static final Histogram ioMetric =
-      Histogram.build().name("io_bytes_read").help("I/O (bytes)").register();
+      Histogram.build()
+          .name("io_bytes_read")
+          .buckets(new double[] {10, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000})
+          .help("Read I/O (bytes)")
+          .register();
 
   private final Runnable onStop;
   private final long maxEntrySizeBytes;

--- a/src/main/java/build/buildfarm/server/ContentAddressableStorageService.java
+++ b/src/main/java/build/buildfarm/server/ContentAddressableStorageService.java
@@ -58,7 +58,11 @@ public class ContentAddressableStorageService
   private static final Logger logger =
       Logger.getLogger(ContentAddressableStorageService.class.getName());
   private static final Histogram missingBlobs =
-      Histogram.build().name("missing_blobs").help("Find missing blobs.").register();
+      Histogram.build()
+          .exponentialBuckets(1, 2, 6)
+          .name("missing_blobs")
+          .help("Find missing blobs.")
+          .register();
 
   private final Instance instance;
   private final long writeDeadlineAfter;

--- a/src/main/java/build/buildfarm/server/WriteStreamObserver.java
+++ b/src/main/java/build/buildfarm/server/WriteStreamObserver.java
@@ -53,7 +53,11 @@ import javax.annotation.concurrent.GuardedBy;
 class WriteStreamObserver implements StreamObserver<WriteRequest> {
   private static final Logger logger = Logger.getLogger(WriteStreamObserver.class.getName());
   private static final Histogram ioMetric =
-      Histogram.build().name("io_bytes_write").help("I/O (bytes)").register();
+      Histogram.build()
+          .name("io_bytes_write")
+          .buckets(new double[] {10, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000})
+          .help("Write I/O (bytes)")
+          .register();
 
   private final Instance instance;
   private final long deadlineAfter;


### PR DESCRIPTION
Currently, we are using default buckets for `io_bytes_read` `io_bytes_write` and `missing_blobs`. The buckets are `.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10` and do not offer enough insight as data is counted in bytes and missing blobs is a counter. Adjust bucket sizing to make them more useful. 

For bytes, making them steps of 10x up up to 1GB, and for missing counts, making them binary up to 32 (and then inf).