### PR TITLE
Reduce amount of execution metadata being logged to completed operations only

### DIFF
--- a/_site/docs/configuration.md
+++ b/_site/docs/configuration.md
@@ -116,7 +116,7 @@ server:
 | Configuration       | Accepted and _Default_ Values | Description                                                                               |
 |---------------------|-------------------------------|-------------------------------------------------------------------------------------------|
 | publisher           | String, aws, gcp, _log_       | Specify publisher type for sending metadata                                               |
-| logLevel            | String, INFO, _OFF_           | Specify log level ("log" publisher only, all Java util logging levels are allowed here)   |
+| logLevel            | String, INFO, _FINEST_        | Specify log level ("log" publisher only, all Java util logging levels are allowed here)   |
 | topic               | String, _test_                | Specify SNS topic name for cloud publishing ("aws" publisher only)                        |
 | topicMaxConnections | Integer, 1000                 | Specify maximum number of connections allowed for cloud publishing ("aws" publisher only) |
 | secretName          | String, _test_                | Specify secret name to pull SNS permissions from ("aws" publisher only)                   |

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -32,7 +32,7 @@ server:
     enableGracefulShutdown: false
   metrics:
     publisher: LOG
-    logLevel: OFF
+    logLevel: FINEST
     topic: test
     topicMaxConnections: 1000
     secretName: test

--- a/src/main/java/build/buildfarm/common/config/Metrics.java
+++ b/src/main/java/build/buildfarm/common/config/Metrics.java
@@ -11,18 +11,16 @@ public class Metrics {
   }
 
   public enum LOG_LEVEL {
-    OFF,
     SEVERE,
     WARNING,
     INFO,
     FINE,
     FINER,
     FINEST,
-    ALL
   }
 
   private PUBLISHER publisher = PUBLISHER.LOG;
-  private LOG_LEVEL logLevel = LOG_LEVEL.OFF;
+  private LOG_LEVEL logLevel = LOG_LEVEL.FINEST;
   private String topic;
   private int topicMaxConnections;
   private String secretName;

--- a/src/main/java/build/buildfarm/metrics/log/LogMetricsPublisher.java
+++ b/src/main/java/build/buildfarm/metrics/log/LogMetricsPublisher.java
@@ -14,9 +14,11 @@
 
 package build.buildfarm.metrics.log;
 
+import build.bazel.remote.execution.v2.ExecutionStage;
 import build.bazel.remote.execution.v2.RequestMetadata;
 import build.buildfarm.common.config.BuildfarmConfigs;
 import build.buildfarm.metrics.AbstractMetricsPublisher;
+import build.buildfarm.v1test.OperationRequestMetadata;
 import com.google.longrunning.Operation;
 import java.util.logging.Level;
 import lombok.extern.java.Log;
@@ -40,12 +42,16 @@ public class LogMetricsPublisher extends AbstractMetricsPublisher {
   @Override
   public void publishRequestMetadata(Operation operation, RequestMetadata requestMetadata) {
     try {
-      log.log(
-          logLevel,
-          formatRequestMetadataToJson(populateRequestMetadata(operation, requestMetadata)));
+      OperationRequestMetadata metadata = populateRequestMetadata(operation, requestMetadata);
+      if (metadata
+          .getExecuteOperationMetadata()
+          .getStage()
+          .equals(ExecutionStage.Value.COMPLETED)) {
+        log.log(logLevel, formatRequestMetadataToJson(metadata));
+      }
     } catch (Exception e) {
       log.log(
-          Level.WARNING,
+          Level.FINE,
           String.format("Could not publish request metadata to LOG for %s.", operation.getName()),
           e);
     }


### PR DESCRIPTION
Log operations with a COMPLETED stage only, ignoring other stages to reduce the large amounts of metadata of questionable value and reduce the load on the logging system.