### PR TITLE
Restore interrupt sequence for fallback expiry

### DIFF
--- a/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
+++ b/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
@@ -1795,11 +1795,23 @@ public abstract class CASFileCache implements ContentAddressableStorage {
                 + e.referenceCount
                 + " references");
       }
-      expireEntryFallback(e);
+      boolean interrupted = false;
+      try {
+        expireEntryFallback(e);
+      } catch (IOException ioEx) {
+        interrupted =
+            Thread.interrupted()
+                || ioEx.getCause() instanceof InterruptedException
+                || ioEx instanceof ClosedByInterruptException;
+      }
       Entry removedEntry = storage.remove(e.key);
       // reference compare on purpose
       if (removedEntry == e) {
-        return dischargeEntryFuture(e, service);
+        ListenableFuture<Entry> entryFuture = dischargeEntryFuture(e, service);
+        if (interrupted) {
+          Thread.currentThread().interrupt();
+        }
+        return entryFuture;
       }
       if (removedEntry == null) {
         logger.log(Level.SEVERE, format("entry %s was already removed during expiration", e.key));
@@ -1820,6 +1832,10 @@ public abstract class CASFileCache implements ContentAddressableStorage {
             "removed entry %s did not match last unreferenced entry, restoring it",
             e.key);
         storage.put(e.key, removedEntry);
+      }
+      // possibly delegated, but no removal, if we're interrupted, abort loop
+      if (interrupted || Thread.currentThread().isInterrupted()) {
+        throw new InterruptedException();
       }
     }
     return null;
@@ -2870,7 +2886,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
         write);
   }
 
-  private void expireEntryFallback(Entry e) throws IOException, InterruptedException {
+  private void expireEntryFallback(Entry e) throws IOException {
     if (delegate != null) {
       FileEntryKey fileEntryKey = parseFileEntryKey(e.key, e.size);
       if (fileEntryKey == null) {
@@ -2884,14 +2900,14 @@ public abstract class CASFileCache implements ContentAddressableStorage {
     }
   }
 
-  private void performCopy(Write write, Entry e) throws IOException, InterruptedException {
+  private void performCopy(Write write, Entry e) throws IOException {
     try (OutputStream out = write.getOutput(1, MINUTES, () -> {});
         InputStream in = Files.newInputStream(getPath(e.key))) {
       ByteStreams.copy(in, out);
     } catch (IOException ioEx) {
       write.reset();
       logger.log(Level.SEVERE, format("error delegating expired entry %s", e.key), ioEx);
-      throw new InterruptedException();
+      throw ioEx;
     }
   }
 }

--- a/src/test/java/build/buildfarm/cas/cfc/CASFileCacheTest.java
+++ b/src/test/java/build/buildfarm/cas/cfc/CASFileCacheTest.java
@@ -708,6 +708,7 @@ class CASFileCacheTest {
 
     verify(delegate, times(1))
         .getWrite(eq(expiringDigest), any(UUID.class), any(RequestMetadata.class));
+    assertThat(storage).isEmpty();
   }
 
   void decrementReference(Path path) throws IOException, InterruptedException {


### PR DESCRIPTION
And guard it with a test this time. The entry found should be expired,
even in the event of an exception from the delegate.