### PR TITLE
bump "platforms" to build in M1 machine

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -12,7 +12,7 @@ def archive_dependencies(third_party):
     return [
         {
             "name": "platforms",
-            "urls":[
+            "urls": [
                 "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.6/platforms-0.0.6.tar.gz",
                 "https://github.com/bazelbuild/platforms/releases/download/0.0.6/platforms-0.0.6.tar.gz",
             ],

--- a/deps.bzl
+++ b/deps.bzl
@@ -11,6 +11,14 @@ RULES_JVM_EXTERNAL_SHA = "cd1a77b7b02e8e008439ca76fd34f5b07aecb8c752961f9640dea1
 def archive_dependencies(third_party):
     return [
         {
+            "name": "platforms",
+            "urls":[
+                "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.6/platforms-0.0.6.tar.gz",
+                "https://github.com/bazelbuild/platforms/releases/download/0.0.6/platforms-0.0.6.tar.gz",
+            ],
+            "sha256": "5308fc1d8865406a49427ba24a9ab53087f17f5266a7aabbfc28823f3916e1ca",
+        },
+        {
             "name": "rules_jvm_external",
             "strip_prefix": "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
             "sha256": RULES_JVM_EXTERNAL_SHA,


### PR DESCRIPTION
I am trying to build buildfarm in a M1 macbook, and I have the error
```
ERROR: /Users/tawang/Developer.noindex/external_repos/bazel-buildfarm-fork/src/main/java/build/buildfarm/BUILD:54:12: While resolving toolchains for target //src/main/java/build/buildfarm:buildfarm-shard-worker: No matching toolchains found for types @bazel_tools//tools/cpp:toolchain_type. Maybe --incompatible_use_cc_configure_from_rules_cc has been flipped and there is no default C++ toolchain added in the WORKSPACE file? See https://github.com/bazelbuild/bazel/issues/10134 for details and migration instructions.
```

There is [a similar issue](https://github.com/bazelbuild/bazel/issues/15175) and after I follow the suggestions in this issue I found out that this error is due to the old `platform` dependencies as well, which is pulled transitively from `rules-docker` -> `rules-go`. Here is the output of `bazel query //external:platforms --output=build`:
```
# /Users/tawang/Developer.noindex/external_repos/bazel-buildfarm-fork/WORKSPACE:17:17
http_archive(
  name = "platforms",
  generator_name = "platforms",
  generator_function = "buildfarm_images",
  generator_location = "external_repos/bazel-buildfarm-fork/WORKSPACE:17:17",
  urls = ["https://mirror.bazel.build/github.com/bazelbuild/platforms/archive/681f1ee032566aa2d443cf0335d012925d9c58d4.zip", "https://github.com/bazelbuild/platforms/archive/681f1ee032566aa2d443cf0335d012925d9c58d4.zip"],
  sha256 = "ae95e4bfcd9f66e9dc73a92cee0107fede74163f788e3deefe00f3aaae75c431",
  strip_prefix = "platforms-681f1ee032566aa2d443cf0335d012925d9c58d4",
)
# Rule platforms instantiated at (most recent call last):
#   /Users/tawang/Developer.noindex/external_repos/bazel-buildfarm-fork/WORKSPACE:17:17                                                   in <toplevel>
#   /Users/tawang/Developer.noindex/external_repos/bazel-buildfarm-fork/images.bzl:13:19                                                  in buildfarm_images
#   /private/var/tmp/_bazel_tawang/646b5973c764103a29dce28665524b06/external/io_bazel_rules_docker/repositories/deps.bzl:38:12            in deps
#   /private/var/tmp/_bazel_tawang/646b5973c764103a29dce28665524b06/external/io_bazel_rules_docker/repositories/go_repositories.bzl:39:26 in go_deps
#   /private/var/tmp/_bazel_tawang/646b5973c764103a29dce28665524b06/external/io_bazel_rules_go/go/private/repositories.bzl:44:11          in go_rules_dependencies
#   /private/var/tmp/_bazel_tawang/646b5973c764103a29dce28665524b06/external/io_bazel_rules_go/go/private/repositories.bzl:279:18         in _maybe
# Rule http_archive defined at (most recent call last):
#   /private/var/tmp/_bazel_tawang/646b5973c764103a29dce28665524b06/external/bazel_tools/tools/build_defs/repo/http.bzl:353:31 in <toplevel>
```

If I pin the `platforms` directly in the dependencies then I can build successfully. 

Or we can bump `rules-go` in `rules-docker`, then bump the latest `rules-docker` in buildfarm. In `rules-go` `v0.2.51` they upgraded `platforms` to `0.0.4` which can also work. But when I try the bump using `local_repository`, I see some build errors in buildfarm. I am not familiar with either rule so no sure how trivial it is to use the latest `rules_docker`.
