### PR TITLE
Add cas indexer results prometheus metrics

### DIFF
--- a/src/main/java/build/buildfarm/common/BUILD
+++ b/src/main/java/build/buildfarm/common/BUILD
@@ -28,6 +28,7 @@ java_library(
         "@maven//:io_grpc_grpc_api",
         "@maven//:io_grpc_grpc_context",
         "@maven//:io_grpc_grpc_protobuf",
+        "@maven//:io_prometheus_simpleclient",
         "@maven//:org_apache_commons_commons_compress",
         "@maven//:org_threeten_threetenbp",
         "@remote_apis//:build_bazel_remote_execution_v2_remote_execution_java_proto",


### PR DESCRIPTION
Emit prometheus metrics for CAS indexer results per each Redis shard:

- Number of hosts removed from keys (cas_indexer_removed_keys)
- Number of keys removed due to no workers containing them (cas_indexer_removed_hosts)

Above metrics contain a "node" label to separate these metrics per Redis shard.