### PR TITLE
Clean vuln scan for buildfarm-server

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -76,7 +76,8 @@ def buildfarm_init(name = "buildfarm"):
     maven_install(
         artifacts = ["com.amazonaws:aws-java-sdk-%s:1.11.729" % module for module in COM_AWS_MODULES] +
                     [
-                        "com.fasterxml.jackson.core:jackson-databind:2.13.3",
+                        "com.fasterxml.jackson.core:jackson-databind:2.14.1",
+                        "org.yaml:snakeyaml:1.33",
                         "com.github.ben-manes.caffeine:caffeine:2.9.0",
                         "com.github.docker-java:docker-java:3.2.11",
                         "com.github.jnr:jffi:1.2.16",

--- a/defs.bzl
+++ b/defs.bzl
@@ -76,8 +76,7 @@ def buildfarm_init(name = "buildfarm"):
     maven_install(
         artifacts = ["com.amazonaws:aws-java-sdk-%s:1.11.729" % module for module in COM_AWS_MODULES] +
                     [
-                        "com.fasterxml.jackson.core:jackson-databind:2.14.1",
-                        "org.yaml:snakeyaml:1.33",
+                        "com.fasterxml.jackson.core:jackson-databind:2.15.0",
                         "com.github.ben-manes.caffeine:caffeine:2.9.0",
                         "com.github.docker-java:docker-java:3.2.11",
                         "com.github.jnr:jffi:1.2.16",
@@ -134,7 +133,7 @@ def buildfarm_init(name = "buildfarm"):
                         "org.threeten:threetenbp:1.3.3",
                         "org.xerial:sqlite-jdbc:3.34.0",
                         "org.jetbrains:annotations:16.0.2",
-                        "org.yaml:snakeyaml:1.30",
+                        "org.yaml:snakeyaml:2.0",
                         "org.projectlombok:lombok:1.18.24",
                     ],
         generate_compat_repositories = True,

--- a/src/main/java/build/buildfarm/common/config/BuildfarmConfigs.java
+++ b/src/main/java/build/buildfarm/common/config/BuildfarmConfigs.java
@@ -20,6 +20,7 @@ import java.util.List;
 import javax.naming.ConfigurationException;
 import lombok.Data;
 import lombok.extern.java.Log;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
 
@@ -52,7 +53,7 @@ public final class BuildfarmConfigs {
 
   public static BuildfarmConfigs loadConfigs(Path configLocation) throws IOException {
     try (InputStream inputStream = Files.newInputStream(configLocation)) {
-      Yaml yaml = new Yaml(new Constructor(buildfarmConfigs.getClass()));
+      Yaml yaml = new Yaml(new Constructor(buildfarmConfigs.getClass(), new LoaderOptions()));
       buildfarmConfigs = yaml.load(inputStream);
       if (buildfarmConfigs == null) {
         throw new RuntimeException("Could not load configs from path: " + configLocation);


### PR DESCRIPTION
Updates all libraries and deps to fix severe & critical vulnerabilities in buildfarm-server found by AWS scan

1. `com.fasterxml.jackson.core:jackson-databind:2.13.3`
2. `org.yaml:snakeyaml:1.33`

snakeyaml is a transitve dep - of `com.fasterxml.jackson` - but that doesn't seem to be pulled to a clean version automatically so update it here