### PR TITLE
Use lombok for logger definition

### DIFF
--- a/src/main/java/build/buildfarm/admin/aws/AwsAdmin.java
+++ b/src/main/java/build/buildfarm/admin/aws/AwsAdmin.java
@@ -46,10 +46,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
 import java.util.logging.Level;
-import java.util.logging.Logger;
+import lombok.extern.java.Log;
 
+@Log
 public class AwsAdmin implements Admin {
-  private static final Logger logger = Logger.getLogger(Admin.class.getName());
   private final AmazonAutoScaling scale;
   private final AmazonEC2 ec2;
   private final AWSSimpleSystemsManagement ssm;
@@ -63,7 +63,7 @@ public class AwsAdmin implements Admin {
   @Override
   public void terminateHost(String hostId) {
     ec2.terminateInstances(new TerminateInstancesRequest().withInstanceIds(hostId));
-    logger.log(Level.INFO, String.format("Terminated host: %s", hostId));
+    log.log(Level.INFO, String.format("Terminated host: %s", hostId));
   }
 
   @Override
@@ -77,8 +77,7 @@ public class AwsAdmin implements Admin {
             .withDocumentName("AWS-RunShellScript")
             .withInstanceIds(hostId)
             .withParameters(parameters));
-    logger.log(
-        Level.INFO, String.format("Stopped container: %s on host: %s", containerName, hostId));
+    log.log(Level.INFO, String.format("Stopped container: %s on host: %s", containerName, hostId));
   }
 
   @Override
@@ -114,7 +113,7 @@ public class AwsAdmin implements Admin {
     }
     resultBuilder.addAllHosts(hosts);
     resultBuilder.setNumHosts(hosts.size());
-    logger.log(Level.FINE, String.format("Got %d hosts for filter: %s", hosts.size(), filter));
+    log.log(Level.FINE, String.format("Got %d hosts for filter: %s", hosts.size(), filter));
     return resultBuilder.build();
   }
 
@@ -144,7 +143,7 @@ public class AwsAdmin implements Admin {
                       .withOnDemandPercentageAboveBaseCapacity(targetReservedHostsPercent)));
     }
     scale.updateAutoScalingGroup(request);
