### PR TITLE
Apple based execution wrapper

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -38,6 +38,7 @@ java_library(
         ":as-nobody",
         ":delay",
         ":linux-sandbox.binary",
+        ":macos-wrapper",
         ":process-wrapper.binary",
         ":skip_sleep.binary",
         ":skip_sleep.preload",
@@ -106,6 +107,11 @@ genrule(
 sh_binary(
     name = "delay",
     srcs = ["delay.sh"],
+)
+
+sh_binary(
+    name = "macos-wrapper",
+    srcs = ["macos-wrapper.sh"],
 )
 
 # Docker images for buildfarm components

--- a/macos-wrapper.sh
+++ b/macos-wrapper.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# An Apple specific Apple execution wrapper - mainly to set SDKROOT and
+# DEVELOPER_DIR.
+# There is no enforcement of where Xcode.app is installed locally or remote so
+# isn't possible to assume the remote path is identical to the local path.
+
+# In "Apple" actions we will see the following ENV - but Bazel has to read the
+# Xcode config to map this to DEVELOPER_DIR and SDKROOT.
+# XCODE_VERSION_OVERRIDE=13.0.0.13A233
+# APPLE_SDK_PLATFORM=iPhoneSimulator
+# APPLE_SDK_VERSION_OVERRIDE=15.0
+# PWD=/private/tmp/worker-macos/shard/operations/6d9822e7-29b8-451b-908e-41b09250536f
+
+set -e
+
+# When given a XCODE_VERSION_OVERRIDE locate the specific Xcode and export
+if [[ -n "${XCODE_VERSION_OVERRIDE:-}" ]]; then
+    # For DEVELOPER_DIR - we need to map from how the host is configured to this
+    # path.
+    OVERRIDE_PATH=""
+
+    # Store the version file adjacent to the worker to avoid re-querying launchd
+    # for a given version.
+    CACHED_VERSION_FILE="$(dirname $(dirname "$PWD"))/$XCODE_VERSION_OVERRIDE.info"
+    if [[ -f "$CACHED_VERSION_FILE" ]]; then
+        OVERRIDE_PATH="$(cat $CACHED_VERSION_FILE)"
+    else
+        SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+        # Assuming the user has installed xcode-locator adjacent to the wrapper
+        # https://github.com/bazelbuild/bazel/blob/master/tools/osx/BUILD
+        # note: This program is highly tied to darwin
+        if [[ -f "$SCRIPT_DIR/xcode-locator" ]]; then
+            VERSION=$($SCRIPT_DIR/xcode-locator -v 2> /dev/null | grep ${XCODE_VERSION_OVERRIDE})
+            VERSION_PARTS=(${VERSION//:/ })
+            OVERRIDE_PATH="${VERSION_PARTS[2]}"
+            echo "$OVERRIDE_PATH" > "$CACHED_VERSION_FILE"
+        fi
+    fi
+
+    # Check in /Applications/Xcode-$VERSION - an existing convention or one you can
+    # follow without using xcode-locator
+    if [[ ! -n "${OVERRIDE_PATH}" ]]; then
+        OVERRIDE_PATH="/Applications/Xcode-${XCODE_VERSION_OVERRIDE%.*}.app/Contents/Developer/"
+    fi
+
+    if [[ -d "$OVERRIDE_PATH" ]]; then
+        # Success
+        export DEVELOPER_DIR="$OVERRIDE_PATH"
+    else
+        # If the user didn't give a developer dir - then set it.
+        # xcode-select is installed as part of Xcode.
+        export DEVELOPER_DIR="$(xcode-select -p)"
+        [[ -n "$DEVELOPER_DIR" ]] || (>&2 echo "error: missing xcode" && exit 1)
+    fi
+fi
+
+# In Apple based compiling and linking tools often needs the SDKROOT. We can't
+# naively export SDKROOT though. This code is simple and also requires
+# APPLE_SDK_PLATFORM to be set to set the SDK. For now, remove all fallbacks.
+if [[ ! -n "${SDKROOT:-}" ]] && [[ -n "${APPLE_SDK_PLATFORM:-}" ]]; then
+    # If provided incorrectly - most code on Apple platforms will fail due to
+    # nested and low level usage of this variable - in code and ways not obvious
+    export SDKROOT="${DEVELOPER_DIR}/Platforms/${APPLE_SDK_PLATFORM}.platform/Developer/SDKs/${APPLE_SDK_PLATFORM}${APPLE_SDK_VERSION_OVERRIDE:-}.sdk"
+fi
+
+"$@"


### PR DESCRIPTION
Implement an execution wrapper for macOS to set `SDKROOT` and `DEVELOPER_DIR`

In Apple based builds - this is required by clang, llvm, and related
native compilers and linkers.

Because there is no way to govern where Xcode.app is installed locally
or remotly it must be detected by Bazel. Because isn't possible to
assume the remote path is identical to the local path a buildfarm worker
must solve for this. We either query launchd where it was installed (
using Bazel's `xcode-locator` on darwin) _or_ map to the directory based
on convention. I added documentation about this problem and how it's
solved in the wrapper incase folks are new to this.

At the time of writing there is no notion of a macOS worker in this repo
 so I didn't add build rules for this yet. We don't have docker on
macOS but, I'd propose making a tarball rule longer term if people are
on-board with this idea. We can work towards a reference and canonical
example to build and release a worker end to end including, config, and
wrapper, and xcode-locator.