### PR TITLE
Fix worker indexer functionality

### DIFF
--- a/admin/main/src/main/java/tech/aurora/bfadmin/rest/AdminApi.java
+++ b/admin/main/src/main/java/tech/aurora/bfadmin/rest/AdminApi.java
@@ -53,9 +53,9 @@ public class AdminApi {
     return adminService.getClusterDetails();
   }
 
-  @RequestMapping("/reindexallcas")
-  public void reindexAllCas() {
-    adminService.reindexAllCas();
+  @RequestMapping("/reindexcas")
+  public void reindexCas() {
+    adminService.reindexCas();
   }
 
   @RequestMapping("/restart/{instanceId}")

--- a/admin/main/src/main/java/tech/aurora/bfadmin/service/AdminService.java
+++ b/admin/main/src/main/java/tech/aurora/bfadmin/service/AdminService.java
@@ -18,7 +18,7 @@ public interface AdminService {
 
   ClusterDetails getClusterDetails();
 
-  void reindexAllCas();
+  void reindexCas();
 
   String scaleGroup(String asgName, Integer desiredInstances);
 

--- a/admin/main/src/main/java/tech/aurora/bfadmin/service/impl/AdminServiceImpl.java
+++ b/admin/main/src/main/java/tech/aurora/bfadmin/service/impl/AdminServiceImpl.java
@@ -6,7 +6,7 @@ import build.buildfarm.v1test.GetClientStartTimeResult;
 import build.buildfarm.v1test.GetClientStartTime;
 import build.buildfarm.v1test.StopContainerRequest;
 import build.buildfarm.v1test.TerminateHostRequest;
-import build.buildfarm.v1test.ReindexAllCasRequest;
+import build.buildfarm.v1test.ReindexCasRequest;
 import build.buildfarm.v1test.ReindexCasRequestResults;
 import com.amazonaws.services.autoscaling.AmazonAutoScaling;
 import com.amazonaws.services.autoscaling.AmazonAutoScalingClientBuilder;
@@ -263,11 +263,11 @@ public class AdminServiceImpl implements AdminService {
   }
 
   @Override
-  public void reindexAllCas(){
+  public void reindexCas(){
     ManagedChannel channel = ManagedChannelBuilder.forAddress(deploymentDomain, deploymentPort).usePlaintext().build();
     AdminGrpc.AdminFutureStub stub = AdminGrpc.newFutureStub(channel);
-    ReindexAllCasRequest request = ReindexAllCasRequest.newBuilder().setInstanceName("shard").build();
-    stub.reindexAllCas(request);
+    ReindexCasRequest request = ReindexCasRequest.newBuilder().setInstanceName("shard").build();
+    stub.reindexCas(request);
   }
 
   private String getTagValue(String tagName, List<Tag> tags) {

--- a/admin/main/src/main/resources/proto/buildfarm.proto
+++ b/admin/main/src/main/resources/proto/buildfarm.proto
@@ -54,12 +54,6 @@ service Admin {
     };
   }
 
-  rpc ReindexAllCas(ReindexAllCasRequest) returns (ReindexCasRequestResults) {
-    option (google.api.http) = {
-      get : "/v1test/admin:reindexAllCas"
-    };
-  }
-
   rpc ShutDownWorkerGracefully(ShutDownWorkerGracefullyRequest)
       returns (ShutDownWorkerGracefullyRequestResults) {
     option (google.api.http) = {
@@ -93,8 +87,6 @@ message ReindexCasRequest {
   // format: ip:port
   string host_id = 2;
 }
-
-message ReindexAllCasRequest { string instance_name = 1; }
 
 message ReindexCasRequestResults {
   int32 removedHosts = 1;

--- a/src/main/java/build/buildfarm/backplane/Backplane.java
+++ b/src/main/java/build/buildfarm/backplane/Backplane.java
@@ -82,7 +82,7 @@ public interface Backplane {
    */
   boolean removeWorker(String workerName, String reason) throws IOException;
 
-  CasIndexResults reindexCas(String workerName) throws IOException;
+  CasIndexResults reindexCas() throws IOException;
 
   void deregisterWorker(String hostName) throws IOException;
 

--- a/src/main/java/build/buildfarm/common/CasIndexResults.java
+++ b/src/main/java/build/buildfarm/common/CasIndexResults.java
@@ -25,21 +25,21 @@ public class CasIndexResults {
    * @brief The number of CAS entries the worker was removed from.
    * @details This indicates how much CAS data the shard new the worker had.
    */
-  public int removedHosts = 0;
+  public long removedHosts = 0;
 
   /**
    * @field removedKeys
    * @brief The number of CAS entries removed due to loss of worker.
    * @details This indicates how many CAS entries were held only by the removed worker.
    */
-  public int removedKeys = 0;
+  public long removedKeys = 0;
 
   /**
    * @field totalKeys
    * @brief The total number of keys processed.
    * @details A fraction can be made with removed keys to see the total percentage of CAS lost.
    */
-  public int totalKeys = 0;
+  public long totalKeys = 0;
 
   /**
    * @brief Get a string message from performing worker indexing on the CAS.

--- a/src/main/java/build/buildfarm/common/CasIndexSettings.java
+++ b/src/main/java/build/buildfarm/common/CasIndexSettings.java
@@ -14,21 +14,12 @@
 
 package build.buildfarm.common;
 
-import java.util.List;
-
 /**
  * @class CasIndexSettings
  * @brief Settings used to determine how to index CAS entries and remove worker entries.
  * @details These are used for reindexing when a worker is leaving the cluster.
  */
 public class CasIndexSettings {
-  /**
-   * @field hostName
-   * @brief The name of the worker.
-   * @details This correlates the the worker that needs removed from CAS entries.
-   */
-  public List<String> hostNames;
-
   /**
    * @field scanAmount
    * @brief The number of redis entries to scan at a time.

--- a/src/main/java/build/buildfarm/instance/Instance.java
+++ b/src/main/java/build/buildfarm/instance/Instance.java
@@ -49,7 +49,6 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nullable;
 
 public interface Instance {
   String getName();
@@ -145,7 +144,7 @@ public interface Instance {
 
   GetClientStartTimeResult getClientStartTime(GetClientStartTimeRequest request);
 
-  CasIndexResults reindexCas(@Nullable String hostName);
+  CasIndexResults reindexCas();
 
   void deregisterWorker(String workerName);
 

--- a/src/main/java/build/buildfarm/instance/memory/MemoryInstance.java
+++ b/src/main/java/build/buildfarm/instance/memory/MemoryInstance.java
@@ -1045,7 +1045,7 @@ public class MemoryInstance extends AbstractServerInstance {
   }
 
   @Override
-  public CasIndexResults reindexCas(@Nullable String hostName) {
+  public CasIndexResults reindexCas() {
     throw new UnsupportedOperationException();
   }
 

--- a/src/main/java/build/buildfarm/instance/server/AbstractServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/server/AbstractServerInstance.java
@@ -1893,7 +1893,7 @@ public abstract class AbstractServerInstance implements Instance {
   public abstract GetClientStartTimeResult getClientStartTime(GetClientStartTimeRequest request);
 
   @Override
-  public abstract CasIndexResults reindexCas(String hostName);
+  public abstract CasIndexResults reindexCas();
 
   public abstract FindOperationsResults findOperations(String filterPredicate);
 

--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -2457,9 +2457,9 @@ public class ShardInstance extends AbstractServerInstance {
   }
 
   @Override
-  public CasIndexResults reindexCas(String hostName) {
+  public CasIndexResults reindexCas() {
     try {
-      return backplane.reindexCas(hostName);
+      return backplane.reindexCas();
     } catch (IOException e) {
       throw Status.fromThrowable(e).asRuntimeException();
     }

--- a/src/main/java/build/buildfarm/instance/stub/StubInstance.java
+++ b/src/main/java/build/buildfarm/instance/stub/StubInstance.java
@@ -82,7 +82,6 @@ import build.buildfarm.v1test.PollOperationRequest;
 import build.buildfarm.v1test.PrepareWorkerForGracefulShutDownRequest;
 import build.buildfarm.v1test.PrepareWorkerForGracefulShutDownRequestResults;
 import build.buildfarm.v1test.QueueEntry;
-import build.buildfarm.v1test.ReindexAllCasRequest;
 import build.buildfarm.v1test.ReindexCasRequest;
 import build.buildfarm.v1test.ReindexCasRequestResults;
 import build.buildfarm.v1test.ShutDownWorkerGracefullyRequest;
@@ -879,16 +878,10 @@ public class StubInstance implements Instance {
   }
 
   @Override
-  public CasIndexResults reindexCas(@Nullable String hostName) {
+  public CasIndexResults reindexCas() {
     throwIfStopped();
     ReindexCasRequestResults proto =
-        adminBlockingStub.get().reindexAllCas(ReindexAllCasRequest.newBuilder().build());
-    if (hostName != null) {
-      proto =
-          adminBlockingStub
-              .get()
-              .reindexCas(ReindexCasRequest.newBuilder().setHostId(hostName).build());
-    }
+        adminBlockingStub.get().reindexCas(ReindexCasRequest.newBuilder().build());
     CasIndexResults results = new CasIndexResults();
     results.removedHosts = proto.getRemovedHosts();
     results.removedKeys = proto.getRemovedKeys();

--- a/src/main/java/build/buildfarm/server/AdminService.java
+++ b/src/main/java/build/buildfarm/server/AdminService.java
@@ -14,8 +14,6 @@
 
 package build.buildfarm.server;
 
-import static java.util.logging.Level.INFO;
-
 import build.buildfarm.admin.Admin;
 import build.buildfarm.admin.aws.AwsAdmin;
 import build.buildfarm.admin.gcp.GcpAdmin;
@@ -30,7 +28,6 @@ import build.buildfarm.v1test.GetClientStartTimeResult;
 import build.buildfarm.v1test.GetHostsRequest;
 import build.buildfarm.v1test.GetHostsResult;
 import build.buildfarm.v1test.PrepareWorkerForGracefulShutDownRequest;
-import build.buildfarm.v1test.ReindexAllCasRequest;
 import build.buildfarm.v1test.ReindexCasRequest;
 import build.buildfarm.v1test.ReindexCasRequestResults;
 import build.buildfarm.v1test.ScaleClusterRequest;
@@ -144,28 +141,8 @@ public class AdminService extends AdminGrpc.AdminImplBase {
   public void reindexCas(
       ReindexCasRequest request, StreamObserver<ReindexCasRequestResults> responseObserver) {
     try {
-      CasIndexResults results = instance.reindexCas(request.getHostId());
-      logger.log(INFO, "Indexer results: " + results.toMessage());
-      responseObserver.onNext(
-          ReindexCasRequestResults.newBuilder()
-              .setRemovedHosts(results.removedHosts)
-              .setRemovedKeys(results.removedKeys)
-              .setTotalKeys(results.totalKeys)
-              .build());
-      responseObserver.onCompleted();
-    } catch (Exception e) {
-      logger.log(Level.SEVERE, "Could not reindex CAS.", e);
-      responseObserver.onError(io.grpc.Status.fromThrowable(e).asException());
-    }
-  }
-
-  @Override
-  public void reindexAllCas(
-      ReindexAllCasRequest request, StreamObserver<ReindexCasRequestResults> responseObserver) {
-    try {
-      String arg = null;
-      CasIndexResults results = instance.reindexCas(arg);
-      logger.log(INFO, "Indexer results: " + results.toMessage());
+      CasIndexResults results = instance.reindexCas();
+      logger.info(String.format("CAS Indexer Results: %s", results.toMessage()));
       responseObserver.onNext(
           ReindexCasRequestResults.newBuilder()
               .setRemovedHosts(results.removedHosts)

--- a/src/main/java/build/buildfarm/tools/IndexWorker.java
+++ b/src/main/java/build/buildfarm/tools/IndexWorker.java
@@ -37,10 +37,9 @@ class IndexWorker {
     String host = args[0];
     String instanceName = args[1];
     DigestUtil digestUtil = DigestUtil.forHash(args[2]);
-    String reindexworker = args[3];
     ManagedChannel channel = createChannel(host);
     Instance instance = new StubInstance(instanceName, digestUtil, channel);
-    CasIndexResults results = instance.reindexCas(reindexworker);
+    CasIndexResults results = instance.reindexCas();
     System.out.println(results.toMessage());
     instance.stop();
   }

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerInstance.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerInstance.java
@@ -372,9 +372,9 @@ public class ShardWorkerInstance extends AbstractServerInstance {
   }
 
   @Override
-  public CasIndexResults reindexCas(String hostName) {
+  public CasIndexResults reindexCas() {
     try {
-      return backplane.reindexCas(hostName);
+      return backplane.reindexCas();
     } catch (IOException e) {
       throw Status.fromThrowable(e).asRuntimeException();
     }

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -53,11 +53,6 @@ service Admin {
       get : "/v1test/admin:reindexCas"
     };
   }
-  rpc ReindexAllCas(ReindexAllCasRequest) returns (ReindexCasRequestResults) {
-    option (google.api.http) = {
-      get : "/v1test/admin:reindexAllCas"
-    };
-  }
 
   rpc ShutDownWorkerGracefully(ShutDownWorkerGracefullyRequest)
       returns (ShutDownWorkerGracefullyRequestResults) {
@@ -93,14 +88,12 @@ message ReindexCasRequest {
   string host_id = 2;
 }
 
-message ReindexAllCasRequest { string instance_name = 1; }
-
 message ReindexCasRequestResults {
-  int32 removedHosts = 1;
+  int64 removedHosts = 1;
 
-  int32 removedKeys = 2;
+  int64 removedKeys = 2;
 
-  int32 totalKeys = 3;
+  int64 totalKeys = 3;
 }
 
 message TerminateHostRequest {

--- a/src/test/java/build/buildfarm/instance/server/AbstractServerInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/server/AbstractServerInstanceTest.java
@@ -76,7 +76,6 @@ import io.grpc.stub.StreamObserver;
 import java.io.InputStream;
 import java.util.Stack;
 import java.util.logging.Logger;
-import javax.annotation.Nullable;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -195,7 +194,7 @@ public class AbstractServerInstanceTest {
     }
 
     @Override
-    public CasIndexResults reindexCas(@Nullable String hostName) {
+    public CasIndexResults reindexCas() {
       throw new UnsupportedOperationException();
     }
 


### PR DESCRIPTION
Current worker indexer performance is preventing it from useful as it takes an unreasonable amount of time to complete. I ran the indexer against a small Redis cluster and it was not able to complete iterating through all the keys on a single node after running for 12+ hours.

After the changes, I was able to run the indexer against the same cluster in under 15 minutes.

- This PR removes the old /reindexcas functionality which was able to ingest an individual worker to remove from index as that functionality proved to be very slow.
- The /reindexallcas is renamed to /reindexcas which now performs a full reindex against all active workers.