### PR TITLE
[config] derive public name in config files

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -1,9 +1,9 @@
 # -*- mode: Python -*-
 
 # This Tiltfile defines a complete dev environment for buildfarm.
-# It automates all the steps from a code change to a new process:
-# watching files, building container images, and bringing your environment up-to-date.
-# Think docker build && kubectl apply or docker-compose up.
+# It automates all the steps from a code change to a new cluster:
+# watching files, building container images, and redeploying parts of the cluster.
+# Think bazel-watcher + docker build + kubectl apply or docker-compose up.
 
 # Install: https://docs.tilt.dev/
 # Run `tilt up`.
@@ -18,6 +18,19 @@ load('./bazel.Tiltfile', 'bazel_sourcefile_deps')
 # This avoids that from happening.
 analytics_settings(False)
 
+# This is provided as an option because it is often slow to compute file changes this way.
+USE_BAZEL_QUERY_TO_REBUILD=False
+
+def worker_deps():
+  if USE_BAZEL_QUERY_TO_REBUILD:
+    return bazel_sourcefile_deps('//:buildfarm-shard-worker.tar')
+  return ()
+  
+def server_deps():
+  if USE_BAZEL_QUERY_TO_REBUILD:
+    return bazel_sourcefile_deps('//:buildfarm-shard-worker.tar')
+  return ()
+
 # Inform tilt about the custom images built within the repository.
 # When you change code, these images will be re-built and re-deployed.
 custom_build(
@@ -28,7 +41,7 @@ custom_build(
     'docker tag bazel:buildfarm-shard-worker $EXPECTED_REF'
 
     ),
-  deps=bazel_sourcefile_deps('//:buildfarm-shard-worker.tar')
+    deps = worker_deps()
 )
 custom_build(
   ref='buildfarm-server-image',
@@ -38,7 +51,7 @@ custom_build(
     'docker tag bazel:buildfarm-server $EXPECTED_REF'
 
     ),
-  deps=bazel_sourcefile_deps('//:buildfarm-server.tar')
+    deps = server_deps()
 )
 
 local_resource("unit tests",'bazelisk test --javabase=@bazel_tools//tools/jdk:remote_jdk11 //src/test/java/...')

--- a/config/BUILD
+++ b/config/BUILD
@@ -3,3 +3,8 @@ config_setting(
     constraint_values = ["@platforms//os:windows"],
     visibility = ["//visibility:public"],
 )
+
+config_setting(
+    name = "open_telemetry",
+    values = {"define": "open_telemetry=true"},
+)

--- a/kubernetes/deployments/shard-worker.yaml
+++ b/kubernetes/deployments/shard-worker.yaml
@@ -30,5 +30,3 @@ spec:
         env:
         - name: REDIS_URI
           value: "redis://redis-cluster-service:6379"
-        - name: INSTANCE_NAME
-          value: "shard-worker-service:8981"

