### PR TITLE
[docs] Document bf-run.  Update it to use bazelbuild image.

### DIFF
--- a/_site/docs/quick_start.md
+++ b/_site/docs/quick_start.md
@@ -91,6 +91,20 @@ INFO: 2 processes: 2 remote.
 
 That `2 remote` indicates that your compile and link ran remotely. Congratulations, you just build something through remote execution!
 
+## Container Quick Start
+
+To bring up a minimal buildfarm cluster, you can run:
+```
+./examples/bf-run start
+```
+This will start all of the necessary containers at the latest version.
+Once the containers are up, you can build with `bazel run --remote_executor=grpc://localhost:8980 :main`.
+
+To stop the containers, run:
+```
+./examples/bf-run stop
+```
+
 ## Buildfarm Manager
 
 You can now easily launch a new Buildfarm cluster locally or in AWS using an open sourced <a href="https://github.com/80degreeswest/bfmgr">Buildfarm Manager</a>.

--- a/examples/bf-run
+++ b/examples/bf-run
@@ -2,20 +2,24 @@
 
 set -e
 
+REDIS_IMAGE="buildfarm-redis"
+SERVER_IMAGE="bazelbuild/buildfarm-server:latest"
+WORKER_IMAGE="bazelbuild/buildfarm-server:latest"
+
 # Start Buildfarm Cluster
 start_buildfarm () {
   # Run Redis Container
-  docker run -d --name buildfarm-redis -p 6379:6379 redis:5.0.9
+  docker run -d --name $REDIS_IMAGE -p 6379:6379 redis:5.0.9
 
   # Run Buildfarm Server Container
   docker run -d --name buildfarm-server -v $(pwd)/examples:/var/lib/buildfarm-server -p 8980:8980 --network host \
-  80dw/buildfarm-server:latest /var/lib/buildfarm-server/config.minimal.yml -p 8980
+  $SERVER_IMAGE /var/lib/buildfarm-server/config.minimal.yml -p 8980
 
   # Run Buildfarm Shard Worker Container
   mkdir -p /tmp/worker
   docker run -d --name buildfarm-worker --privileged -v $(pwd)/examples:/var/lib/buildfarm-shard-worker \
   -v /tmp/worker:/tmp/worker -p 8981:8981 --network host \
-  80dw/buildfarm-worker:latest /var/lib/buildfarm-shard-worker/config.minimal.yml --public_name=localhost:8981
+  $WORKER_IMAGE /var/lib/buildfarm-shard-worker/config.minimal.yml --public_name=localhost:8981
 
   echo "Buildfarm cluster started with endpoint: localhost:8980"
 }


### PR DESCRIPTION
`bf-run` works great, but the current images from [80dw](https://hub.docker.com/r/80dw/buildfarm-worker) are too old and will crash on boot.  We can switch to [bazelbuild](https://hub.docker.com/r/bazelbuild/buildfarm-worker) images and document the script.