### PR TITLE
Update grpc-java dependency

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -50,9 +50,9 @@ def archive_dependencies(third_party):
         # Needed for @grpc_java//compiler:grpc_java_plugin.
         {
             "name": "io_grpc_grpc_java",
-            "sha256": "101b21af120901e9bf342384988f57af3332b59d997f64d5f41a1e24ffb96f19",
-            "strip_prefix": "grpc-java-1.42.0",
-            "urls": ["https://github.com/grpc/grpc-java/archive/v1.42.0.zip"],
+            "sha256": "2484054e9ac47d3b4d4a797b9a0caaf4f50f23e13efb5b23ce3703b363f13023",
+            "strip_prefix": "grpc-java-1.52.1",
+            "urls": ["https://github.com/grpc/grpc-java/archive/v1.52.1.zip"],
         },
 
         # The APIs that we implement.


### PR DESCRIPTION
Use grpc-java version 1.52.1 which contains https://github.com/grpc/grpc-java/commit/e325dc9112079ecd64e3099093ff0615e7e72de5 to fix [the CI failure with Bazel@Head](https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/2842#0186059b-e6fa-4cdb-b3b4-b163078fb55d):

```
File "/var/lib/buildkite-agent/.cache/bazel/_bazel_buildkite-agent/e20cba2f6cb8b170347b0ae07ec5eef3/external/io_grpc_grpc_java/java_grpc_library.bzl", line 88, column 78, in _java_rpc_library_impl
--
  | args.add_joined("--descriptor_set_in", descriptor_set_in, join_with = ctx.host_configuration.host_path_separator)
  | Error: 'ctx' value has no field or method 'host_configuration'
  | (02:21:56) ERROR: /var/lib/buildkite-agent/builds/bk-docker-kczd/bazel-downstream-projects/bazel-buildfarm/src/main/protobuf/BUILD.bazel:30:18: Analysis of target '//src/main/protobuf:build_buildfarm_v1test_buildfarm_java_grpc' failed
```