--- a/src/main/java/build/buildfarm/common/config/Backplane.java
+++ b/src/main/java/build/buildfarm/common/config/Backplane.java
@@ -45,10 +45,13 @@ public class Backplane {
   private boolean cacheCas = false;
 
   public String getRedisUri() {
-    if (!Strings.isNullOrEmpty(redisUri)) {
-      return redisUri;
-    } else {
+
+    // use environment override (useful for containerized deployment)
+    if (!Strings.isNullOrEmpty(System.getenv("REDIS_URI"))) {
       return System.getenv("REDIS_URI");
     }
+
+    // use configured value
+    return redisUri;
   }
 }

--- a/src/main/java/build/buildfarm/common/config/Server.java
+++ b/src/main/java/build/buildfarm/common/config/Server.java
@@ -53,7 +53,7 @@ public class Server {
 
     // derive a value
     try {
-      return InetAddress.getLocalHost().getHostAddress();
+      return InetAddress.getLocalHost().getHostAddress() + ":" + port;
     } catch (Exception e) {
       log.severe("publicName could not be derived:" + e);
       return publicName;

--- a/src/main/java/build/buildfarm/common/config/Server.java
+++ b/src/main/java/build/buildfarm/common/config/Server.java
@@ -1,10 +1,13 @@
 package build.buildfarm.common.config;
 
 import com.google.common.base.Strings;
+import java.net.InetAddress;
 import java.util.UUID;
 import lombok.Data;
+import lombok.extern.java.Log;
 
 @Data
+@Log
 public class Server {
   public enum INSTANCE_TYPE {
     SHARD
@@ -38,10 +41,22 @@ public class Server {
   private String publicName;
 
   public String getPublicName() {
+    // use environment override (useful for containerized deployment)
+    if (!Strings.isNullOrEmpty(System.getenv("INSTANCE_NAME"))) {
+      return System.getenv("INSTANCE_NAME");
+    }
+
+    // use configured value
     if (!Strings.isNullOrEmpty(publicName)) {
       return publicName;
-    } else {
-      return System.getenv("INSTANCE_NAME");
+    }
+
+    // derive a value
+    try {
+      return InetAddress.getLocalHost().getHostAddress();
+    } catch (Exception e) {
+      log.severe("publicName could not be derived:" + e);
+      return publicName;
     }
   }
 

--- a/src/main/java/build/buildfarm/common/config/Worker.java
+++ b/src/main/java/build/buildfarm/common/config/Worker.java
@@ -51,7 +51,7 @@ public class Worker {
 
     // derive a value
     try {
-      return InetAddress.getLocalHost().getHostAddress();
+      return InetAddress.getLocalHost().getHostAddress() + ":" + port;
     } catch (Exception e) {
       log.severe("publicName could not be derived:" + e);
       return publicName;

--- a/src/main/java/build/buildfarm/common/config/Worker.java
+++ b/src/main/java/build/buildfarm/common/config/Worker.java
@@ -59,13 +59,18 @@ public class Worker {
   }
 
   public int getExecuteStageWidth() {
+    // use environment override (useful for containerized deployment)
+    if (!Strings.isNullOrEmpty(System.getenv("EXECUTION_STAGE_WIDTH"))) {
+      return Integer.parseInt(System.getenv("EXECUTION_STAGE_WIDTH"));
+    }
+
+    // use configured value
     if (executeStageWidth > 0) {
       return executeStageWidth;
-    } else if (!Strings.isNullOrEmpty(System.getenv("EXECUTION_STAGE_WIDTH"))) {
-      return Integer.parseInt(System.getenv("EXECUTION_STAGE_WIDTH"));
-    } else {
-      return Math.max(1, Runtime.getRuntime().availableProcessors() - executeStageWidthOffset);
     }
+
+    // derive a value
+    return Math.max(1, Runtime.getRuntime().availableProcessors() - executeStageWidthOffset);
   }
 
   public int getInputFetchStageWidth() {

--- a/src/main/java/build/buildfarm/common/s3/S3Bucket.java
+++ b/src/main/java/build/buildfarm/common/s3/S3Bucket.java
@@ -48,7 +48,6 @@ import lombok.extern.java.Log;
  */
 @Log
 public class S3Bucket {
-
   /**
    * @field s3
    * @brief The S3 client used for interacting with S3 buckets


### PR DESCRIPTION
### Context
Buildfarm configs require that a `publicName` be given to the server and worker.  These names are used as a URI for the nodes to communicate. Since buildfarm is often deployed as many servers and workers, there is a complexity to providing these URIs at the configuration level.  We'd like to provide a derivation in the event that the configuration value is not given.

### Changes

   #### Config value selection
   - allow `pubicName` for server/worker to derive as hostname
   - fixed order of other env variables (`REDIS_URI` and `EXECUTION_SLOT_WIDTH`)

   #### Fix Tilt deployment (For k8s testing)
   - separated out open telemetry jvm flags
   - made open telemetry optional for default containers (spews some errors to logs when enabled)
   - made Tilt refresh optional based on bazel query optional (too slow)
   
   ### Testing
   Tested this with repo k8s files, and was able to perform remote builds.
   
   ### Speculation on k8s compatibility:
   
When looking at the pod I see:
```
kubectl get pods -o wide | grep worker | tr -s " "
shard-worker-56b6cd6d6d-2g96n 1/1 Running 0 73m 10.1.110.85 desktop <none> <none>
```
Which is indeed a different IP than what I see for the service:
```
kubectl get service --all-namespaces | grep worker | tr -s " "
default shard-worker-service ClusterIP 10.152.183.219 <none> 8981/TCP,9091/TCP 74m
```
However, when looking at the endpoint, I see the same pod IP:
```
kubectl get endpoints | grep worker | tr -s " "
shard-worker-service 10.1.110.85:8981,10.1.110.85:9091 74m
```

All this is to say, leaving out publicName resulted in 10.1.110.85:8981 being derived which did work in my local k8s deployment and allow me to perform remote bazel builds. I don't know enough about k8s to claim that this will work for all other deployments (such as yours). I'll have more experience on that when I do a production level k8s deployment and try to leverage this.

I can imagine a future adjustment where we detect that were inside a k8s pod, and query for the correct publicly visible endpoint or something. For now, getLocalHost() seems fairly robust.