### PR TITLE
Convert all relevant strings to enums

### DIFF
--- a/_site/docs/configuration.md
+++ b/_site/docs/configuration.md
@@ -120,7 +120,7 @@ server:
 
 | Configuration         | Accepted and _Default_ Values | Description                                                                    |
 |-----------------------|-------------------------------|--------------------------------------------------------------------------------|
-| deploymentEnvironment | String, aws, gcp              | Specify deloyment environment in the cloud                                     |
+| deploymentEnvironment | String, AWS, GCP              | Specify deloyment environment in the cloud                                     |
 | clusterEndpoint       | String, grpc://localhost      | Buildfarm cluster endpoint for Admin use (this is a full buildfarm endpoint)   |
 
 Example:
@@ -128,7 +128,7 @@ Example:
 ```
 server:
   admin:
-    deploymentEnvironment: aws
+    deploymentEnvironment: AWS
     clusterEndpoint: "grpc://localhost"
 ```
 
@@ -137,7 +137,7 @@ server:
 | Configuration       | Accepted and _Default_ Values | Description                                                                               |
 |---------------------|-------------------------------|-------------------------------------------------------------------------------------------|
 | publisher           | String, aws, gcp, _log_       | Specify publisher type for sending metadata                                               |
-| logLevel            | String, INFO, _FINE_          | Specify log level ("log" publisher only, all Java util logging levels are allowed here)   |
+| logLevel            | String, INFO, _OFF_           | Specify log level ("log" publisher only, all Java util logging levels are allowed here)   |
 | topic               | String, _test_                | Specify SNS topic name for cloud publishing ("aws" publisher only)                        |
 | topicMaxConnections | Integer, 1000                 | Specify maximum number of connections allowed for cloud publishing ("aws" publisher only) |
 | secretName          | String, _test_                | Specify secret name to pull SNS permissions from ("aws" publisher only)                   |
@@ -193,7 +193,7 @@ server:
 | runFailsafeOperation         | boolean, _true_                          | Enable an agent in the backplane client which monitors watched operations and ensures they are in a known maintained, or expirable state                             |
 | maxQueueDepth                | Integer, _100000_                        | Maximum length that the ready to run queue is allowed to reach to control an arrival flow for execution                                                              |
 | maxPreQueueDepth             | Integer, _1000000_                       | Maximum lengh that the arrival queue is allowed to reach to control load on the Redis cluster                                                                        |
-| redisQueueType               | _REGULAR_, PRIORITY                      | Priority queue type allows prioritizing operations based on Bazel's --remote_execution_priority=<an integer> flag                                                    |
+| priorityQueue                | boolean, _false_                         | Priority queue type allows prioritizing operations based on Bazel's --remote_execution_priority=<an integer> flag                                                    |
 | timeout                      | Integer, _10000_                         | Default timeout                                                                                                                                                      |
 | maxAttempts                  | Integer, _20_                            | Maximum number of execution attempts                                                                                                                                 |
 | cacheCas                     | boolean, _false_                         |                                                                                                                                                                      |
@@ -204,7 +204,7 @@ Example:
 backplane:
   type: SHARD
   redisUri: "redis://localhost:6379"
