### PR TITLE
Show client error context when failing to establish exec root.

### DIFF
--- a/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
+++ b/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
@@ -2042,6 +2042,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
           log.log(Level.FINE, format("directory %s has been unlocked", path.getFileName()));
         },
         service);
+
     return putFuture;
   }
 
@@ -2089,7 +2090,8 @@ public abstract class CASFileCache implements ContentAddressableStorage {
     private final List<Throwable> exceptions;
 
     PutDirectoryException(Path path, Digest digest, List<Throwable> exceptions) {
-      super(String.format("%s: %d exceptions", path, exceptions.size()));
+      // When printing the exception, show the captured sub-exceptions.
+      super(String.format("%s: %d exceptions: %s", path, exceptions.size(), exceptions));
       this.path = path;
       this.digest = digest;
       this.exceptions = exceptions;

--- a/src/main/java/build/buildfarm/common/FailedOperationGetter.java
+++ b/src/main/java/build/buildfarm/common/FailedOperationGetter.java
@@ -1,0 +1,79 @@
+// Copyright 2023 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.common;
+
+import static build.buildfarm.common.Errors.VIOLATION_TYPE_MISSING;
+
+import build.bazel.remote.execution.v2.ExecuteOperationMetadata;
+import build.bazel.remote.execution.v2.ExecuteResponse;
+import build.bazel.remote.execution.v2.ExecutionStage;
+import build.buildfarm.v1test.ExecuteEntry;
+import com.google.longrunning.Operation;
+import com.google.protobuf.Any;
+import com.google.rpc.PreconditionFailure;
+import io.grpc.Status.Code;
+
+/**
+ * @class FailedOperationGetter
+ * @brief Converts any operation into a failed operation.
+ * @details Sets properties on the existing operation so that the new operation is considered
+ *     finished and failed.
+ */
+public class FailedOperationGetter {
+  public static Operation get(
+      Operation operation,
+      ExecuteEntry executeEntry,
+      String failureMessage,
+      String failureDetails) {
+    return operation
+        .toBuilder()
+        .setName(executeEntry.getOperationName())
+        .setDone(true)
+        .setMetadata(
+            Any.pack(executeOperationMetadata(executeEntry, ExecutionStage.Value.COMPLETED)))
+        .setResponse(Any.pack(failResponse(executeEntry, failureMessage, failureDetails)))
+        .build();
+  }
+
+  private static ExecuteOperationMetadata executeOperationMetadata(
+      ExecuteEntry executeEntry, ExecutionStage.Value stage) {
+    return ExecuteOperationMetadata.newBuilder()
+        .setActionDigest(executeEntry.getActionDigest())
+        .setStdoutStreamName(executeEntry.getStdoutStreamName())
+        .setStderrStreamName(executeEntry.getStderrStreamName())
+        .setStage(stage)
+        .build();
+  }
+
+  private static ExecuteResponse failResponse(
+      ExecuteEntry executeEntry, String failureMessage, String failureDetails) {
+    PreconditionFailure.Builder preconditionFailureBuilder = PreconditionFailure.newBuilder();
+    preconditionFailureBuilder
+        .addViolationsBuilder()
+        .setType(VIOLATION_TYPE_MISSING)
+        .setSubject("blobs/" + DigestUtil.toString(executeEntry.getActionDigest()))
+        .setDescription(failureDetails);
+    PreconditionFailure preconditionFailure = preconditionFailureBuilder.build();
+
+    return ExecuteResponse.newBuilder()
+        .setStatus(
+            com.google.rpc.Status.newBuilder()
+                .setCode(Code.FAILED_PRECONDITION.value())
+                .setMessage(failureMessage)
+                .addDetails(Any.pack(preconditionFailure))
+                .build())
+        .build();
+  }
+}

--- a/src/main/java/build/buildfarm/worker/shard/CFCExecFileSystem.java
+++ b/src/main/java/build/buildfarm/worker/shard/CFCExecFileSystem.java
@@ -295,7 +295,8 @@ class CFCExecFileSystem implements ExecFileSystem {
     private final List<Throwable> exceptions;
 
     ExecDirException(Path path, List<Throwable> exceptions) {
-      super(String.format("%s: %d exceptions", path, exceptions.size()));
+      // When printing the exception, show the captured sub-exceptions.
+      super(String.format("%s: %d exceptions: %s", path, exceptions.size(), exceptions));
       this.path = path;
       this.exceptions = exceptions;
       for (Throwable exception : exceptions) {


### PR DESCRIPTION
### Context:
Buildfarm's CAS implementation relies heavily on being able to hardlink files.  There is a known limitation for particular filesystems like ext4 in which the hardlinking limit of any individual file can not exceed 65k.  Here is how you can reproduce that limitation by creating multiple targets that reference the same file in their input root:
```
# duplicate.bzl
def sh_test_duplicate(name,srcs,amount):
    for index in range(amount):
        native.sh_test(
            name = name + str(index),
            srcs = srcs,
        )

# BUILD
sh_test_duplicate(
    name = "main",
    srcs = ["main.sh"],
    amount = 65537, # Expose the ext4 hardlinking limit: (2^16)+1
)

# client
bazelisk test --remote_executor=grpc://localhost:8980 //code/programs/example_tests/hardlinking/...
```

### Problem:
When this limitation is reached, the client does not get an appropriate failure message.  The `InputFetchStage` will immediately expire the operation causing the `DispatchMonitor` to requeue it. Eventually the client gets a requeue fail message that looks like this:
