### PR TITLE
Add basic batch scripts to start server and worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ redis-cli config set stop-writes-on-bgsave-error no
 Run via
 
 ```
-bazel run //src/main/java/build/buildfarm:buildfarm-server -- <logfile> <configfile>
+bazelisk run //src/main/java/build/buildfarm:buildfarm-server -- <logfile> <configfile>
 
-Ex: bazel run //src/main/java/build/buildfarm:buildfarm-server -- --jvm_flag=-Dlogging.config=file:$PWD/examples/logging.properties $PWD/examples/config.minimal.yml
+Ex: bazelisk run //src/main/java/build/buildfarm:buildfarm-server -- --jvm_flag=-Dlogging.config=file:$PWD/examples/logging.properties $PWD/examples/config.minimal.yml
 ```
 **`logfile`** has to be in the [standard java util logging format](https://docs.oracle.com/cd/E57471_01/bigData.100/data_processing_bdd/src/rdp_logging_config.html) and passed as a --jvm_flag=-Dlogging.config=file:
 **`configfile`** has to be in [yaml format](https://bazelbuild.github.io/bazel-buildfarm/docs/configuration).
@@ -43,9 +43,9 @@ Ex: bazel run //src/main/java/build/buildfarm:buildfarm-server -- --jvm_flag=-Dl
 Run via
 
 ```
-bazel run //src/main/java/build/buildfarm:buildfarm-shard-worker -- <logfile> <configfile>
+bazelisk run //src/main/java/build/buildfarm:buildfarm-shard-worker -- <logfile> <configfile>
 
-Ex: bazel run //src/main/java/build/buildfarm:buildfarm-shard-worker -- --jvm_flag=-Dlogging.config=file:$PWD/examples/logging.properties $PWD/examples/config.minimal.yml
+Ex: bazelisk run //src/main/java/build/buildfarm:buildfarm-shard-worker -- --jvm_flag=-Dlogging.config=file:$PWD/examples/logging.properties $PWD/examples/config.minimal.yml
 
 ```
 **`logfile`** has to be in the [standard java util logging format](https://docs.oracle.com/cd/E57471_01/bigData.100/data_processing_bdd/src/rdp_logging_config.html) and passed as a --jvm_flag=-Dlogging.config=file:

--- a/_site/docs/quick_start.md
+++ b/_site/docs/quick_start.md
@@ -44,7 +44,7 @@ A Buildfarm server with an instance can be used strictly as an ActionCache and C
 
 Download the buildfarm repository and change into its directory, then:
 
-run `bazel run src/main/java/build/buildfarm:buildfarm-server $PWD/examples/config.minimal.yml`
+run `bazelisk run src/main/java/build/buildfarm:buildfarm-server $PWD/examples/config.minimal.yml`
 
 This will wait while the server runs, indicating that it is ready for requests.
 
@@ -73,11 +73,11 @@ Now we will use buildfarm for remote execution with a minimal configuration - a 
 First, we should restart the buildfarm server to ensure that we get remote execution (this can also be forced from the client by using `--noremote_accept_cached`). From the buildfarm server prompt and directory:
 
 interrupt a running `buildfarm-server`
-run `bazel run src/main/java/build/buildfarm:buildfarm-server $PWD/examples/config.minimal.yml`
+run `bazelisk run src/main/java/build/buildfarm:buildfarm-server $PWD/examples/config.minimal.yml`
 
 From another prompt in the buildfarm repository directory:
 
-run `bazel run src/main/java/build/buildfarm:buildfarm-shard-worker $PWD/examples/config.minimal.yml`
+run `bazelisk run src/main/java/build/buildfarm:buildfarm-shard-worker $PWD/examples/config.minimal.yml`
 
 From another prompt, in your client workspace:
 

--- a/run_server
+++ b/run_server
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+set -o pipefail
+
+# Run Redis docker container
+docker start buildfarm-redis || docker run -d --rm --name buildfarm-redis -p 6379:6379 redis:5.0.9
+redis-cli config set stop-writes-on-bgsave-error no
+
+# Determine which configuration file to use - default or user provided
+if [[ -z "$1" ]]
+then
+  config=$PWD/examples/config.minimal.yml
+else
+  config=$1
+fi
+
+# Run Server
+bazelisk run //src/main/java/build/buildfarm:buildfarm-server -- --jvm_flag=-Dlogging.config=file:$PWD/examples/logging.properties $config

--- a/run_worker
+++ b/run_worker
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+set -o pipefail
+
+# Run Redis docker container
+docker start buildfarm-redis || docker run -d --rm --name buildfarm-redis -p 6379:6379 redis:5.0.9
+redis-cli config set stop-writes-on-bgsave-error no
+
+# Determine which configuration file to use - default or user provided
+if [[ -z "$1" ]]
+then
+  config=$PWD/examples/config.minimal.yml
+else
+  config=$1
+fi
+
+# Run Server
+bazelisk run //src/main/java/build/buildfarm:buildfarm-shard-worker -- --jvm_flag=-Dlogging.config=file:$PWD/examples/logging.properties $config


### PR DESCRIPTION
Add  two basic scripts to start buildfarm server and buildfarm worker with default logging and yaml configuration.

```
./run_server
./run_worker
```