### PR TITLE
Restore containsBlob functionality for shard

### DIFF
--- a/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
+++ b/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
@@ -448,9 +448,13 @@ public abstract class CASFileCache implements ContentAddressableStorage {
   public Iterable<Digest> findMissingBlobs(Iterable<Digest> digests) throws InterruptedException {
     ImmutableList.Builder<Digest> builder = ImmutableList.builder();
     ImmutableList.Builder<String> found = ImmutableList.builder();
+    Digest.Builder result = Digest.newBuilder();
     for (Digest digest : digests) {
-      if (digest.getSizeBytes() != 0 && !containsLocal(digest, null, found::add)) {
+      if (digest.getSizeBytes() != 0 && !containsLocal(digest, result, found::add)) {
         builder.add(digest);
+      } else if (digest.getSizeBytes() == -1) {
+        // may misbehave with delegate
+        builder.add(result.build());
       }
     }
     List<String> foundDigests = found.build();

--- a/src/main/java/build/buildfarm/common/services/ByteStreamService.java
+++ b/src/main/java/build/buildfarm/common/services/ByteStreamService.java
@@ -387,8 +387,12 @@ public class ByteStreamService extends ByteStreamImplBase {
 
       @Override
       public boolean isComplete() {
-        return instance.containsBlob(
-            digest, Digest.newBuilder(), TracingMetadataUtils.fromCurrentContext());
+        try {
+          return instance.containsBlob(
+              digest, Digest.newBuilder(), TracingMetadataUtils.fromCurrentContext());
+        } catch (InterruptedException e) {
+          throw new RuntimeException("interrupted checking for completion", e);
+        }
       }
 
       @Override

--- a/src/main/java/build/buildfarm/instance/Instance.java
+++ b/src/main/java/build/buildfarm/instance/Instance.java
@@ -68,7 +68,8 @@ public interface Instance {
   ListenableFuture<Iterable<Digest>> findMissingBlobs(
       Iterable<Digest> digests, RequestMetadata requestMetadata);
 
-  boolean containsBlob(Digest digest, Digest.Builder result, RequestMetadata requestMetadata);
+  boolean containsBlob(Digest digest, Digest.Builder result, RequestMetadata requestMetadata)
+      throws InterruptedException;
 
   String readResourceName(Compressor.Value compressor, Digest blobDigest);
 

--- a/src/main/java/build/buildfarm/instance/server/AbstractServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/server/AbstractServerInstance.java
@@ -521,8 +521,8 @@ public abstract class AbstractServerInstance implements Instance {
   }
 
   @Override
-  public boolean containsBlob(
-      Digest digest, Digest.Builder result, RequestMetadata requestMetadata) {
+  public boolean containsBlob(Digest digest, Digest.Builder result, RequestMetadata requestMetadata)
+      throws InterruptedException {
     return contentAddressableStorage.contains(digest, result);
   }
 

--- a/src/main/java/build/buildfarm/server/services/FetchService.java
+++ b/src/main/java/build/buildfarm/server/services/FetchService.java
@@ -33,13 +33,18 @@ public class FetchService extends FetchImplBase {
   @Override
   public void fetchBlob(
       FetchBlobRequest request, StreamObserver<FetchBlobResponse> responseObserver) {
-    fetchBlob(instance, request, responseObserver);
+    try {
+      fetchBlob(instance, request, responseObserver);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
   }
 
   private void fetchBlob(
       Instance instance,
       FetchBlobRequest request,
-      StreamObserver<FetchBlobResponse> responseObserver) {
+      StreamObserver<FetchBlobResponse> responseObserver)
+      throws InterruptedException {
     Digest expectedDigest = null;
     RequestMetadata requestMetadata = TracingMetadataUtils.fromCurrentContext();
     if (request.getQualifiersCount() == 0) {

--- a/src/test/java/build/buildfarm/instance/shard/ShardInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/shard/ShardInstanceTest.java
@@ -23,6 +23,7 @@ import static build.buildfarm.common.Errors.VIOLATION_TYPE_MISSING;
 import static build.buildfarm.instance.server.AbstractServerInstance.INVALID_PLATFORM;
 import static build.buildfarm.instance.server.AbstractServerInstance.MISSING_ACTION;
 import static build.buildfarm.instance.server.AbstractServerInstance.MISSING_COMMAND;
+import static com.google.common.base.Predicates.notNull;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static com.google.common.util.concurrent.MoreExecutors.listeningDecorator;
@@ -76,7 +77,7 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Sets;
+import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.longrunning.Operation;
 import com.google.protobuf.Any;
@@ -93,7 +94,7 @@ import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
 import java.io.IOException;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -121,7 +122,7 @@ public class ShardInstanceTest {
       Command.newBuilder().addAllArguments(ImmutableList.of("true")).build();
 
   private ShardInstance instance;
-  private Set<Digest> blobDigests;
+  private Map<String, Long> blobDigests;
 
   @Mock private Backplane mockBackplane;
 
@@ -134,7 +135,7 @@ public class ShardInstanceTest {
   @Before
   public void setUp() throws InterruptedException {
     MockitoAnnotations.initMocks(this);
-    blobDigests = Sets.newHashSet();
+    blobDigests = Maps.newHashMap();
     ActionCache actionCache = new ShardActionCache(10, mockBackplane, newDirectExecutorService());
     instance =
         new ShardInstance(
@@ -207,7 +208,7 @@ public class ShardInstanceTest {
                   Iterable<Digest> digests = (Iterable<Digest>) invocation.getArguments()[0];
                   return immediateFuture(
                       StreamSupport.stream(digests.spliterator(), false)
-                          .filter((digest) -> !blobDigests.contains(digest))
+                          .filter((digest) -> !blobDigests.containsKey(digest.getHash()))
                           .collect(Collectors.toList()));
                 })
         .when(mockWorkerInstance)
@@ -765,7 +766,7 @@ public class ShardInstanceTest {
 
   @SuppressWarnings("unchecked")
   private void provideBlob(Digest digest, ByteString content) {
-    blobDigests.add(digest);
+    blobDigests.put(digest.getHash(), digest.getSizeBytes());
     // FIXME use better answer definitions, without indexes
     doAnswer(
             (Answer<Void>)
@@ -977,5 +978,68 @@ public class ShardInstanceTest {
     // check that result is null (i.e. no exceptions thrown)
     CompletableFuture<String> result = cache.get("missing", getCallback);
     assertThat(result.get()).isNull();
+  }
+
+  private static Digest findMissingWithUnknown(Digest digest, Map<String, Long> digests) {
+    Long size = digests.get(digest.getHash());
+    if (digest.getSizeBytes() != -1) {
+      if (size != null && size.equals(digest.getSizeBytes())) {
+        return null;
+      }
+    } else if (size != null) {
+      return Digest.newBuilder().setHash(digest.getHash()).setSizeBytes(size).build();
+    }
+    return digest;
+  }
+
+  @Test
+  public void containsBlobReflectsWorkerWithUnknownSize() throws Exception {
+    String workerName = "worker";
+    when(mockInstanceLoader.load(eq(workerName))).thenReturn(mockWorkerInstance);
+
+    ImmutableSet<String> workers = ImmutableSet.of(workerName);
+    when(mockBackplane.getWorkers()).thenReturn(workers);
+
+    ByteString blob = ByteString.copyFromUtf8("blobOnWorker");
+    Digest actualDigest = DIGEST_UTIL.compute(blob);
+    Digest searchDigest = DIGEST_UTIL.build(actualDigest.getHash(), -1);
+    Iterable<Digest> searchDigests = ImmutableList.of(searchDigest);
+
+    doAnswer(
+            (Answer<ListenableFuture<Iterable<Digest>>>)
+                invocation -> {
+                  Iterable<Digest> digests = (Iterable<Digest>) invocation.getArguments()[0];
+                  return immediateFuture(
+                      StreamSupport.stream(digests.spliterator(), false)
+                          .map(digest -> findMissingWithUnknown(digest, blobDigests))
+                          .filter(notNull())
+                          .collect(Collectors.toList()));
+                })
+        .when(mockWorkerInstance)
+        .findMissingBlobs(any(Iterable.class), any(RequestMetadata.class));
+
+    ArgumentMatcher<Iterable<Digest>> searchMatcher =
+        (digests) -> Iterables.elementsEqual(digests, searchDigests);
+
+    Digest.Builder result = Digest.newBuilder();
+    boolean containsBeforeAdding =
+        instance.containsBlob(searchDigest, result, RequestMetadata.getDefaultInstance());
+    verify(mockWorkerInstance, times(1))
+        .findMissingBlobs(argThat(searchMatcher), any(RequestMetadata.class));
+    assertThat(containsBeforeAdding).isFalse();
+
+    blobDigests.put(actualDigest.getHash(), actualDigest.getSizeBytes());
+
+    result = Digest.newBuilder();
+    boolean containsAfterAdding =
+        instance.containsBlob(searchDigest, result, RequestMetadata.getDefaultInstance());
+    verify(mockWorkerInstance, times(2))
+        .findMissingBlobs(argThat(searchMatcher), any(RequestMetadata.class));
+
+    assertThat(containsAfterAdding).isTrue();
+    assertThat(result.build()).isEqualTo(actualDigest);
+
+    verify(mockBackplane, atLeastOnce()).getWorkers();
+    verify(mockInstanceLoader, atLeastOnce()).load(eq(workerName));
   }
 }


### PR DESCRIPTION
Needed for FetchService.
FindMissingBlobs requests may contain any number of -1 sized digests
The response for -1 will be the original -1 sized digest if missing (unchanged from >0), and the digest populated with size if present. This differs from >0 behavior by returning a value for entries which exist, but functionally returns an unrequested digest in the response, differing by size.
ShardInstance containsBlob interprets these results appropriately to return a blocking boolean properly for any known or unknown size.