-    logger.log(Level.INFO, String.format("Scaled: %s", scaleGroupName));
+    log.log(Level.INFO, String.format("Scaled: %s", scaleGroupName));
   }
 
   private long getHostUptimeInMinutes(Date launchTime) {
@@ -163,7 +162,7 @@ public class AwsAdmin implements Admin {
     Instance workerInstance = getInstanceId(privateDnsName);
     if (workerInstance == null) {
       String errorMessage = "Cannot find instance with private DNS name " + privateDnsName;
-      logger.log(Level.SEVERE, errorMessage);
+      log.log(Level.SEVERE, errorMessage);
       throw new RuntimeException(errorMessage);
     }
     String instanceId = workerInstance.getInstanceId();
@@ -171,7 +170,7 @@ public class AwsAdmin implements Admin {
     if (autoScalingGroup == null || autoScalingGroup.length() == 0) {
       String errorMessage =
           "Cannot find AutoScalingGroup name of worker with private DNS name " + privateDnsName;
-      logger.log(Level.SEVERE, errorMessage);
+      log.log(Level.SEVERE, errorMessage);
       throw new RuntimeException(errorMessage);
     }
 
@@ -182,7 +181,7 @@ public class AwsAdmin implements Admin {
             .withAutoScalingGroupName(autoScalingGroup)
             .withProtectedFromScaleIn(false);
     SetInstanceProtectionResult result = scale.setInstanceProtection(disableProtectionRequest);
-    logger.log(
+    log.log(
         Level.INFO,
         String.format(
             "Disable protection of host: %s in AutoScalingGroup: %s and get result: %s",

--- a/src/main/java/build/buildfarm/admin/aws/BUILD
+++ b/src/main/java/build/buildfarm/admin/aws/BUILD
@@ -1,6 +1,7 @@
 java_library(
     name = "aws",
     srcs = glob(["*.java"]),
+    plugins = ["//src/main/java/build/buildfarm/common:lombok"],
     visibility = ["//visibility:public"],
     deps = [
         "//src/main/java/build/buildfarm/admin",
@@ -15,6 +16,7 @@ java_library(
         "@maven//:com_amazonaws_aws_java_sdk_ssm",
         "@maven//:com_google_guava_guava",
         "@maven//:com_google_protobuf_protobuf_java_util",
+        "@maven//:org_projectlombok_lombok",
         "@remote_apis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
     ],
 )

--- a/src/main/java/build/buildfarm/cas/BUILD
+++ b/src/main/java/build/buildfarm/cas/BUILD
@@ -1,6 +1,7 @@
 java_library(
     name = "cas",
     srcs = glob(["**/*.java"]),
+    plugins = ["//src/main/java/build/buildfarm/common:lombok"],
     visibility = ["//visibility:public"],
     runtime_deps = [
         "@maven//:org_xerial_sqlite_jdbc",
@@ -27,6 +28,7 @@ java_library(
         "@maven//:io_grpc_grpc_stub",
         "@maven//:io_prometheus_simpleclient",
         "@maven//:net_jcip_jcip_annotations",
+        "@maven//:org_projectlombok_lombok",
         "@remote_apis//:build_bazel_remote_execution_v2_remote_execution_java_grpc",
         "@remote_apis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
     ],

--- a/src/main/java/build/buildfarm/cas/MemoryCAS.java
+++ b/src/main/java/build/buildfarm/cas/MemoryCAS.java
@@ -40,11 +40,11 @@ import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.annotation.concurrent.GuardedBy;
+import lombok.extern.java.Log;
 
+@Log
 public class MemoryCAS implements ContentAddressableStorage {
-  private static final Logger logger = Logger.getLogger(MemoryCAS.class.getName());
 
   private final long maxSizeInBytes;
   private final Consumer<Digest> onPut;
@@ -190,7 +190,7 @@ public class MemoryCAS implements ContentAddressableStorage {
         response.setData(blob).setStatus(OK);
       }
     } catch (Throwable t) {
-      logger.log(Level.SEVERE, "error getting " + DigestUtil.toString(digest), t);
+      log.log(Level.SEVERE, "error getting " + DigestUtil.toString(digest), t);
       response.setStatus(statusFromThrowable(t));
     }
     return response.build();
@@ -272,7 +272,7 @@ public class MemoryCAS implements ContentAddressableStorage {
     }
 
     if (sizeInBytes > maxSizeInBytes) {
-      logger.log(
+      log.log(
           Level.WARNING,
           String.format(
               "Out of nodes to remove, sizeInBytes = %d, maxSizeInBytes = %d, storage = %d, list = %d",
@@ -303,7 +303,7 @@ public class MemoryCAS implements ContentAddressableStorage {
   @GuardedBy("this")
   private void expireEntry(Entry e) {
     Digest digest = DigestUtil.buildDigest(e.key, e.value.size());
-    logger.log(Level.INFO, "MemoryLRUCAS: expiring " + DigestUtil.toString(digest));
+    log.log(Level.INFO, "MemoryLRUCAS: expiring " + DigestUtil.toString(digest));
     if (delegate != null) {
       try {
         Write write =
@@ -312,7 +312,7 @@ public class MemoryCAS implements ContentAddressableStorage {
           e.value.getData().writeTo(out);
         }
       } catch (IOException ioEx) {
-        logger.log(
+        log.log(
             Level.SEVERE, String.format("error delegating %s", DigestUtil.toString(digest)), ioEx);
       }
     }

--- a/src/main/java/build/buildfarm/common/BUILD
+++ b/src/main/java/build/buildfarm/common/BUILD
@@ -6,6 +6,7 @@ java_library(
         "io/*.java",
         "redis/*.java",
     ]),
+    plugins = [":lombok"],
     visibility = ["//visibility:public"],
     deps = [
         "//src/main/java/build/buildfarm/common/resources",
@@ -30,7 +31,16 @@ java_library(
         "@maven//:io_grpc_grpc_protobuf",
         "@maven//:io_prometheus_simpleclient",
         "@maven//:org_apache_commons_commons_compress",
+        "@maven//:org_projectlombok_lombok",
         "@maven//:org_threeten_threetenbp",
         "@remote_apis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
     ],
+)
+
+java_plugin(
+    name = "lombok",
+    generates_api = True,
+    processor_class = "lombok.launch.AnnotationProcessorHider$AnnotationProcessor",
+    visibility = ["//visibility:public"],
+    deps = ["@maven//:org_projectlombok_lombok"],
 )

--- a/src/main/java/build/buildfarm/common/ProtoUtils.java
+++ b/src/main/java/build/buildfarm/common/ProtoUtils.java
@@ -20,15 +20,15 @@ import build.buildfarm.v1test.QueuedOperation;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import java.util.logging.Level;
-import java.util.logging.Logger;
+import lombok.extern.java.Log;
 
 /**
  * @class ProtoUtils
  * @brief Utilities related to parsing proto data.
  * @details Performs validation and error reporting of proto data.
  */
+@Log
 public class ProtoUtils {
-  private static final Logger logger = Logger.getLogger(ProtoUtils.class.getName());
 
   public static QueuedOperation parseQueuedOperation(
       ByteString queuedOperationBlob, QueueEntry queueEntry) {
@@ -36,7 +36,7 @@ public class ProtoUtils {
     String operationName = queueEntry.getExecuteEntry().getOperationName();
 
     if (queuedOperationBlob == null) {
-      logger.log(
+      log.log(
           Level.WARNING,
           String.format(
               "missing queued operation: %s(%s)",
@@ -46,7 +46,7 @@ public class ProtoUtils {
     try {
       return QueuedOperation.parseFrom(queuedOperationBlob);
     } catch (InvalidProtocolBufferException e) {
-      logger.log(
+      log.log(
           Level.WARNING,
           String.format(
               "invalid queued operation: %s(%s).  Cannot parse operation blob: %s",

--- a/src/main/java/build/buildfarm/common/WorkerIndexer.java
+++ b/src/main/java/build/buildfarm/common/WorkerIndexer.java
@@ -17,8 +17,8 @@ package build.buildfarm.common;
 import io.prometheus.client.Gauge;
 import java.util.List;
 import java.util.Set;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import lombok.extern.java.Log;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.ScanParams;
@@ -30,8 +30,8 @@ import redis.clients.jedis.ScanResult;
  * @details When workers leave the cluster, the CAS keys must be updated to inform other workers
  *     that they can no longer obtain CAS data from the missing worker.
  */
+@Log
 public class WorkerIndexer {
-  private static final Logger logger = Logger.getLogger(WorkerIndexer.class.getName());
   private static final Gauge indexerKeysRemovedGauge =
       Gauge.build()
           .name("cas_indexer_removed_keys")
@@ -89,7 +89,7 @@ public class WorkerIndexer {
     Long removedKeys = 0L;
     Long removedHosts = 0L;
     Set<String> activeWorkers = cluster.hkeys("Workers");
-    logger.info(
+    log.info(
         String.format(
             "Initializing CAS Indexer for Node %s with %d active workers.",
             node.getClient().getHost(), activeWorkers.size()));

--- a/src/main/java/build/buildfarm/common/config/BUILD
+++ b/src/main/java/build/buildfarm/common/config/BUILD
@@ -3,7 +3,7 @@ java_library(
     srcs = glob([
         "*.java",
     ]),
-    plugins = [":lombok-java"],
+    plugins = ["//src/main/java/build/buildfarm/common:lombok"],
     visibility = ["//visibility:public"],
     deps = [
         "//src/main/java/build/buildfarm/common",
@@ -17,12 +17,4 @@ java_library(
         "@maven//:org_projectlombok_lombok",
         "@maven//:org_yaml_snakeyaml",
     ],
-)
-
-java_plugin(
-    name = "lombok-java",
-    generates_api = True,
-    processor_class = "lombok.launch.AnnotationProcessorHider$AnnotationProcessor",
-    visibility = ["//visibility:public"],
-    deps = ["@maven//:org_projectlombok_lombok"],
 )

--- a/src/main/java/build/buildfarm/common/grpc/BUILD
+++ b/src/main/java/build/buildfarm/common/grpc/BUILD
@@ -1,6 +1,7 @@
 java_library(
     name = "grpc",
     srcs = glob(["*.java"]),
+    plugins = ["//src/main/java/build/buildfarm/common:lombok"],
     visibility = ["//visibility:public"],
     deps = [
         "//src/main/java/build/buildfarm/common",
@@ -14,6 +15,7 @@ java_library(
         "@maven//:io_grpc_grpc_core",
         "@maven//:io_grpc_grpc_protobuf",
         "@maven//:io_grpc_grpc_stub",
+        "@maven//:org_projectlombok_lombok",
         "@remote_apis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
     ],
 )

--- a/src/main/java/build/buildfarm/common/grpc/StubWriteOutputStream.java
+++ b/src/main/java/build/buildfarm/common/grpc/StubWriteOutputStream.java
@@ -44,11 +44,11 @@ import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
-import java.util.logging.Logger;
 import javax.annotation.concurrent.GuardedBy;
+import lombok.extern.java.Log;
 
+@Log
 public class StubWriteOutputStream extends FeedbackOutputStream implements Write {
-  private static final Logger logger = Logger.getLogger(StubWriteOutputStream.class.getName());
 
   public static final long UNLIMITED_EXPECTED_SIZE = Long.MAX_VALUE;
 
@@ -218,7 +218,7 @@ public class StubWriteOutputStream extends FeedbackOutputStream implements Write
                       long committedSize = response.getCommittedSize();
                       if (expectedSize != UNLIMITED_EXPECTED_SIZE
                           && committedSize != expectedSize) {
-                        logger.log(
+                        log.log(
                             WARNING,
                             format(
                                 "received WriteResponse with unexpected committedSize: %d != %d",

--- a/src/main/java/build/buildfarm/common/io/Directories.java
+++ b/src/main/java/build/buildfarm/common/io/Directories.java
@@ -37,10 +37,10 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.logging.Level;
-import java.util.logging.Logger;
+import lombok.extern.java.Log;
 
+@Log
 public class Directories {
-  private static final Logger logger = Logger.getLogger(Directories.class.getName());
 
   private static final Set<PosixFilePermission> writablePerms =
       PosixFilePermissions.fromString("rwxr-xr-x");
@@ -102,7 +102,7 @@ public class Directories {
               try {
                 remove(tmpPath);
               } catch (IOException e) {
-                logger.log(Level.SEVERE, "error removing directory " + tmpPath, e);
+                log.log(Level.SEVERE, "error removing directory " + tmpPath, e);
               }
             },
             null);

--- a/src/main/java/build/buildfarm/common/io/Utils.java
+++ b/src/main/java/build/buildfarm/common/io/Utils.java
@@ -40,19 +40,19 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import jnr.constants.platform.OpenFlags;
 import jnr.ffi.LibraryLoader;
 import jnr.ffi.Pointer;
 import jnr.posix.FileStat;
 import jnr.posix.POSIX;
+import lombok.extern.java.Log;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.io.IOUtils;
 
+@Log
 public class Utils {
-  private static final Logger logger = Logger.getLogger(Utils.class.getName());
 
   @SuppressWarnings("Guava")
   private static final Supplier<LibC> libc =
@@ -158,7 +158,7 @@ public class Utils {
     Pointer DIR = libc.opendir(path.toString());
 
     if (DIR == null) {
-      logger.log(Level.SEVERE, "libc.opendir failed: " + path.toString());
+      log.log(Level.SEVERE, "libc.opendir failed: " + path.toString());
       return dirents;
     }
 
@@ -490,12 +490,12 @@ public class Utils {
                     Path reference = Files.readSymbolicLink(path);
                     paths.add(reference);
                   } catch (IOException e) {
-                    logger.log(Level.WARNING, "Could not derive symbolic link: ", e);
+                    log.log(Level.WARNING, "Could not derive symbolic link: ", e);
                   }
                 }
               });
     } catch (Exception e) {
-      logger.log(Level.WARNING, "Could not traverse dir: ", e);
+      log.log(Level.WARNING, "Could not traverse dir: ", e);
     }
 
     return paths;

--- a/src/main/java/build/buildfarm/common/s3/BUILD
+++ b/src/main/java/build/buildfarm/common/s3/BUILD
@@ -1,6 +1,7 @@
 java_library(
     name = "S3Bucket",
     srcs = ["S3Bucket.java"],
+    plugins = ["//src/main/java/build/buildfarm/common:lombok"],
     visibility = ["//visibility:public"],
     deps = [
         "//src/main/protobuf:build_buildfarm_v1test_buildfarm_java_proto",
@@ -8,5 +9,6 @@ java_library(
         "@maven//:com_amazonaws_aws_java_sdk_s3",
         "@maven//:com_amazonaws_aws_java_sdk_secretsmanager",
         "@maven//:com_fasterxml_jackson_core_jackson_databind",
+        "@maven//:org_projectlombok_lombok",
     ],
 )

--- a/src/main/java/build/buildfarm/common/s3/S3Bucket.java
+++ b/src/main/java/build/buildfarm/common/s3/S3Bucket.java
@@ -38,7 +38,7 @@ import java.io.IOException;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.logging.Level;
-import java.util.logging.Logger;
+import lombok.extern.java.Log;
 
 /**
  * @class S3Bucket
@@ -46,12 +46,12 @@ import java.util.logging.Logger;
  * @details This uses configuration to fetch secret information and obtain the S3 bucket. If the
  *     bucket does not already exist remotely, it is created upon construction.
  */
+@Log
 public class S3Bucket {
   /**
    * @field logger
    * @brief Used for printing error information.
    */
-  private static final Logger logger = Logger.getLogger(S3Bucket.class.getName());
 
   /**
    * @field s3
@@ -98,8 +98,7 @@ public class S3Bucket {
     try {
       s3.putObject(bucket.getName(), keyName, new File(filePath));
     } catch (AmazonServiceException e) {
-      logger.log(
-          Level.SEVERE, String.format("Blob could not be uploaded: %s", e.getErrorMessage()));
+      log.log(Level.SEVERE, String.format("Blob could not be uploaded: %s", e.getErrorMessage()));
       return false;
     }
     return true;
@@ -124,17 +123,17 @@ public class S3Bucket {
       s3is.close();
       fos.close();
     } catch (AmazonServiceException e) {
-      logger.log(
+      log.log(
           Level.SEVERE,
           String.format("Service exception while downloading blob: %s", e.getErrorMessage()));
     } catch (FileNotFoundException e) {
-      logger.log(Level.SEVERE, String.format("Blob does not exist in bucket: %s", e.getMessage()));
+      log.log(Level.SEVERE, String.format("Blob does not exist in bucket: %s", e.getMessage()));
     } catch (IOException e) {
-      logger.log(
+      log.log(
           Level.SEVERE,
           String.format("Failure creating file from downloaded blob: %s", e.getMessage()));
     } catch (Exception e) {
-      logger.log(Level.SEVERE, String.format("Unknown Failure: %s", e.getMessage()));
+      log.log(Level.SEVERE, String.format("Unknown Failure: %s", e.getMessage()));
     }
   }
 
@@ -156,7 +155,7 @@ public class S3Bucket {
     try {
       return s3.createBucket(bucketName);
     } catch (AmazonS3Exception e) {
-      logger.log(Level.SEVERE, e.getMessage());
+      log.log(Level.SEVERE, e.getMessage());
     }
 
     // The bucket could not be created.
@@ -231,7 +230,7 @@ public class S3Bucket {
     try {
       getSecretValueResult = client.getSecretValue(getSecretValueRequest);
     } catch (Exception e) {
-      logger.log(Level.SEVERE, String.format("Could not get secret %s from AWS.", secretName));
+      log.log(Level.SEVERE, String.format("Could not get secret %s from AWS.", secretName));
     }
 
     // decode secret
@@ -253,7 +252,7 @@ public class S3Bucket {
         final String secretKey = secretMap.get("secret_key");
         return AwsSecret.newBuilder().setAccessKeyId(accessKeyId).setSecretKey(secretKey).build();
       } catch (IOException e) {
-        logger.log(Level.SEVERE, String.format("Could not parse secret %s from AWS", secretName));
+        log.log(Level.SEVERE, String.format("Could not parse secret %s from AWS", secretName));
       }
     }
 

--- a/src/main/java/build/buildfarm/common/services/BUILD
+++ b/src/main/java/build/buildfarm/common/services/BUILD
@@ -1,6 +1,7 @@
 java_library(
     name = "services",
     srcs = glob(["*.java"]),
+    plugins = ["//src/main/java/build/buildfarm/common:lombok"],
     visibility = ["//visibility:public"],
     deps = [
         "//src/main/java/build/buildfarm/cas",
@@ -26,6 +27,7 @@ java_library(
         "@maven//:io_grpc_grpc_services",
         "@maven//:io_grpc_grpc_stub",
         "@maven//:io_prometheus_simpleclient",
+        "@maven//:org_projectlombok_lombok",
         "@remote_apis//:build_bazel_remote_asset_v1_remote_asset_java_proto",
         "@remote_apis//:build_bazel_remote_execution_v2_remote_execution_java_grpc",
         "@remote_apis//:build_bazel_semver_java_proto",

--- a/src/main/java/build/buildfarm/common/services/ByteStreamService.java
+++ b/src/main/java/build/buildfarm/common/services/ByteStreamService.java
@@ -56,10 +56,10 @@ import java.nio.file.NoSuchFileException;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
-import java.util.logging.Logger;
+import lombok.extern.java.Log;
 
+@Log
 public class ByteStreamService extends ByteStreamImplBase {
-  private static final Logger logger = Logger.getLogger(ByteStreamService.class.getName());
 
   public static final int CHUNK_SIZE = 64 * 1024;
 
@@ -112,7 +112,7 @@ public class ByteStreamService extends ByteStreamImplBase {
         }
 
         if (readBytes > remaining) {
-          logger.log(Level.WARNING, format("read %d bytes, expected %d", readBytes, remaining));
+          log.log(Level.WARNING, format("read %d bytes, expected %d", readBytes, remaining));
           readBytes = (int) remaining;
         }
         remaining -= readBytes;
@@ -185,7 +185,7 @@ public class ByteStreamService extends ByteStreamImplBase {
             message +=
                 format(" after %d responses and %d bytes of content", responseCount, responseBytes);
           }
-          logger.log(level, message, t);
+          log.log(level, message, t);
         }
         delegate.onError(t);
       }
@@ -288,7 +288,7 @@ public class ByteStreamService extends ByteStreamImplBase {
             try {
               in.close();
             } catch (IOException e) {
-              logger.log(Level.SEVERE, "error closing stream", e);
+              log.log(Level.SEVERE, "error closing stream", e);
             }
           });
       readFrom(in, limit, onErrorLogReadObserver(resourceName, offset, target));
@@ -321,7 +321,7 @@ public class ByteStreamService extends ByteStreamImplBase {
     String resourceName = request.getResourceName();
     long offset = request.getReadOffset();
     long limit = request.getReadLimit();
-    logger.log(
+    log.log(
         Level.FINER,
         format("read resource_name=%s offset=%d limit=%d", resourceName, offset, limit));
 
@@ -337,7 +337,7 @@ public class ByteStreamService extends ByteStreamImplBase {
       QueryWriteStatusRequest request, StreamObserver<QueryWriteStatusResponse> responseObserver) {
     String resourceName = request.getResourceName();
     try {
-      logger.log(Level.FINE, format("queryWriteStatus(%s)", resourceName));
+      log.log(Level.FINE, format("queryWriteStatus(%s)", resourceName));
       Write write = getWrite(resourceName);
       responseObserver.onNext(
           QueryWriteStatusResponse.newBuilder()
@@ -345,20 +345,20 @@ public class ByteStreamService extends ByteStreamImplBase {
               .setComplete(write.isComplete())
               .build());
       responseObserver.onCompleted();
-      logger.log(
+      log.log(
           Level.FINE,
           format(
               "queryWriteStatus(%s) => committed_size = %d, complete = %s",
               resourceName, write.getCommittedSize(), write.isComplete()));
     } catch (IllegalArgumentException | InvalidResourceNameException e) {
-      logger.log(Level.SEVERE, format("queryWriteStatus(%s)", resourceName), e);
+      log.log(Level.SEVERE, format("queryWriteStatus(%s)", resourceName), e);
       responseObserver.onError(INVALID_ARGUMENT.withDescription(e.getMessage()).asException());
     } catch (EntryLimitException e) {
-      logger.log(Level.WARNING, format("queryWriteStatus(%s): %s", resourceName, e.getMessage()));
+      log.log(Level.WARNING, format("queryWriteStatus(%s): %s", resourceName, e.getMessage()));
       responseObserver.onNext(QueryWriteStatusResponse.getDefaultInstance());
       responseObserver.onCompleted();
     } catch (RuntimeException e) {
-      logger.log(Level.SEVERE, format("queryWriteStatus(%s)", resourceName), e);
+      log.log(Level.SEVERE, format("queryWriteStatus(%s)", resourceName), e);
       responseObserver.onError(Status.fromThrowable(e).asException());
     }
   }

--- a/src/main/java/build/buildfarm/common/services/ContentAddressableStorageService.java
+++ b/src/main/java/build/buildfarm/common/services/ContentAddressableStorageService.java
@@ -50,14 +50,13 @@ import io.grpc.stub.StreamObserver;
 import io.prometheus.client.Histogram;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
+import lombok.extern.java.Log;
 
+@Log
 public class ContentAddressableStorageService
     extends ContentAddressableStorageGrpc.ContentAddressableStorageImplBase {
-  private static final Logger logger =
-      Logger.getLogger(ContentAddressableStorageService.class.getName());
   private static final Histogram missingBlobs =
       Histogram.build()
           .exponentialBuckets(1, 2, 6)
@@ -108,7 +107,7 @@ public class ContentAddressableStorageService
               responseObserver.onCompleted();
               long elapsedMicros = stopwatch.elapsed(MICROSECONDS);
               missingBlobs.observe(request.getBlobDigestsList().size());
-              logger.log(
+              log.log(
                   Level.FINE,
                   "FindMissingBlobs("
                       + instance.getName()
@@ -126,7 +125,7 @@ public class ContentAddressableStorageService
           public void onFailure(Throwable t) {
             Status status = Status.fromThrowable(t);
             if (status.getCode() != Code.CANCELLED) {
-              logger.log(
+              log.log(
                   Level.SEVERE,
                   format(
                       "findMissingBlobs(%s): %d",

--- a/src/main/java/build/buildfarm/instance/server/AbstractServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/server/AbstractServerInstance.java
@@ -136,9 +136,10 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import javax.annotation.Nullable;
+import lombok.extern.java.Log;
 
+@Log
 public abstract class AbstractServerInstance implements Instance {
-  private static final Logger logger = Logger.getLogger(AbstractServerInstance.class.getName());
 
   private final String name;
   protected final ContentAddressableStorage contentAddressableStorage;
@@ -649,7 +650,7 @@ public abstract class AbstractServerInstance implements Instance {
             });
         return immediateFuture(actualDigestBuilder.build());
       } catch (Exception e) {
-        logger.log(Level.WARNING, "download attempt failed", e);
+        log.log(Level.WARNING, "download attempt failed", e);
         // ignore?
       }
     }
@@ -955,7 +956,7 @@ public abstract class AbstractServerInstance implements Instance {
         getLogger().log(Level.SEVERE, "no rpc status from exception", cause);
         status = asExecutionStatus(cause);
       } else if (Code.forNumber(status.getCode()) == Code.DEADLINE_EXCEEDED) {
-        logger.log(
+        log.log(
             Level.WARNING, "an rpc status was thrown with DEADLINE_EXCEEDED, discarding it", cause);
         status =
             com.google.rpc.Status.newBuilder()
@@ -1401,7 +1402,7 @@ public abstract class AbstractServerInstance implements Instance {
           @SuppressWarnings("NullableProblems")
           @Override
           public void onFailure(Throwable t) {
-            logger.log(
+            log.log(
                 Level.WARNING,
                 format("action cache check of %s failed", DigestUtil.toString(actionDigest)),
                 t);
@@ -1418,7 +1419,7 @@ public abstract class AbstractServerInstance implements Instance {
       try {
         return metadata.unpack(QueuedOperationMetadata.class);
       } catch (InvalidProtocolBufferException e) {
-        logger.log(Level.SEVERE, format("invalid executing operation metadata %s", name), e);
+        log.log(Level.SEVERE, format("invalid executing operation metadata %s", name), e);
       }
     }
     return null;
@@ -1430,7 +1431,7 @@ public abstract class AbstractServerInstance implements Instance {
       try {
         return metadata.unpack(ExecutingOperationMetadata.class);
       } catch (InvalidProtocolBufferException e) {
-        logger.log(Level.SEVERE, format("invalid executing operation metadata %s", name), e);
+        log.log(Level.SEVERE, format("invalid executing operation metadata %s", name), e);
       }
     }
     return null;
@@ -1442,7 +1443,7 @@ public abstract class AbstractServerInstance implements Instance {
       try {
         return metadata.unpack(CompletedOperationMetadata.class);
       } catch (InvalidProtocolBufferException e) {
-        logger.log(Level.SEVERE, format("invalid completed operation metadata %s", name), e);
+        log.log(Level.SEVERE, format("invalid completed operation metadata %s", name), e);
       }
     }
     return null;
@@ -1488,7 +1489,7 @@ public abstract class AbstractServerInstance implements Instance {
     try {
       return operation.getMetadata().unpack(ExecuteOperationMetadata.class);
     } catch (InvalidProtocolBufferException e) {
-      logger.log(
+      log.log(
           Level.SEVERE, format("invalid execute operation metadata %s", operation.getName()), e);
     }
     return null;
@@ -1506,7 +1507,7 @@ public abstract class AbstractServerInstance implements Instance {
             try {
               future.set(parser.parseFrom(blob));
             } catch (InvalidProtocolBufferException e) {
-              logger.log(
+              log.log(
                   Level.WARNING,
                   format("expect parse for %s failed", DigestUtil.toString(digest)),
                   e);
@@ -1520,7 +1521,7 @@ public abstract class AbstractServerInstance implements Instance {
             Status status = Status.fromThrowable(t);
             // NOT_FOUNDs are not notable enough to log independently
             if (status.getCode() != io.grpc.Status.Code.NOT_FOUND) {
-              logger.log(
+              log.log(
                   Level.WARNING, format("expect for %s failed", DigestUtil.toString(digest)), t);
             }
             future.setException(t);

--- a/src/main/java/build/buildfarm/instance/server/BUILD
+++ b/src/main/java/build/buildfarm/instance/server/BUILD
@@ -6,6 +6,7 @@ java_library(
         "OperationsMap.java",
         "WatchFuture.java",
     ],
+    plugins = ["//src/main/java/build/buildfarm/common:lombok"],
     visibility = ["//visibility:public"],
     deps = [
         "//src/main/java/build/buildfarm/ac",
@@ -28,6 +29,7 @@ java_library(
         "@maven//:io_grpc_grpc_protobuf",
         "@maven//:io_grpc_grpc_stub",
         "@maven//:io_netty_netty_codec_http",
+        "@maven//:org_projectlombok_lombok",
         "@remote_apis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
     ],
 )

--- a/src/main/java/build/buildfarm/instance/shard/BUILD
+++ b/src/main/java/build/buildfarm/instance/shard/BUILD
@@ -1,6 +1,7 @@
 java_library(
     name = "shard",
     srcs = glob(["*.java"]),
+    plugins = ["//src/main/java/build/buildfarm/common:lombok"],
     visibility = ["//visibility:public"],
     deps = [
         "//src/main/java/build/buildfarm/ac",
@@ -33,6 +34,7 @@ java_library(
         "@maven//:io_prometheus_simpleclient",
         "@maven//:net_javacrumbs_future_converter_future_converter_java8_guava",
         "@maven//:org_apache_commons_commons_pool2",
+        "@maven//:org_projectlombok_lombok",
         "@maven//:org_redisson_redisson",
         "@remote_apis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
     ],

--- a/src/main/java/build/buildfarm/instance/shard/DispatchedMonitor.java
+++ b/src/main/java/build/buildfarm/instance/shard/DispatchedMonitor.java
@@ -31,10 +31,10 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.logging.Level;
-import java.util.logging.Logger;
+import lombok.extern.java.Log;
 
+@Log
 class DispatchedMonitor implements Runnable {
-  private static final Logger logger = Logger.getLogger(DispatchedMonitor.class.getName());
 
   private final Backplane backplane;
   private final BiFunction<QueueEntry, Duration, ListenableFuture<Void>> requeuer;
@@ -60,7 +60,7 @@ class DispatchedMonitor implements Runnable {
         () -> {
           long endTime = System.nanoTime();
           float ms = (endTime - startTime) / 1000000.0f;
-          logger.log(
+          log.log(
               Level.INFO, format("DispatchedMonitor::run: requeue(%s) %gms", operationName, ms));
         },
         directExecutor());
@@ -75,7 +75,7 @@ class DispatchedMonitor implements Runnable {
         String.format(
             "DispatchedMonitor: Testing %s because %dms overdue (%d >= %d)",
             operationName, overdue_amount, now, o.getRequeueAt());
-    logger.log(Level.INFO, message);
+    log.log(Level.INFO, message);
   }
 
   private void testDispatchedOperations(
@@ -100,7 +100,7 @@ class DispatchedMonitor implements Runnable {
       }
     } catch (Exception e) {
       if (!backplane.isStopped()) {
-        logger.log(Level.SEVERE, "error during dispatch evaluation", e);
+        log.log(Level.SEVERE, "error during dispatch evaluation", e);
       }
     }
     return successfulAsList(requeuedFutures.build());
@@ -112,7 +112,7 @@ class DispatchedMonitor implements Runnable {
     } catch (ExecutionException e) {
       // unlikely, successfulAsList prevents this as the only return
       Throwable cause = e.getCause();
-      logger.log(Level.SEVERE, "unexpected exception", cause);
+      log.log(Level.SEVERE, "unexpected exception", cause);
       if (cause instanceof RuntimeException) {
         throw (RuntimeException) cause;
       }
@@ -136,13 +136,13 @@ class DispatchedMonitor implements Runnable {
 
   @Override
   public synchronized void run() {
-    logger.log(Level.INFO, "DispatchedMonitor: Running");
+    log.log(Level.INFO, "DispatchedMonitor: Running");
     try {
       runInterruptibly();
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
     } finally {
-      logger.log(Level.INFO, "DispatchedMonitor: Exiting");
+      log.log(Level.INFO, "DispatchedMonitor: Exiting");
     }
   }
 }

--- a/src/main/java/build/buildfarm/instance/shard/RedisShardSubscriber.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardSubscriber.java
@@ -34,13 +34,13 @@ import java.util.concurrent.Executor;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.annotation.Nullable;
+import lombok.extern.java.Log;
 import redis.clients.jedis.Client;
 import redis.clients.jedis.JedisPubSub;
 
+@Log
 class RedisShardSubscriber extends JedisPubSub {
-  private static final Logger logger = Logger.getLogger(RedisShardSubscriber.class.getName());
 
   abstract static class TimedWatchFuture extends WatchFuture {
     private final TimedWatcher watcher;
@@ -138,7 +138,7 @@ class RedisShardSubscriber extends JedisPubSub {
         new TimedWatchFuture(watcher) {
           @Override
           public void unwatch() {
-            logger.log(Level.FINE, format("unwatching %s", channel));
+            log.log(Level.FINE, format("unwatching %s", channel));
             RedisShardSubscriber.this.unwatch(channel, this);
           }
         };
@@ -178,7 +178,7 @@ class RedisShardSubscriber extends JedisPubSub {
         (watcher) -> {
           boolean expired = force || watcher.isExpiredAt(now);
           if (expired) {
-            logger.log(
+            log.log(
                 Level.SEVERE,
                 format(
                     "Terminating expired watcher of %s because: %s >= %s%s",
@@ -200,7 +200,7 @@ class RedisShardSubscriber extends JedisPubSub {
       @Nullable Instant expiresAt) {
     List<TimedWatchFuture> operationWatchers = watchers.get(channel);
     boolean observe = operation == null || operation.hasMetadata() || operation.getDone();
-    logger.log(Level.FINE, format("onOperation %s: %s", channel, operation));
+    log.log(Level.FINE, format("onOperation %s: %s", channel, operation));
     synchronized (watchers) {
       ImmutableList.Builder<Consumer<Operation>> observers = ImmutableList.builder();
       for (TimedWatchFuture watchFuture : operationWatchers) {
@@ -216,7 +216,7 @@ class RedisShardSubscriber extends JedisPubSub {
         executor.execute(
             () -> {
               if (observe) {
-                logger.log(Level.FINE, "observing " + operation);
+                log.log(Level.FINE, "observing " + operation);
                 observer.accept(operation);
               }
             });
@@ -237,14 +237,14 @@ class RedisShardSubscriber extends JedisPubSub {
     try {
       onWorkerChange(parseWorkerChange(message));
     } catch (InvalidProtocolBufferException e) {
-      logger.log(Level.INFO, format("invalid worker change message: %s", message), e);
+      log.log(Level.INFO, format("invalid worker change message: %s", message), e);
     }
   }
 
   void onWorkerChange(WorkerChange workerChange) {
     switch (workerChange.getTypeCase()) {
       case TYPE_NOT_SET:
-        logger.log(
+        log.log(
             Level.SEVERE,
             format(
                 "WorkerChange oneof type is not set from %s at %s",
@@ -275,7 +275,7 @@ class RedisShardSubscriber extends JedisPubSub {
     try {
       onOperationChange(channel, parseOperationChange(message));
     } catch (InvalidProtocolBufferException e) {
-      logger.log(
+      log.log(
           Level.INFO, format("invalid operation change message for %s: %s", channel, message), e);
     }
   }
@@ -293,7 +293,7 @@ class RedisShardSubscriber extends JedisPubSub {
     switch (operationChange.getTypeCase()) {
       case TYPE_NOT_SET:
         // FIXME present nice timestamp
-        logger.log(
+        log.log(
             Level.SEVERE,
             format(
                 "OperationChange oneof type is not set from %s at %s",

--- a/src/main/java/build/buildfarm/instance/shard/RedisShardSubscription.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardSubscription.java
@@ -23,12 +23,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.logging.Level;
-import java.util.logging.Logger;
+import lombok.extern.java.Log;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.JedisPubSub;
 
+@Log
 class RedisShardSubscription implements Runnable {
-  private static final Logger logger = Logger.getLogger(RedisShardSubscription.class.getName());
 
   private final JedisPubSub subscriber;
   private final InterruptingRunnable onUnsubscribe;
@@ -69,7 +69,7 @@ class RedisShardSubscription implements Runnable {
       switch (status.getCode()) {
         case DEADLINE_EXCEEDED:
         case UNAVAILABLE:
-          logger.log(Level.WARNING, "failed to subscribe", e);
+          log.log(Level.WARNING, "failed to subscribe", e);
           /* ignore */
           break;
         default:
@@ -82,7 +82,7 @@ class RedisShardSubscription implements Runnable {
     boolean first = true;
     while (!stopped.get()) {
       if (!first) {
-        logger.log(Level.SEVERE, "unexpected subscribe return, reconnecting...");
+        log.log(Level.SEVERE, "unexpected subscribe return, reconnecting...");
       }
       iterate(!first);
       first = false;
@@ -100,7 +100,7 @@ class RedisShardSubscription implements Runnable {
     try {
       mainLoop();
     } catch (Exception e) {
-      logger.log(Level.SEVERE, "RedisShardSubscription: Calling onUnsubscribe...", e);
+      log.log(Level.SEVERE, "RedisShardSubscription: Calling onUnsubscribe...", e);
       try {
         onUnsubscribe.runInterruptibly();
       } catch (InterruptedException intEx) {

--- a/src/main/java/build/buildfarm/instance/shard/RemoteInputStreamFactory.java
+++ b/src/main/java/build/buildfarm/instance/shard/RemoteInputStreamFactory.java
@@ -52,11 +52,11 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.annotation.Nullable;
+import lombok.extern.java.Log;
 
+@Log
 public class RemoteInputStreamFactory implements InputStreamFactory {
-  private static final Logger logger = Logger.getLogger(RemoteInputStreamFactory.class.getName());
 
   public interface UnavailableConsumer {
     void accept(String worker, Throwable t, String context);
@@ -94,7 +94,7 @@ public class RemoteInputStreamFactory implements InputStreamFactory {
     try {
       return workerStubs.get(worker);
     } catch (ExecutionException e) {
-      logger.log(Level.SEVERE, String.format("error getting worker stub for %s", worker), e);
+      log.log(Level.SEVERE, String.format("error getting worker stub for %s", worker), e);
       throw new IllegalStateException("stub instance creation must not fail");
     }
   }

--- a/src/main/java/build/buildfarm/instance/shard/Util.java
+++ b/src/main/java/build/buildfarm/instance/shard/Util.java
@@ -42,10 +42,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.logging.Level;
-import java.util.logging.Logger;
+import lombok.extern.java.Log;
 
+@Log
 public class Util {
-  private static final Logger logger = Logger.getLogger(Util.class.getName());
   public static final Predicate<Status> SHARD_IS_RETRIABLE =
       st -> st.getCode() != Code.CANCELLED && Retrier.DEFAULT_IS_RETRIABLE.apply(st);
 
@@ -97,7 +97,7 @@ public class Util {
           try {
             backplane.adjustBlobLocations(digest, foundWorkers, newLocationSet);
           } catch (IOException e) {
-            logger.log(
+            log.log(
                 Level.SEVERE,
                 format("error adjusting blob location for %s", DigestUtil.toString(digest)),
                 e);
@@ -140,7 +140,7 @@ public class Util {
             fail(Status.fromThrowable(t).asRuntimeException());
           }
         };
-    logger.log(
+    log.log(
         Level.FINE,
         format(
             "scanning through %d workers to find %s",
@@ -183,7 +183,7 @@ public class Util {
           @Override
           public void onSuccess(Iterable<Digest> missingDigests) {
             boolean found = Iterables.isEmpty(missingDigests);
-            logger.log(
+            log.log(
                 Level.FINE,
                 format(
                     "check missing response for %s to %s was %sfound",
@@ -196,7 +196,7 @@ public class Util {
           public void onFailure(Throwable t) {
             Status status = Status.fromThrowable(t);
             if (status.getCode() == Code.UNAVAILABLE) {
-              logger.log(
+              log.log(
                   Level.FINE,
                   format(
                       "check missing response for %s to %s was not found for unavailable",
@@ -206,7 +206,7 @@ public class Util {
                 || Context.current().isCancelled()
                 || status.getCode() == Code.DEADLINE_EXCEEDED
                 || !SHARD_IS_RETRIABLE.test(status)) {
-              logger.log(
+              log.log(
                   Level.SEVERE,
                   format("error checking for %s on %s", DigestUtil.toString(digest), worker),
                   t);

--- a/src/main/java/build/buildfarm/instance/stub/BUILD
+++ b/src/main/java/build/buildfarm/instance/stub/BUILD
@@ -1,6 +1,7 @@
 java_library(
     name = "stub",
     srcs = glob(["*.java"]),
+    plugins = ["//src/main/java/build/buildfarm/common:lombok"],
     visibility = ["//visibility:public"],
     deps = [
         "//src/main/java/build/buildfarm/common",
@@ -23,6 +24,7 @@ java_library(
         "@maven//:io_grpc_grpc_netty",
         "@maven//:io_grpc_grpc_protobuf",
         "@maven//:io_grpc_grpc_stub",
+        "@maven//:org_projectlombok_lombok",
         "@remote_apis//:build_bazel_remote_execution_v2_remote_execution_java_grpc",
         "@remote_apis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
     ],

--- a/src/main/java/build/buildfarm/instance/stub/ByteStreamUploader.java
+++ b/src/main/java/build/buildfarm/instance/stub/ByteStreamUploader.java
@@ -54,17 +54,17 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
+import lombok.extern.java.Log;
 
 /**
  * A client implementing the {@code Write} method of the {@code ByteStream} gRPC service.
  *
  * <p>Users must call {@link #shutdown()} before exiting.
  */
+@Log
 public class ByteStreamUploader {
-  private static final Logger logger = Logger.getLogger(ByteStreamUploader.class.getName());
 
   private final String instanceName;
   private final Channel channel;
@@ -402,7 +402,7 @@ public class ByteStreamUploader {
                 // This exception indicates that closing the underlying input stream failed.
                 // We don't expect this to ever happen, but don't want to swallow the exception
                 // completely.
-                logger.log(Level.WARNING, "Chunker failed closing data source", e);
+                log.log(Level.WARNING, "Chunker failed closing data source", e);
               }
 
               if (status.isOk() || Code.ALREADY_EXISTS.equals(status.getCode())) {
@@ -449,7 +449,7 @@ public class ByteStreamUploader {
                     // This exception indicates that closing the underlying input stream failed.
                     // We don't expect this to ever happen, but don't want to swallow the exception
                     // completely.
-                    logger.log(Level.WARNING, format("Chunker failed closing data source: %s", e1));
+                    log.log(Level.WARNING, format("Chunker failed closing data source: %s", e1));
                   } finally {
                     call.cancel("Failed to read next chunk.", e);
                   }

--- a/src/main/java/build/buildfarm/instance/stub/StubInstance.java
+++ b/src/main/java/build/buildfarm/instance/stub/StubInstance.java
@@ -142,12 +142,12 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
+import lombok.extern.java.Log;
 
+@Log
 public class StubInstance implements Instance {
-  private static final Logger logger = Logger.getLogger(StubInstance.class.getName());
 
   private static final long DEFAULT_DEADLINE_DAYS = 100 * 365;
 
@@ -354,7 +354,7 @@ public class StubInstance implements Instance {
     channel.shutdownNow();
     channel.awaitTermination(0, TimeUnit.SECONDS);
     if (retryService != null && !shutdownAndAwaitTermination(retryService, 10, TimeUnit.SECONDS)) {
-      logger.log(Level.SEVERE, format("Could not shut down retry service for %s", identifier));
+      log.log(Level.SEVERE, format("Could not shut down retry service for %s", identifier));
     }
   }
 
@@ -756,7 +756,7 @@ public class StubInstance implements Instance {
     com.google.rpc.Status status = deadlined(operationQueueBlockingStub).put(operation);
     int code = status.getCode();
     if (code != Code.OK.getNumber() && code != Code.INVALID_ARGUMENT.getNumber()) {
-      logger.log(
+      log.log(
           Level.SEVERE,
           format("putOperation(%s) response was unexpected", operation.getName()),
           StatusProto.toStatusException(status));
@@ -781,7 +781,7 @@ public class StubInstance implements Instance {
                     .build());
     int code = status.getCode();
     if (code != Code.OK.getNumber() && code != Code.INVALID_ARGUMENT.getNumber()) {
-      logger.log(
+      log.log(
           Level.SEVERE,
           format("pollOperation(%s) response was unexpected", operationName),
           StatusProto.toStatusException(status));

--- a/src/main/java/build/buildfarm/metrics/AbstractMetricsPublisher.java
+++ b/src/main/java/build/buildfarm/metrics/AbstractMetricsPublisher.java
@@ -27,10 +27,10 @@ import io.prometheus.client.Counter;
 import io.prometheus.client.Gauge;
 import io.prometheus.client.Histogram;
 import java.util.logging.Level;
-import java.util.logging.Logger;
+import lombok.extern.java.Log;
 
+@Log
 public abstract class AbstractMetricsPublisher implements MetricsPublisher {
-  private static final Logger logger = Logger.getLogger(AbstractMetricsPublisher.class.getName());
 
   private static final Counter actionsCounter =
       Counter.build().name("actions").help("Number of actions.").register();
@@ -151,7 +151,7 @@ public abstract class AbstractMetricsPublisher implements MetricsPublisher {
       }
       return operationRequestMetadata;
     } catch (Exception e) {
-      logger.log(
+      log.log(
           Level.WARNING,
           String.format("Could not populate request metadata for %s.", operation.getName()),
           e);
@@ -173,7 +173,7 @@ public abstract class AbstractMetricsPublisher implements MetricsPublisher {
             .usingTypeRegistry(typeRegistry)
             .omittingInsignificantWhitespace()
             .print(operationRequestMetadata);
-    logger.log(Level.FINE, "{}", formattedRequestMetadata);
+    log.log(Level.FINE, "{}", formattedRequestMetadata);
     return formattedRequestMetadata;
   }
 }

--- a/src/main/java/build/buildfarm/metrics/BUILD
+++ b/src/main/java/build/buildfarm/metrics/BUILD
@@ -1,6 +1,7 @@
 java_library(
     name = "metrics",
     srcs = glob(["*.java"]),
+    plugins = ["//src/main/java/build/buildfarm/common:lombok"],
     visibility = ["//visibility:public"],
     deps = [
         "//src/main/protobuf:build_buildfarm_v1test_buildfarm_java_proto",
@@ -11,6 +12,7 @@ java_library(
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:com_google_protobuf_protobuf_java_util",
         "@maven//:io_prometheus_simpleclient",
+        "@maven//:org_projectlombok_lombok",
         "@remote_apis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
     ],
 )

--- a/src/main/java/build/buildfarm/metrics/aws/AwsMetricsPublisher.java
+++ b/src/main/java/build/buildfarm/metrics/aws/AwsMetricsPublisher.java
@@ -36,10 +36,10 @@ import java.io.IOException;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.logging.Level;
-import java.util.logging.Logger;
+import lombok.extern.java.Log;
 
+@Log
 public class AwsMetricsPublisher extends AbstractMetricsPublisher {
-  private static final Logger logger = Logger.getLogger(AwsMetricsPublisher.class.getName());
 
   private static BuildfarmConfigs configs = BuildfarmConfigs.getInstance();
   private static AmazonSNSAsync snsClient;
@@ -76,7 +76,7 @@ public class AwsMetricsPublisher extends AbstractMetricsPublisher {
             new AsyncHandler<PublishRequest, PublishResult>() {
               @Override
               public void onError(Exception e) {
-                logger.log(Level.WARNING, "Could not publish metrics data to SNS.", e);
+                log.log(Level.WARNING, "Could not publish metrics data to SNS.", e);
               }
 
               @Override
@@ -84,7 +84,7 @@ public class AwsMetricsPublisher extends AbstractMetricsPublisher {
             });
       }
     } catch (Exception e) {
-      logger.log(
+      log.log(
           Level.WARNING,
           String.format("Could not publish request metadata to SNS for %s.", operation.getName()),
           e);
@@ -92,7 +92,7 @@ public class AwsMetricsPublisher extends AbstractMetricsPublisher {
   }
 
   private AmazonSNSAsync initSnsClient() {
-    logger.log(Level.INFO, "Initializing SNS Client.");
+    log.log(Level.INFO, "Initializing SNS Client.");
     return AmazonSNSAsyncClientBuilder.standard()
         .withRegion(region)
         .withClientConfiguration(
@@ -127,7 +127,7 @@ public class AwsMetricsPublisher extends AbstractMetricsPublisher {
     try {
       getSecretValueResult = client.getSecretValue(getSecretValueRequest);
     } catch (Exception e) {
-      logger.log(Level.SEVERE, String.format("Could not get secret %s from AWS.", secretName));
+      log.log(Level.SEVERE, String.format("Could not get secret %s from AWS.", secretName));
       return;
     }
     String secret;
@@ -145,7 +145,7 @@ public class AwsMetricsPublisher extends AbstractMetricsPublisher {
         accessKeyId = secretMap.get("access_key");
         secretKey = secretMap.get("secret_key");
       } catch (IOException e) {
-        logger.log(Level.SEVERE, String.format("Could not parse secret %s from AWS", secretName));
+        log.log(Level.SEVERE, String.format("Could not parse secret %s from AWS", secretName));
       }
     }
   }

--- a/src/main/java/build/buildfarm/metrics/aws/BUILD
+++ b/src/main/java/build/buildfarm/metrics/aws/BUILD
@@ -1,6 +1,7 @@
 java_library(
     name = "aws",
     srcs = glob(["*.java"]),
+    plugins = ["//src/main/java/build/buildfarm/common:lombok"],
     visibility = ["//visibility:public"],
     deps = [
         "//src/main/java/build/buildfarm/common/config",
@@ -15,6 +16,7 @@ java_library(
         "@maven//:com_fasterxml_jackson_core_jackson_databind",
         "@maven//:com_google_guava_guava",
         "@maven//:com_google_protobuf_protobuf_java_util",
+        "@maven//:org_projectlombok_lombok",
         "@remote_apis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
     ],
 )

--- a/src/main/java/build/buildfarm/metrics/log/BUILD
+++ b/src/main/java/build/buildfarm/metrics/log/BUILD
@@ -1,6 +1,7 @@
 java_library(
     name = "log",
     srcs = glob(["*.java"]),
+    plugins = ["//src/main/java/build/buildfarm/common:lombok"],
     visibility = ["//visibility:public"],
     deps = [
         "//src/main/java/build/buildfarm/common/config",
@@ -11,6 +12,7 @@ java_library(
         "@googleapis//:google_rpc_status_java_proto",
         "@maven//:com_google_guava_guava",
         "@maven//:com_google_protobuf_protobuf_java_util",
+        "@maven//:org_projectlombok_lombok",
         "@remote_apis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
     ],
 )

--- a/src/main/java/build/buildfarm/metrics/log/LogMetricsPublisher.java
+++ b/src/main/java/build/buildfarm/metrics/log/LogMetricsPublisher.java
@@ -19,10 +19,10 @@ import build.buildfarm.common.config.BuildfarmConfigs;
 import build.buildfarm.metrics.AbstractMetricsPublisher;
 import com.google.longrunning.Operation;
 import java.util.logging.Level;
-import java.util.logging.Logger;
+import lombok.extern.java.Log;
 
+@Log
 public class LogMetricsPublisher extends AbstractMetricsPublisher {
-  private static final Logger logger = Logger.getLogger(LogMetricsPublisher.class.getName());
 
   private static BuildfarmConfigs configs = BuildfarmConfigs.getInstance();
 
@@ -40,11 +40,11 @@ public class LogMetricsPublisher extends AbstractMetricsPublisher {
   @Override
   public void publishRequestMetadata(Operation operation, RequestMetadata requestMetadata) {
     try {
-      logger.log(
+      log.log(
           logLevel,
           formatRequestMetadataToJson(populateRequestMetadata(operation, requestMetadata)));
     } catch (Exception e) {
-      logger.log(
+      log.log(
           Level.WARNING,
           String.format("Could not publish request metadata to LOG for %s.", operation.getName()),
           e);
@@ -53,6 +53,6 @@ public class LogMetricsPublisher extends AbstractMetricsPublisher {
 
   @Override
   public void publishMetric(String metricName, Object metricValue) {
-    logger.log(Level.INFO, String.format("%s: %s", metricName, metricValue.toString()));
+    log.log(Level.INFO, String.format("%s: %s", metricName, metricValue.toString()));
   }
 }

--- a/src/main/java/build/buildfarm/metrics/prometheus/BUILD
+++ b/src/main/java/build/buildfarm/metrics/prometheus/BUILD
@@ -3,10 +3,12 @@ java_library(
     srcs = [
         "PrometheusPublisher.java",
     ],
+    plugins = ["//src/main/java/build/buildfarm/common:lombok"],
     visibility = ["//visibility:public"],
     deps = [
         "@maven//:io_prometheus_simpleclient",
         "@maven//:io_prometheus_simpleclient_hotspot",
         "@maven//:io_prometheus_simpleclient_httpserver",
+        "@maven//:org_projectlombok_lombok",
     ],
 )

--- a/src/main/java/build/buildfarm/metrics/prometheus/PrometheusPublisher.java
+++ b/src/main/java/build/buildfarm/metrics/prometheus/PrometheusPublisher.java
@@ -17,10 +17,10 @@ package build.buildfarm.metrics.prometheus;
 import io.prometheus.client.exporter.HTTPServer;
 import io.prometheus.client.hotspot.DefaultExports;
 import java.io.IOException;
-import java.util.logging.Logger;
+import lombok.extern.java.Log;
 
+@Log
 public class PrometheusPublisher {
-  private static final Logger logger = Logger.getLogger(PrometheusPublisher.class.getName());
   private static HTTPServer server;
 
   public static void startHttpServer(int port) {
@@ -28,12 +28,12 @@ public class PrometheusPublisher {
       if (port > 0) {
         DefaultExports.initialize();
         server = new HTTPServer(port);
-        logger.info("Started Prometheus HTTP Server on port " + port);
+        log.info("Started Prometheus HTTP Server on port " + port);
       } else {
-        logger.info("Prometheus port is not configured. HTTP Server will not be started");
+        log.info("Prometheus port is not configured. HTTP Server will not be started");
       }
     } catch (IOException e) {
-      logger.severe("Could not start Prometheus HTTP Server on port " + port);
+      log.severe("Could not start Prometheus HTTP Server on port " + port);
     }
   }
 

--- a/src/main/java/build/buildfarm/operations/finder/BUILD
+++ b/src/main/java/build/buildfarm/operations/finder/BUILD
@@ -4,6 +4,7 @@ java_library(
         "EnrichedOperationBuilder.java",
         "OperationsFinder.java",
     ],
+    plugins = ["//src/main/java/build/buildfarm/common:lombok"],
     visibility = ["//visibility:public"],
     deps = [
         "//src/main/java/build/buildfarm/instance",
@@ -24,6 +25,7 @@ java_library(
         "@maven//:io_grpc_grpc_protobuf",
         "@maven//:io_grpc_grpc_stub",
         "@maven//:org_apache_commons_commons_pool2",
+        "@maven//:org_projectlombok_lombok",
         "@remote_apis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
     ],
 )

--- a/src/main/java/build/buildfarm/operations/finder/EnrichedOperationBuilder.java
+++ b/src/main/java/build/buildfarm/operations/finder/EnrichedOperationBuilder.java
@@ -31,7 +31,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
 import com.google.rpc.PreconditionFailure;
 import java.util.logging.Level;
-import java.util.logging.Logger;
+import lombok.extern.java.Log;
 import redis.clients.jedis.JedisCluster;
 
 /**
@@ -41,8 +41,8 @@ import redis.clients.jedis.JedisCluster;
  * @details For performance reasons, only build these enriched operations when you intend to use the
  *     extra provided metadata.
  */
+@Log
 public class EnrichedOperationBuilder {
-  private static final Logger logger = Logger.getLogger(EnrichedOperationBuilder.class.getName());
 
   /**
    * @brief Create an enriched operation based on an operation key.
@@ -112,7 +112,7 @@ public class EnrichedOperationBuilder {
             .ignoringUnknownFields();
 
     if (json == null) {
-      logger.log(Level.WARNING, "Operation Json is empty");
+      log.log(Level.WARNING, "Operation Json is empty");
       return null;
     }
     try {
@@ -120,7 +120,7 @@ public class EnrichedOperationBuilder {
       operationParser.merge(json, operationBuilder);
       return operationBuilder.build();
     } catch (InvalidProtocolBufferException e) {
-      logger.log(Level.WARNING, "InvalidProtocolBufferException while building an operation.", e);
+      log.log(Level.WARNING, "InvalidProtocolBufferException while building an operation.", e);
       return null;
     }
   }
@@ -154,7 +154,7 @@ public class EnrichedOperationBuilder {
       }
 
     } catch (InvalidProtocolBufferException e) {
-      logger.log(Level.WARNING, "InvalidProtocolBufferException while building an operation.", e);
+      log.log(Level.WARNING, "InvalidProtocolBufferException while building an operation.", e);
       metadata = null;
     }
 
@@ -177,11 +177,11 @@ public class EnrichedOperationBuilder {
         action = Action.parseFrom(blob);
         return action;
       } catch (InvalidProtocolBufferException e) {
-        logger.log(Level.WARNING, "InvalidProtocolBufferException while building an operation.", e);
+        log.log(Level.WARNING, "InvalidProtocolBufferException while building an operation.", e);
         return null;
       }
     } catch (Exception e) {
-      logger.log(Level.WARNING, e.getMessage());
+      log.log(Level.WARNING, e.getMessage());
       return null;
     }
   }
@@ -202,11 +202,11 @@ public class EnrichedOperationBuilder {
         command = Command.parseFrom(blob);
         return command;
       } catch (InvalidProtocolBufferException e) {
-        logger.log(Level.WARNING, "InvalidProtocolBufferException while building an operation.", e);
+        log.log(Level.WARNING, "InvalidProtocolBufferException while building an operation.", e);
         return null;
       }
     } catch (Exception e) {
-      logger.log(Level.WARNING, e.getMessage());
+      log.log(Level.WARNING, e.getMessage());
       return null;
     }
   }

--- a/src/main/java/build/buildfarm/proxy/http/BUILD
+++ b/src/main/java/build/buildfarm/proxy/http/BUILD
@@ -1,6 +1,7 @@
 java_library(
     name = "http",
     srcs = glob(["*.java"]),
+    plugins = ["//src/main/java/build/buildfarm/common:lombok"],
     visibility = ["//visibility:public"],
     deps = [
         "//src/main/java/build/buildfarm/common",
@@ -31,6 +32,7 @@ java_library(
         "@maven//:io_netty_netty_transport_native_epoll",
         "@maven//:io_netty_netty_transport_native_kqueue",
         "@maven//:io_netty_netty_transport_native_unix_common",
+        "@maven//:org_projectlombok_lombok",
         "@remote_apis//:build_bazel_remote_execution_v2_remote_execution_java_grpc",
         "@remote_apis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
     ],

--- a/src/main/java/build/buildfarm/proxy/http/BlobWriteObserver.java
+++ b/src/main/java/build/buildfarm/proxy/http/BlobWriteObserver.java
@@ -24,10 +24,10 @@ import com.google.common.base.Throwables;
 import com.google.protobuf.ByteString;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
-import java.util.logging.Logger;
+import lombok.extern.java.Log;
 
+@Log
 class BlobWriteObserver implements WriteObserver {
-  private static final Logger logger = Logger.getLogger(BlobWriteObserver.class.getName());
   private static final int BLOB_BUFFER_SIZE = 64 * 1024;
 
   private final String resourceName;
@@ -71,7 +71,7 @@ class BlobWriteObserver implements WriteObserver {
     checkError();
     String requestResourceName = request.getResourceName();
     if (!requestResourceName.isEmpty() && !resourceName.equals(requestResourceName)) {
-      logger.log(
+      log.log(
           Level.WARNING,
           String.format(
               "ByteStreamServer:write:%s: resource name %s does not match first request",
@@ -82,7 +82,7 @@ class BlobWriteObserver implements WriteObserver {
               resourceName, requestResourceName));
     }
     if (complete) {
-      logger.log(
+      log.log(
           Level.WARNING,
           String.format(
               "ByteStreamServer:write:%s: write received after finish_write specified",
@@ -91,7 +91,7 @@ class BlobWriteObserver implements WriteObserver {
     }
     long committedSize = getCommittedSize();
     if (request.getWriteOffset() != committedSize) {
-      logger.log(
+      log.log(
           Level.WARNING,
           String.format(
               "ByteStreamServer:write:%s: offset %d != committed_size %d",
@@ -100,7 +100,7 @@ class BlobWriteObserver implements WriteObserver {
     }
     long sizeAfterWrite = committedSize + request.getData().size();
     if (request.getFinishWrite() && sizeAfterWrite != size) {
-      logger.log(
+      log.log(
           Level.WARNING,
           String.format(
               "ByteStreamServer:write:%s: finish_write request of size %d for write size %d != expected %d",

--- a/src/main/java/build/buildfarm/proxy/http/HttpProxy.java
+++ b/src/main/java/build/buildfarm/proxy/http/HttpProxy.java
@@ -31,12 +31,13 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLException;
+import lombok.extern.java.Log;
 
+@Log
 public class HttpProxy extends LoggingMain {
   // We need to keep references to the root and netty loggers to prevent them from being garbage
   // collected, which would cause us to loose their configuration.
   private static final Logger nettyLogger = Logger.getLogger("io.grpc.netty");
-  public static final Logger logger = Logger.getLogger(HttpProxy.class.getName());
 
   private final Server server;
 

--- a/src/main/java/build/buildfarm/server/BUILD
+++ b/src/main/java/build/buildfarm/server/BUILD
@@ -1,6 +1,7 @@
 java_library(
     name = "server",
     srcs = glob(["*.java"]),
+    plugins = ["//src/main/java/build/buildfarm/common:lombok"],
     visibility = ["//visibility:public"],
     deps = [
         "//src/main/java/build/buildfarm/common",
@@ -21,5 +22,6 @@ java_library(
         "@maven//:io_prometheus_simpleclient",
         "@maven//:me_dinowernli_java_grpc_prometheus",
         "@maven//:org_bouncycastle_bcprov_jdk15on",
+        "@maven//:org_projectlombok_lombok",
     ],
 )

--- a/src/main/java/build/buildfarm/server/BuildFarmServer.java
+++ b/src/main/java/build/buildfarm/server/BuildFarmServer.java
@@ -53,19 +53,19 @@ import java.util.UUID;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.naming.ConfigurationException;
+import lombok.extern.java.Log;
 import me.dinowernli.grpc.prometheus.Configuration;
 import me.dinowernli.grpc.prometheus.MonitoringServerInterceptor;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 @SuppressWarnings("deprecation")
+@Log
 public class BuildFarmServer extends LoggingMain {
   // We need to keep references to the root and netty loggers to prevent them from being garbage
   // collected, which would cause us to loose their configuration.
   private static final java.util.logging.Logger nettyLogger =
       java.util.logging.Logger.getLogger("io.grpc.netty");
-  private static final Logger logger = Logger.getLogger(BuildFarmServer.class.getName());
   private static final Counter healthCheckMetric =
       Counter.build()
           .name("health_check")
@@ -125,7 +125,7 @@ public class BuildFarmServer extends LoggingMain {
     handleGrpcMetricIntercepts(serverBuilder);
     server = serverBuilder.build();
 
-    logger.log(Level.INFO, String.format("%s initialized", session));
+    log.log(Level.INFO, String.format("%s initialized", session));
   }
 
   public static void handleGrpcMetricIntercepts(ServerBuilder<?> serverBuilder) {
@@ -189,7 +189,7 @@ public class BuildFarmServer extends LoggingMain {
       }
     }
     if (!shutdownAndAwaitTermination(keepaliveScheduler, 10, TimeUnit.SECONDS)) {
-      logger.log(Level.WARNING, "could not shut down keepalive scheduler");
+      log.log(Level.WARNING, "could not shut down keepalive scheduler");
     }
   }
 
@@ -200,8 +200,8 @@ public class BuildFarmServer extends LoggingMain {
   }
 
   private static void printUsage(OptionsParser parser) {
-    logger.log(Level.INFO, "Usage: CONFIG_PATH");
-    logger.log(
+    log.log(Level.INFO, "Usage: CONFIG_PATH");
+    log.log(
         Level.INFO,
         parser.describeOptions(Collections.emptyMap(), OptionsParser.HelpVerbosity.LONG));
   }
@@ -229,7 +229,7 @@ public class BuildFarmServer extends LoggingMain {
     try {
       configs = BuildfarmConfigs.loadConfigs(residue.get(0));
     } catch (IOException e) {
-      logger.severe("Could not parse yml configuration file." + e);
+      log.severe("Could not parse yml configuration file." + e);
     }
 
     String session = "buildfarm-server";
@@ -241,7 +241,7 @@ public class BuildFarmServer extends LoggingMain {
       configs.getServer().setPort(options.port);
     }
     session += "-" + UUID.randomUUID();
-    logger.info(configs.toString());
+    log.info(configs.toString());
     BuildFarmServer server;
     try {
       server = new BuildFarmServer(session);

--- a/src/main/java/build/buildfarm/server/services/ActionCacheService.java
+++ b/src/main/java/build/buildfarm/server/services/ActionCacheService.java
@@ -33,11 +33,11 @@ import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
 import io.prometheus.client.Counter;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.annotation.Nullable;
+import lombok.extern.java.Log;
 
+@Log
 public class ActionCacheService extends ActionCacheGrpc.ActionCacheImplBase {
-  public static final Logger logger = Logger.getLogger(ActionCacheService.class.getName());
   private static final Counter actionResultsMetric =
       Counter.build().name("action_results").help("Action results.").register();
 
@@ -82,7 +82,7 @@ public class ActionCacheService extends ActionCacheGrpc.ActionCacheImplBase {
           @SuppressWarnings("NullableProblems")
           @Override
           public void onFailure(Throwable t) {
-            logger.log(
+            log.log(
                 Level.WARNING,
                 String.format(
                     "getActionResult(%s): %s",

--- a/src/main/java/build/buildfarm/server/services/AdminService.java
+++ b/src/main/java/build/buildfarm/server/services/AdminService.java
@@ -43,10 +43,10 @@ import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
 import io.grpc.stub.StreamObserver;
 import java.util.logging.Level;
-import java.util.logging.Logger;
+import lombok.extern.java.Log;
 
+@Log
 public class AdminService extends AdminGrpc.AdminImplBase {
-  private static final Logger logger = Logger.getLogger(AdminService.class.getName());
 
   private final Admin adminController;
   private final Instance instance;
@@ -67,7 +67,7 @@ public class AdminService extends AdminGrpc.AdminImplBase {
       responseObserver.onNext(Status.newBuilder().setCode(Code.OK_VALUE).build());
       responseObserver.onCompleted();
     } catch (Exception e) {
-      logger.log(Level.SEVERE, "Could not terminate host.", e);
+      log.log(Level.SEVERE, "Could not terminate host.", e);
       responseObserver.onError(io.grpc.Status.fromThrowable(e).asException());
     }
   }
@@ -81,7 +81,7 @@ public class AdminService extends AdminGrpc.AdminImplBase {
       responseObserver.onNext(Status.newBuilder().setCode(Code.OK_VALUE).build());
       responseObserver.onCompleted();
     } catch (Exception e) {
-      logger.log(Level.SEVERE, "Could not stop container.", e);
+      log.log(Level.SEVERE, "Could not stop container.", e);
       responseObserver.onError(io.grpc.Status.fromThrowable(e).asException());
     }
   }
@@ -98,7 +98,7 @@ public class AdminService extends AdminGrpc.AdminImplBase {
       responseObserver.onNext(result);
       responseObserver.onCompleted();
     } catch (Exception e) {
-      logger.log(Level.SEVERE, "Could not get hosts.", e);
+      log.log(Level.SEVERE, "Could not get hosts.", e);
       responseObserver.onError(io.grpc.Status.fromThrowable(e).asException());
     }
   }
@@ -112,7 +112,7 @@ public class AdminService extends AdminGrpc.AdminImplBase {
       responseObserver.onNext(result);
       responseObserver.onCompleted();
     } catch (Exception e) {
-      logger.log(
+      log.log(
           Level.SEVERE,
           String.format("Could not get client start time for %s.", request.getInstanceName()),
           e);
@@ -134,7 +134,7 @@ public class AdminService extends AdminGrpc.AdminImplBase {
       responseObserver.onNext(Status.newBuilder().setCode(Code.OK_VALUE).build());
       responseObserver.onCompleted();
     } catch (Exception e) {
-      logger.log(Level.SEVERE, "Could not scale cluster.", e);
+      log.log(Level.SEVERE, "Could not scale cluster.", e);
       responseObserver.onError(io.grpc.Status.fromThrowable(e).asException());
     }
   }
@@ -144,7 +144,7 @@ public class AdminService extends AdminGrpc.AdminImplBase {
       ReindexCasRequest request, StreamObserver<ReindexCasRequestResults> responseObserver) {
     try {
       CasIndexResults results = instance.reindexCas();
-      logger.info(String.format("CAS Indexer Results: %s", results.toMessage()));
+      log.info(String.format("CAS Indexer Results: %s", results.toMessage()));
       responseObserver.onNext(
           ReindexCasRequestResults.newBuilder()
               .setRemovedHosts(results.removedHosts)
@@ -153,7 +153,7 @@ public class AdminService extends AdminGrpc.AdminImplBase {
               .build());
       responseObserver.onCompleted();
     } catch (Exception e) {
-      logger.log(Level.SEVERE, "Could not reindex CAS.", e);
+      log.log(Level.SEVERE, "Could not reindex CAS.", e);
       responseObserver.onError(io.grpc.Status.fromThrowable(e).asException());
     }
   }
@@ -178,7 +178,7 @@ public class AdminService extends AdminGrpc.AdminImplBase {
           String.format(
               "Could not inform the worker %s to prepare for graceful shutdown with error %s.",
               request.getWorkerName(), e.getMessage());
-      logger.log(Level.SEVERE, errorMessage);
+      log.log(Level.SEVERE, errorMessage);
       responseObserver.onError(new Exception(errorMessage));
     }
   }

--- a/src/main/java/build/buildfarm/server/services/BUILD
+++ b/src/main/java/build/buildfarm/server/services/BUILD
@@ -1,6 +1,7 @@
 java_library(
     name = "services",
     srcs = glob(["*.java"]),
+    plugins = ["//src/main/java/build/buildfarm/common:lombok"],
     visibility = ["//visibility:public"],
     deps = [
         "//src/main/java/build/buildfarm/admin",
@@ -34,6 +35,7 @@ java_library(
         "@maven//:io_grpc_grpc_services",
         "@maven//:io_grpc_grpc_stub",
         "@maven//:io_prometheus_simpleclient",
+        "@maven//:org_projectlombok_lombok",
         "@remote_apis//:build_bazel_remote_asset_v1_remote_asset_java_grpc",
         "@remote_apis//:build_bazel_remote_asset_v1_remote_asset_java_proto",
         "@remote_apis//:build_bazel_remote_execution_v2_remote_execution_java_grpc",

--- a/src/main/java/build/buildfarm/server/services/ExecutionService.java
+++ b/src/main/java/build/buildfarm/server/services/ExecutionService.java
@@ -42,11 +42,11 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.annotation.Nullable;
+import lombok.extern.java.Log;
 
+@Log
 public class ExecutionService extends ExecutionGrpc.ExecutionImplBase {
-  private static final Logger logger = Logger.getLogger(ExecutionService.class.getName());
 
   private final Instance instance;
   private final long keepaliveAfter;
@@ -86,7 +86,7 @@ public class ExecutionService extends ExecutionGrpc.ExecutionImplBase {
           @Override
           public void onFailure(Throwable t) {
             if (!isCancelled() && !(t instanceof CancellationException)) {
-              logger.log(Level.WARNING, "error occurred during execution", t);
+              log.log(Level.WARNING, "error occurred during execution", t);
               serverCallStreamObserver.onError(Status.fromThrowable(t).asException());
             }
           }

--- a/src/main/java/build/buildfarm/server/services/FetchService.java
+++ b/src/main/java/build/buildfarm/server/services/FetchService.java
@@ -20,10 +20,10 @@ import com.google.common.util.concurrent.FutureCallback;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import java.util.logging.Level;
-import java.util.logging.Logger;
+import lombok.extern.java.Log;
 
+@Log
 public class FetchService extends FetchImplBase {
-  public static final Logger logger = Logger.getLogger(ActionCacheService.class.getName());
 
   private final Instance instance;
 
@@ -67,7 +67,7 @@ public class FetchService extends FetchImplBase {
           new FutureCallback<Digest>() {
             @Override
             public void onSuccess(Digest actualDigest) {
-              logger.log(
+              log.log(
                   Level.INFO,
                   format(
                       "fetch blob succeeded: %s inserted into CAS",
@@ -81,7 +81,7 @@ public class FetchService extends FetchImplBase {
             @Override
             public void onFailure(Throwable t) {
               // handle NoSuchFileException
-              logger.log(Level.SEVERE, "fetch blob failed", t);
+              log.log(Level.SEVERE, "fetch blob failed", t);
               responseObserver.onError(t);
             }
           },
@@ -108,7 +108,7 @@ public class FetchService extends FetchImplBase {
   @Override
   public void fetchDirectory(
       FetchDirectoryRequest request, StreamObserver<FetchDirectoryResponse> responseObserver) {
-    logger.log(
+    log.log(
         Level.SEVERE,
         "fetchDirectory: "
             + request.toString()

--- a/src/main/java/build/buildfarm/server/services/PublishBuildEventService.java
+++ b/src/main/java/build/buildfarm/server/services/PublishBuildEventService.java
@@ -26,10 +26,10 @@ import io.grpc.Status;
 import io.grpc.StatusException;
 import io.grpc.stub.StreamObserver;
 import java.util.logging.Level;
-import java.util.logging.Logger;
+import lombok.extern.java.Log;
 
+@Log
 public class PublishBuildEventService extends PublishBuildEventImplBase {
-  public static final Logger logger = Logger.getLogger(PublishBuildEventService.class.getName());
 
   private static BuildfarmConfigs configs = BuildfarmConfigs.getInstance();
 
@@ -70,7 +70,7 @@ public class PublishBuildEventService extends PublishBuildEventImplBase {
 
   private void recordEvent(PublishBuildToolEventStreamRequest in) {
     if (configs.getServer().isRecordBesEvents() && in.hasOrderedBuildEvent()) {
-      logger.log(Level.INFO, TextFormat.shortDebugString(in.getOrderedBuildEvent()));
+      log.log(Level.INFO, TextFormat.shortDebugString(in.getOrderedBuildEvent()));
     }
   }
 }

--- a/src/main/java/build/buildfarm/worker/BUILD
+++ b/src/main/java/build/buildfarm/worker/BUILD
@@ -1,6 +1,7 @@
 java_library(
     name = "worker",
     srcs = glob(["*.java"]),
+    plugins = ["//src/main/java/build/buildfarm/common:lombok"],
     visibility = ["//visibility:public"],
     deps = [
         "//src/main/java/build/buildfarm/common",
@@ -36,5 +37,6 @@ java_library(
         "@maven//:io_prometheus_simpleclient",
         "@maven//:org_apache_commons_commons_compress",
         "@maven//:org_jetbrains_annotations",
+        "@maven//:org_projectlombok_lombok",
     ],
 )

--- a/src/main/java/build/buildfarm/worker/DockerExecutor.java
+++ b/src/main/java/build/buildfarm/worker/DockerExecutor.java
@@ -45,7 +45,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
-import java.util.logging.Logger;
+import lombok.extern.java.Log;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 
 /**
@@ -62,14 +62,8 @@ import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
  *     container" model for action execution. Bazel toolchains expects you to provide container
  *     images when defining platform configurations in bazel.
  */
+@Log
 public class DockerExecutor {
-  /**
-   * @field logger
-   * @brief Logger for the context of the class.
-   * @details Used to log issues with action execution.
-   */
-  private static Logger logger = Logger.getLogger(DockerExecutor.class.getName());
-
   /**
    * @brief Run the action using the docker client and populate the results.
    * @details This will fetch any images as needed, spawn a container for execution, and clean up
@@ -257,7 +251,7 @@ public class DockerExecutor {
     try {
       dockerClient.removeContainerCmd(containerId).withRemoveVolumes(true).withForce(true).exec();
     } catch (Exception e) {
-      logger.log(Level.SEVERE, "couldn't shutdown container: ", e);
+      log.log(Level.SEVERE, "couldn't shutdown container: ", e);
     }
   }
   /**
@@ -318,7 +312,7 @@ public class DockerExecutor {
     // run container creation and log any warnings
     CreateContainerResponse response = createContainerCmd.exec();
     if (response.getWarnings().length != 0) {
-      logger.log(Level.WARNING, Arrays.toString(response.getWarnings()));
+      log.log(Level.WARNING, Arrays.toString(response.getWarnings()));
     }
     // container is ready and started
     return response.getId();
@@ -375,7 +369,7 @@ public class DockerExecutor {
         Utils.unTar(tarStream, new File(path.toString()));
       }
     } catch (Exception e) {
-      logger.log(Level.WARNING, "Could not extract file from container: ", e);
+      log.log(Level.WARNING, "Could not extract file from container: ", e);
     }
   }
 }

--- a/src/main/java/build/buildfarm/worker/ExecuteActionStage.java
+++ b/src/main/java/build/buildfarm/worker/ExecuteActionStage.java
@@ -26,9 +26,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import lombok.extern.java.Log;
 
+@Log
 public class ExecuteActionStage extends SuperscalarPipelineStage {
-  private static final Logger logger = Logger.getLogger(ExecuteActionStage.class.getName());
   private static final Gauge executionSlotUsage =
       Gauge.build().name("execution_slot_usage").help("Execution slot Usage.").register();
   private static final Histogram executionTime =
@@ -61,7 +62,7 @@ public class ExecuteActionStage extends SuperscalarPipelineStage {
         try {
           workerContext.destroyExecDir(operationContext.execDir);
         } catch (IOException e) {
-          logger.log(
+          log.log(
               Level.SEVERE, "error while destroying action root " + operationContext.execDir, e);
         } finally {
           output.put(operationContext);
@@ -72,7 +73,7 @@ public class ExecuteActionStage extends SuperscalarPipelineStage {
 
   @Override
   protected Logger getLogger() {
-    return logger;
+    return log;
   }
 
   @Override

--- a/src/main/java/build/buildfarm/worker/FuseCAS.java
+++ b/src/main/java/build/buildfarm/worker/FuseCAS.java
@@ -36,7 +36,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 import jnr.constants.platform.Access;
 import jnr.constants.platform.OpenFlags;
 import jnr.ffi.Pointer;
@@ -45,6 +44,7 @@ import jnr.ffi.types.mode_t;
 import jnr.ffi.types.off_t;
 import jnr.ffi.types.size_t;
 import jnr.ffi.types.uid_t;
+import lombok.extern.java.Log;
 import ru.serce.jnrfuse.ErrorCodes;
 import ru.serce.jnrfuse.FuseException;
 import ru.serce.jnrfuse.FuseFillDir;
@@ -53,8 +53,8 @@ import ru.serce.jnrfuse.struct.FileStat;
 import ru.serce.jnrfuse.struct.FuseFileInfo;
 import ru.serce.jnrfuse.struct.Timespec;
 
+@Log
 public class FuseCAS extends FuseStubFS {
-  private static final Logger logger = Logger.getLogger(FuseCAS.class.getName());
 
   private final Path mountPath;
   private final InputStreamFactory inputStreamFactory;
@@ -396,7 +396,7 @@ public class FuseCAS extends FuseStubFS {
         unmounter.stop();
       }
       if (!mounted) {
-        logger.log(Level.INFO, "Mounting FuseCAS");
+        log.log(Level.INFO, "Mounting FuseCAS");
         String[] fuseOpts = {"-o", "max_write=131072", "-o", "big_writes"};
         try {
           mount(mountPath, /* blocking=*/ false, /* debug=*/ false, /* fuseOpts=*/ fuseOpts);
@@ -410,12 +410,12 @@ public class FuseCAS extends FuseStubFS {
 
   private synchronized void decMounts() {
     if (--mounts == 0 && mountPath != null) {
-      logger.log(Level.INFO, "Scheduling FuseCAS unmount in 10s");
+      log.log(Level.INFO, "Scheduling FuseCAS unmount in 10s");
       unmounter =
           new Watchdog(
               Duration.newBuilder().setSeconds(10).setNanos(0).build(),
               () -> {
-                logger.log(Level.INFO, "Unmounting FuseCAS");
+                log.log(Level.INFO, "Unmounting FuseCAS");
                 umount();
                 mounted = false;
               });
@@ -445,7 +445,7 @@ public class FuseCAS extends FuseStubFS {
         children = builder.build();
         childrenCache.put(digest, children);
       } catch (InvalidProtocolBufferException e) {
-        logger.log(Level.SEVERE, "error parsing directory " + DigestUtil.toString(digest), e);
+        log.log(Level.SEVERE, "error parsing directory " + DigestUtil.toString(digest), e);
       }
     }
     return children;
@@ -747,7 +747,7 @@ public class FuseCAS extends FuseStubFS {
 
   @Override
   public int getxattr(String path, String name, Pointer value, @size_t long size) {
-    // logger.log(Level.INFO, "GETXATTR: " + name);
+    // log.log(Level.INFO, "GETXATTR: " + name);
     // seen security.capability so far...
     return -ErrorCodes.EOPNOTSUPP();
   }

--- a/src/main/java/build/buildfarm/worker/InputFetchStage.java
+++ b/src/main/java/build/buildfarm/worker/InputFetchStage.java
@@ -21,9 +21,10 @@ import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.logging.Logger;
+import lombok.extern.java.Log;
 
+@Log
 public class InputFetchStage extends SuperscalarPipelineStage {
-  private static final Logger logger = Logger.getLogger(InputFetchStage.class.getName());
   private static final Gauge inputFetchSlotUsage =
       Gauge.build().name("input_fetch_slot_usage").help("Input fetch slot Usage.").register();
   private static final Histogram inputFetchTime =
@@ -43,7 +44,7 @@ public class InputFetchStage extends SuperscalarPipelineStage {
 
   @Override
   protected Logger getLogger() {
-    return logger;
+    return log;
   }
 
   @Override

--- a/src/main/java/build/buildfarm/worker/InputFetcher.java
+++ b/src/main/java/build/buildfarm/worker/InputFetcher.java
@@ -41,11 +41,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.annotation.Nullable;
+import lombok.extern.java.Log;
 
+@Log
 public class InputFetcher implements Runnable {
-  private static final Logger logger = Logger.getLogger(InputFetcher.class.getName());
 
   private final WorkerContext workerContext;
   private final OperationContext operationContext;
@@ -162,7 +162,7 @@ public class InputFetcher implements Runnable {
 
   private long fetchPolled(Stopwatch stopwatch) throws InterruptedException {
     String operationName = operationContext.queueEntry.getExecuteEntry().getOperationName();
-    logger.log(Level.FINE, format("fetching inputs: %s", operationName));
+    log.log(Level.FINE, format("fetching inputs: %s", operationName));
 
     ExecutedActionMetadata.Builder executedAction =
         operationContext
@@ -178,7 +178,7 @@ public class InputFetcher implements Runnable {
       queuedOperation = workerContext.getQueuedOperation(operationContext.queueEntry);
       List<String> constraintFailures = validateQueuedOperation(queuedOperation);
       if (!constraintFailures.isEmpty()) {
-        logger.log(
+        log.log(
             Level.SEVERE,
             format("invalid queued operation: %s", String.join(" ", constraintFailures)));
         owner.error().put(operationContext);
@@ -194,7 +194,7 @@ public class InputFetcher implements Runnable {
               queuedOperation.getAction(),
               queuedOperation.getCommand());
     } catch (IOException e) {
-      logger.log(Level.SEVERE, format("error creating exec dir for %s", operationName), e);
+      log.log(Level.SEVERE, format("error creating exec dir for %s", operationName), e);
       owner.error().put(operationContext);
       return 0;
     }
@@ -227,7 +227,7 @@ public class InputFetcher implements Runnable {
         try {
           workerContext.destroyExecDir(execDir);
         } catch (IOException e) {
-          logger.log(
+          log.log(
               Level.SEVERE,
               format("error deleting exec dir for %s after interrupt", operationName));
         }
@@ -265,8 +265,7 @@ public class InputFetcher implements Runnable {
       }
     } else {
       String operationName = operationContext.queueEntry.getExecuteEntry().getOperationName();
-      logger.log(
-          Level.FINE, "InputFetcher: Operation " + operationName + " Failed to claim output");
+      log.log(Level.FINE, "InputFetcher: Operation " + operationName + " Failed to claim output");
 
       owner.error().put(operationContext);
     }
@@ -284,16 +283,16 @@ public class InputFetcher implements Runnable {
       try {
         owner.error().put(operationContext);
       } catch (InterruptedException errorEx) {
-        logger.log(Level.SEVERE, format("interrupted while erroring %s", operationName), errorEx);
+        log.log(Level.SEVERE, format("interrupted while erroring %s", operationName), errorEx);
       } finally {
         Thread.currentThread().interrupt();
       }
     } catch (Exception e) {
-      logger.log(Level.WARNING, format("error while fetching inputs: %s", operationName), e);
+      log.log(Level.WARNING, format("error while fetching inputs: %s", operationName), e);
       try {
         owner.error().put(operationContext);
       } catch (InterruptedException errorEx) {
-        logger.log(Level.SEVERE, format("interrupted while erroring %s", operationName), errorEx);
+        log.log(Level.SEVERE, format("interrupted while erroring %s", operationName), errorEx);
       }
       throw e;
     } finally {

--- a/src/main/java/build/buildfarm/worker/MatchStage.java
+++ b/src/main/java/build/buildfarm/worker/MatchStage.java
@@ -31,9 +31,10 @@ import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Timestamps;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
+import lombok.extern.java.Log;
 
+@Log
 public class MatchStage extends PipelineStage {
-  private static final Logger logger = Logger.getLogger(MatchStage.class.getName());
   private boolean inGracefulShutdown = false;
 
   public MatchStage(WorkerContext workerContext, PipelineStage output, PipelineStage error) {
@@ -122,7 +123,7 @@ public class MatchStage extends PipelineStage {
 
   @Override
   protected Logger getLogger() {
-    return logger;
+    return log;
   }
 
   @Override

--- a/src/main/java/build/buildfarm/worker/Pipeline.java
+++ b/src/main/java/build/buildfarm/worker/Pipeline.java
@@ -19,10 +19,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
-import java.util.logging.Logger;
+import lombok.extern.java.Log;
 
+@Log
 public class Pipeline {
-  private static final Logger logger = Logger.getLogger(Pipeline.class.getName());
 
   private final Map<PipelineStage, Thread> stageThreads;
   private final Map<PipelineStage, Integer> stageClosePriorities;
@@ -81,7 +81,7 @@ public class Pipeline {
       if (stage instanceof InputFetchStage) {
         int slotUsage = ((InputFetchStage) stage).getSlotUsage();
         if (slotUsage != 0) {
-          logger.log(
+          log.log(
               Level.INFO,
               String.format("InputFetchStage is not empty with slot usage: %d!", slotUsage));
           return false;
@@ -89,12 +89,12 @@ public class Pipeline {
       } else if (stage instanceof ExecuteActionStage) { // ExecuteActionStage
         int slotUsage = ((ExecuteActionStage) stage).getSlotUsage();
         if (slotUsage != 0) {
-          logger.log(Level.INFO, String.format("ExecuteActionStage slot usage: %d!", slotUsage));
+          log.log(Level.INFO, String.format("ExecuteActionStage slot usage: %d!", slotUsage));
           return false;
         }
       } else { // not SuperScalar stage
         if (stage.claimed) {
-          logger.log(Level.INFO, "NonSuperScalarPipelineStage is not empty yet!");
+          log.log(Level.INFO, "NonSuperScalarPipelineStage is not empty yet!");
           return false;
         }
       }
@@ -135,7 +135,7 @@ public class Pipeline {
             }
           }
           if (stageToClose != null && !stageToClose.isClosed()) {
-            logger.log(Level.FINE, "Closing stage at priority " + maxPriority);
+            log.log(Level.FINE, "Closing stage at priority " + maxPriority);
             stageToClose.close();
           }
         }
@@ -157,7 +157,7 @@ public class Pipeline {
           }
 
           if (!thread.isAlive()) {
-            logger.log(
+            log.log(
                 Level.FINE,
                 "Stage "
                     + stage.name()
@@ -165,7 +165,7 @@ public class Pipeline {
                     + stageClosePriorities.get(stage));
             inactiveStages.add(stage);
           } else if (stage.isClosed()) {
-            logger.log(
+            log.log(
                 Level.INFO,
                 "Interrupting unterminated closed thread in stage "
                     + stage.name()

--- a/src/main/java/build/buildfarm/worker/ReportResultStage.java
+++ b/src/main/java/build/buildfarm/worker/ReportResultStage.java
@@ -42,9 +42,10 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import lombok.extern.java.Log;
 
+@Log
 public class ReportResultStage extends PipelineStage {
-  private static final Logger logger = Logger.getLogger(ReportResultStage.class.getName());
 
   private final BlockingQueue<OperationContext> queue = new ArrayBlockingQueue<>(1);
 
@@ -54,7 +55,7 @@ public class ReportResultStage extends PipelineStage {
 
   @Override
   protected Logger getLogger() {
-    return logger;
+    return log;
   }
 
   @Override
@@ -108,7 +109,7 @@ public class ReportResultStage extends PipelineStage {
         // already failing
         Status status = StatusProto.fromThrowable(e);
         if (status == null) {
-          logger.log(
+          log.log(
               Level.SEVERE, String.format("no rpc status from exception for %s", operationName), e);
           status = asExecutionStatus(e);
         }
@@ -121,7 +122,7 @@ public class ReportResultStage extends PipelineStage {
       // cancellation here should not be logged
       return null;
     } catch (IOException e) {
-      logger.log(Level.SEVERE, String.format("error uploading outputs for %s", operationName), e);
+      log.log(Level.SEVERE, String.format("error uploading outputs for %s", operationName), e);
       return null;
     }
 
@@ -134,7 +135,7 @@ public class ReportResultStage extends PipelineStage {
               .unpack(ExecutingOperationMetadata.class)
               .getExecuteOperationMetadata();
     } catch (InvalidProtocolBufferException e) {
-      logger.log(
+      log.log(
           Level.SEVERE,
           String.format("invalid execute operation metadata for %s", operationName),
           e);
@@ -161,7 +162,7 @@ public class ReportResultStage extends PipelineStage {
               DigestUtil.asActionKey(metadata.getActionDigest()), executeResponse.getResult());
         }
       } catch (IOException e) {
-        logger.log(
+        log.log(
             Level.SEVERE, String.format("error reporting action result for %s", operationName), e);
         return null;
       }
@@ -188,7 +189,7 @@ public class ReportResultStage extends PipelineStage {
         return null;
       }
     } catch (IOException e) {
-      logger.log(
+      log.log(
           Level.SEVERE,
           String.format("error reporting operation complete for %s", operationName),
           e);
@@ -205,7 +206,7 @@ public class ReportResultStage extends PipelineStage {
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
     } catch (IOException e) {
-      logger.log(
+      log.log(
           Level.SEVERE,
           String.format("error destroying exec dir %s", operationContext.execDir.toString()),
           e);

--- a/src/main/java/build/buildfarm/worker/cgroup/BUILD
+++ b/src/main/java/build/buildfarm/worker/cgroup/BUILD
@@ -1,10 +1,12 @@
 java_library(
     name = "cgroup",
     srcs = glob(["*.java"]),
+    plugins = ["//src/main/java/build/buildfarm/common:lombok"],
     visibility = ["//visibility:public"],
     deps = [
         "//src/main/java/build/buildfarm/worker",
         "@maven//:com_google_code_findbugs_jsr305",
         "@maven//:com_google_guava_guava",
+        "@maven//:org_projectlombok_lombok",
     ],
 )

--- a/src/main/java/build/buildfarm/worker/cgroup/Group.java
+++ b/src/main/java/build/buildfarm/worker/cgroup/Group.java
@@ -22,11 +22,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
-import java.util.logging.Logger;
 import javax.annotation.Nullable;
+import lombok.extern.java.Log;
 
+@Log
 public final class Group {
-  private static final Logger logger = Logger.getLogger(Group.class.getName());
   private static final Group root = new Group(/* name=*/ null, /* parent=*/ null);
   private static final Path rootPath = Paths.get("/sys/fs/cgroup");
 
@@ -103,7 +103,7 @@ public final class Group {
       // TODO check arg limits, exit status, etc
       Runtime.getRuntime()
           .exec("kill -SIGKILL " + pids.stream().map(Object::toString).collect(joining(" ")));
-      logger.warning("Killed processes with PIDs: " + pids);
+      log.warning("Killed processes with PIDs: " + pids);
       return false;
     }
     return true;

--- a/src/main/java/build/buildfarm/worker/shard/BUILD
+++ b/src/main/java/build/buildfarm/worker/shard/BUILD
@@ -1,6 +1,7 @@
 java_library(
     name = "shard",
     srcs = glob(["*.java"]),
+    plugins = ["//src/main/java/build/buildfarm/common:lombok"],
     visibility = ["//visibility:public"],
     deps = [
         "//src/main/java/build/buildfarm/backplane",
@@ -34,5 +35,6 @@ java_library(
         "@maven//:io_grpc_grpc_services",
         "@maven//:io_grpc_grpc_stub",
         "@maven//:io_prometheus_simpleclient",
+        "@maven//:org_projectlombok_lombok",
     ],
 )

--- a/src/main/java/build/buildfarm/worker/shard/CFCExecFileSystem.java
+++ b/src/main/java/build/buildfarm/worker/shard/CFCExecFileSystem.java
@@ -59,11 +59,11 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.annotation.Nullable;
+import lombok.extern.java.Log;
 
+@Log
 class CFCExecFileSystem implements ExecFileSystem {
-  private static final Logger logger = Logger.getLogger(Worker.class.getName());
 
   private final Path root;
   private final CASFileCache fileCache;
@@ -106,7 +106,7 @@ class CFCExecFileSystem implements ExecFileSystem {
     try {
       dirents = readdir(root, /* followSymlinks= */ false, Files.getFileStore(root));
     } catch (IOException e) {
-      logger.log(Level.SEVERE, "error reading directory " + root.toString(), e);
+      log.log(Level.SEVERE, "error reading directory " + root.toString(), e);
     }
 
     ImmutableList.Builder<ListenableFuture<Void>> removeDirectoryFutures = ImmutableList.builder();
@@ -137,13 +137,13 @@ class CFCExecFileSystem implements ExecFileSystem {
   @Override
   public void stop() {
     if (!shutdownAndAwaitTermination(fetchService, 1, MINUTES)) {
-      logger.log(Level.SEVERE, "could not terminate fetchService");
+      log.log(Level.SEVERE, "could not terminate fetchService");
     }
     if (!shutdownAndAwaitTermination(removeDirectoryService, 1, MINUTES)) {
-      logger.log(Level.SEVERE, "could not terminate removeDirectoryService");
+      log.log(Level.SEVERE, "could not terminate removeDirectoryService");
     }
     if (!shutdownAndAwaitTermination(accessRecorder, 1, MINUTES)) {
-      logger.log(Level.SEVERE, "could not terminate accessRecorder");
+      log.log(Level.SEVERE, "could not terminate accessRecorder");
     }
   }
 
@@ -365,8 +365,7 @@ class CFCExecFileSystem implements ExecFileSystem {
     ImmutableList.Builder<String> inputFiles = new ImmutableList.Builder<>();
     ImmutableList.Builder<Digest> inputDirectories = new ImmutableList.Builder<>();
 
-    logger.log(
-        Level.FINE, "ExecFileSystem::createExecDir(" + operationName + ") calling fetchInputs");
+    log.log(Level.FINE, "ExecFileSystem::createExecDir(" + operationName + ") calling fetchInputs");
     Iterable<ListenableFuture<Void>> fetchedFutures =
         fetchInputs(
             execDir,
@@ -418,7 +417,7 @@ class CFCExecFileSystem implements ExecFileSystem {
     rootInputFiles.put(execDir, inputFiles.build());
     rootInputDirectories.put(execDir, inputDirectories.build());
 
-    logger.log(
+    log.log(
         Level.FINE,
         "ExecFileSystem::createExecDir(" + operationName + ") stamping output directories");
     boolean stamped = false;

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerInstance.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerInstance.java
@@ -60,9 +60,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import lombok.extern.java.Log;
 
+@Log
 public class ShardWorkerInstance extends AbstractServerInstance {
-  private static final Logger logger = Logger.getLogger(ShardWorkerInstance.class.getName());
 
   private final Backplane backplane;
 
@@ -132,7 +133,7 @@ public class ShardWorkerInstance extends AbstractServerInstance {
             try {
               backplane.removeBlobLocation(digest, getName());
             } catch (IOException backplaneException) {
-              logger.log(
+              log.log(
                   Level.SEVERE,
                   String.format("error removing blob location for %s", DigestUtil.toString(digest)),
                   backplaneException);
@@ -300,7 +301,7 @@ public class ShardWorkerInstance extends AbstractServerInstance {
             .unpack(QueuedOperationMetadata.class)
             .getExecuteOperationMetadata();
       } catch (InvalidProtocolBufferException e) {
-        logger.log(
+        log.log(
             Level.SEVERE,
             String.format("error unpacking queued operation metadata from %s", operation.getName()),
             e);
@@ -313,7 +314,7 @@ public class ShardWorkerInstance extends AbstractServerInstance {
             .unpack(ExecutingOperationMetadata.class)
             .getExecuteOperationMetadata();
       } catch (InvalidProtocolBufferException e) {
-        logger.log(
+        log.log(
             Level.SEVERE,
             String.format(
                 "error unpacking executing operation metadata from %s", operation.getName()),
@@ -327,7 +328,7 @@ public class ShardWorkerInstance extends AbstractServerInstance {
             .unpack(CompletedOperationMetadata.class)
             .getExecuteOperationMetadata();
       } catch (InvalidProtocolBufferException e) {
-        logger.log(
+        log.log(
             Level.SEVERE,
             String.format(
                 "error unpacking completed operation metadata from %s", operation.getName()),
@@ -359,7 +360,7 @@ public class ShardWorkerInstance extends AbstractServerInstance {
 
   @Override
   protected Logger getLogger() {
-    return logger;
+    return log;
   }
 
   @Override

--- a/src/main/java/build/buildfarm/worker/shard/ShutDownWorkerGracefully.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShutDownWorkerGracefully.java
@@ -22,10 +22,10 @@ import build.buildfarm.v1test.PrepareWorkerForGracefulShutDownRequestResults;
 import build.buildfarm.v1test.ShutDownWorkerGrpc;
 import io.grpc.stub.StreamObserver;
 import java.util.concurrent.CompletableFuture;
-import java.util.logging.Logger;
+import lombok.extern.java.Log;
 
+@Log
 public class ShutDownWorkerGracefully extends ShutDownWorkerGrpc.ShutDownWorkerImplBase {
-  private static final Logger logger = Logger.getLogger(ShutDownWorkerGracefully.class.getName());
 
   private static BuildfarmConfigs configs = BuildfarmConfigs.getInstance();
   private final Worker worker;
@@ -56,7 +56,7 @@ public class ShutDownWorkerGracefully extends ShutDownWorkerGrpc.ShutDownWorkerI
               "Current AdminConfig doesn't have cluster_id or cluster_endpoint set, "
                   + "the worker %s won't be shut down.",
               configs.getWorker().getPublicName());
-      logger.log(WARNING, errorMessage);
+      log.log(WARNING, errorMessage);
       responseObserver.onError(new RuntimeException(errorMessage));
       return;
     }
@@ -67,7 +67,7 @@ public class ShutDownWorkerGracefully extends ShutDownWorkerGrpc.ShutDownWorkerI
               "Current AdminConfig doesn't support shut down worker gracefully, "
                   + "the worker %s won't be shut down.",
               configs.getWorker().getPublicName());
-      logger.log(WARNING, errorMessage);
+      log.log(WARNING, errorMessage);
       responseObserver.onError(new RuntimeException(errorMessage));
       return;
     }

--- a/src/test/java/build/buildfarm/instance/server/AbstractServerInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/server/AbstractServerInstanceTest.java
@@ -76,6 +76,7 @@ import io.grpc.stub.StreamObserver;
 import java.io.InputStream;
 import java.util.Stack;
 import java.util.logging.Logger;
+import lombok.extern.java.Log;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -83,8 +84,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.stubbing.Answer;
 
 @RunWith(JUnit4.class)
+@Log
 public class AbstractServerInstanceTest {
-  private static final Logger logger = Logger.getLogger(AbstractServerInstanceTest.class.getName());
 
   private static final DigestUtil DIGEST_UTIL = new DigestUtil(HashFunction.SHA256);
 
@@ -108,7 +109,7 @@ public class AbstractServerInstanceTest {
 
     @Override
     protected Logger getLogger() {
-      return logger;
+      return log;
     }
 
     @Override

--- a/src/test/java/build/buildfarm/instance/server/BUILD
+++ b/src/test/java/build/buildfarm/instance/server/BUILD
@@ -2,6 +2,7 @@ java_test(
     name = "tests",
     size = "small",
     srcs = glob(["*.java"]),
+    plugins = ["//src/main/java/build/buildfarm/common:lombok"],
     test_class = "build.buildfarm.AllTests",
     deps = [
         "//src/main/java/build/buildfarm/ac",
@@ -20,6 +21,7 @@ java_test(
         "@maven//:io_grpc_grpc_api",
         "@maven//:io_grpc_grpc_stub",
         "@maven//:org_mockito_mockito_core",
+        "@maven//:org_projectlombok_lombok",
         "@remote_apis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
     ],
 )

--- a/src/test/java/build/buildfarm/worker/BUILD
+++ b/src/test/java/build/buildfarm/worker/BUILD
@@ -14,6 +14,7 @@ java_test(
         "//conditions:default": [],
     }),
     data = ["//examples:example_configs"],
+    plugins = ["//src/main/java/build/buildfarm/common:lombok"],
     test_class = "build.buildfarm.AllTests",
     deps = [
         "//src/main/java/build/buildfarm/common",
@@ -36,6 +37,7 @@ java_test(
         "@maven//:io_grpc_grpc_core",
         "@maven//:io_grpc_grpc_protobuf",
         "@maven//:org_mockito_mockito_core",
+        "@maven//:org_projectlombok_lombok",
         "@remote_apis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
     ],
 )

--- a/src/test/java/build/buildfarm/worker/InputFetchStageTest.java
+++ b/src/test/java/build/buildfarm/worker/InputFetchStageTest.java
@@ -30,14 +30,15 @@ import io.grpc.Deadline;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
+import lombok.extern.java.Log;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
+@Log
 public class InputFetchStageTest {
   static class PipelineSink extends PipelineStage {
-    private static final Logger logger = Logger.getLogger(PipelineSink.class.getName());
 
     private final List<OperationContext> operationContexts = Lists.newArrayList();
     private final Predicate<OperationContext> onPutShouldClose;
@@ -53,7 +54,7 @@ public class InputFetchStageTest {
 
     @Override
     public Logger getLogger() {
-      return logger;
+      return log;
     }
 
     @Override

--- a/src/test/java/build/buildfarm/worker/PipelineStageTest.java
+++ b/src/test/java/build/buildfarm/worker/PipelineStageTest.java
@@ -19,13 +19,14 @@ import static com.google.common.truth.Truth.assertThat;
 import com.google.longrunning.Operation;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Logger;
+import lombok.extern.java.Log;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
+@Log
 public class PipelineStageTest {
-  private static final Logger logger = Logger.getLogger(PipelineStageTest.class.getName());
 
   static class StubPipelineStage extends PipelineStage {
     public StubPipelineStage(String name) {
@@ -39,7 +40,7 @@ public class PipelineStageTest {
 
     @Override
     public Logger getLogger() {
-      return logger;
+      return log;
     }
 
     @Override

--- a/src/test/java/build/buildfarm/worker/PipelineTest.java
+++ b/src/test/java/build/buildfarm/worker/PipelineTest.java
@@ -15,13 +15,14 @@
 package build.buildfarm.worker;
 
 import java.util.logging.Logger;
+import lombok.extern.java.Log;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
+@Log
 public class PipelineTest {
-  private static final Logger logger = Logger.getLogger(PipelineTest.class.getName());
 
   abstract static class AbstractPipelineStage extends PipelineStage {
     public AbstractPipelineStage(String name) {
@@ -30,7 +31,7 @@ public class PipelineTest {
 
     @Override
     public Logger getLogger() {
-      return logger;
+      return log;
     }
 
     @Override

--- a/src/test/java/build/buildfarm/worker/SuperscalarPipelineStageTest.java
+++ b/src/test/java/build/buildfarm/worker/SuperscalarPipelineStageTest.java
@@ -22,13 +22,14 @@ import com.google.longrunning.Operation;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.logging.Logger;
+import lombok.extern.java.Log;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
+@Log
 public class SuperscalarPipelineStageTest {
-  private static final Logger logger = Logger.getLogger(PipelineStageTest.class.getName());
 
   static class AbstractSuperscalarPipelineStage extends SuperscalarPipelineStage {
     public AbstractSuperscalarPipelineStage(String name, PipelineStage output, int width) {
@@ -46,7 +47,7 @@ public class SuperscalarPipelineStageTest {
 
     @Override
     public Logger getLogger() {
-      return logger;
+      return log;
     }
 
     @Override


### PR DESCRIPTION
Use lombok's @Log annotation to define the standard java.util.Logger. This simplifies future usage of logger and removes boiler plate code.