### PR TITLE
Update worker instructions to get logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Run via
 ```
 bazel run //src/main/java/build/buildfarm:buildfarm-shard-worker -- <logfile> <configfile>
 
-Ex: bazel run //src/main/java/build/buildfarm:buildfarm-shard-worker -- --jvm_flag=-Dlogging.config=file:$PWD/examples/logging.properties $PWD/examples/config.minimal.yml
+Ex: bazel run //src/main/java/build/buildfarm:buildfarm-shard-worker -- --jvm_flag=-Djava.util.logging.config.file=$PWD/examples/logging.properties $PWD/examples/config.minimal.yml
 
 ```
 **`logfile`** has to be in the [standard java util logging format](https://docs.oracle.com/cd/E57471_01/bigData.100/data_processing_bdd/src/rdp_logging_config.html) and passed as a --jvm_flag=-Dlogging.config=file:


### PR DESCRIPTION
The worker appears to ignore logging.config jvm specification, and instead prefers the fqdn to load useful configurations.