### PR TITLE
[admin] Enable worker indexer scheduler

### DIFF
--- a/admin/main/src/main/java/tech/aurora/bfadmin/service/AdminService.java
+++ b/admin/main/src/main/java/tech/aurora/bfadmin/service/AdminService.java
@@ -27,4 +27,6 @@ public interface AdminService {
   String getInstanceIdByPrivateDnsName(String dnsName);
 
   int stopDockerContainer(String instanceId, String containerType, String grpcEndpoint, int grpcPort);
+
+  boolean isPrimaryAdminHost();
 }

--- a/admin/main/src/main/java/tech/aurora/bfadmin/tasks/ScheduledTasks.java
+++ b/admin/main/src/main/java/tech/aurora/bfadmin/tasks/ScheduledTasks.java
@@ -1,0 +1,34 @@
+package tech.aurora.bfadmin.tasks;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import tech.aurora.bfadmin.service.AdminService;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@Component
+@EnableScheduling
+@EnableAsync
+public class ScheduledTasks {
+  private static final Logger logger = LoggerFactory.getLogger(ScheduledTasks.class);
+
+  @Autowired
+  AdminService adminService;
+
+  @Value("${buildfarm.scheduled.indexer}")
+  private boolean indexerTaskEnabled;
+
+  @Async
+  @Scheduled(cron = "${buildfarm.scheduled.indexer.cron}")
+  public void runWorkerIndexer() {
+    if (adminService.isPrimaryAdminHost() && indexerTaskEnabled) {
+      logger.info("Running worker indexer...");
+      adminService.reindexCas();
+    }
+  }
+}

--- a/admin/main/src/main/resources/application.properties
+++ b/admin/main/src/main/resources/application.properties
@@ -19,3 +19,7 @@ springdoc.swagger-ui.operationsSorter=method
 
 # REST API Security (TODO: CHANGE IT!!!)
 security.http.auth-token=CHANGEME-1234567890
+
+# Scheduled Tasks
+buildfarm.scheduled.indexer=false
+buildfarm.scheduled.indexer.cron=0 0 0 * * *


### PR DESCRIPTION
This PR adds buildfarm indexer scheduler to Buildfarm Admin. To enable the scheduler add/modify the following configs to BFAdmin's application.properties. By default, the scheduler is disabled.

buildfarm.scheduled.indexer=true
buildfarm.scheduled.indexer.cron=0 0 0 * * *