### PR TITLE
Only add transaction dirs after linkDirectory

### DIFF
--- a/src/main/java/build/buildfarm/worker/memory/OperationQueueWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/memory/OperationQueueWorkerContext.java
@@ -561,8 +561,8 @@ class OperationQueueWorkerContext implements WorkerContext {
         fetchInputs(
             dirPath, digest, directoriesIndex, childOutputDirectory, inputFiles, inputDirectories);
       } else {
-        inputDirectories.add(digest);
         linkDirectory(dirPath, digest, directoriesIndex);
+        inputDirectories.add(digest);
       }
     }
   }


### PR DESCRIPTION
Prevent dereference-time exceptions due to missing directories when a
directory creation has failed, but the inputDirectories contains its
digest.

References #1129 (not a fix for original issue)