### PR TITLE
Introduce Persistent Workers

### DIFF
--- a/persistentworkers/examples/src/main/java/BUILD
+++ b/persistentworkers/examples/src/main/java/BUILD
@@ -1,0 +1,17 @@
+java_library(
+    name = "adder-lib",
+    srcs = glob(["**/*.java"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//persistentworkers/src/main/java/persistent/bazel:bazel-persistent-workers",
+        "//persistentworkers/src/main/java/persistent/common:persistent-common",
+        "@maven//:com_google_guava_guava",
+    ],
+)
+
+java_binary(
+    name = "adder-bin",
+    main_class = "adder.Adder",
+    visibility = ["//visibility:public"],
+    runtime_deps = [":adder-lib"],
+)

--- a/persistentworkers/examples/src/main/java/adder/Adder.java
+++ b/persistentworkers/examples/src/main/java/adder/Adder.java
@@ -1,0 +1,50 @@
+package adder;
+
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+
+import persistent.bazel.processes.WorkRequestHandler;
+
+/**
+ * Example of a service which supports being run as a persistent worker
+ */
+public class Adder {
+
+  public static void main(String[] args) {
+    if (args.length == 1 && args[0].equals("--persistent_worker")) {
+      WorkRequestHandler handler = initialize();
+      int exitCode = handler.processForever(System.in, System.out, System.err);
+      System.exit(exitCode);
+    }
+  }
+
+  private static WorkRequestHandler initialize() {
+    return new WorkRequestHandler((actionArgs, pw) -> {
+      String res = work(actionArgs);
+      pw.write(res);
+      return 0;
+    });
+  }
+
+  private static String work(List<String> args) {
+    if (args.size() == 1 && args.get(0).equals("stop!")) {
+      System.err.println("exiting!");
+      System.exit(0);
+      return "";
+    } else if (args.size() != 2) {
+      System.err.println("Cannot handle args: " + ImmutableList.copyOf(args).toString());
+      System.exit(2);
+      return "";
+    }
+    else {
+      int a = Integer.parseInt(args.get(0));
+      int b = Integer.parseInt(args.get(1));
+      return String.valueOf(compute(a, b));
+    }
+  }
+
+  private static int compute(int a, int b) {
+    return a + b;
+  }
+}

--- a/persistentworkers/examples/src/main/java/adder/Adder.java
+++ b/persistentworkers/examples/src/main/java/adder/Adder.java
@@ -31,17 +31,13 @@ public class Adder {
     if (args.size() == 1 && args.get(0).equals("stop!")) {
       System.err.println("exiting!");
       System.exit(0);
-      return "";
     } else if (args.size() != 2) {
       System.err.println("Cannot handle args: " + ImmutableList.copyOf(args).toString());
       System.exit(2);
-      return "";
     }
-    else {
-      int a = Integer.parseInt(args.get(0));
-      int b = Integer.parseInt(args.get(1));
-      return String.valueOf(compute(a, b));
-    }
+    int a = Integer.parseInt(args.get(0));
+    int b = Integer.parseInt(args.get(1));
+    return String.valueOf(compute(a, b));
   }
 
   private static int compute(int a, int b) {

--- a/persistentworkers/examples/src/test/java/BUILD
+++ b/persistentworkers/examples/src/test/java/BUILD
@@ -1,0 +1,15 @@
+java_test(
+    name = "tests",
+    size = "small",
+    srcs = glob(["**/*.java"]),
+    test_class = "adder.AdderTest",
+    deps = [
+        "//persistentworkers/examples/src/main/java:adder-lib",
+        "//persistentworkers/src/main/java/persistent/bazel:bazel-persistent-workers",
+        "//persistentworkers/src/main/java/persistent/common:persistent-common",
+        "//persistentworkers/src/test/java/persistent/testutil",
+        "@bazel_tools//src/main/protobuf:worker_protocol_java_proto",
+        "@maven//:com_google_truth_truth",
+        "@maven//:org_mockito_mockito_core",
+    ],
+)

--- a/persistentworkers/examples/src/test/java/adder/AdderTest.java
+++ b/persistentworkers/examples/src/test/java/adder/AdderTest.java
@@ -1,0 +1,73 @@
+package adder;
+
+import java.io.IOException;
+
+import com.google.devtools.build.lib.worker.WorkerProtocol;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import persistent.common.processes.JavaProcessWrapper;
+import persistent.common.processes.ProcessWrapper;
+import persistent.bazel.processes.ProtoWorkerRW;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import static persistent.testutil.ProcessUtils.spawnPersistentWorkerProcess;
+
+@RunWith(JUnit4.class)
+public class AdderTest {
+
+  private JavaProcessWrapper spawnAdderProcess() throws IOException {
+    return spawnPersistentWorkerProcess(
+        System.getProperty("java.class.path"),
+        Adder.class
+    );
+  }
+
+  @SuppressWarnings("CheckReturnValue")
+  @Test
+  public void canInitAndDoWorkWithoutDying() throws Exception {
+    ProcessWrapper pw;
+    try (JavaProcessWrapper jpw = spawnAdderProcess()) {
+      pw = jpw;
+      ProtoWorkerRW rw = new ProtoWorkerRW(jpw);
+      rw.write(WorkerProtocol.WorkRequest.newBuilder().addArguments("1").addArguments("3").build());
+
+      assertThat(rw.waitAndRead().getOutput()).isEqualTo("4");
+      assertThat(jpw.isAlive()).isTrue();
+    }
+    assertThat(pw).isNotNull();
+
+    pw.waitFor();
+    assertThat(pw.isAlive()).isFalse();
+    assertThat(pw.exitValue()).isNotEqualTo(0);
+  }
+
+  @SuppressWarnings("CheckReturnValue")
+  @Test
+  public void canShutdownAdder() throws Exception {
+    try (JavaProcessWrapper jpw = spawnAdderProcess()) {
+      ProtoWorkerRW rw = new ProtoWorkerRW(jpw);
+      rw.write(WorkerProtocol.WorkRequest.newBuilder().addArguments("stop!").build());
+      jpw.waitFor();
+
+      assertThat(jpw.isAlive()).isFalse();
+      assertThat(jpw.exitValue()).isEqualTo(0);
+    }
+  }
+
+  @SuppressWarnings("CheckReturnValue")
+  @Test
+  public void adderBadRequest() throws Exception {
+    try (JavaProcessWrapper jpw = spawnAdderProcess()) {
+      ProtoWorkerRW rw = new ProtoWorkerRW(jpw);
+      rw.write(WorkerProtocol.WorkRequest.newBuilder().addArguments("bad request").build());
+      jpw.waitFor();
+
+      assertThat(jpw.isAlive()).isFalse();
+      assertThat(jpw.exitValue()).isEqualTo(2);
+    }
+  }
+}

--- a/persistentworkers/src/main/java/persistent/README.md
+++ b/persistentworkers/src/main/java/persistent/README.md
@@ -1,0 +1,19 @@
+Persistent Workers for Buildfarm
+===
+An attempt at an interface for Persistent Workers,
+based off Bazel's persistent workers implementation.
+
+___
+
+We split persistent workers into two targets:  
+`persistentworkers/src/main/java/persistent/common:persistent-common`  
+`persistentworkers/src/main/java/persistent/bazel:bazel-persistent-workers`
+
+
+`persisent-common` aims to provide an interface for general persistent worker processes,
+as well as a sort of "code as documentation".
+
+`bazel-persistent-workers` implements `persistent-common` in the context of Bazel's persistent workers model.
+
+Buildfarm workers will then be able to spin up and execute actions on persistent workers,
+similar to how Bazel itself uses persistent workers.

--- a/persistentworkers/src/main/java/persistent/bazel/BUILD
+++ b/persistentworkers/src/main/java/persistent/bazel/BUILD
@@ -1,0 +1,21 @@
+java_library(
+    name = "bazel-persistent-workers",
+    srcs = glob(["**/*.java"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//persistentworkers/src/main/java/persistent/common:persistent-common",
+        "@bazel_tools//src/main/protobuf:worker_protocol_java_proto",
+        "@maven//:com_github_pcj_google_options",
+        "@maven//:com_google_guava_guava",
+        "@maven//:com_google_protobuf_protobuf_java",
+        "@maven//:com_google_protobuf_protobuf_java_util",
+        "@maven//:commons_io_commons_io",
+        "@maven//:io_grpc_grpc_api",
+        "@maven//:io_grpc_grpc_context",
+        "@maven//:io_grpc_grpc_core",
+        "@maven//:io_grpc_grpc_netty",
+        "@maven//:io_grpc_grpc_protobuf",
+        "@maven//:io_grpc_grpc_stub",
+        "@maven//:org_apache_commons_commons_pool2",
+    ],
+)

--- a/persistentworkers/src/main/java/persistent/bazel/README.md
+++ b/persistentworkers/src/main/java/persistent/bazel/README.md
@@ -1,0 +1,15 @@
+Implements Bazel's Persistent Worker idea, using interfaces from our own `:persistent-common`: https://bazel.build/remote/persistent
+We use Apache Commons Pool (commons-pool2) as the object pool backend.
+
+Much of the code is ripped from Bazel itself, with a few adjustments specifically for Buildfarm.
+
+Remote persistent workers (for Buildfarm) rely on the `--experimental_mark_tool_inputs` proposal:
+https://github.com/bazelbuild/proposals/blob/main/designs/2021-03-06-remote-persistent-workers.md
+
+There may be some confusion in the naming between "Buildfarm Workers" and "Bazel Persistent Workers".  
+Whereas Buildfarm workers are a (execute and/or CAS) node in Buildfarm,
+Bazel persistent workers are a persistent *process* which run certain Bazel actions.
+
+We want to wrap the the persistent worker process in a useful API.  
+This API will be used on the "client" side, i.e. the client submitting requests (i.e. actions) to 
+the persistent worker process.

--- a/persistentworkers/src/main/java/persistent/bazel/client/CommonsWorkerPool.java
+++ b/persistentworkers/src/main/java/persistent/bazel/client/CommonsWorkerPool.java
@@ -1,0 +1,13 @@
+package persistent.bazel.client;
+
+import persistent.common.CommonsPool;
+
+/**
+ * Specializes CommmonsPool for PersistentWorker
+ */
+public class CommonsWorkerPool extends CommonsPool<WorkerKey, PersistentWorker> {
+
+  public CommonsWorkerPool(WorkerSupervisor supervisor, int maxPerKey) {
+    super(supervisor, maxPerKey);
+  }
+}

--- a/persistentworkers/src/main/java/persistent/bazel/client/PersistentWorker.java
+++ b/persistentworkers/src/main/java/persistent/bazel/client/PersistentWorker.java
@@ -1,0 +1,154 @@
+package persistent.bazel.client;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.hash.HashCode;
+import com.google.devtools.build.lib.worker.WorkerProtocol.WorkRequest;
+import com.google.devtools.build.lib.worker.WorkerProtocol.WorkResponse;
+
+import persistent.bazel.processes.ProtoWorkerRW;
+import persistent.common.Worker;
+import persistent.common.processes.ProcessWrapper;
+
+/**
+ * Wraps a persistent worker process, using ProtoWorkerRW.
+ * The process is created with a working directory under the execRoot of the WorkerKey.
+ * <p>
+ * Maintains the metadata of the underlying process,
+ * i.e. its WorkerKey and the command used to run it.
+ * <p>
+ * Also takes care of the underlying process's environment, i.e. directories and files.
+ */
+public class PersistentWorker implements Worker<WorkRequest, WorkResponse> {
+
+  /**
+   * Services supporting being run as persistent workers need to parse this flag
+   */
+  public static final String PERSISTENT_WORKER_FLAG = "--persistent_worker";
+
+  private static final Logger logger = Logger.getLogger(PersistentWorker.class.getName());
+
+  public static final String TOOL_INPUT_SUBDIR = "tool_inputs";
+
+  private final WorkerKey key;
+  private final ImmutableList<String> initCmd;
+  private final Path execRoot;
+  private final ProtoWorkerRW workerRW;
+
+  public PersistentWorker(WorkerKey key, String workerDir) throws IOException {
+    this.key = key;
+    this.execRoot = key.getExecRoot().resolve(workerDir);
+    this.initCmd = ImmutableList.<String>builder()
+        .addAll(key.getCmd())
+        .addAll(key.getArgs())
+        .build();
+
+    Files.createDirectories(execRoot);
+
+    Set<Path> workerFiles = ImmutableSet.copyOf(key.getWorkerFilesWithHashes().keySet());
+    logger.log(
+        Level.FINE,
+        "Starting Worker[" + key.getMnemonic() + "]<" + execRoot + ">("
+            + initCmd + ") with files: \n"
+            + workerFiles
+    );
+
+    ProcessWrapper processWrapper = new ProcessWrapper(execRoot, initCmd, key.getEnv());
+    this.workerRW = new ProtoWorkerRW(processWrapper);
+  }
+
+  @Override
+  public WorkResponse doWork(WorkRequest request) {
+    WorkResponse response = null;
+    try {
+      logRequest(request);
+
+      workerRW.write(request);
+      response = workerRW.waitAndRead();
+
+      logIfBadResponse(response);
+    } catch (IOException e) {
+      e.printStackTrace();
+      logger.severe("IO Failing with : " + e.getMessage());
+    } catch (Exception e) {
+      e.printStackTrace();
+      logger.severe("Failing with : " + e.getMessage());
+    }
+    return response;
+  }
+
+  public Optional<Integer> getExitValue() {
+    ProcessWrapper pw = workerRW.getProcessWrapper();
+    return pw != null && !pw.isAlive()
+        ? Optional.of(pw.exitValue())
+        : Optional.empty();
+  }
+
+  public String getStdErr() {
+    try {
+      return this.workerRW.getProcessWrapper().getErrorString();
+    } catch (IOException e) {
+      e.printStackTrace();
+      return "getStdErr Exception: " + e;
+    }
+  }
+
+  public String flushStdErr() {
+    try {
+      return this.workerRW.getProcessWrapper().flushErrorString();
+    } catch (IOException e) {
+      e.printStackTrace();
+      return "flushStdErr Exception: " + e;
+    }
+  }
+
+  public WorkerKey getKey() {
+    return this.key;
+  }
+
+  public ImmutableList<String> getInitCmd() {
+    return this.initCmd;
+  }
+
+  public Path getExecRoot() {
+    return this.execRoot;
+  }
+
+  private void logRequest(WorkRequest request) {
+    logger.log(
+        Level.FINE,
+        "doWork()------<" +
+            "Got request with args: " + request.getArgumentsList() +
+            "------>"
+    );
+  }
+
+  private void logIfBadResponse(WorkResponse response) throws IOException {
+    int returnCode = response.getExitCode();
+    if (returnCode != 0) {
+      StringBuilder sb = new StringBuilder();
+      sb.append("logBadResponse(err)");
+      sb.append("\nResponse non-zero exit_code: ");
+      sb.append(returnCode);
+      sb.append("\nResponse output: ");
+      sb.append(response.getOutput());
+      sb.append("\n\tProcess stderr: ");
+      String stderr = workerRW.getProcessWrapper().getErrorString();
+      sb.append(stderr);
+      logger.log(Level.SEVERE, sb.toString());
+    }
+  }
+
+  @Override
+  public void destroy() {
+    this.workerRW.getProcessWrapper().destroy();
+  }
+}

--- a/persistentworkers/src/main/java/persistent/bazel/client/WorkCoordinator.java
+++ b/persistentworkers/src/main/java/persistent/bazel/client/WorkCoordinator.java
@@ -1,0 +1,19 @@
+package persistent.bazel.client;
+
+import com.google.devtools.build.lib.worker.WorkerProtocol.WorkRequest;
+import com.google.devtools.build.lib.worker.WorkerProtocol.WorkResponse;
+
+import persistent.common.CtxAround;
+import persistent.common.Coordinator;
+import persistent.common.ObjectPool;
+
+/**
+ * Fills in/specializes Coordinator type parameters specifically for PersistentWorker usage
+ */
+public abstract class WorkCoordinator<I extends CtxAround<WorkRequest>, O extends CtxAround<WorkResponse>, P extends ObjectPool<WorkerKey, PersistentWorker>>
+    extends Coordinator<WorkerKey, WorkRequest, WorkResponse, PersistentWorker, I, O, P> {
+
+  public WorkCoordinator(P workerPool) {
+    super(workerPool);
+  }
+}

--- a/persistentworkers/src/main/java/persistent/bazel/client/WorkerFilesHash.java
+++ b/persistentworkers/src/main/java/persistent/bazel/client/WorkerFilesHash.java
@@ -1,0 +1,40 @@
+// Copyright 2016 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package persistent.bazel.client;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.SortedMap;
+
+import com.google.common.hash.HashCode;
+import com.google.common.hash.Hasher;
+import com.google.common.hash.Hashing;
+
+/**
+ * Calculates the hash based on the files, which should be unchanged on disk for a worker to get
+ * reused.
+ */
+public final class WorkerFilesHash {
+
+  public static HashCode getCombinedHash(Path toolsRoot, SortedMap<Path, HashCode> hashedTools) {
+    Hasher hasher = Hashing.sha256().newHasher();
+    hashedTools.forEach((relPath, toolHash) -> {
+      hasher.putString(toolsRoot.resolve(relPath).toString(), StandardCharsets.UTF_8);
+      hasher.putBytes(toolHash.asBytes());
+    });
+    return hasher.hash();
+  }
+}

--- a/persistentworkers/src/main/java/persistent/bazel/client/WorkerKey.java
+++ b/persistentworkers/src/main/java/persistent/bazel/client/WorkerKey.java
@@ -1,0 +1,194 @@
+package persistent.bazel.client;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.hash.HashCode;
+
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.SortedMap;
+
+/**
+ * Based off of copy-pasting from Bazel's WorkerKey.
+ * Comments also ripped off, credits to the Bazel Authors.
+ * Has less dependencies, but only ProtoBuf and non-multiplex support.
+ *
+ * Data container that uniquely identifies a kind of worker process.
+ */
+public final class WorkerKey {
+
+  private final ImmutableList<String> cmd;
+
+  private final ImmutableList<String> args;
+
+  private final ImmutableMap<String, String> env;
+
+  private final Path execRoot;
+
+  /** Mnemonic of the worker; but we don't actually have the real action mnemonic */
+  private final String mnemonic;
+
+  /**
+   * These are used during validation whether a worker is still usable. They are not used to
+   * uniquely identify a kind of worker, thus it is not to be used by the .equals() / .hashCode()
+   * methods.
+   */
+  private final HashCode workerFilesCombinedHash;
+
+  /** Worker files with the corresponding hash code.
+   *
+   *  These paths should be stable, so use relative paths
+   *  (unless its a universal absolute path like /tmp/my_tools/...)
+   * */
+  private final SortedMap<Path, HashCode> workerFilesWithHashes;
+
+  /** If true, the workers run inside a sandbox. */
+  private final boolean sandboxed;
+
+  /** If true, the workers for this key are able to cancel work requests. */
+  private final boolean cancellable;
+
+  /**
+   * Cached value for the hash of this key, because the value is expensive to calculate
+   * (ImmutableMap and ImmutableList do not cache their hashcodes).
+   */
+  private final int hash;
+
+  public WorkerKey(
+      ImmutableList<String> cmd,
+      ImmutableList<String> args,
+      ImmutableMap<String, String> env,
+      Path execRoot,
+      String mnemonic,
+      HashCode workerFilesCombinedHash,
+      SortedMap<Path, HashCode> workerFilesWithHashes,
+      boolean sandboxed,
+      boolean cancellable
+  ) {
+    // Part of hash
+    this.cmd = Preconditions.checkNotNull(cmd);
+    this.args = Preconditions.checkNotNull(args);
+    this.env = Preconditions.checkNotNull(env);
+    this.execRoot = Preconditions.checkNotNull(execRoot);
+    this.mnemonic = Preconditions.checkNotNull(mnemonic);
+    this.sandboxed = sandboxed;
+    this.cancellable = cancellable;
+    // Not part of hash
+    this.workerFilesCombinedHash = Preconditions.checkNotNull(workerFilesCombinedHash);
+    this.workerFilesWithHashes = Preconditions.checkNotNull(workerFilesWithHashes);
+
+    this.hash = calculateHashCode();
+  }
+
+  /** Getter function for variable cmd. */
+  public ImmutableList<String> getCmd() {
+    return cmd;
+  }
+
+  /** Getter function for variable args. */
+  public ImmutableList<String> getArgs() {
+    return args;
+  }
+
+  /** Getter function for variable env. */
+  public ImmutableMap<String, String> getEnv() {
+    return env;
+  }
+
+  /** Getter function for variable execRoot. */
+  public Path getExecRoot() {
+    return execRoot;
+  }
+
+  /** Getter function for variable mnemonic. */
+  public String getMnemonic() {
+    return mnemonic;
+  }
+
+  /** Getter function for variable workerFilesCombinedHash. */
+  public HashCode getWorkerFilesCombinedHash() {
+    return workerFilesCombinedHash;
+  }
+
+  /** Getter function for variable workerFilesWithHashes. */
+  public SortedMap<Path, HashCode> getWorkerFilesWithHashes() {
+    return workerFilesWithHashes;
+  }
+
+  /** Returns true if workers are sandboxed. */
+  public boolean isSandboxed() {
+    return sandboxed;
+  }
+
+  public boolean isCancellable() {
+    return cancellable;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    WorkerKey workerKey = (WorkerKey) o;
+    if (this.hash != workerKey.hash) {
+      return false;
+    }
+    if (!cmd.equals(workerKey.cmd)) {
+      return false;
+    }
+    if (!args.equals(workerKey.args)) {
+      return false;
+    }
+    if (!cancellable == workerKey.cancellable) {
+      return false;
+    }
+    if (!sandboxed == workerKey.sandboxed) {
+      return false;
+    }
+    if (!env.equals(workerKey.env)) {
+      return false;
+    }
+    if (!execRoot.equals(workerKey.execRoot)) {
+      return false;
+    }
+    return mnemonic.equals(workerKey.mnemonic);
+
+  }
+
+  /** Since all fields involved in the {@code hashCode} are final, we cache the result. */
+  @Override
+  public int hashCode() {
+    return hash;
+  }
+
+  private int calculateHashCode() {
+    // Use the string representation of the protocolFormat because the hash of the same enum value
+    // can vary across instances.
+    return Objects.hash(
+        cmd,
+        args,
+        env,
+        execRoot,
+        mnemonic,
+        cancellable,
+        sandboxed
+    );
+  }
+
+  // Not as cool as using Bazel CommandFailureUtils
+  @Override
+  public String toString() {
+    return "WorkerKey(" + "\n\t"
+        + "cmd=" + cmd + ",\n\t"
+        + "args=" + args + ",\n\t"
+        + "env=" + env + ",\n\t"
+        + "mnemonic=" + mnemonic + ",\n\t"
+        + "execRoot=" + execRoot.toAbsolutePath()
+        + "\n)";
+  }
+}

--- a/persistentworkers/src/main/java/persistent/bazel/client/WorkerSupervisor.java
+++ b/persistentworkers/src/main/java/persistent/bazel/client/WorkerSupervisor.java
@@ -1,0 +1,87 @@
+package persistent.bazel.client;
+
+
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.TreeSet;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.google.common.hash.HashCode;
+
+import org.apache.commons.pool2.PooledObject;
+import org.apache.commons.pool2.impl.DefaultPooledObject;
+
+import persistent.common.CommonsSupervisor;
+
+public abstract class WorkerSupervisor extends CommonsSupervisor<WorkerKey, PersistentWorker> {
+
+  public static WorkerSupervisor simple() {
+    return new WorkerSupervisor() {
+      @Override
+      public PersistentWorker create(WorkerKey workerKey) throws Exception {
+        return new PersistentWorker(workerKey, "");
+      }
+    };
+  }
+
+  private final Logger logger = Logger.getLogger(this.getClass().getName());
+
+  public abstract PersistentWorker create(WorkerKey workerKey) throws Exception;
+
+  @Override
+  public PooledObject<PersistentWorker> wrap(PersistentWorker persistentWorker) {
+    return new DefaultPooledObject<>(persistentWorker);
+  }
+
+  @Override
+  public boolean validateObject(WorkerKey key, PooledObject<PersistentWorker> p) {
+    PersistentWorker worker = p.getObject();
+    Optional<Integer> exitValue = worker.getExitValue();
+    if (exitValue.isPresent()) {
+      String errorStr;
+      try {
+        String err = worker.getStdErr();
+        errorStr = "Stderr:\n" + err;
+      } catch (Exception e) {
+        errorStr = "Couldn't read Stderr: " + e;
+      }
+      String msg = String.format(
+          "Worker unexpectedly died with exit code %d. Key:\n%s\n%s",
+          exitValue.get(),
+          key,
+          errorStr
+      );
+      logger.log(Level.SEVERE, msg);
+      return false;
+    }
+
+    WorkerKey currentWorkerKey = worker.getKey();
+    boolean filesChanged =
+        !key.getWorkerFilesCombinedHash().equals(currentWorkerKey.getWorkerFilesCombinedHash());
+
+    if (filesChanged) {
+      StringBuilder msg = new StringBuilder();
+      msg.append("Worker can no longer be used, because its files have changed on disk:\n");
+      msg.append(key);
+      TreeSet<Path> files = new TreeSet<>();
+      files.addAll(key.getWorkerFilesWithHashes().keySet());
+      files.addAll(currentWorkerKey.getWorkerFilesWithHashes().keySet());
+      for (Path file : files) {
+        HashCode oldHash = currentWorkerKey.getWorkerFilesWithHashes().get(file);
+        HashCode newHash = key.getWorkerFilesWithHashes().get(file);
+        if (!oldHash.equals(newHash)) {
+          msg.append("\n")
+              .append(file.normalize())
+              .append(": ")
+              .append(oldHash != null ? oldHash : "<none>")
+              .append(" -> ")
+              .append(newHash != null ? newHash : "<none>");
+        }
+      }
+      logger.log(Level.SEVERE, msg.toString());
+    }
+
+    return !filesChanged;
+  }
+}

--- a/persistentworkers/src/main/java/persistent/bazel/processes/ProtoWorkerRW.java
+++ b/persistentworkers/src/main/java/persistent/bazel/processes/ProtoWorkerRW.java
@@ -1,0 +1,107 @@
+package persistent.bazel.processes;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.function.Supplier;
+
+import com.google.devtools.build.lib.worker.WorkerProtocol.WorkRequest;
+import com.google.devtools.build.lib.worker.WorkerProtocol.WorkResponse;
+import com.google.protobuf.GeneratedMessageV3;
+
+import org.apache.commons.io.IOUtils;
+
+import persistent.common.processes.ProcessWrapper;
+
+/**
+ * Based off Google's ProtoWorkerProtocol
+ * Slightly generified to encapsulate read/writes
+ * Should be used by both the PersistentWorker (client-side)
+ *  and the WorkRequestHandler (in the persistent worker process)
+ *
+ * Writes WorkRequest protos to the persistent worker
+ * Reads WorkResponse protos from the persistent worker
+ *
+ * Static methods also expose some useful(?) utilities
+ *
+ * TODO: What happens to input/output streams when the process dies?
+ *  Presumably, it is closed (as per tests).
+ */
+public class ProtoWorkerRW {
+
+  private final ProcessWrapper processWrapper;
+
+  private final InputStream readStream;
+
+  private final OutputStream writeStream;
+
+  public ProtoWorkerRW(ProcessWrapper processWrapper) {
+    this.processWrapper = processWrapper;
+    this.readStream = processWrapper.getStdOut();
+    this.writeStream = processWrapper.getStdIn();
+  }
+
+  public ProcessWrapper getProcessWrapper() {
+    return this.processWrapper;
+  }
+
+  public void write(WorkRequest req) throws IOException {
+    writeTo(req, this.writeStream);
+  }
+
+  public WorkResponse waitAndRead() throws IOException, InterruptedException {
+    try {
+      waitForInput(processWrapper::isAlive, readStream);
+    } catch (IOException e) {
+      String stdErrMsg = processWrapper.getErrorString();
+      String stdOut = "";
+      try {
+        if (processWrapper.isAlive() && readStream.available() > 0) {
+          stdOut = IOUtils.toString(readStream, StandardCharsets.UTF_8);
+        } else {
+          stdOut = "no stream available";
+        }
+      } catch (IOException e2) {
+        stdOut = "Exception trying to read stdout: " + e2;
+      }
+      throw new IOException("IOException on waitForInput; stdErr: " + stdErrMsg + "\nStdout: " + stdOut, e);
+    }
+    return readResponse(readStream);
+  }
+
+  public static <R extends GeneratedMessageV3> void writeTo(R req, OutputStream outputStream) throws IOException {
+    try {
+      req.writeDelimitedTo(outputStream);
+    } finally {
+      outputStream.flush();
+    }
+  }
+
+  public static WorkResponse readResponse(InputStream inputStream) throws IOException {
+    return WorkResponse.parseDelimitedFrom(inputStream);
+  }
+
+  public static WorkRequest readRequest(InputStream inputStream) throws IOException {
+    return WorkRequest.parseDelimitedFrom(inputStream);
+  }
+
+  public static void waitForInput(Supplier<Boolean> liveCheck, InputStream inputStream) throws IOException, InterruptedException {
+    String workerDeathMsg = "Worker process for died while waiting for response";
+    // TODO can we do better than spinning? i.e. condition variable?
+    while (inputAvailable(inputStream, workerDeathMsg) == 0) {
+      Thread.sleep(10);
+      if (!liveCheck.get()) {
+        throw new IOException(workerDeathMsg + "\n");
+      }
+    }
+  }
+
+  private static int inputAvailable(InputStream inputStream, String errorMsg) throws IOException {
+    try {
+      return inputStream.available();
+    } catch (IOException e) {
+      throw new IOException(errorMsg, e);
+    }
+  }
+}

--- a/persistentworkers/src/main/java/persistent/bazel/processes/WorkRequestHandler.java
+++ b/persistentworkers/src/main/java/persistent/bazel/processes/WorkRequestHandler.java
@@ -1,0 +1,77 @@
+package persistent.bazel.processes;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.List;
+import java.util.function.BiFunction;
+
+import com.google.devtools.build.lib.worker.WorkerProtocol.WorkRequest;
+import com.google.devtools.build.lib.worker.WorkerProtocol.WorkResponse;
+
+/**
+ * Persistent-worker-compatible tools should instantiate this class
+ * Reads WorkRequests, handles them, and returns WorkResponses -- forever
+ */
+public class WorkRequestHandler {
+
+  private final BiFunction<List<String>, PrintWriter, Integer> requestHandler;
+
+  public WorkRequestHandler(BiFunction<List<String>, PrintWriter, Integer> callback) {
+    this.requestHandler = callback;
+  }
+
+  public void writeToStream(WorkResponse workResponse, PrintStream out) throws IOException {
+    synchronized (this) {
+      ProtoWorkerRW.writeTo(workResponse, out);
+    }
+  }
+
+  public int processForever(InputStream in, PrintStream out, PrintStream err) {
+    while (true) {
+      try {
+        WorkRequest request = ProtoWorkerRW.readRequest(in);
+
+        if (request == null) {
+          break;
+        } else {
+          WorkResponse response = respondTo(request);
+          writeToStream(response, out);
+        }
+      } catch (IOException e) {
+        e.printStackTrace(err);
+        return 1;
+      }
+    }
+    return 0;
+  }
+
+  public WorkResponse respondTo(WorkRequest request) throws IOException {
+    try (StringWriter outputWriter = new StringWriter();
+         PrintWriter outputPrinter = new PrintWriter(outputWriter)) {
+
+      int exitCode;
+      try {
+        exitCode = requestHandler.apply(request.getArgumentsList(), outputPrinter);
+      } catch (RuntimeException e) {
+        e.printStackTrace(outputPrinter);
+        exitCode = 1;
+      }
+
+      outputPrinter.flush();
+      String output = outputWriter.toString();
+
+      if (exitCode != 0) {
+        System.err.println(output);
+      }
+      return WorkResponse
+          .newBuilder()
+          .setOutput(output)
+          .setExitCode(exitCode)
+          .setRequestId(request.getRequestId())
+          .build();
+    }
+  }
+}

--- a/persistentworkers/src/main/java/persistent/common/BUILD
+++ b/persistentworkers/src/main/java/persistent/common/BUILD
@@ -1,0 +1,21 @@
+java_library(
+    name = "persistent-common",
+    srcs = glob(["**/*.java"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//persistentworkers/src/main/java/persistent/common/util",
+        "@bazel_tools//src/main/protobuf:worker_protocol_java_proto",
+        "@maven//:com_github_pcj_google_options",
+        "@maven//:com_google_guava_guava",
+        "@maven//:com_google_protobuf_protobuf_java",
+        "@maven//:com_google_protobuf_protobuf_java_util",
+        "@maven//:commons_io_commons_io",
+        "@maven//:io_grpc_grpc_api",
+        "@maven//:io_grpc_grpc_context",
+        "@maven//:io_grpc_grpc_core",
+        "@maven//:io_grpc_grpc_netty",
+        "@maven//:io_grpc_grpc_protobuf",
+        "@maven//:io_grpc_grpc_stub",
+        "@maven//:org_apache_commons_commons_pool2",
+    ],
+)

--- a/persistentworkers/src/main/java/persistent/common/CommonsObjPool.java
+++ b/persistentworkers/src/main/java/persistent/common/CommonsObjPool.java
@@ -1,0 +1,24 @@
+package persistent.common;
+
+import org.apache.commons.pool2.KeyedPooledObjectFactory;
+import org.apache.commons.pool2.impl.GenericKeyedObjectPool;
+import org.apache.commons.pool2.impl.GenericKeyedObjectPoolConfig;
+
+// ObjectPool which uses Apache Commons
+public abstract class CommonsObjPool<K, V> extends GenericKeyedObjectPool<K, V> implements ObjectPool<K, V> {
+
+  public CommonsObjPool(
+      KeyedPooledObjectFactory<K, V> factory,
+      GenericKeyedObjectPoolConfig<V> config
+  ) {
+    super(factory, config);
+  }
+
+  public V obtain(K key) throws Exception {
+    return this.borrowObject(key);
+  }
+
+  public void release(K key, V obj) {
+    this.returnObject(key, obj);
+  }
+}

--- a/persistentworkers/src/main/java/persistent/common/CommonsPool.java
+++ b/persistentworkers/src/main/java/persistent/common/CommonsPool.java
@@ -1,0 +1,71 @@
+package persistent.common;
+
+
+import java.io.IOException;
+
+import com.google.common.base.Throwables;
+
+import org.apache.commons.pool2.BaseKeyedPooledObjectFactory;
+import org.apache.commons.pool2.impl.GenericKeyedObjectPool;
+import org.apache.commons.pool2.impl.GenericKeyedObjectPoolConfig;
+
+/**
+ * Pool based on Apache Commons, ripped from Bazel as usual
+ * @param <K>
+ * @param <V>
+ */
+public class CommonsPool<K, V> extends CommonsObjPool<K, V> {
+
+  public CommonsPool(BaseKeyedPooledObjectFactory<K, V> factory, int maxPerKey) {
+    super(factory, makeConfig(maxPerKey));
+  }
+
+  @Override
+  public V borrowObject(K key) throws IOException, InterruptedException {
+    try {
+      return super.borrowObject(key);
+    } catch (Throwable t) {
+      Throwables.propagateIfPossible(t, IOException.class, InterruptedException.class);
+      throw new RuntimeException("unexpected@<borrowObject>", t);
+    }
+  }
+
+  @Override
+  public void invalidateObject(K key, V obj) throws IOException, InterruptedException {
+    try {
+      super.invalidateObject(key, obj);
+    } catch (Throwable t) {
+      Throwables.propagateIfPossible(t, IOException.class, InterruptedException.class);
+      throw new RuntimeException("unexpected@<invalidateObject>", t);
+    }
+  }
+
+  static <V> GenericKeyedObjectPoolConfig<V> makeConfig(int max) {
+    GenericKeyedObjectPoolConfig<V> config = new GenericKeyedObjectPoolConfig<>();
+
+    // It's better to re-use a worker as often as possible and keep it hot, in order to profit
+    // from JIT optimizations as much as possible.
+    config.setLifo(true);
+
+    // Keep a fixed number of workers running per key.
+    config.setMaxIdlePerKey(max);
+    config.setMaxTotalPerKey(max);
+    config.setMinIdlePerKey(max);
+
+    // Don't limit the total number of worker processes, as otherwise the pool might be full of
+    // workers for one WorkerKey and can't accommodate a worker for another WorkerKey.
+    config.setMaxTotal(-1);
+
+    // Wait for a worker to become ready when a thread needs one.
+    config.setBlockWhenExhausted(true);
+
+    // Always test the liveliness of worker processes.
+    config.setTestOnBorrow(true);
+    config.setTestOnCreate(true);
+    config.setTestOnReturn(true);
+
+    // No eviction of idle workers.
+    config.setTimeBetweenEvictionRunsMillis(-1);
+    return config;
+  }
+}

--- a/persistentworkers/src/main/java/persistent/common/CommonsSupervisor.java
+++ b/persistentworkers/src/main/java/persistent/common/CommonsSupervisor.java
@@ -1,0 +1,57 @@
+package persistent.common;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.apache.commons.pool2.BaseKeyedPooledObjectFactory;
+import org.apache.commons.pool2.PooledObject;
+import org.apache.commons.pool2.impl.DefaultPooledObject;
+
+/**
+ * A Supervisor is an ObjectFactory with default `wrap` and `destroyObject` overrides,
+ * and abstract `create` and `validateObject` methods.
+ * <p>
+ * An aside: Why does an ObjectFactory do more than create the object?
+ *
+ * @param <K>
+ * @param <V> must be a Destructable
+ */
+public abstract class CommonsSupervisor<K, V extends Destructable>
+    extends BaseKeyedPooledObjectFactory<K, V>
+    implements Supervisor<K, V, PooledObject<V>> {
+
+  private static final Logger logger = Logger.getLogger(CommonsSupervisor.class.getName());
+
+  public abstract V create(K k) throws Exception;
+
+  public abstract boolean validateObject(K key, PooledObject<V> p);
+
+  protected Logger getLogger() {
+    return logger;
+  }
+
+  @Override
+  public PooledObject<V> wrap(V v) {
+    return new DefaultPooledObject<>(v);
+  }
+
+  @Override
+  public void destroyObject(K key, PooledObject<V> p) {
+    V obj = p.getObject();
+
+    StringBuilder msgBuilder = new StringBuilder();
+    msgBuilder.append("Supervisor.destroyObject() from key:\n");
+    msgBuilder.append(key);
+    msgBuilder.append("\nobj.toString():\n");
+    msgBuilder.append(obj);
+    msgBuilder.append("\nSupervisor.destroyObject() stackTrack:");
+    for (StackTraceElement e : Thread.currentThread().getStackTrace()) {
+      msgBuilder.append("\n\t");
+      msgBuilder.append(e);
+    }
+
+    getLogger().log(Level.FINE, msgBuilder.toString());
+
+    obj.destroy();
+  }
+}

--- a/persistentworkers/src/main/java/persistent/common/Coordinator.java
+++ b/persistentworkers/src/main/java/persistent/common/Coordinator.java
@@ -1,0 +1,68 @@
+package persistent.common;
+
+import java.io.IOException;
+
+import persistent.common.CtxAround.Id;
+
+/**
+ * Manages worker lifetimes and acts as the mediator between executors and workers.
+ * It also manages pre-work initialization and post-work cleanup.
+ *
+ * @param <K> worker key type
+ * @param <I> request type
+ * @param <O> work response type
+ * @param <W> worker type
+ * @param <CI> request with extra context/info
+ * @param <CO> response with extra context/info
+ * @param <P> pool type
+ */
+public abstract class Coordinator<K, I, O, W extends Worker<I, O>, CI extends CtxAround<I>, CO extends CtxAround<O>, P extends  ObjectPool<K, W>> {
+
+  protected final P workerPool;
+
+  public Coordinator(P workerPool) {
+    this.workerPool = workerPool;
+  }
+
+  public CO runRequest(K workerKey, CI reqWithCtx) throws Exception {
+    W worker = workerPool.obtain(workerKey);
+
+    I request = preWorkInit(workerKey, reqWithCtx, worker);
+    O workResponse = worker.doWork(request);
+    CO responseAfterCLeanup = postWorkCleanup(workResponse, worker, reqWithCtx);
+
+    workerPool.release(workerKey, worker);
+    return responseAfterCLeanup;
+  }
+
+  public abstract I preWorkInit(K workerKey, CI request, W worker) throws IOException;
+
+  public abstract CO postWorkCleanup(O response, W worker, CI request) throws IOException;
+
+  public static <K, I, O, W extends Worker<I, O>> SimpleCoordinator<K, I, O, W> simple(
+      ObjectPool<K, W> workerPool
+  ) {
+    return new SimpleCoordinator<>(workerPool);
+  }
+
+  /**
+   * A Coordinator which doesn't have any extra metadata for the request and response types
+   * Its pool type is also filled in as an ObjectPool interface
+   */
+  public static class SimpleCoordinator<K, I, O, W extends Worker<I, O>> extends Coordinator<K, I, O, W, Id<I>, Id<O>, ObjectPool<K, W>> {
+
+    public SimpleCoordinator(ObjectPool<K, W> workerPool) {
+      super(workerPool);
+    }
+
+    @Override
+    public I preWorkInit(K workerKey, Id<I> request, W worker) {
+      return request.get();
+    }
+
+    @Override
+    public Id<O> postWorkCleanup(O response, W worker, Id<I> request) {
+      return Id.of(response);
+    }
+  }
+}

--- a/persistentworkers/src/main/java/persistent/common/CtxAround.java
+++ b/persistentworkers/src/main/java/persistent/common/CtxAround.java
@@ -1,0 +1,29 @@
+package persistent.common;
+
+public interface CtxAround<T> {
+
+  T get();
+
+  // i.e. no context
+  class Id<T> implements CtxAround<T> {
+    T value;
+
+    public Id(T value) {
+      this.value = value;
+    }
+
+    @Override
+    public T get() {
+      return value;
+    }
+
+    public static <T> Id<T> of(T value) {
+      return new Id<>(value);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      return obj.equals(this.value);
+    }
+  }
+}

--- a/persistentworkers/src/main/java/persistent/common/Destructable.java
+++ b/persistentworkers/src/main/java/persistent/common/Destructable.java
@@ -1,0 +1,7 @@
+package persistent.common;
+
+// Closeable.close() has a checked exception (IOException)
+public interface Destructable {
+
+  void destroy();
+}

--- a/persistentworkers/src/main/java/persistent/common/MapPool.java
+++ b/persistentworkers/src/main/java/persistent/common/MapPool.java
@@ -1,0 +1,29 @@
+package persistent.common;
+
+import java.util.HashMap;
+import java.util.function.Function;
+
+public class MapPool<K, V> implements ObjectPool<K, V> {
+
+  private final HashMap<K, V> map;
+
+  private final Function<K, V> objFactory;
+
+  public MapPool(Function<K, V> factory) {
+    this.map = new HashMap<>();
+    this.objFactory = factory;
+  }
+
+  @Override
+  public V obtain(K key) {
+    if (map.containsKey(key)) {
+      return map.remove(key);
+    }
+    return objFactory.apply(key);
+  }
+
+  @Override
+  public void release(K key, V obj) {
+    map.put(key, obj);
+  }
+}

--- a/persistentworkers/src/main/java/persistent/common/ObjectPool.java
+++ b/persistentworkers/src/main/java/persistent/common/ObjectPool.java
@@ -1,0 +1,8 @@
+package persistent.common;
+
+public interface ObjectPool<K, V> {
+
+  V obtain(K key) throws Exception;
+
+  void release(K key, V obj);
+}

--- a/persistentworkers/src/main/java/persistent/common/Supervisor.java
+++ b/persistentworkers/src/main/java/persistent/common/Supervisor.java
@@ -1,0 +1,13 @@
+package persistent.common;
+
+public interface Supervisor<K, V extends Destructable, P> {
+
+
+  V create(K k) throws Exception;
+
+  P wrap(V v);
+
+  boolean validateObject(K key, P p);
+
+  void destroyObject(K key, P p);
+}

--- a/persistentworkers/src/main/java/persistent/common/Worker.java
+++ b/persistentworkers/src/main/java/persistent/common/Worker.java
@@ -1,0 +1,8 @@
+package persistent.common;
+
+public interface Worker<I, O> extends Destructable {
+
+  O doWork(I request);
+
+  default void destroy() {}
+}

--- a/persistentworkers/src/main/java/persistent/common/processes/JavaProcessWrapper.java
+++ b/persistentworkers/src/main/java/persistent/common/processes/JavaProcessWrapper.java
@@ -1,0 +1,33 @@
+package persistent.common.processes;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+
+public class JavaProcessWrapper extends ProcessWrapper {
+
+  public JavaProcessWrapper(
+      Path workDir, String classPath, String fullClassName, String[] args
+  ) throws IOException {
+    super(workDir, cmdArgs(
+        new String[]{
+            "java",
+            "-cp",
+            classPath,
+            fullClassName
+        },
+        args
+    ));
+  }
+
+  public static ImmutableList<String> cmdArgs(String[] cmd, String[] args) {
+      List<String> resultList = new ArrayList<>(cmd.length + args.length);
+      Collections.addAll(resultList, cmd);
+      Collections.addAll(resultList, args);
+      return ImmutableList.copyOf(resultList);
+  }
+}

--- a/persistentworkers/src/main/java/persistent/common/processes/ProcessWrapper.java
+++ b/persistentworkers/src/main/java/persistent/common/processes/ProcessWrapper.java
@@ -1,0 +1,141 @@
+package persistent.common.processes;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
+import static java.nio.file.StandardOpenOption.WRITE;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Wraps a process, giving it a (possible different) working directory and environment variables.
+ * Redirects stderr to a file under its working dir using a random uuid, i.e. "{{randomUUID()}}.stderr"
+ * Exposes its stdin as OutputStream and stdout as InputStream.
+ *
+ * Constructor immediately starts a process and checks isAlive() right after.
+ */
+public class ProcessWrapper implements Closeable {
+
+  private static Logger logger = Logger.getLogger(ProcessWrapper.class.getName());
+
+  private final Process process;
+
+  private final Path workRoot;
+
+  private final ImmutableList<String> args;
+
+  private final Path errorFile;
+
+  private final UUID uuid;
+
+  public ProcessWrapper(Path workDir, ImmutableList<String> args) throws IOException {
+    this(workDir, args, new HashMap<>());
+  }
+
+  public ProcessWrapper(
+      Path workDir, ImmutableList<String> args, Map<String, String> env
+  ) throws IOException {
+    this.args = checkNotNull(args);
+    this.workRoot = checkNotNull(workDir);
+    Preconditions.checkArgument(
+        Files.isDirectory(workDir),
+        "Process workDir must be a directory, got: " + workDir
+    );
+    this.uuid = UUID.randomUUID();
+
+    this.errorFile = this.workRoot.resolve(this.uuid + ".stderr");
+
+    logger.log(Level.FINE, "Starting Process:");
+    logger.log(Level.FINE, "\tcmd: " + this.args);
+    logger.log(Level.FINE, "\tdir: " + this.workRoot);
+    logger.log(Level.FINE, "\tenv: " + ImmutableMap.copyOf(env));
+    logger.log(Level.FINE, "\tenv: " + errorFile);
+
+    ProcessBuilder pb = new ProcessBuilder()
+        .command(this.args)
+        .directory(this.workRoot.toFile())
+        .redirectError(ProcessBuilder.Redirect.to(this.errorFile.toFile()));
+
+    pb.environment().putAll(env);
+
+    try {
+      this.process = pb.start();
+    } catch (IOException e) {
+      String msg = "Failed to start process: " + e;
+      logger.log(Level.SEVERE, msg);
+      e.printStackTrace();
+      throw new IOException(msg, e);
+    }
+
+    if (!this.process.isAlive()) {
+      int exitVal = this.process.exitValue();
+      String msg = "Process instantly terminated with: " + exitVal + "; " + getErrorString();
+      throw new IOException(msg);
+    }
+  }
+
+  public ImmutableList<String> getInitialArgs() {
+    return this.args;
+  }
+
+  public Path getWorkRoot() {
+    return this.workRoot;
+  }
+
+  public OutputStream getStdIn() {
+    return this.process.getOutputStream();
+  }
+
+  public InputStream getStdOut() {
+    return this.process.getInputStream();
+  }
+
+  public String getErrorString() throws IOException {
+    if (Files.exists(this.errorFile)) {
+      return new String(Files.readAllBytes(this.errorFile));
+    } else {
+      return "[No errorFile...]";
+    }
+  }
+
+  public String flushErrorString() throws IOException {
+    String contents = getErrorString();
+    Files.write(this.errorFile, "".getBytes(), WRITE, TRUNCATE_EXISTING);
+    return contents;
+  }
+
+  public boolean isAlive() {
+    return this.process.isAlive();
+  }
+
+  public int exitValue() {
+    return this.process.exitValue();
+  }
+
+  public int waitFor() throws InterruptedException {
+    return this.process.waitFor();
+  }
+
+  public void destroy() {
+    this.process.destroyForcibly();
+  }
+
+  @Override
+  public void close() throws IOException {
+    this.destroy();
+  }
+}

--- a/persistentworkers/src/main/java/persistent/common/util/Args.java
+++ b/persistentworkers/src/main/java/persistent/common/util/Args.java
@@ -1,0 +1,39 @@
+package persistent.common.util;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+public class Args {
+
+  public static final String ARGSFILE_START = "@";
+
+  public static final String ARGSFILE_ESCAPE = "@@";
+
+  public static boolean isArgsFile(String arg) {
+    return arg.startsWith(ARGSFILE_START) && !arg.startsWith(ARGSFILE_ESCAPE);
+  }
+
+  // Expand arguments of argsfiles
+  public static List<String> expandArgsfiles(List<String> args) throws IOException {
+    List<String> res = new ArrayList<>();
+    for (String arg : args) {
+      if (isArgsFile(arg)) {
+        res.addAll(readAllLines(arg));
+      } else {
+        res.add(arg);
+      }
+    }
+    return res;
+  }
+
+  public static List<String> readAllLines(String fileArg) throws IOException {
+    String file = isArgsFile(fileArg)
+        ? fileArg.substring(1)
+        : fileArg;
+
+    return Files.readAllLines(Paths.get(file));
+  }
+}

--- a/persistentworkers/src/main/java/persistent/common/util/BUILD
+++ b/persistentworkers/src/main/java/persistent/common/util/BUILD
@@ -1,0 +1,6 @@
+java_library(
+    name = "util",
+    srcs = glob(["**/*.java"]),
+    visibility = ["//visibility:public"],
+    deps = [],
+)

--- a/persistentworkers/src/test/java/persistent/bazel/BUILD
+++ b/persistentworkers/src/test/java/persistent/bazel/BUILD
@@ -1,0 +1,40 @@
+COMMON_DEPS = [
+    "//persistentworkers/src/main/java/persistent/common:persistent-common",
+    "//persistentworkers/src/main/java/persistent/bazel:bazel-persistent-workers",
+    "//persistentworkers/src/test/java/persistent/testutil:testutil",
+    "@bazel_tools//src/main/protobuf:worker_protocol_java_proto",
+    "@maven//:com_google_protobuf_protobuf_java",
+    "@maven//:com_google_truth_truth",
+    "@maven//:commons_io_commons_io",
+    "@maven//:org_mockito_mockito_core",
+]
+
+java_test(
+    name = "TestDepsTest",
+    size = "small",
+    srcs = ["processes/TestDepsTest.java"],
+    resources = [
+        "//persistentworkers/examples/src/main/java:adder-bin_deploy.jar",
+    ],
+    deps = COMMON_DEPS,
+)
+
+java_test(
+    name = "ProtoWorkerRWTest",
+    size = "small",
+    srcs = ["processes/ProtoWorkerRWTest.java"],
+    resources = [
+        "//persistentworkers/examples/src/main/java:adder-bin_deploy.jar",
+    ],
+    deps = COMMON_DEPS,
+)
+
+java_test(
+    name = "PersistentWorkerTest",
+    size = "small",
+    srcs = ["processes/PersistentWorkerTest.java"],
+    resources = [
+        "//persistentworkers/examples/src/main/java:adder-bin_deploy.jar",
+    ],
+    deps = COMMON_DEPS,
+)

--- a/persistentworkers/src/test/java/persistent/bazel/processes/PersistentWorkerTest.java
+++ b/persistentworkers/src/test/java/persistent/bazel/processes/PersistentWorkerTest.java
@@ -1,0 +1,82 @@
+package persistent.bazel.processes;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import com.google.common.collect.ImmutableList;
+import com.google.devtools.build.lib.worker.WorkerProtocol.WorkRequest;
+import com.google.devtools.build.lib.worker.WorkerProtocol.WorkResponse;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import persistent.bazel.client.PersistentWorker;
+import persistent.bazel.client.WorkerKey;
+import persistent.testutil.ProcessUtils;
+import persistent.testutil.WorkerUtils;
+
+@RunWith(JUnit4.class)
+public class PersistentWorkerTest {
+
+  static WorkResponse sendAddRequest(PersistentWorker worker, Path stdErrLog, int x, int y) throws IOException {
+    ImmutableList<String> arguments = ImmutableList.of(String.valueOf(x), String.valueOf(y));
+
+    WorkRequest request = WorkRequest.newBuilder()
+        .addAllArguments(arguments)
+        .setRequestId(0)
+        .build();
+
+    WorkResponse response;
+    try {
+      response = worker.doWork(request);
+    } catch (Exception e) {
+      System.err.println(e.getMessage());
+      System.err.println(Files.readAllLines(stdErrLog));
+      throw e;
+    }
+    return response;
+  }
+
+  @SuppressWarnings("CheckReturnValue")
+  @Test
+  public void endToEndAdder() throws Exception {
+    Path workDir = Files.createTempDirectory("test-workdir-");
+
+    String filename = "adder-bin_deploy.jar";
+
+    Path jarPath = ProcessUtils.retrieveFileResource(
+        getClass().getClassLoader(),
+        filename,
+        workDir.resolve(filename)
+    );
+
+    ImmutableList<String> initCmd = ImmutableList.of(
+        "java",
+        "-cp",
+        jarPath.toString(),
+        "adder.Adder",
+        "--persistent_worker"
+    );
+
+    WorkerKey key = WorkerUtils.emptyWorkerKey(workDir, initCmd);
+
+    Path stdErrLog = workDir.resolve("test-err.log");
+    PersistentWorker worker = new PersistentWorker(key, "worker-dir");
+
+    WorkResponse response = sendAddRequest(worker, stdErrLog, 2, 4);
+
+    Assert.assertEquals(response.getOutput(), "6");
+    Assert.assertEquals(response.getExitCode(), 0);
+    Assert.assertEquals(worker.getExitValue(), Optional.empty()); // Not yet exited
+
+    WorkResponse response2 = sendAddRequest(worker, stdErrLog, 13, 37);
+
+    Assert.assertEquals(response2.getOutput(), "50");
+    Assert.assertEquals(response2.getExitCode(), 0);
+    Assert.assertEquals(worker.getExitValue(), Optional.empty()); // Not yet exited
+  }
+}

--- a/persistentworkers/src/test/java/persistent/bazel/processes/ProtoWorkerRWTest.java
+++ b/persistentworkers/src/test/java/persistent/bazel/processes/ProtoWorkerRWTest.java
@@ -1,0 +1,60 @@
+package persistent.bazel.processes;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import com.google.devtools.build.lib.worker.WorkerProtocol;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import persistent.common.processes.JavaProcessWrapper;
+import persistent.common.processes.ProcessWrapper;
+import persistent.testutil.ProcessUtils;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import static persistent.testutil.ProcessUtils.spawnPersistentWorkerProcess;
+
+@RunWith(JUnit4.class)
+public class ProtoWorkerRWTest {
+
+  // Similar to AdderTest; but spawns the process via a jar
+  @SuppressWarnings("CheckReturnValue")
+  @Test
+  public void canAddMultipleTimesWithAdder() throws Exception {
+    Path workDir = Files.createTempDirectory("test-workdir-");
+
+    String filename = "adder-bin_deploy.jar";
+
+    Path jarPath = ProcessUtils.retrieveFileResource(
+        getClass().getClassLoader(),
+        filename,
+        workDir.resolve(filename)
+    );
+
+    ProcessWrapper process;
+    try (JavaProcessWrapper jpw = spawnPersistentWorkerProcess(jarPath, "adder.Adder")) {
+      process = jpw;
+      ProtoWorkerRW rw = new ProtoWorkerRW(jpw);
+
+      assertThat(jpw.isAlive()).isTrue();
+
+      rw.write(WorkerProtocol.WorkRequest.newBuilder().addArguments("1").addArguments("3").build());
+      assertThat(rw.waitAndRead().getOutput()).isEqualTo("4");
+      assertThat(jpw.isAlive()).isTrue();
+
+      rw.write(WorkerProtocol.WorkRequest.newBuilder().addArguments("2").addArguments("5").build());
+      assertThat(rw.waitAndRead().getOutput()).isEqualTo("7");
+      assertThat(jpw.isAlive()).isTrue();
+    }
+
+    // try-with-resources done -> close() called, process should have been destroyForicbly()'d
+    assertThat(process).isNotNull();
+    process.waitFor();
+
+    assertThat(process.isAlive()).isFalse();
+    assertThat(process.exitValue()).isNotEqualTo(0);
+  }
+}

--- a/persistentworkers/src/test/java/persistent/bazel/processes/TestDepsTest.java
+++ b/persistentworkers/src/test/java/persistent/bazel/processes/TestDepsTest.java
@@ -1,0 +1,34 @@
+package persistent.bazel.processes;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import persistent.testutil.ProcessUtils;
+
+import static com.google.common.truth.Truth.assertThat;
+
+@RunWith(JUnit4.class)
+public class TestDepsTest {
+
+  @SuppressWarnings("CheckReturnValue")
+  @Test
+  public void canRetrieveAdderBinDeployJar() throws Exception {
+    Path workDir = Files.createTempDirectory("test-workdir-");
+
+    String filename = "adder-bin_deploy.jar";
+
+    Path jarPath = ProcessUtils.retrieveFileResource(
+        getClass().getClassLoader(),
+        filename,
+        workDir.resolve(filename)
+    );
+
+    assertThat(Files.exists(jarPath)).isTrue();
+
+    assertThat(Files.size(jarPath)).isAtLeast(11000000L); // at least 11mb
+  }
+}

--- a/persistentworkers/src/test/java/persistent/common/BUILD
+++ b/persistentworkers/src/test/java/persistent/common/BUILD
@@ -1,0 +1,13 @@
+java_test(
+    name = "CoordinatorTest",
+    size = "small",
+    srcs = glob(["**/*.java"]),
+    deps = [
+        "//persistentworkers/src/main/java/persistent/common:persistent-common",
+        "//persistentworkers/src/test/java/persistent/testutil",
+        "@bazel_tools//src/main/protobuf:worker_protocol_java_proto",
+        "@maven//:com_google_truth_truth",
+        "@maven//:commons_io_commons_io",
+        "@maven//:org_mockito_mockito_core",
+    ],
+)

--- a/persistentworkers/src/test/java/persistent/common/processes/CoordinatorTest.java
+++ b/persistentworkers/src/test/java/persistent/common/processes/CoordinatorTest.java
@@ -1,0 +1,39 @@
+package persistent.common.processes;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import persistent.common.Coordinator;
+import persistent.common.Coordinator.SimpleCoordinator;
+import persistent.common.CtxAround.Id;
+import persistent.common.MapPool;
+import persistent.common.ObjectPool;
+import persistent.common.Worker;
+
+import static com.google.common.truth.Truth.assertThat;
+
+@RunWith(JUnit4.class)
+public class CoordinatorTest {
+
+  @SuppressWarnings("CheckReturnValue")
+  @Test
+  public void simpleTestWorks() throws Exception {
+
+    // Creates an objectpool that uses Strings as a Key for its Workers
+    // Workers increment an integer and returns its string value.
+    ObjectPool<String, Worker<Integer, String>> spool = new MapPool<>(
+        key -> new Worker<Integer, String>() {
+          @Override
+          public String doWork(Integer request) {
+            return String.valueOf(request + 1);
+          }
+        });
+
+    SimpleCoordinator<String, Integer, String, Worker<Integer, String>> pc =
+        Coordinator.simple(spool);
+
+    assertThat(pc.runRequest("someWorkerKey", Id.of(1)))
+        .isEqualTo(Id.of("2"));
+  }
+}

--- a/persistentworkers/src/test/java/persistent/testutil/BUILD
+++ b/persistentworkers/src/test/java/persistent/testutil/BUILD
@@ -1,0 +1,15 @@
+java_library(
+    name = "testutil",
+    srcs = glob(["**/*.java"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//persistentworkers/src/main/java/persistent/bazel:bazel-persistent-workers",
+        "//persistentworkers/src/main/java/persistent/common:persistent-common",
+        "@bazel_tools//src/main/protobuf:worker_protocol_java_proto",
+        "@maven//:com_google_guava_guava",
+        "@maven//:com_google_protobuf_protobuf_java",
+        "@maven//:com_google_truth_truth",
+        "@maven//:commons_io_commons_io",
+        "@maven//:org_mockito_mockito_core",
+    ],
+)

--- a/persistentworkers/src/test/java/persistent/testutil/ProcessUtils.java
+++ b/persistentworkers/src/test/java/persistent/testutil/ProcessUtils.java
@@ -1,0 +1,50 @@
+package persistent.testutil;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.apache.commons.io.IOUtils;
+
+import persistent.bazel.client.PersistentWorker;
+import persistent.common.processes.JavaProcessWrapper;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class ProcessUtils {
+
+  /**
+   * Creates a new java process with the specified classpath and classname (with the main method),
+   *  passing along the --persistent_worker flag.
+   */
+  public static JavaProcessWrapper spawnPersistentWorkerProcess(String classpath, String className) throws IOException {
+    JavaProcessWrapper jpw = new JavaProcessWrapper(
+        Paths.get("."),
+        classpath,
+        className,
+        new String[]{PersistentWorker.PERSISTENT_WORKER_FLAG}
+    );
+    assertThat(jpw.isAlive()).isTrue();
+    return jpw;
+  }
+
+  public static JavaProcessWrapper spawnPersistentWorkerProcess(Path jar, String className) throws IOException {
+    return spawnPersistentWorkerProcess(jar.toString(), className);
+  }
+
+  public static JavaProcessWrapper spawnPersistentWorkerProcess(String classpath, Class<?> clazz) throws IOException {
+    String className = clazz.getPackage().getName() + "." + clazz.getSimpleName();
+    return spawnPersistentWorkerProcess(classpath, className);
+  }
+
+  public static Path retrieveFileResource(ClassLoader classLoader, String filename, Path targetPath) throws IOException {
+
+    InputStream is = classLoader.getResourceAsStream(filename);
+
+    Files.write(targetPath, IOUtils.toByteArray(is));
+
+    return targetPath;
+  }
+}

--- a/persistentworkers/src/test/java/persistent/testutil/WorkerUtils.java
+++ b/persistentworkers/src/test/java/persistent/testutil/WorkerUtils.java
@@ -1,0 +1,27 @@
+package persistent.testutil;
+
+import java.nio.file.Path;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.hash.HashCode;
+
+import persistent.bazel.client.WorkerKey;
+
+public class WorkerUtils {
+
+  public static WorkerKey emptyWorkerKey(Path execDir, ImmutableList<String> initCmd) {
+    return new WorkerKey(
+        initCmd,
+        ImmutableList.of(),
+        ImmutableMap.of(),
+        execDir,
+        "TestOp-Adder",
+        HashCode.fromInt(0),
+        ImmutableSortedMap.of(),
+        false,
+        false
+    );
+  }
+}

--- a/persistentworkers/src/test/resources/BUILD
+++ b/persistentworkers/src/test/resources/BUILD
@@ -1,0 +1,5 @@
+filegroup(
+    name = "test-files",
+    data = ["//persistentworkers/examples/src/main/java:adder-bin.jar"],
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
Bazel Persistent Workers for Buildfarm
===
### Goal: 
Buildfarm workers will be able to spin up and execute actions on persistent workers,
similar to how Bazel itself uses persistent workers.

See: https://bazel.build/remote/persistent

In our testing, this sped up JVM builds (i.e. with mnemonics of `Javac`, `Scalac`, etc.) by ~70-90%.
Tested with a modified Bazel `5.3.0` binary: https://github.com/wiwa/bazel/commit/07d40cef1019dc510aacf49de22ae39831bd647e

The Bazel modification is based off of `--experimental_mark_tool_inputs` [design](https://github.com/bazelbuild/proposals/pull/219) (original issue [here](https://github.com/bazelbuild/bazel/issues/10091)), with a PR currently open: https://github.com/bazelbuild/bazel/pull/16362

We also use a modified Buildfarm (1.16.0): https://github.com/wiwa/bazel-buildfarm/tree/p/16pw  
Presumably, the changes needed to actually _use_ persistent workers would come after this PR.
___

We split persistent workers into two targets:  
`persistentworkers/src/main/java/persistent/common:persistent-common`  
`persistentworkers/src/main/java/persistent/bazel:bazel-persistent-workers`

`persisent-common` aims to provide an interface for general persistent worker processes,
as well as a sort of "code as documentation". Bazel's own `libworker` is not publicly visible: [here](https://github.com/bazelbuild/bazel/blob/master/src/main/java/com/google/devtools/build/lib/worker/BUILD) and  [here](https://github.com/bazelbuild/bazel/blob/master/src/main/java/com/google/devtools/build/lib/BUILD)

`bazel-persistent-workers` implements `persistent-common` in the context of Bazel's persistent workers model.

Co-authored-by: Shane Delmore <shane@delmore.io>