### PR TITLE
Add queue_failure metric

### DIFF
--- a/_site/docs/metrics/metrics.md
+++ b/_site/docs/metrics/metrics.md
@@ -36,9 +36,13 @@ Gauge of a number of items in prequeue
 
 Counter for number of CAS misses from worker-worker
 
+**queue_failure**
+
+Counter for number of operations that failed to queue
+
 **requeue_failure**
 
-Counterfor number of operations that failed to requeue
+Counter for number of operations that failed to requeue
 
 **dispatched_operations_size**
 


### PR DESCRIPTION
Add a queue_failure counter metric to add ability to alert when operations fail to queue. This can be a helpful indicator to detect issues with the cluster when schedulers enter a bad state.