### PR TITLE
[refactor] isolate core limit expression

### DIFF
--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -754,9 +754,13 @@ class ShardWorkerContext implements WorkerContext {
     return Size.mbToBytes(100);
   }
 
+  boolean shouldLimitCoreUsage() {
+    return limitGlobalExecution || onlyMulticoreTests || defaultMaxCores > 0;
+  }
+
   @Override
   public void createExecutionLimits() {
-    if (limitGlobalExecution || onlyMulticoreTests || defaultMaxCores > 0) {
+    if (shouldLimitCoreUsage()) {
       createOperationExecutionLimits();
     }
   }
@@ -825,7 +829,7 @@ class ShardWorkerContext implements WorkerContext {
       ImmutableList.Builder<String> arguments,
       Command command,
       Path workingDirectory) {
-    if (limitGlobalExecution || onlyMulticoreTests || defaultMaxCores > 0) {
+    if (shouldLimitCoreUsage()) {
       ResourceLimits limits = commandExecutionSettings(command);
       return limitSpecifiedExecution(limits, operationName, arguments, workingDirectory);
     }


### PR DESCRIPTION
`limitSpecifiedExecution` does a lot more than just limit cores.  However, our current expression was written to limit based on core information.  For now, isolate the expression.