### PR TITLE
Consolidate maxEntrySizeBytes config to avoid duplicaton

### DIFF
--- a/_site/docs/configuration.md
+++ b/_site/docs/configuration.md
@@ -29,6 +29,7 @@ worker:
 | digestFunction       | _SHA256_, SHA1                | Digest function for this implementation           |
 | defaultActionTimeout | Integer, _600_                | Default timeout value for an action (seconds)     |
 | maximumActionTimeout | Integer, _3600_               | Maximum allowed action timeout (seconds)          |
+| maxEntrySizeBytes    | Long, _2147483648_            | Maximum size of a single blob accepted (bytes)    |
 | prometheusPort       | Integer, _9090_               | Listening port of the Prometheus metrics endpoint |
 
 Example:
@@ -59,7 +60,6 @@ worker:
 | dispatchedMonitorIntervalSeconds | Integer, _1_                  | Dispatched monitor's lease expiration check interval (seconds)                                                              |
 | runOperationQueuer               | boolean, _true_               | Aquire execute request entries cooperatively from an arrival queue on the backplane                                         |
 | ensureOutputsPresent             | boolean, _false_              | Decide if all outputs are also present in the CAS. If any outputs are missing a cache miss is returned                      |
-| maxEntrySizeBytes                | Long, _2147483648_            | Maximum size of a single blob accepted (bytes)                                                                              |
 | maxCpu                           | Integer, _0_                  | Maximum number of CPU cores that any min/max-cores property may request (0 = unlimited)                                     |
 | maxRequeueAttempts               | Integer, _5_                  | Maximum number of requeue attempts for an operation                                                                         |
 | useDenyList                      | boolean, _true_               | Allow usage of a deny list when looking up actions and invocations (for cache only it is recommended to disable this check) |
@@ -280,7 +280,6 @@ worker:
 | type                         | _FILESYSTEM_, GRPC            | Type of CAS used                                                                                              |
 | path                         | String, _cache_               | Local cache location relative to the 'root', or absolute                                                      |
 | maxSizeBytes                 | Integer, _2147483648_         | Limit for contents of files retained from CAS in the cache                                                    |
-| maxEntrySizeBytes            | Integer, _2147483648_         | Limit on the content size of the files retained in CAS                                                        |
 | fileDirectoriesIndexInMemory | boolean, _false_              | Determines if the file directories bidirectional mapping should be stored in memory or in sqllite             |
 | skipLoad                     | boolean, _false_              | Determines if transient data on the worker should be loaded into CAS on worker startup (affects startup time) |
 | target                       | String, _null_                | For GRPC CAS type, target for external CAS endpoint                                                           |

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -1,6 +1,7 @@
 digestFunction: SHA256
 defaultActionTimeout: 600
 maximumActionTimeout: 3600
+maxEntrySizeBytes: 2147483648 # 2 * 1024 * 1024 * 1024
 prometheusPort: 9090
 server:
   instanceType: SHARD
@@ -17,7 +18,6 @@ server:
   dispatchedMonitorIntervalSeconds: 1
   runOperationQueuer: true
   ensureOutputsPresent: false
-  maxEntrySizeBytes: 2147483648 # 2 * 1024 * 1024 * 1024
   maxCpu: 0
   maxRequeueAttempts: 5
   useDenyList: true
@@ -94,7 +94,6 @@ worker:
     type: FILESYSTEM
     path: "cache"
     maxSizeBytes: 2147483648 # 2 * 1024 * 1024 * 1024
-    maxEntrySizeBytes: 2147483648 # 2 * 1024 * 1024 * 1024
     fileDirectoriesIndexInMemory: false
     skipLoad: false
     target:

--- a/src/main/java/build/buildfarm/cas/ContentAddressableStorages.java
+++ b/src/main/java/build/buildfarm/cas/ContentAddressableStorages.java
@@ -74,7 +74,7 @@ public final class ContentAddressableStorages {
       throw new ConfigurationException("filesystem cas path is empty");
     }
     long maxSizeBytes = configs.getWorker().getCas().getMaxSizeBytes();
