### PR TITLE
[refactor] isolate action fetching during operation queue to a separate function

### DIFF
--- a/src/main/java/build/buildfarm/common/config/Backplane.java
+++ b/src/main/java/build/buildfarm/common/config/Backplane.java
@@ -45,7 +45,6 @@ public class Backplane {
   private boolean cacheCas = false;
 
   public String getRedisUri() {
-
     // use environment override (useful for containerized deployment)
     if (!Strings.isNullOrEmpty(System.getenv("REDIS_URI"))) {
       return System.getenv("REDIS_URI");

--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -2115,7 +2115,6 @@ public class ShardInstance extends AbstractServerInstance {
             "ShardInstance(%s): queue(%s): fetching action %s",
             getName(), operation.getName(), actionDigest.getHash()));
 
-    // Fetch an action from the CAS and invalidate it from the AC if requested.
     return FluentFuture.from(expectAction(actionDigest, requestMetadata))
         .transformAsync(
             action -> transformActionViaActionCache(action, metadata, operation),
@@ -2174,6 +2173,7 @@ public class ShardInstance extends AbstractServerInstance {
     Digest actionDigest = metadata.getActionDigest();
     RequestMetadata requestMetadata = executeEntry.getRequestMetadata();
 
+    // Fetch an action from the CAS and invalidate it from the AC if requested.
     ListenableFuture<Action> actionFuture = fetchAction(requestMetadata, metadata, operation);
 
     QueuedOperation.Builder queuedOperationBuilder = QueuedOperation.newBuilder();

--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -2116,18 +2116,14 @@ public class ShardInstance extends AbstractServerInstance {
             getName(), operation.getName(), actionDigest.getHash()));
 
     // Fetch an action from the CAS and invalidate it from the AC if requested.
-    ListenableFuture<Action> actionFuture =
-        FluentFuture.from(expectAction(actionDigest, requestMetadata))
-            .transformAsync(
-                action ->
-                    transformActionViaActionCache(action, requestMetadata, metadata, operation),
-                operationTransformService)
-            .catchingAsync(
-                StatusException.class,
-                e -> describeFailedActionFetch(e, actionDigest),
-                operationTransformService);
-
-    return actionFuture;
+    return FluentFuture.from(expectAction(actionDigest, requestMetadata))
+        .transformAsync(
+            action -> transformActionViaActionCache(action, requestMetadata, metadata, operation),
+            operationTransformService)
+        .catchingAsync(
+            StatusException.class,
+            e -> describeFailedActionFetch(e, actionDigest),
+            operationTransformService);
   }
 
   private ListenableFuture<Action> transformActionViaActionCache(

--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -2118,7 +2118,7 @@ public class ShardInstance extends AbstractServerInstance {
     // Fetch an action from the CAS and invalidate it from the AC if requested.
     return FluentFuture.from(expectAction(actionDigest, requestMetadata))
         .transformAsync(
-            action -> transformActionViaActionCache(action, requestMetadata, metadata, operation),
+            action -> transformActionViaActionCache(action, metadata, operation),
             operationTransformService)
         .catchingAsync(
             StatusException.class,
@@ -2127,10 +2127,7 @@ public class ShardInstance extends AbstractServerInstance {
   }
 
   private ListenableFuture<Action> transformActionViaActionCache(
-      Action action,
-      RequestMetadata requestMetadata,
-      ExecuteOperationMetadata metadata,
-      Operation operation)
+      Action action, ExecuteOperationMetadata metadata, Operation operation)
       throws IOException, StatusException {
     if (action == null) {
       throw Status.NOT_FOUND.asException();


### PR DESCRIPTION
 - Isolate action fetching during operation queue to a separate function
 - Use `FluentFuture`
 
 Behavior should be the same.