### PR TITLE
Fix windows test failures

### DIFF
--- a/src/main/java/build/buildfarm/common/io/Directories.java
+++ b/src/main/java/build/buildfarm/common/io/Directories.java
@@ -122,6 +122,7 @@ public class Directories {
           @Override
           public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
               throws IOException {
+            // we will *NOT* delete the file on windows if it is still open
             Files.delete(file);
             return FileVisitResult.CONTINUE;
           }

--- a/src/test/java/build/buildfarm/cas/cfc/CASFileCacheTest.java
+++ b/src/test/java/build/buildfarm/cas/cfc/CASFileCacheTest.java
@@ -158,11 +158,7 @@ class CASFileCacheTest {
     // bazel appears to have a problem with us creating directories under
     // windows that are marked as no-delete. clean up after ourselves with
     // our utils
-    try {
-      Directories.remove(root);
-    } catch (Exception e) {
-      // Directory does not exist
-    }
+    Directories.remove(root);
     if (!shutdownAndAwaitTermination(putService, 1, SECONDS)) {
       throw new RuntimeException("could not shut down put service");
     }
@@ -634,6 +630,7 @@ class CASFileCacheTest {
     try (OutputStream secondOut = write.getOutput(1, SECONDS, () -> {})) {
       assertThat(writeClosed.get()).isTrue();
     }
+    write.reset(); // ensure that the output stream is closed
   }
 
   @Test
@@ -650,6 +647,7 @@ class CASFileCacheTest {
     firstOut.get().close();
     assertThat(secondOut.isDone()).isTrue();
     secondOut.get().close();
+    write.reset(); // ensure that the output stream is closed
   }
 
   @Test(expected = DigestMismatchException.class)
@@ -911,6 +909,7 @@ class CASFileCacheTest {
     int remaining = content.size() - 6;
     assertThat(in.read(buf, 6, remaining)).isEqualTo(remaining);
     assertThat(ByteString.copyFrom(buf)).isEqualTo(content);
+    in.close();
   }
 
   @Test


### PR DESCRIPTION
Windows fails with DirectoryNotEmptyException for hex bucket dirs

This is because windows, unlike posix, does not willingly remove files that are currently open for read/write.

Files.delete(file) does not throw an exception for this. Short of checking if the file still exists after deleting it, which we can't do anything about, there doesn't seem to be anything we can do. Let the exception throw, and we will force all unit tests to close files as a result (which they should have been doing anyway).