### PR TITLE
[admin] Update base docker image for bfadmin

### DIFF
--- a/admin/main/src/main/docker/Dockerfile
+++ b/admin/main/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8
+FROM amazoncorretto:17
 USER root
 VOLUME /tmp
 VOLUME /var/lib


### PR DESCRIPTION
Existing java:8 image has been deprecated and is no longer available to pull as the base image for bfadmin.

Replacing with Amazon's Corretto image and upgrading to Java 17.