### PR TITLE
[config] make execution wrappers configurable

### DIFF
--- a/examples/config.yml
+++ b/examples/config.yml
@@ -118,3 +118,12 @@ worker:
       executionWrapper:
         path: "/"
         arguments:
+executionWrappers:
+  cgroups: /usr/bin/cgexec
+  unshare: /usr/bin/unshare
+  linuxSandbox: /app/build_buildfarm/linux-sandbox
+  asNobody: /app/build_buildfarm/as-nobody
+  processWrapper: /app/build_buildfarm/process-wrapper
+  skipSleep: /app/build_buildfarm/skip_sleep
+  skipSleepPreload: /app/build_buildfarm/skip_sleep_preload.so
+  delay: /app/build_buildfarm/delay.sh

--- a/src/main/java/build/buildfarm/common/config/BuildfarmConfigs.java
+++ b/src/main/java/build/buildfarm/common/config/BuildfarmConfigs.java
@@ -31,6 +31,7 @@ public final class BuildfarmConfigs {
   private Server server = new Server();
   private Backplane backplane = new Backplane();
   private Worker worker = new Worker();
+  private ExecutionWrappers executionWrappers = new ExecutionWrappers();
 
   private BuildfarmConfigs() {}
 

--- a/src/main/java/build/buildfarm/common/config/ExecutionWrappers.java
+++ b/src/main/java/build/buildfarm/common/config/ExecutionWrappers.java
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package build.buildfarm.common;
+package build.buildfarm.common.config;
+
+import lombok.Data;
 
 /**
  * @class Execution Wrappers
@@ -21,62 +23,63 @@ package build.buildfarm.common;
  *     wrappers to use. Users can still configure their own unique execution wrappers as execution
  *     policies in the worker configuration file.
  */
+@Data
 public class ExecutionWrappers {
   /**
-   * @field CGROUPS
+   * @field cgroups
    * @brief The program to use when running actions under cgroups.
    * @details This program is expected to be packaged with the worker image.
    */
-  public static final String CGROUPS = "/usr/bin/cgexec";
+  public String cgroups = "/usr/bin/cgexec";
 
   /**
-   * @field UNSHARE
+   * @field unshare
    * @brief The program to use when desiring to unshare namespaces from the action.
    * @details This program is expected to be packaged with the worker image.
    */
-  public static final String UNSHARE = "/usr/bin/unshare";
+  public String unshare = "/usr/bin/unshare";
 
   /**
-   * @field LINUX_SANDBOX
+   * @field linuxSandbox
    * @brief The program to use when running actions under bazel's sandbox.
    * @details This program is expected to be packaged with the worker image.
    */
-  public static final String LINUX_SANDBOX = "/app/build_buildfarm/linux-sandbox";
+  public String linuxSandbox = "/app/build_buildfarm/linux-sandbox";
 
   /**
-   * @field AS_NOBODY
+   * @field asNobody
    * @brief The program to use when running actions as "as-nobody".
    * @details This program is expected to be packaged with the worker image. The linux-sandbox is
    *     also capable of doing what this standalone programs does and may be chosen instead.
    */
-  public static final String AS_NOBODY = "/app/build_buildfarm/as-nobody";
+  public String asNobody = "/app/build_buildfarm/as-nobody";
 
   /**
-   * @field PROCESS_WRAPPER
+   * @field processWrapper
    * @brief The program to use when running actions under bazel's process-wrapper
    * @details This program is expected to be packaged with the worker image.
    */
-  public static final String PROCESS_WRAPPER = "/app/build_buildfarm/process-wrapper";
+  public String processWrapper = "/app/build_buildfarm/process-wrapper";
 
   /**
-   * @field SKIP_SLEEP
+   * @field skipSleep
    * @brief The program to use when running actions under bazel's skip sleep wrapper.
    * @details This program is expected to be packaged with the worker image.
    */
-  public static final String SKIP_SLEEP = "/app/build_buildfarm/skip_sleep";
+  public String skipSleep = "/app/build_buildfarm/skip_sleep";
 
   /**
-   * @field SKIP_SLEEP_PRELOAD
+   * @field skipSleepPreload
    * @brief The shared object that the skip sleep wrapper uses to spoof syscalls.
    * @details The shared object needs passed to the program which will LD_PRELOAD it.
    */
-  public static final String SKIP_SLEEP_PRELOAD = "/app/build_buildfarm/skip_sleep_preload.so";
+  public String skipSleepPreload = "/app/build_buildfarm/skip_sleep_preload.so";
 
   /**
-   * @field DELAY
+   * @field delay
    * @brief The program to used to timeshift actions when running under skip_sleep.
    * @details This program is expected to be packaged with the worker image. Warning: This wrapper
    *     is only intended to be used with skip_sleep.
    */
-  public static final String DELAY = "/app/build_buildfarm/delay.sh";
+  public String delay = "/app/build_buildfarm/delay.sh";
 }

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -37,7 +37,6 @@ import build.buildfarm.common.CommandUtils;
 import build.buildfarm.common.DigestUtil;
 import build.buildfarm.common.DigestUtil.ActionKey;
 import build.buildfarm.common.EntryLimitException;
-import build.buildfarm.common.ExecutionWrappers;
 import build.buildfarm.common.InputStreamFactory;
 import build.buildfarm.common.LinuxSandboxOptions;
 import build.buildfarm.common.Poller;
@@ -869,7 +868,7 @@ class ShardWorkerContext implements WorkerContext {
     // Decide the CLI for running under cgroups
     if (!usedGroups.isEmpty()) {
       arguments.add(
-          ExecutionWrappers.CGROUPS,
+          configs.getExecutionWrappers().getCgroups(),
           "-g",
           String.join(",", usedGroups) + ":" + group.getHierarchy());
     }
@@ -878,7 +877,7 @@ class ShardWorkerContext implements WorkerContext {
     // This is not the ideal implementation of block-network.
     // For now, without the linux-sandbox, we will unshare the network namespace.
     if (limits.network.blockNetwork && !limits.useLinuxSandbox) {
-      arguments.add(ExecutionWrappers.UNSHARE, "-n", "-r");
+      arguments.add(configs.getExecutionWrappers().getUnshare(), "-n", "-r");
     }
 
     // Decide the CLI for running the sandbox
@@ -890,15 +889,15 @@ class ShardWorkerContext implements WorkerContext {
     }
 
     if (limits.time.skipSleep) {
-      arguments.add(ExecutionWrappers.SKIP_SLEEP);
+      arguments.add(configs.getExecutionWrappers().getSkipSleep());
 
       // we set these values very high because we want sleep calls to return immediately.
       arguments.add("90000000"); // delay factor
       arguments.add("90000000"); // time factor
-      arguments.add(ExecutionWrappers.SKIP_SLEEP_PRELOAD);
+      arguments.add(configs.getExecutionWrappers().getSkipSleepPreload());
 
       if (limits.time.timeShift != 0) {
-        arguments.add(ExecutionWrappers.DELAY);
+        arguments.add(configs.getExecutionWrappers().getDelay());
         arguments.add(String.valueOf(limits.time.timeShift));
       }
     }
@@ -953,10 +952,10 @@ class ShardWorkerContext implements WorkerContext {
 
   private void addLinuxSandboxCli(
       ImmutableList.Builder<String> arguments, LinuxSandboxOptions options) {
-    arguments.add(ExecutionWrappers.AS_NOBODY);
+    arguments.add(configs.getExecutionWrappers().getAsNobody());
 
     // Choose the sandbox which is built and deployed with the worker image.
-    arguments.add(ExecutionWrappers.LINUX_SANDBOX);
+    arguments.add(configs.getExecutionWrappers().getLinuxSandbox());
 
     // Pass flags based on the sandbox CLI options.
     if (options.createNetns) {


### PR DESCRIPTION
### Context
Buildfarm supports different kinds of execution wrappers based on `exec_properties` and global configuration.  It's always been an optional dependency not fully baked into the images we deploy.  Nonetheless, some of them are very important, like the `linux-sandbox`, which is now my preference for supporting additional behavior.  

In order to make this more accessible to more deployments, let's allow the customization of these paths. 

 ### Compatibility 
Defaults are the same.  Configs are forwards compatible.