### PR TITLE
call getFileStore once

### DIFF
--- a/src/main/java/build/buildfarm/common/io/Directories.java
+++ b/src/main/java/build/buildfarm/common/io/Directories.java
@@ -49,10 +49,9 @@ public class Directories {
 
   private static final Integer POSIX = 1;
   private static final Integer ACL = 2;
-  private volatile static Integer attributeView;
+  private static volatile Integer attributeView;
 
   private Directories() {}
-
 
   private static Integer getFileAttributeView(Path dir) throws IOException {
     if (attributeView == null) {
@@ -61,7 +60,7 @@ public class Directories {
           FileStore fileStore = Files.getFileStore(dir);
           if (fileStore.supportsFileAttributeView("posix")) {
             attributeView = POSIX;
-          } else if (fileStore.supportsFileAttributeView("acl")){
+          } else if (fileStore.supportsFileAttributeView("acl")) {
             attributeView = ACL;
           } else {
             throw new UnsupportedOperationException("no recognized attribute view");


### PR DESCRIPTION
When we use Buildfarm in our project, we use cpu profiler and find out that it takes too much time to call getFileStore when walking file tree. We don't need to call it recursively, so I use double checked  locking to call it once. 
![image](https://user-images.githubusercontent.com/105282436/190307488-77e237b9-bdfc-4751-822d-8b9dd77a6f26.png)

![image](https://user-images.githubusercontent.com/105282436/190307794-a1546def-d264-44a5-960e-969ccc5cde76.png)