-  redisQueueType: PRIORITY
+  priorityQueue: true
 ```
 
 ### Execution Queues

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -26,10 +26,10 @@ server:
   clusterId: local
   cloudRegion: us-east-1
   admin:
-    deploymentEnvironment: aws
+    deploymentEnvironment: AWS
     clusterEndpoint: "grpc://localhost"
   metrics:
-    publisher: log
+    publisher: LOG
     logLevel: INFO
     topic: test
     topicMaxConnections: 1000
@@ -64,7 +64,7 @@ backplane:
   runFailsafeOperation: true
   maxQueueDepth: 100000
   maxPreQueueDepth: 1000000
-  redisQueueType: NORMAL
+  priorityQueue: false
   timeout: 10000
   maxAttempts: 20
   cacheCas: false

--- a/src/main/java/build/buildfarm/cas/ContentAddressableStorages.java
+++ b/src/main/java/build/buildfarm/cas/ContentAddressableStorages.java
@@ -114,11 +114,11 @@ public final class ContentAddressableStorages {
     switch (configs.getWorker().getCas().getType()) {
       default:
         throw new IllegalArgumentException("CAS config not set in config");
-      case "FILESYSTEM":
+      case FILESYSTEM:
         return createFilesystemCAS();
-      case "GRPC":
+      case GRPC:
         return createGrpcCAS();
-      case "MEMORY":
+      case MEMORY:
         return new MemoryCAS(configs.getWorker().getCas().getMaxSizeBytes());
     }
   }

--- a/src/main/java/build/buildfarm/common/config/yml/Admin.java
+++ b/src/main/java/build/buildfarm/common/config/yml/Admin.java
@@ -4,7 +4,12 @@ import lombok.Data;
 
 @Data
 public class Admin {
-  private String deploymentEnvironment;
+  public enum DEPLOYMENT_ENVIRONMENT {
+    AWS,
+    GCP
+  }
+
+  private DEPLOYMENT_ENVIRONMENT deploymentEnvironment;
   private String clusterEndpoint;
   private boolean enableGracefulShutdown;
 }

--- a/src/main/java/build/buildfarm/common/config/yml/BUILD
+++ b/src/main/java/build/buildfarm/common/config/yml/BUILD
@@ -14,6 +14,7 @@ java_library(
     plugins = [":lombok-java"],
     visibility = ["//visibility:public"],
     deps = [
+        "//src/main/java/build/buildfarm/common",
         "//src/main/protobuf:build_buildfarm_v1test_buildfarm_java_proto",
         "@maven//:com_google_guava_guava",
         "@maven//:org_projectlombok_lombok",

--- a/src/main/java/build/buildfarm/common/config/yml/Backplane.java
+++ b/src/main/java/build/buildfarm/common/config/yml/Backplane.java
@@ -5,7 +5,11 @@ import lombok.Data;
 
 @Data
 public class Backplane {
-  private String type = "SHARD";
+  public enum BACKPLANE_TYPE {
+    SHARD
+  }
+
+  private BACKPLANE_TYPE type = BACKPLANE_TYPE.SHARD;
   private String redisUri;
   private int jedisPoolMaxTotal = 4000;
   private String workersHashName = "Workers";
@@ -32,7 +36,7 @@ public class Backplane {
   private boolean runFailsafeOperation = true;
   private int maxQueueDepth = 100000;
   private int maxPreQueueDepth = 1000000;
-  private String redisQueueType = "REGULAR";
+  private boolean priorityQueue = false;
   private Queue[] queues;
   private String redisPassword;
   private int timeout = 10000;

--- a/src/main/java/build/buildfarm/common/config/yml/BuildfarmConfigs.java
+++ b/src/main/java/build/buildfarm/common/config/yml/BuildfarmConfigs.java
@@ -1,5 +1,7 @@
 package build.buildfarm.common.config.yml;
 
+import build.bazel.remote.execution.v2.DigestFunction;
+import build.buildfarm.common.DigestUtil;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -14,7 +16,8 @@ import org.yaml.snakeyaml.constructor.Constructor;
 public final class BuildfarmConfigs {
   private static BuildfarmConfigs buildfarmConfigs;
 
-  private static String digestFunction = "SHA256";
+  private static DigestUtil.HashFunction digestFunction =
+      DigestUtil.HashFunction.get(DigestFunction.Value.SHA256);
 
   private static long defaultActionTimeout = 600;
 
@@ -58,12 +61,13 @@ public final class BuildfarmConfigs {
     this.buildfarmConfigs = buildfarmConfigs;
   }
 
-  public String getDigestFunction() {
+  public DigestUtil.HashFunction getDigestFunction() {
     return digestFunction;
   }
 
-  public void setDigestFunction(String digestFunction) {
+  public void setDigestFunction(DigestUtil.HashFunction digestFunction) {
     this.digestFunction = digestFunction;
+    // System.out.println("DEBUG ME: " + DigestUtil.HashFunction.valueOf(digestFunction));
   }
 
   public long getDefaultActionTimeout() {

--- a/src/main/java/build/buildfarm/common/config/yml/Cas.java
+++ b/src/main/java/build/buildfarm/common/config/yml/Cas.java
@@ -4,11 +4,18 @@ import lombok.Data;
 
 @Data
 public class Cas {
+  public enum TYPE {
+    FILESYSTEM,
+    GRPC,
+    MEMORY,
+    FUSE
+  }
+
+  private TYPE type = TYPE.FILESYSTEM;
   private String path = "cache";
   private long maxSizeBytes = 2147483648L; // 2 * 1024 * 1024 * 1024
   private long maxEntrySizeBytes = 2147483648L; // 2 * 1024 * 1024 * 1024
   private boolean fileDirectoriesIndexInMemory = false;
   private boolean skipLoad = false;
-  private String type = "FILESYSTEM";
   private String target;
 }

--- a/src/main/java/build/buildfarm/common/config/yml/Memory.java
+++ b/src/main/java/build/buildfarm/common/config/yml/Memory.java
@@ -1,6 +1,7 @@
 package build.buildfarm.common.config.yml;
 
 import build.bazel.remote.execution.v2.Platform;
+import build.buildfarm.v1test.CASInsertionPolicy;
 import lombok.Data;
 
 @Data
@@ -16,7 +17,7 @@ public class Memory {
   private int deadlineAfterSeconds = 60;
   private boolean streamStdout = true;
   private boolean streamStderr = true;
-  private String casPolicy = "ALWAYS_INSERT";
+  private CASInsertionPolicy casPolicy = CASInsertionPolicy.ALWAYS_INSERT;
   private int treePageSize = 0;
   private Platform platform = Platform.newBuilder().build();
   private Property[] properties;

--- a/src/main/java/build/buildfarm/common/config/yml/Metrics.java
+++ b/src/main/java/build/buildfarm/common/config/yml/Metrics.java
@@ -4,8 +4,25 @@ import lombok.Data;
 
 @Data
 public class Metrics {
-  private String publisher = "log";
-  private String logLevel = "FINE";
+  public enum PUBLISHER {
+    LOG,
+    AWS,
+    GCP
+  }
+
+  public enum LOG_LEVEL {
+    OFF,
+    SEVERE,
+    WARNING,
+    INFO,
+    FINE,
+    FINER,
+    FINEST,
+    ALL
+  }
+
+  private PUBLISHER publisher = PUBLISHER.LOG;
+  private LOG_LEVEL logLevel = LOG_LEVEL.OFF;
   private String topic;
   private int topicMaxConnections;
   private String secretName;

--- a/src/main/java/build/buildfarm/common/config/yml/Queue.java
+++ b/src/main/java/build/buildfarm/common/config/yml/Queue.java
@@ -6,6 +6,11 @@ import lombok.Data;
 
 @Data
 public class Queue {
+  public enum QUEUE_TYPE {
+    priority,
+    standard
+  }
+
   private String name;
   private boolean allowUnmatched = true;
   private List<Property> properties;

--- a/src/main/java/build/buildfarm/common/config/yml/Server.java
+++ b/src/main/java/build/buildfarm/common/config/yml/Server.java
@@ -5,7 +5,12 @@ import lombok.Data;
 
 @Data
 public class Server {
-  private String instanceType;
+  public enum INSTANCE_TYPE {
+    SHARD,
+    MEMORY
+  }
+
+  private INSTANCE_TYPE instanceType;
   private String name;
   private boolean actionCacheReadOnly = false;
   private int port = 8980;

--- a/src/main/java/build/buildfarm/common/redis/BUILD
+++ b/src/main/java/build/buildfarm/common/redis/BUILD
@@ -4,6 +4,7 @@ java_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/main/java/build/buildfarm/common",
+        "//src/main/java/build/buildfarm/common/config/yml",
         "//src/main/protobuf:build_buildfarm_v1test_buildfarm_java_proto",
         "//third_party/jedis",
         "@maven//:com_google_guava_guava",

--- a/src/main/java/build/buildfarm/common/redis/BalancedRedisQueue.java
+++ b/src/main/java/build/buildfarm/common/redis/BalancedRedisQueue.java
@@ -49,7 +49,7 @@ public class BalancedRedisQueue {
    * @brief Type of the queue.
    * @details It's used for selecting between regular and priority queues
    */
-  private final String queueType;
+  private final Queue.QUEUE_TYPE queueType;
 
   /**
    * @field originalHashtag
@@ -102,7 +102,7 @@ public class BalancedRedisQueue {
    * @note Overloaded.
    */
   public BalancedRedisQueue(String name, List<String> hashtags) {
-    this(name, hashtags, -1, Queue.QUEUE_TYPE.standard.name());
+    this(name, hashtags, -1, Queue.QUEUE_TYPE.standard);
   }
 
   /**
@@ -113,7 +113,7 @@ public class BalancedRedisQueue {
    * @param queueType Type of the queue in use
    * @note Overloaded.
    */
-  public BalancedRedisQueue(String name, List<String> hashtags, String queueType) {
+  public BalancedRedisQueue(String name, List<String> hashtags, Queue.QUEUE_TYPE queueType) {
     this(name, hashtags, -1, queueType);
   }
 
@@ -126,7 +126,7 @@ public class BalancedRedisQueue {
    * @note Overloaded.
    */
   public BalancedRedisQueue(String name, List<String> hashtags, int maxQueueSize) {
-    this(name, hashtags, maxQueueSize, Queue.QUEUE_TYPE.standard.name());
+    this(name, hashtags, maxQueueSize, Queue.QUEUE_TYPE.standard);
   }
 
   /**
@@ -139,10 +139,10 @@ public class BalancedRedisQueue {
    * @note Overloaded.
    */
   public BalancedRedisQueue(
-      String name, List<String> hashtags, int maxQueueSize, String queueType) {
+      String name, List<String> hashtags, int maxQueueSize, Queue.QUEUE_TYPE queueType) {
     this.originalHashtag = RedisHashtags.existingHash(name);
     this.name = RedisHashtags.unhashedName(name);
-    this.queueType = queueType.toLowerCase();
+    this.queueType = queueType;
     this.maxQueueSize = maxQueueSize;
     createHashedQueues(this.name, hashtags, this.queueType);
   }
@@ -380,7 +380,7 @@ public class BalancedRedisQueue {
    * @param name The global name of the queue.
    * @param hashtags Hashtags to distribute queue data.
    */
-  private void createHashedQueues(String name, List<String> hashtags, String queueType) {
+  private void createHashedQueues(String name, List<String> hashtags, Queue.QUEUE_TYPE queueType) {
     // create an internal queue for each of the provided hashtags
     for (String hashtag : hashtags) {
       queues.add(

--- a/src/main/java/build/buildfarm/common/redis/BalancedRedisQueue.java
+++ b/src/main/java/build/buildfarm/common/redis/BalancedRedisQueue.java
@@ -15,6 +15,7 @@
 package build.buildfarm.common.redis;
 
 import build.buildfarm.common.StringVisitor;
+import build.buildfarm.common.config.yml.Queue;
 import build.buildfarm.v1test.QueueStatus;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -101,7 +102,7 @@ public class BalancedRedisQueue {
    * @note Overloaded.
    */
   public BalancedRedisQueue(String name, List<String> hashtags) {
-    this(name, hashtags, -1, "regular");
+    this(name, hashtags, -1, Queue.QUEUE_TYPE.standard.name());
   }
 
   /**
@@ -125,7 +126,7 @@ public class BalancedRedisQueue {
    * @note Overloaded.
    */
   public BalancedRedisQueue(String name, List<String> hashtags, int maxQueueSize) {
-    this(name, hashtags, maxQueueSize, "regular");
+    this(name, hashtags, maxQueueSize, Queue.QUEUE_TYPE.standard.name());
   }
 
   /**

--- a/src/main/java/build/buildfarm/common/redis/ProvisionedRedisQueue.java
+++ b/src/main/java/build/buildfarm/common/redis/ProvisionedRedisQueue.java
@@ -91,7 +91,7 @@ public class ProvisionedRedisQueue {
    */
   public ProvisionedRedisQueue(
       String name, List<String> hashtags, SetMultimap<String, String> filterProvisions) {
-    this(name, Queue.QUEUE_TYPE.standard.name(), hashtags, filterProvisions, false);
+    this(name, Queue.QUEUE_TYPE.standard, hashtags, filterProvisions, false);
   }
 
   /**
@@ -109,7 +109,7 @@ public class ProvisionedRedisQueue {
       List<String> hashtags,
       SetMultimap<String, String> filterProvisions,
       boolean allowUserUnmatched) {
-    this(name, Queue.QUEUE_TYPE.standard.name(), hashtags, filterProvisions, allowUserUnmatched);
+    this(name, Queue.QUEUE_TYPE.standard, hashtags, filterProvisions, allowUserUnmatched);
   }
 
   /**
@@ -123,7 +123,7 @@ public class ProvisionedRedisQueue {
    */
   public ProvisionedRedisQueue(
       String name,
-      String type,
+      Queue.QUEUE_TYPE type,
       List<String> hashtags,
       SetMultimap<String, String> filterProvisions) {
     this(name, type, hashtags, filterProvisions, false);
@@ -142,7 +142,7 @@ public class ProvisionedRedisQueue {
    */
   public ProvisionedRedisQueue(
       String name,
-      String type,
+      Queue.QUEUE_TYPE type,
       List<String> hashtags,
       SetMultimap<String, String> filterProvisions,
       boolean allowUserUnmatched) {

--- a/src/main/java/build/buildfarm/common/redis/ProvisionedRedisQueue.java
+++ b/src/main/java/build/buildfarm/common/redis/ProvisionedRedisQueue.java
@@ -16,6 +16,7 @@ package build.buildfarm.common.redis;
 
 import build.buildfarm.common.ExecutionProperties;
 import build.buildfarm.common.MapUtils;
+import build.buildfarm.common.config.yml.Queue;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.SetMultimap;
@@ -90,7 +91,7 @@ public class ProvisionedRedisQueue {
    */
   public ProvisionedRedisQueue(
       String name, List<String> hashtags, SetMultimap<String, String> filterProvisions) {
-    this(name, "regular", hashtags, filterProvisions, false);
+    this(name, Queue.QUEUE_TYPE.standard.name(), hashtags, filterProvisions, false);
   }
 
   /**
@@ -108,7 +109,7 @@ public class ProvisionedRedisQueue {
       List<String> hashtags,
       SetMultimap<String, String> filterProvisions,
       boolean allowUserUnmatched) {
-    this(name, "regular", hashtags, filterProvisions, allowUserUnmatched);
+    this(name, Queue.QUEUE_TYPE.standard.name(), hashtags, filterProvisions, allowUserUnmatched);
   }
 
   /**

--- a/src/main/java/build/buildfarm/common/redis/RedisQueueFactory.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisQueueFactory.java
@@ -14,6 +14,8 @@
 
 package build.buildfarm.common.redis;
 
+import build.buildfarm.common.config.yml.Queue;
+
 /**
  * @class RedisQueueFactory
  * @brief A redis queue factory.
@@ -23,9 +25,9 @@ public class RedisQueueFactory {
     if (queueType == null) {
       return null;
     }
-    if (queueType.equalsIgnoreCase("regular")) {
+    if (queueType.equalsIgnoreCase(Queue.QUEUE_TYPE.standard.name())) {
       return new RedisQueue(name);
-    } else if (queueType.equalsIgnoreCase("priority")) {
+    } else if (queueType.equalsIgnoreCase(Queue.QUEUE_TYPE.priority.name())) {
       return new RedisPriorityQueue(name);
     }
     return null;

--- a/src/main/java/build/buildfarm/common/redis/RedisQueueFactory.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisQueueFactory.java
@@ -21,13 +21,13 @@ import build.buildfarm.common.config.yml.Queue;
  * @brief A redis queue factory.
  */
 public class RedisQueueFactory {
-  public QueueInterface getQueue(String queueType, String name) {
+  public QueueInterface getQueue(Queue.QUEUE_TYPE queueType, String name) {
     if (queueType == null) {
       return null;
     }
-    if (queueType.equalsIgnoreCase(Queue.QUEUE_TYPE.standard.name())) {
+    if (queueType.equals(Queue.QUEUE_TYPE.standard)) {
       return new RedisQueue(name);
-    } else if (queueType.equalsIgnoreCase(Queue.QUEUE_TYPE.priority.name())) {
+    } else if (queueType.equals(Queue.QUEUE_TYPE.priority)) {
       return new RedisPriorityQueue(name);
     }
     return null;

--- a/src/main/java/build/buildfarm/instance/memory/MemoryInstance.java
+++ b/src/main/java/build/buildfarm/instance/memory/MemoryInstance.java
@@ -249,11 +249,11 @@ public class MemoryInstance extends AbstractServerInstance {
     switch (configs.getWorker().getCas().getType()) {
       default:
         throw new IllegalArgumentException("ActionCache config not set in config");
-      case "GRPC":
+      case GRPC:
         return createGrpcActionCache();
-      case "MEMORY":
+      case MEMORY:
         return createDelegateCASActionCache(cas, digestUtil);
-      case "FILESYSTEM":
+      case FILESYSTEM:
         return createFilesystemActionCache();
     }
   }

--- a/src/main/java/build/buildfarm/instance/shard/DistributedStateCreator.java
+++ b/src/main/java/build/buildfarm/instance/shard/DistributedStateCreator.java
@@ -87,7 +87,7 @@ public class DistributedStateCreator {
         getPreQueuedOperationsListName(),
         getQueueHashes(client, getPreQueuedOperationsListName()),
         configs.getBackplane().getMaxPreQueueDepth(),
-        queueTypeToSr());
+        getQueueType());
   }
 
   private static OperationQueue createOperationQueue(RedisClient client) throws IOException {
@@ -101,7 +101,7 @@ public class DistributedStateCreator {
       ProvisionedRedisQueue provisionedQueue =
           new ProvisionedRedisQueue(
               getQueueName(queueConfig),
-              queueTypeToSr(),
+              getQueueType(),
               getQueueHashes(client, getQueueName(queueConfig)),
               toMultimap(queueConfig.getPlatform().getPropertiesList()),
               queueConfig.isAllowUnmatched());
@@ -121,7 +121,7 @@ public class DistributedStateCreator {
       ProvisionedRedisQueue defaultQueue =
           new ProvisionedRedisQueue(
               getQueuedOperationsListName(),
-              queueTypeToSr(),
+              getQueueType(),
               getQueueHashes(client, getQueuedOperationsListName()),
               defaultProvisions);
       provisionedQueues.add(defaultQueue);
@@ -145,33 +145,30 @@ public class DistributedStateCreator {
     return set;
   }
 
-  private static String queueTypeToSr() {
+  private static Queue.QUEUE_TYPE getQueueType() {
     return configs.getBackplane().isPriorityQueue()
-        ? Queue.QUEUE_TYPE.priority.name()
-        : Queue.QUEUE_TYPE.standard.name();
+        ? Queue.QUEUE_TYPE.priority
+        : Queue.QUEUE_TYPE.standard;
   }
 
   private static String getQueuedOperationsListName() {
     String name = configs.getBackplane().getQueuedOperationsListName();
-    String queue_type = queueTypeToSr();
-    return createFullQueueName(name, queue_type);
+    return createFullQueueName(name, getQueueType());
   }
 
   private static String getPreQueuedOperationsListName() {
     String name = configs.getBackplane().getPreQueuedOperationsListName();
-    String queue_type = queueTypeToSr();
-    return createFullQueueName(name, queue_type);
+    return createFullQueueName(name, getQueueType());
   }
 
   private static String getQueueName(Queue pconfig) {
     String name = pconfig.getName();
-    String queue_type = queueTypeToSr();
-    return createFullQueueName(name, queue_type);
+    return createFullQueueName(name, getQueueType());
   }
 
-  private static String createFullQueueName(String base, String type) {
+  private static String createFullQueueName(String base, Queue.QUEUE_TYPE type) {
     // To maintain forwards compatibility, we do not append the type to the regular queue
     // implementation.
-    return ((!type.equals(Queue.QUEUE_TYPE.standard.name())) ? base + "_" + type : base);
+    return ((!type.equals(Queue.QUEUE_TYPE.standard)) ? base + "_" + type : base);
   }
 }

--- a/src/main/java/build/buildfarm/instance/shard/DistributedStateCreator.java
+++ b/src/main/java/build/buildfarm/instance/shard/DistributedStateCreator.java
@@ -146,7 +146,9 @@ public class DistributedStateCreator {
   }
 
   private static String queueTypeToSr() {
-    return configs.getBackplane().getRedisQueueType().toLowerCase();
+    return configs.getBackplane().isPriorityQueue()
+        ? Queue.QUEUE_TYPE.priority.name()
+        : Queue.QUEUE_TYPE.standard.name();
   }
 
   private static String getQueuedOperationsListName() {
@@ -170,6 +172,6 @@ public class DistributedStateCreator {
   private static String createFullQueueName(String base, String type) {
     // To maintain forwards compatibility, we do not append the type to the regular queue
     // implementation.
-    return ((!type.equals("regular")) ? base + "_" + type : base);
+    return ((!type.equals(Queue.QUEUE_TYPE.standard.name())) ? base + "_" + type : base);
   }
 }

--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -19,6 +19,7 @@ import static build.buildfarm.common.Actions.checkPreconditionFailure;
 import static build.buildfarm.common.Actions.invalidActionVerboseMessage;
 import static build.buildfarm.common.Errors.VIOLATION_TYPE_INVALID;
 import static build.buildfarm.common.Errors.VIOLATION_TYPE_MISSING;
+import static build.buildfarm.common.config.yml.Backplane.BACKPLANE_TYPE.SHARD;
 import static build.buildfarm.instance.shard.Util.SHARD_IS_RETRIABLE;
 import static build.buildfarm.instance.shard.Util.correctMissingBlob;
 import static com.google.common.base.Preconditions.checkState;
@@ -241,7 +242,7 @@ public class ShardInstance extends AbstractServerInstance {
   private static final Duration queueTimeout = Durations.fromSeconds(60);
 
   private static Backplane createBackplane(String identifier) throws ConfigurationException {
-    if ("SHARD".equals(configs.getBackplane().getType())) {
+    if (configs.getBackplane().getType().equals(SHARD)) {
       return new RedisShardBackplane(
           identifier, ShardInstance::stripOperation, ShardInstance::stripQueuedOperation);
     } else {

--- a/src/main/java/build/buildfarm/metrics/log/LogMetricsPublisher.java
+++ b/src/main/java/build/buildfarm/metrics/log/LogMetricsPublisher.java
@@ -31,7 +31,7 @@ public class LogMetricsPublisher extends AbstractMetricsPublisher {
   public LogMetricsPublisher() {
     super(configs.getServer().getClusterId());
     if (configs.getServer().getMetrics().getLogLevel() != null) {
-      logLevel = Level.parse(configs.getServer().getMetrics().getLogLevel());
+      logLevel = Level.parse(configs.getServer().getMetrics().getLogLevel().name());
     } else {
       logLevel = Level.FINEST;
     }

--- a/src/main/java/build/buildfarm/server/AdminService.java
+++ b/src/main/java/build/buildfarm/server/AdminService.java
@@ -248,9 +248,9 @@ public class AdminService extends AdminGrpc.AdminImplBase {
     switch (configs.getServer().getAdmin().getDeploymentEnvironment()) {
       default:
         return null;
-      case "aws":
+      case AWS:
         return new AwsAdmin(configs.getServer().getCloudRegion());
-      case "gcp":
+      case GCP:
         return new GcpAdmin();
     }
   }

--- a/src/main/java/build/buildfarm/server/BuildFarmInstances.java
+++ b/src/main/java/build/buildfarm/server/BuildFarmInstances.java
@@ -34,10 +34,10 @@ public class BuildFarmInstances {
     switch (configs.getServer().getInstanceType()) {
       default:
         throw new IllegalArgumentException("Instance type not set in config");
-      case "MEMORY":
+      case MEMORY:
         instance = new MemoryInstance(name, digestUtil);
         break;
-      case "SHARD":
+      case SHARD:
         instance = new ShardInstance(name, session + "-" + name, digestUtil, onStop);
         break;
     }
@@ -45,6 +45,6 @@ public class BuildFarmInstances {
   }
 
   private static HashFunction getValidHashFunction() {
-    return HashFunction.valueOf(configs.getDigestFunction());
+    return configs.getDigestFunction();
   }
 }

--- a/src/main/java/build/buildfarm/server/ExecutionService.java
+++ b/src/main/java/build/buildfarm/server/ExecutionService.java
@@ -209,9 +209,9 @@ public class ExecutionService extends ExecutionGrpc.ExecutionImplBase {
     switch (configs.getServer().getMetrics().getPublisher()) {
       default:
         return new LogMetricsPublisher();
-      case "aws":
+      case AWS:
         return new AwsMetricsPublisher();
-      case "gcp":
+      case GCP:
         return new GcpMetricsPublisher();
     }
   }

--- a/src/main/java/build/buildfarm/worker/memory/OperationQueueWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/memory/OperationQueueWorkerContext.java
@@ -182,17 +182,17 @@ class OperationQueueWorkerContext implements WorkerContext {
 
   @Override
   public CASInsertionPolicy getFileCasPolicy() {
-    return CASInsertionPolicy.valueOf(configs.getMemory().getCasPolicy());
+    return configs.getMemory().getCasPolicy();
   }
 
   @Override
   public CASInsertionPolicy getStdoutCasPolicy() {
-    return CASInsertionPolicy.valueOf(configs.getMemory().getCasPolicy());
+    return configs.getMemory().getCasPolicy();
   }
 
   @Override
   public CASInsertionPolicy getStderrCasPolicy() {
-    return CASInsertionPolicy.valueOf(configs.getMemory().getCasPolicy());
+    return configs.getMemory().getCasPolicy();
   }
 
   @Override
@@ -256,8 +256,8 @@ class OperationQueueWorkerContext implements WorkerContext {
         outputDirs,
         uploader,
         configs.getWorker().getInlineContentLimit(),
-        CASInsertionPolicy.valueOf(configs.getMemory().getCasPolicy()),
-        CASInsertionPolicy.valueOf(configs.getMemory().getCasPolicy()));
+        configs.getMemory().getCasPolicy(),
+        configs.getMemory().getCasPolicy());
   }
 
   @Override

--- a/src/main/java/build/buildfarm/worker/memory/Worker.java
+++ b/src/main/java/build/buildfarm/worker/memory/Worker.java
@@ -108,7 +108,7 @@ public class Worker extends LoggingMain {
 
   private static HashFunction getValidHashFunction() throws ConfigurationException {
     try {
-      return HashFunction.valueOf(configs.getDigestFunction());
+      return configs.getDigestFunction();
     } catch (IllegalArgumentException e) {
       throw new ConfigurationException("hash_function value unrecognized");
     }

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -256,12 +256,6 @@ message S3BucketConfig {
   string secret_name = 4;
 }
 
-enum QueueType {
-  // the type of the redis queue
-  REGULAR = 0;
-  PRIORITY = 1;
-};
-
 enum WorkerType {
   EXECUTE = 0;
 

--- a/src/test/java/build/buildfarm/common/redis/BalancedRedisQueueMockTest.java
+++ b/src/test/java/build/buildfarm/common/redis/BalancedRedisQueueMockTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import build.buildfarm.common.StringVisitor;
+import build.buildfarm.common.config.yml.Queue;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -347,7 +348,8 @@ public class BalancedRedisQueueMockTest {
     when(redis.zcard(any(String.class))).thenReturn(0L);
 
     // ARRANGE
-    BalancedRedisQueue queue = new BalancedRedisQueue("test", ImmutableList.of(), "priority");
+    BalancedRedisQueue queue =
+        new BalancedRedisQueue("test", ImmutableList.of(), Queue.QUEUE_TYPE.priority.name());
 
     // ACT
     Boolean isEvenlyDistributed = queue.isEvenlyDistributed(redis);
@@ -384,7 +386,8 @@ public class BalancedRedisQueueMockTest {
     when(redis.zcard(any(String.class))).thenReturn(999L);
 
     // ARRANGE
-    BalancedRedisQueue queue = new BalancedRedisQueue("test", ImmutableList.of(), -1, "priority");
+    BalancedRedisQueue queue =
+        new BalancedRedisQueue("test", ImmutableList.of(), -1, Queue.QUEUE_TYPE.priority.name());
 
     // ACT
     boolean canQueue = queue.canQueue(redis);
@@ -420,7 +423,8 @@ public class BalancedRedisQueueMockTest {
     when(redis.zcard(any(String.class))).thenReturn(123L);
 
     // ARRANGE
-    BalancedRedisQueue queue = new BalancedRedisQueue("test", ImmutableList.of(), 123, "priority");
+    BalancedRedisQueue queue =
+        new BalancedRedisQueue("test", ImmutableList.of(), 123, Queue.QUEUE_TYPE.priority.name());
 
     // ACT
     boolean canQueue = queue.canQueue(redis);

--- a/src/test/java/build/buildfarm/common/redis/BalancedRedisQueueMockTest.java
+++ b/src/test/java/build/buildfarm/common/redis/BalancedRedisQueueMockTest.java
@@ -349,7 +349,7 @@ public class BalancedRedisQueueMockTest {
 
     // ARRANGE
     BalancedRedisQueue queue =
-        new BalancedRedisQueue("test", ImmutableList.of(), Queue.QUEUE_TYPE.priority.name());
+        new BalancedRedisQueue("test", ImmutableList.of(), Queue.QUEUE_TYPE.priority);
 
     // ACT
     Boolean isEvenlyDistributed = queue.isEvenlyDistributed(redis);
@@ -387,7 +387,7 @@ public class BalancedRedisQueueMockTest {
 
     // ARRANGE
     BalancedRedisQueue queue =
-        new BalancedRedisQueue("test", ImmutableList.of(), -1, Queue.QUEUE_TYPE.priority.name());
+        new BalancedRedisQueue("test", ImmutableList.of(), -1, Queue.QUEUE_TYPE.priority);
 
     // ACT
     boolean canQueue = queue.canQueue(redis);
@@ -424,7 +424,7 @@ public class BalancedRedisQueueMockTest {
 
     // ARRANGE
     BalancedRedisQueue queue =
-        new BalancedRedisQueue("test", ImmutableList.of(), 123, Queue.QUEUE_TYPE.priority.name());
+        new BalancedRedisQueue("test", ImmutableList.of(), 123, Queue.QUEUE_TYPE.priority);
 
     // ACT
     boolean canQueue = queue.canQueue(redis);

--- a/src/test/java/build/buildfarm/common/redis/BalancedRedisQueueTest.java
+++ b/src/test/java/build/buildfarm/common/redis/BalancedRedisQueueTest.java
@@ -257,7 +257,7 @@ public class BalancedRedisQueueTest {
     // ARRANGE
     List<String> hashtags = RedisNodeHashes.getEvenlyDistributedHashes(redis);
     BalancedRedisQueue queue =
-        new BalancedRedisQueue("{hash}queue_name", hashtags, Queue.QUEUE_TYPE.priority.name());
+        new BalancedRedisQueue("{hash}queue_name", hashtags, Queue.QUEUE_TYPE.priority);
     // ACT
     String name = queue.getName();
 
@@ -290,8 +290,7 @@ public class BalancedRedisQueueTest {
     List<String> hashtags = RedisNodeHashes.getEvenlyDistributedHashes(redis);
     // similar to what has been seen in configuration files
     BalancedRedisQueue queue =
-        new BalancedRedisQueue(
-            "{Execution}:QueuedOperations", hashtags, Queue.QUEUE_TYPE.priority.name());
+        new BalancedRedisQueue("{Execution}:QueuedOperations", hashtags, Queue.QUEUE_TYPE.priority);
     // ACT
     String name = queue.getName();
 
@@ -388,8 +387,7 @@ public class BalancedRedisQueueTest {
   public void sizeAdjustPushPopPriority() throws Exception {
     // ARRANGE
     List<String> hashtags = RedisNodeHashes.getEvenlyDistributedHashes(redis);
-    BalancedRedisQueue queue =
-        new BalancedRedisQueue("test", hashtags, Queue.QUEUE_TYPE.priority.name());
+    BalancedRedisQueue queue = new BalancedRedisQueue("test", hashtags, Queue.QUEUE_TYPE.priority);
 
     // ACT / ASSERT
     assertThat(queue.size(redis)).isEqualTo(0);
@@ -465,8 +463,7 @@ public class BalancedRedisQueueTest {
   public void visitCheckVisitOfEachElementPriority() throws Exception {
     // ARRANGE
     List<String> hashtags = RedisNodeHashes.getEvenlyDistributedHashes(redis);
-    BalancedRedisQueue queue =
-        new BalancedRedisQueue("test", hashtags, Queue.QUEUE_TYPE.priority.name());
+    BalancedRedisQueue queue = new BalancedRedisQueue("test", hashtags, Queue.QUEUE_TYPE.priority);
     queue.push(redis, "element 1");
     queue.push(redis, "element 2");
     queue.push(redis, "element 3");
@@ -521,8 +518,7 @@ public class BalancedRedisQueueTest {
   public void isEvenlyDistributedEmptyIsEvenlyDistributedPriority() throws Exception {
     // ARRANGE
     List<String> hashtags = RedisNodeHashes.getEvenlyDistributedHashes(redis);
-    BalancedRedisQueue queue =
-        new BalancedRedisQueue("test", hashtags, Queue.QUEUE_TYPE.priority.name());
+    BalancedRedisQueue queue = new BalancedRedisQueue("test", hashtags, Queue.QUEUE_TYPE.priority);
 
     // ACT
     Boolean isEvenlyDistributed = queue.isEvenlyDistributed(redis);
@@ -559,8 +555,7 @@ public class BalancedRedisQueueTest {
   public void isEvenlyDistributedFourNodesFourHundredPushesIsEvenPriority() throws Exception {
     // ARRANGE
     List<String> hashtags = Arrays.asList("node1", "node2", "node3", "node4");
-    BalancedRedisQueue queue =
-        new BalancedRedisQueue("test", hashtags, Queue.QUEUE_TYPE.priority.name());
+    BalancedRedisQueue queue = new BalancedRedisQueue("test", hashtags, Queue.QUEUE_TYPE.priority);
 
     // ACT
     for (int i = 0; i < 400; ++i) {
@@ -600,8 +595,7 @@ public class BalancedRedisQueueTest {
   public void isEvenlyDistributedFourNodesFourHundredOnePushesIsNotEvenPriority() throws Exception {
     // ARRANGE
     List<String> hashtags = Arrays.asList("node1", "node2", "node3", "node4");
-    BalancedRedisQueue queue =
-        new BalancedRedisQueue("test", hashtags, Queue.QUEUE_TYPE.priority.name());
+    BalancedRedisQueue queue = new BalancedRedisQueue("test", hashtags, Queue.QUEUE_TYPE.priority);
 
     // ACT
     for (int i = 0; i < 401; ++i) {
@@ -650,8 +644,7 @@ public class BalancedRedisQueueTest {
   public void isEvenlyDistributedSingleNodeAlwaysEvenlyDistributesPriority() throws Exception {
     // ARRANGE
     List<String> hashtags = Collections.singletonList("single_node");
-    BalancedRedisQueue queue =
-        new BalancedRedisQueue("test", hashtags, Queue.QUEUE_TYPE.priority.name());
+    BalancedRedisQueue queue = new BalancedRedisQueue("test", hashtags, Queue.QUEUE_TYPE.priority);
 
     // ACT / ASSERT
     queue.push(redis, "foo");
@@ -720,8 +713,7 @@ public class BalancedRedisQueueTest {
   public void isEvenlyDistributedTwoNodeExamplePriority() throws Exception {
     // ARRANGE
     List<String> hashtags = Arrays.asList("node_1", "node_2");
-    BalancedRedisQueue queue =
-        new BalancedRedisQueue("test", hashtags, Queue.QUEUE_TYPE.priority.name());
+    BalancedRedisQueue queue = new BalancedRedisQueue("test", hashtags, Queue.QUEUE_TYPE.priority);
 
     // ACT / ASSERT
     assertThat(queue.isEvenlyDistributed(redis)).isTrue();

--- a/src/test/java/build/buildfarm/common/redis/BalancedRedisQueueTest.java
+++ b/src/test/java/build/buildfarm/common/redis/BalancedRedisQueueTest.java
@@ -18,6 +18,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 import build.buildfarm.common.StringVisitor;
 import build.buildfarm.common.config.yml.BuildfarmConfigs;
+import build.buildfarm.common.config.yml.Queue;
 import build.buildfarm.instance.shard.JedisClusterFactory;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
@@ -255,7 +256,8 @@ public class BalancedRedisQueueTest {
   public void getNameNameHasHashtagRemovedFrontPriority() throws Exception {
     // ARRANGE
     List<String> hashtags = RedisNodeHashes.getEvenlyDistributedHashes(redis);
-    BalancedRedisQueue queue = new BalancedRedisQueue("{hash}queue_name", hashtags, "priority");
+    BalancedRedisQueue queue =
+        new BalancedRedisQueue("{hash}queue_name", hashtags, Queue.QUEUE_TYPE.priority.name());
     // ACT
     String name = queue.getName();
 
@@ -288,7 +290,8 @@ public class BalancedRedisQueueTest {
     List<String> hashtags = RedisNodeHashes.getEvenlyDistributedHashes(redis);
     // similar to what has been seen in configuration files
     BalancedRedisQueue queue =
-        new BalancedRedisQueue("{Execution}:QueuedOperations", hashtags, "priority");
+        new BalancedRedisQueue(
+            "{Execution}:QueuedOperations", hashtags, Queue.QUEUE_TYPE.priority.name());
     // ACT
     String name = queue.getName();
 
@@ -385,7 +388,8 @@ public class BalancedRedisQueueTest {
   public void sizeAdjustPushPopPriority() throws Exception {
     // ARRANGE
     List<String> hashtags = RedisNodeHashes.getEvenlyDistributedHashes(redis);
-    BalancedRedisQueue queue = new BalancedRedisQueue("test", hashtags, "priority");
+    BalancedRedisQueue queue =
+        new BalancedRedisQueue("test", hashtags, Queue.QUEUE_TYPE.priority.name());
 
     // ACT / ASSERT
     assertThat(queue.size(redis)).isEqualTo(0);
@@ -461,7 +465,8 @@ public class BalancedRedisQueueTest {
   public void visitCheckVisitOfEachElementPriority() throws Exception {
     // ARRANGE
     List<String> hashtags = RedisNodeHashes.getEvenlyDistributedHashes(redis);
-    BalancedRedisQueue queue = new BalancedRedisQueue("test", hashtags, "priority");
+    BalancedRedisQueue queue =
+        new BalancedRedisQueue("test", hashtags, Queue.QUEUE_TYPE.priority.name());
     queue.push(redis, "element 1");
     queue.push(redis, "element 2");
     queue.push(redis, "element 3");
@@ -516,7 +521,8 @@ public class BalancedRedisQueueTest {
   public void isEvenlyDistributedEmptyIsEvenlyDistributedPriority() throws Exception {
     // ARRANGE
     List<String> hashtags = RedisNodeHashes.getEvenlyDistributedHashes(redis);
-    BalancedRedisQueue queue = new BalancedRedisQueue("test", hashtags, "priority");
+    BalancedRedisQueue queue =
+        new BalancedRedisQueue("test", hashtags, Queue.QUEUE_TYPE.priority.name());
 
     // ACT
     Boolean isEvenlyDistributed = queue.isEvenlyDistributed(redis);
@@ -553,7 +559,8 @@ public class BalancedRedisQueueTest {
   public void isEvenlyDistributedFourNodesFourHundredPushesIsEvenPriority() throws Exception {
     // ARRANGE
     List<String> hashtags = Arrays.asList("node1", "node2", "node3", "node4");
-    BalancedRedisQueue queue = new BalancedRedisQueue("test", hashtags, "priority");
+    BalancedRedisQueue queue =
+        new BalancedRedisQueue("test", hashtags, Queue.QUEUE_TYPE.priority.name());
 
     // ACT
     for (int i = 0; i < 400; ++i) {
@@ -593,7 +600,8 @@ public class BalancedRedisQueueTest {
   public void isEvenlyDistributedFourNodesFourHundredOnePushesIsNotEvenPriority() throws Exception {
     // ARRANGE
     List<String> hashtags = Arrays.asList("node1", "node2", "node3", "node4");
-    BalancedRedisQueue queue = new BalancedRedisQueue("test", hashtags, "priority");
+    BalancedRedisQueue queue =
+        new BalancedRedisQueue("test", hashtags, Queue.QUEUE_TYPE.priority.name());
 
     // ACT
     for (int i = 0; i < 401; ++i) {
@@ -642,7 +650,8 @@ public class BalancedRedisQueueTest {
   public void isEvenlyDistributedSingleNodeAlwaysEvenlyDistributesPriority() throws Exception {
     // ARRANGE
     List<String> hashtags = Collections.singletonList("single_node");
-    BalancedRedisQueue queue = new BalancedRedisQueue("test", hashtags, "priority");
+    BalancedRedisQueue queue =
+        new BalancedRedisQueue("test", hashtags, Queue.QUEUE_TYPE.priority.name());
 
     // ACT / ASSERT
     queue.push(redis, "foo");
@@ -711,7 +720,8 @@ public class BalancedRedisQueueTest {
   public void isEvenlyDistributedTwoNodeExamplePriority() throws Exception {
     // ARRANGE
     List<String> hashtags = Arrays.asList("node_1", "node_2");
-    BalancedRedisQueue queue = new BalancedRedisQueue("test", hashtags, "priority");
+    BalancedRedisQueue queue =
+        new BalancedRedisQueue("test", hashtags, Queue.QUEUE_TYPE.priority.name());
 
     // ACT / ASSERT
     assertThat(queue.isEvenlyDistributed(redis)).isTrue();

--- a/src/test/java/build/buildfarm/instance/memory/MemoryInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/memory/MemoryInstanceTest.java
@@ -23,6 +23,7 @@ import static build.buildfarm.cas.ContentAddressableStorages.casMapDecorator;
 import static build.buildfarm.common.Actions.invalidActionVerboseMessage;
 import static build.buildfarm.common.Errors.VIOLATION_TYPE_INVALID;
 import static build.buildfarm.common.Errors.VIOLATION_TYPE_MISSING;
+import static build.buildfarm.common.config.yml.Cas.TYPE.MEMORY;
 import static build.buildfarm.instance.memory.MemoryInstance.TIMEOUT_OUT_OF_BOUNDS;
 import static build.buildfarm.instance.server.AbstractServerInstance.MISSING_ACTION;
 import static com.google.common.collect.Multimaps.synchronizedSetMultimap;
@@ -56,6 +57,7 @@ import build.buildfarm.common.DigestUtil;
 import build.buildfarm.common.Watchdog;
 import build.buildfarm.common.Watcher;
 import build.buildfarm.common.config.yml.BuildfarmConfigs;
+import build.buildfarm.common.config.yml.Server;
 import build.buildfarm.instance.MatchListener;
 import build.buildfarm.instance.queues.Worker;
 import build.buildfarm.instance.server.AbstractServerInstance;
@@ -116,10 +118,10 @@ public class MemoryInstanceTest {
 
   @Before
   public void setUp() throws Exception {
-    configs.getServer().setInstanceType("MEMORY");
+    configs.getServer().setInstanceType(Server.INSTANCE_TYPE.MEMORY);
     configs.getServer().setName("memory");
     configs.getWorker().setPublicName("localhost:8981");
-    configs.getWorker().getCas().setType("MEMORY");
+    configs.getWorker().getCas().setType(MEMORY);
     configs.getMemory().setTarget("localhost:8980");
     outstandingOperations = new MemoryInstance.OutstandingOperations();
     watchers =

--- a/src/test/java/build/buildfarm/metrics/MetricsPublisherTest.java
+++ b/src/test/java/build/buildfarm/metrics/MetricsPublisherTest.java
@@ -21,6 +21,7 @@ import build.bazel.remote.execution.v2.ExecuteOperationMetadata;
 import build.bazel.remote.execution.v2.ExecuteResponse;
 import build.bazel.remote.execution.v2.RequestMetadata;
 import build.buildfarm.common.config.yml.BuildfarmConfigs;
+import build.buildfarm.common.config.yml.Metrics;
 import build.buildfarm.metrics.aws.AwsMetricsPublisher;
 import build.buildfarm.metrics.log.LogMetricsPublisher;
 import build.buildfarm.v1test.OperationRequestMetadata;
@@ -68,7 +69,7 @@ public class MetricsPublisherTest {
   public void setUp() throws IOException {
     configs.getServer().setCloudRegion("test");
     configs.getServer().setClusterId("buildfarm-test");
-    configs.getServer().getMetrics().setPublisher("aws");
+    configs.getServer().getMetrics().setPublisher(Metrics.PUBLISHER.AWS);
   }
 
   @Test

--- a/src/test/java/build/buildfarm/server/BuildFarmServerTest.java
+++ b/src/test/java/build/buildfarm/server/BuildFarmServerTest.java
@@ -17,6 +17,7 @@ package build.buildfarm.server;
 import static build.bazel.remote.execution.v2.ExecutionStage.Value.COMPLETED;
 import static build.bazel.remote.execution.v2.ExecutionStage.Value.EXECUTING;
 import static build.buildfarm.common.Errors.VIOLATION_TYPE_INVALID;
+import static build.buildfarm.common.config.yml.Cas.TYPE.MEMORY;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.any;
@@ -46,6 +47,7 @@ import build.bazel.remote.execution.v2.GetActionResultRequest;
 import build.buildfarm.common.DigestUtil;
 import build.buildfarm.common.DigestUtil.HashFunction;
 import build.buildfarm.common.config.yml.BuildfarmConfigs;
+import build.buildfarm.common.config.yml.Server;
 import build.buildfarm.common.grpc.Retrier;
 import build.buildfarm.instance.stub.ByteStreamUploader;
 import build.buildfarm.instance.stub.Chunker;
@@ -101,10 +103,10 @@ public class BuildFarmServerTest {
   @Before
   public void setUp() throws Exception {
     configs.getServer().setClusterId("buildfarm-test");
-    configs.getServer().setInstanceType("MEMORY");
+    configs.getServer().setInstanceType(Server.INSTANCE_TYPE.MEMORY);
     configs.getServer().setName("memory");
     configs.getWorker().setPublicName("localhost:8981");
-    configs.getWorker().getCas().setType("MEMORY");
+    configs.getWorker().getCas().setType(MEMORY);
     configs.getMemory().setTarget("localhost:8980");
     String uniqueServerName = "in-process server for " + getClass();
     server =

--- a/src/test/java/build/buildfarm/worker/shard/ShardWorkerContextTest.java
+++ b/src/test/java/build/buildfarm/worker/shard/ShardWorkerContextTest.java
@@ -14,6 +14,7 @@
 
 package build.buildfarm.worker.shard;
 
+import static build.buildfarm.common.config.yml.Server.INSTANCE_TYPE.SHARD;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -72,7 +73,7 @@ public class ShardWorkerContextTest {
 
   @Before
   public void setUp() throws Exception {
-    configs.getServer().setInstanceType("SHARD");
+    configs.getServer().setInstanceType(SHARD);
     configs.getServer().setName("shard");
     configs.getWorker().setPublicName("localhost:8981");
     configs.getBackplane().setRedisUri("redis://localhost:6379");


### PR DESCRIPTION
Convert all relevant strings to enums. Some of these used to be enums to begin with but were converted to strings during config conversion to yaml. This PR corrects this.