### PR TITLE
Provide digests for images and http files to use cache effectively

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -153,5 +153,6 @@ def buildfarm_dependencies(repository_name = "build_buildfarm"):
 
     http_file(
         name = "tini",
+        sha256 = "12d20136605531b09a2c2dac02ccee85e1b874eb322ef6baf7561cd93f93c855",
         urls = ["https://github.com/krallin/tini/releases/download/v0.18.0/tini"],
     )

--- a/images.bzl
+++ b/images.bzl
@@ -28,6 +28,7 @@ def buildfarm_images():
 
     container_pull(
         name = "ubuntu-bionic",
+        digest = "sha256:4bc527c7a288da405f2041928c63d0a6479a120ad63461c2f124c944def54be2",
         registry = "index.docker.io",
         repository = "bazelbuild/buildfarm-worker-base",
         tag = "bionic-java11-gcc",
@@ -38,4 +39,5 @@ def buildfarm_images():
         registry = "index.docker.io",
         repository = "amazoncorretto",
         tag = "19",
+        digest = "sha256:81d0df4412140416b27211c999e1f3c4565ae89a5cd92889475d20af422ba507",
     )


### PR DESCRIPTION
No digests for the containers especially trigger a ping to docker.io which can be slow. Also avoids the debug messages like:
```
  DEBUG: Rule 'amazon_corretto_java_image_base' indicated that a canonical reproducible form can be obtained by modifying arguments digest = "sha256:81d0df4412140416b27211c999e1f3c4565ae89a5cd92889475d20af422ba507"
```

on first run.