### PR TITLE
Avoid write interaction for unlogged content

### DIFF
--- a/src/main/java/build/buildfarm/common/services/WriteStreamObserver.java
+++ b/src/main/java/build/buildfarm/common/services/WriteStreamObserver.java
@@ -206,11 +206,13 @@ public class WriteStreamObserver implements StreamObserver<WriteRequest> {
       name = resourceName;
       try {
         write = getWrite(resourceName);
-        log.log(
-            Level.FINER,
-            format(
-                "registering callback for %s: committed_size = %d (transient), complete = %s",
-                resourceName, write.getCommittedSize(), write.isComplete()));
+        if (log.isLoggable(Level.FINER)) {
+          log.log(
+              Level.FINER,
+              format(
+                  "registering callback for %s: committed_size = %d (transient), complete = %s",
+                  resourceName, write.getCommittedSize(), write.isComplete()));
+        }
         Futures.addCallback(
             write.getFuture(),
             new FutureCallback<Long>() {


### PR DESCRIPTION
Calling getCommittedSize/isCompleted adds immediate network cost and blocking behaviors to blob reads, which are likely unused except at high logging levels. Avoid this cost by checking for FINER, as there are no callback facilities for logging under JUL