### PR TITLE
Fix slf4j warning by including missing runtime dependency

### DIFF
--- a/src/main/java/build/buildfarm/BUILD
+++ b/src/main/java/build/buildfarm/BUILD
@@ -28,6 +28,7 @@ java_binary(
     visibility = ["//visibility:public"],
     runtime_deps = [
         "//src/main/java/build/buildfarm/server",
+        "@maven//:org_slf4j_slf4j_simple",
     ],
 )
 
@@ -61,6 +62,7 @@ java_binary(
     visibility = ["//visibility:public"],
     runtime_deps = [
         "//src/main/java/build/buildfarm/worker/shard",
+        "@maven//:org_slf4j_slf4j_simple",
     ],
 )
 


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel-buildfarm/issues/1238.