### PR TITLE
[cleanup] remove unused field comment

### DIFF
--- a/src/main/java/build/buildfarm/common/s3/S3Bucket.java
+++ b/src/main/java/build/buildfarm/common/s3/S3Bucket.java
@@ -48,10 +48,6 @@ import lombok.extern.java.Log;
  */
 @Log
 public class S3Bucket {
-  /**
-   * @field logger
-   * @brief Used for printing error information.
-   */
 
   /**
    * @field s3


### PR DESCRIPTION
This logger was removed in place of a derived logger via `@Log`