### PR TITLE
Report slot usage metrics on every change

### DIFF
--- a/src/main/java/build/buildfarm/worker/InputFetchStage.java
+++ b/src/main/java/build/buildfarm/worker/InputFetchStage.java
@@ -61,7 +61,9 @@ public class InputFetchStage extends SuperscalarPipelineStage {
       throw new IllegalStateException("tried to remove unknown fetcher thread");
     }
     releaseClaim(operationName, 1);
-    return fetchers.size();
+    int slotUsage = fetchers.size();
+    inputFetchSlotUsage.set(slotUsage);
+    return slotUsage;
   }
 
   public void releaseInputFetcher(
@@ -69,7 +71,6 @@ public class InputFetchStage extends SuperscalarPipelineStage {
     int size = removeAndRelease(operationName);
     inputFetchTime.observe(usecs / 1000.0);
     inputFetchStallTime.observe(stallUSecs / 1000.0);
-    inputFetchSlotUsage.set(size);
     logComplete(
         operationName,
         usecs,
@@ -100,9 +101,10 @@ public class InputFetchStage extends SuperscalarPipelineStage {
 
     synchronized (this) {
       fetchers.add(fetcher);
+      int slotUsage = fetchers.size();
+      inputFetchSlotUsage.set(slotUsage);
       logStart(
-          operationContext.queueEntry.getExecuteEntry().getOperationName(),
-          getUsage(fetchers.size()));
+          operationContext.queueEntry.getExecuteEntry().getOperationName(), getUsage(slotUsage));
       fetcher.start();
     }
   }


### PR DESCRIPTION
Originally, slot usage metrics were only reported when the slot was released.
In this case, for example, we got a constant value of zero for the `input_fetch_slot_usage` metric with `input_fetch_stage_width: 1`
