### PR TITLE
Workaround for test timeout

### DIFF
--- a/src/main/java/build/buildfarm/worker/Executor.java
+++ b/src/main/java/build/buildfarm/worker/Executor.java
@@ -148,7 +148,7 @@ class Executor {
 
     // decide timeout and begin deadline
     Duration timeout = decideTimeout(timeoutSettings, operationContext.action);
-    Deadline pollDeadline = Time.toDeadline(timeout);
+    Deadline pollDeadline = Time.toDeadline(timeout).offset(30, TimeUnit.SECONDS);
 
     workerContext.resumePoller(
         operationContext.poller,


### PR DESCRIPTION
Currently `timeout` and `pollDeadline` points to the same time. Almost always, when the test timeout expires `pollDeadline` triggers before `timeout` and bazel try retry action instead of report test `TIMEOUT` failure.

For issue reproduce I used rule:
```
sh_test(
    name = "timeout_test",
    size = "small",
    timeout = "short",
    srcs = ["test.sh"],
)
```
with `test.sh` script:
```
#!/bin/sh
echo "$(date -Is): BEGIN"
sleep 90
echo "$(date -Is): END"
exit 1 
```