### PR TITLE
Implement getAllBlobsFuture for Shard

### DIFF
--- a/src/main/java/build/buildfarm/cas/ContentAddressableStorage.java
+++ b/src/main/java/build/buildfarm/cas/ContentAddressableStorage.java
@@ -23,15 +23,22 @@ import build.buildfarm.common.InputStreamFactory;
 import build.buildfarm.common.Write;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.ByteString;
+import com.google.rpc.Code;
+import com.google.rpc.Status;
 import io.grpc.stub.ServerCallStreamObserver;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.List;
 import java.util.UUID;
 import net.jcip.annotations.ThreadSafe;
 
 @ThreadSafe
 public interface ContentAddressableStorage extends InputStreamFactory {
   long UNLIMITED_ENTRY_SIZE_MAX = -1;
+
+  Status OK = Status.newBuilder().setCode(Code.OK.getNumber()).build();
+
+  Status NOT_FOUND = Status.newBuilder().setCode(Code.NOT_FOUND.getNumber()).build();
 
   /**
    * Blob storage for the CAS. This class should be used at all times when interacting with complete
@@ -83,7 +90,7 @@ public interface ContentAddressableStorage extends InputStreamFactory {
   Blob get(Digest digest);
 
   /** Retrieve a set of blobs from the CAS represented by a future. */
-  ListenableFuture<Iterable<Response>> getAllFuture(Iterable<Digest> digests);
+  ListenableFuture<List<Response>> getAllFuture(Iterable<Digest> digests);
 
   InputStream newInput(Digest digest, long offset) throws IOException;
 

--- a/src/main/java/build/buildfarm/cas/ContentAddressableStorages.java
+++ b/src/main/java/build/buildfarm/cas/ContentAddressableStorages.java
@@ -42,6 +42,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import javax.naming.ConfigurationException;
@@ -194,7 +195,7 @@ public final class ContentAddressableStorages {
       }
 
       @Override
-      public ListenableFuture<Iterable<Response>> getAllFuture(Iterable<Digest> digests) {
+      public ListenableFuture<List<Response>> getAllFuture(Iterable<Digest> digests) {
         return immediateFuture(MemoryCAS.getAll(digests, this::getData));
       }
 

--- a/src/main/java/build/buildfarm/cas/GrpcCAS.java
+++ b/src/main/java/build/buildfarm/cas/GrpcCAS.java
@@ -208,7 +208,7 @@ public class GrpcCAS implements ContentAddressableStorage {
   }
 
   @Override
-  public ListenableFuture<Iterable<Response>> getAllFuture(Iterable<Digest> digests) {
+  public ListenableFuture<List<Response>> getAllFuture(Iterable<Digest> digests) {
     // FIXME limit to 4MiB total response
     return transform(
         casFutureStub

--- a/src/main/java/build/buildfarm/cas/MemoryCAS.java
+++ b/src/main/java/build/buildfarm/cas/MemoryCAS.java
@@ -26,7 +26,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.ByteString;
-import com.google.rpc.Code;
 import com.google.rpc.Status;
 import io.grpc.protobuf.StatusProto;
 import io.grpc.stub.ServerCallStreamObserver;
@@ -46,10 +45,6 @@ import javax.annotation.concurrent.GuardedBy;
 
 public class MemoryCAS implements ContentAddressableStorage {
   private static final Logger logger = Logger.getLogger(MemoryCAS.class.getName());
-
-  static final Status OK = Status.newBuilder().setCode(Code.OK.getNumber()).build();
-
-  static final Status NOT_FOUND = Status.newBuilder().setCode(Code.NOT_FOUND.getNumber()).build();
 
   private final long maxSizeInBytes;
   private final Consumer<Digest> onPut;
@@ -151,11 +146,11 @@ public class MemoryCAS implements ContentAddressableStorage {
   }
 
   @Override
-  public ListenableFuture<Iterable<Response>> getAllFuture(Iterable<Digest> digests) {
+  public ListenableFuture<List<Response>> getAllFuture(Iterable<Digest> digests) {
     return immediateFuture(getAll(digests));
   }
 
-  synchronized Iterable<Response> getAll(Iterable<Digest> digests) {
+  synchronized List<Response> getAll(Iterable<Digest> digests) {
     return getAll(
         digests,
         (digest) -> {
@@ -167,7 +162,7 @@ public class MemoryCAS implements ContentAddressableStorage {
         });
   }
 
-  public static Iterable<Response> getAll(
+  public static List<Response> getAll(
       Iterable<Digest> digests, Function<Digest, ByteString> blobGetter) {
     ImmutableList.Builder<Response> responses = ImmutableList.builder();
     for (Digest digest : digests) {

--- a/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
+++ b/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
@@ -460,7 +460,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
   }
 
   @Override
-  public ListenableFuture<Iterable<Response>> getAllFuture(Iterable<Digest> digests) {
+  public ListenableFuture<List<Response>> getAllFuture(Iterable<Digest> digests) {
     throw new UnsupportedOperationException();
   }
 

--- a/src/main/java/build/buildfarm/instance/Instance.java
+++ b/src/main/java/build/buildfarm/instance/Instance.java
@@ -86,7 +86,7 @@ public interface Instance {
       RequestMetadata requestMetadata)
       throws IOException;
 
-  ListenableFuture<Iterable<Response>> getAllBlobsFuture(Iterable<Digest> digests);
+  ListenableFuture<List<Response>> getAllBlobsFuture(Iterable<Digest> digests);
 
   String getTree(Digest rootDigest, int pageSize, String pageToken, Tree.Builder tree);
 

--- a/src/main/java/build/buildfarm/instance/server/AbstractServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/server/AbstractServerInstance.java
@@ -121,6 +121,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.NoSuchFileException;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.Stack;
@@ -401,7 +402,7 @@ public abstract class AbstractServerInstance implements Instance {
   }
 
   @Override
-  public ListenableFuture<Iterable<Response>> getAllBlobsFuture(Iterable<Digest> digests) {
+  public ListenableFuture<List<Response>> getAllBlobsFuture(Iterable<Digest> digests) {
     return contentAddressableStorage.getAllFuture(digests);
   }
 

--- a/src/main/java/build/buildfarm/instance/shard/BUILD
+++ b/src/main/java/build/buildfarm/instance/shard/BUILD
@@ -5,6 +5,7 @@ java_library(
     deps = [
         "//src/main/java/build/buildfarm/ac",
         "//src/main/java/build/buildfarm/backplane",
+        "//src/main/java/build/buildfarm/cas",
         "//src/main/java/build/buildfarm/common",
         "//src/main/java/build/buildfarm/common/config",
         "//src/main/java/build/buildfarm/common/grpc",

--- a/src/main/java/build/buildfarm/instance/stub/StubInstance.java
+++ b/src/main/java/build/buildfarm/instance/stub/StubInstance.java
@@ -135,6 +135,7 @@ import io.grpc.stub.StreamObserver;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Iterator;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -601,7 +602,7 @@ public class StubInstance implements Instance {
   }
 
   @Override
-  public ListenableFuture<Iterable<Response>> getAllBlobsFuture(Iterable<Digest> digests) {
+  public ListenableFuture<List<Response>> getAllBlobsFuture(Iterable<Digest> digests) {
     return transform(
         deadlined(casFutureStub)
             .batchReadBlobs(


### PR DESCRIPTION
Switch the getAllBlobsFuture and cas::getAllFuture interfaces over to
lists to be consistent with allAsList, which comfortably dictates the
minimal behavior, and we shouldn't hide the fact that the response will
be a List, in order according to digests.

Fixes #1135