-    long maxEntrySizeBytes = configs.getWorker().getCas().getMaxEntrySizeBytes();
+    long maxEntrySizeBytes = configs.getMaxEntrySizeBytes();
     int hexBucketLevels = configs.getWorker().getHexBucketLevels();
     boolean storeFileDirsIndexInMemory =
         configs.getWorker().getCas().isFileDirectoriesIndexInMemory();

--- a/src/main/java/build/buildfarm/common/config/BuildfarmConfigs.java
+++ b/src/main/java/build/buildfarm/common/config/BuildfarmConfigs.java
@@ -26,6 +26,7 @@ public final class BuildfarmConfigs {
   private DigestUtil.HashFunction digestFunction = DigestUtil.HashFunction.SHA256;
   private long defaultActionTimeout = 600;
   private long maximumActionTimeout = 3600;
+  private long maxEntrySizeBytes = 2147483648L; // 2 * 1024 * 1024 * 1024
   private int prometheusPort = 9090;
   private Server server = new Server();
   private Backplane backplane = new Backplane();

--- a/src/main/java/build/buildfarm/common/config/Cas.java
+++ b/src/main/java/build/buildfarm/common/config/Cas.java
@@ -17,7 +17,6 @@ public class Cas {
   private TYPE type = TYPE.FILESYSTEM;
   private String path = "cache";
   private long maxSizeBytes = 2147483648L; // 2 * 1024 * 1024 * 1024
-  private long maxEntrySizeBytes = 2147483648L; // 2 * 1024 * 1024 * 1024
   private boolean fileDirectoriesIndexInMemory = false;
   private boolean skipLoad = false;
   private String target;

--- a/src/main/java/build/buildfarm/common/config/Cas.java
+++ b/src/main/java/build/buildfarm/common/config/Cas.java
@@ -19,7 +19,7 @@ public class Cas {
 
   private TYPE type = TYPE.FILESYSTEM;
   private String path = "cache";
-  private long maxSizeBytes = 2147483648L; // 2 * 1024 * 1024 * 1024
+  private long maxSizeBytes = 0;
   private boolean fileDirectoriesIndexInMemory = false;
   private boolean skipLoad = false;
   private String target;

--- a/src/main/java/build/buildfarm/common/config/Server.java
+++ b/src/main/java/build/buildfarm/common/config/Server.java
@@ -24,7 +24,6 @@ public class Server {
   private int dispatchedMonitorIntervalSeconds = 1;
   private boolean runOperationQueuer = true;
   private boolean ensureOutputsPresent = false;
-  private long maxEntrySizeBytes = 2147483648L; // 2 * 1024 * 1024 * 1024
   private int maxRequeueAttempts = 5;
   private boolean useDenyList = true;
   private long grpcTimeout = 3600;

--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -283,7 +283,7 @@ public class ShardInstance extends AbstractServerInstance {
         configs.getServer().isRunDispatchedMonitor(),
         configs.getServer().getDispatchedMonitorIntervalSeconds(),
         configs.getServer().isRunOperationQueuer(),
-        configs.getServer().getMaxEntrySizeBytes(),
+        configs.getMaxEntrySizeBytes(),
         configs.getServer().getMaxCpu(),
         configs.getServer().getMaxRequeueAttempts(),
         Duration.newBuilder().setSeconds(configs.getMaximumActionTimeout()).build(),

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -319,7 +319,7 @@ public class Worker {
             remoteInputStreamFactory,
             root.resolve(configs.getWorker().getCas().getValidPath(root)),
             configs.getWorker().getCas().getMaxSizeBytes(),
-            configs.getWorker().getCas().getMaxEntrySizeBytes(),
+            configs.getMaxEntrySizeBytes(),
             configs.getWorker().getHexBucketLevels(),
             configs.getWorker().getCas().isFileDirectoriesIndexInMemory(),
             digestUtil,


### PR DESCRIPTION
This change consolidates maxEntrySizeBytes config to a single location.

Previous config:
```
server:
  maxEntrySizeBytes: 2147483648 # 2 * 1024 * 1024 * 1024
worker:
  cas:
    maxEntrySizeBytes: 2147483648 # 2 * 1024 * 1024 * 1024
```

New config:
```
maxEntrySizeBytes: 2147483648 # 2 * 1024 * 1024 * 1024
server:
worker:
```