### PR TITLE
Fix use of wrong image in example

### DIFF
--- a/examples/bf-run
+++ b/examples/bf-run
@@ -9,7 +9,7 @@ SERVER_NAME="buildfarm-server"
 SERVER_IMAGE="bazelbuild/buildfarm-server:latest"
 
 WORKER_NAME="buildfarm-worker"
-WORKER_IMAGE="bazelbuild/buildfarm-server:latest"
+WORKER_IMAGE="bazelbuild/buildfarm-worker:latest"
 
 CONFIG="config.minimal.yml"
 


### PR DESCRIPTION
It seems a copy/paste error has been made when the official bazelbuild images were introduced (in https://github.com/bazelbuild/bazel-buildfarm/pull/1246).