### PR TITLE
Update config_setting visibility.

### DIFF
--- a/config/BUILD
+++ b/config/BUILD
@@ -1,4 +1,5 @@
 config_setting(
     name = "windows",
     constraint_values = ["@platforms//os:windows"],
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Discovered in failing Bazel CI with `--incompatible_config_setting_private_default_visibility` flipped: https://buildkite.com/bazel/bazelisk-plus-incompatible-flags/builds/1320#018435e1-8ae3-4db9-9d7e-beb45ba1a392

For https://github.com/bazelbuild/bazel/issues/12933