### PR TITLE
avoid crash with paths starting with double separators

### DIFF
--- a/src/main/java/build/buildfarm/worker/OutputDirectory.java
+++ b/src/main/java/build/buildfarm/worker/OutputDirectory.java
@@ -165,6 +165,9 @@ public class OutputDirectory {
     String prefix = "/";
     for (OutputDirectoryEntry entry : sortedOutputDirs) {
       String outputDir = entry.outputDirectory;
+      if (outputDir.startsWith("//")) {
+        outputDir = outputDir.substring(1);
+      }
       while (!outputDir.startsWith(prefix)) {
         currentBuilder = stack.pop();
         int upPathSeparatorIndex = prefix.lastIndexOf('/', prefix.length() - 2);


### PR DESCRIPTION
This is the error I get on the worker node:
```
Exception in thread "Thread-190" java.lang.IllegalArgumentException: double separator in output directory
        at build.buildfarm.worker.OutputDirectory.parseDirectories(OutputDirectory.java:181)
        at build.buildfarm.worker.OutputDirectory.parse(OutputDirectory.java:109)
        at build.buildfarm.worker.shard.CFCExecFileSystem.createExecDir(CFCExecFileSystem.java:354)
        at build.buildfarm.worker.shard.ShardWorkerContext.createExecDir(ShardWorkerContext.java:713)
        at build.buildfarm.worker.InputFetcher.fetchPolled(InputFetcher.java:191)
        at build.buildfarm.worker.InputFetcher.runInterruptibly(InputFetcher.java:101)
        at build.buildfarm.worker.InputFetcher.run(InputFetcher.java:280)
        at java.base/java.lang.Thread.run(Thread.java:829)
```

To be honest, I don't know why it happens in the first place, but this fixes my problem.

The paths somehow get like this: `//tmp/bazeltest/_tmp/e062d84144817ba3a0e56f6760a7f161/` when e.g. using `bazel build --test_tmpdir=/tmp/bazeltest/`.

It also happens for normal filepaths, but only under certain circumstances (build of tools for genrules for example).

The bazel client that produces this problem is built from this commit: https://github.com/bazelbuild/bazel/commit/4779553eb5814025a465ebadbbced5c158996660 (I built it myself from main).


My remote build runs smoothly when I apply this change