### PR TITLE
WriteComplete during fetchBlobs is Success

### DIFF
--- a/src/main/java/build/buildfarm/common/BUILD
+++ b/src/main/java/build/buildfarm/common/BUILD
@@ -4,6 +4,7 @@ java_library(
         "*.java",
         "function/*.java",
         "io/*.java",
+        "net/*.java",
     ]),
     plugins = [":lombok"],
     visibility = ["//visibility:public"],

--- a/src/main/java/build/buildfarm/common/Write.java
+++ b/src/main/java/build/buildfarm/common/Write.java
@@ -40,6 +40,8 @@ public interface Write {
 
   ListenableFuture<Long> getFuture();
 
+  class WriteCompleteException extends IOException {}
+
   class CompleteWrite implements Write {
     private final long committedSize;
 

--- a/src/main/java/build/buildfarm/common/grpc/StubWriteOutputStream.java
+++ b/src/main/java/build/buildfarm/common/grpc/StubWriteOutputStream.java
@@ -112,8 +112,6 @@ public class StubWriteOutputStream extends FeedbackOutputStream implements Write
   private TimeUnit deadlineAfterUnits = null;
   private Runnable onReadyHandler = null;
 
-  static class WriteCompleteException extends IOException {}
-
   @SuppressWarnings("Guava")
   public StubWriteOutputStream(
       Supplier<ByteStreamBlockingStub> bsBlockingStub,

--- a/src/main/java/build/buildfarm/common/net/URL.java
+++ b/src/main/java/build/buildfarm/common/net/URL.java
@@ -1,0 +1,31 @@
+// Copyright 2022 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.common.net;
+
+import java.io.IOException;
+import java.net.URLConnection;
+
+// solely exists so that we can mock this
+public class URL {
+  private final java.net.URL url;
+
+  public URL(java.net.URL url) {
+    this.url = url;
+  }
+
+  public URLConnection openConnection() throws IOException {
+    return url.openConnection();
+  }
+}

--- a/src/main/java/build/buildfarm/instance/server/AbstractServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/server/AbstractServerInstance.java
@@ -74,6 +74,7 @@ import build.buildfarm.common.TokenizableIterator;
 import build.buildfarm.common.TreeIterator.DirectoryEntry;
 import build.buildfarm.common.Watcher;
 import build.buildfarm.common.Write;
+import build.buildfarm.common.net.URL;
 import build.buildfarm.common.resources.BlobInformation;
 import build.buildfarm.common.resources.DownloadBlobRequest;
 import build.buildfarm.common.resources.ResourceParser;
@@ -122,7 +123,6 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.nio.file.NoSuchFileException;
 import java.util.HashSet;
 import java.util.List;
@@ -615,16 +615,15 @@ public abstract class AbstractServerInstance implements Instance {
     OutputStream create(long contentLength) throws IOException;
   }
 
-  private static void downloadUri(String uri, ContentOutputStreamFactory getContentOutputStream)
+  private static void downloadUrl(URL url, ContentOutputStreamFactory getContentOutputStream)
       throws IOException {
-    URL url = new URL(uri);
     HttpURLConnection connection = (HttpURLConnection) url.openConnection();
     // connect timeout?
     // proxy?
     // authenticator?
     connection.setInstanceFollowRedirects(true);
     // request timeout?
-    long contentLength = connection.getContentLength();
+    long contentLength = connection.getContentLengthLong();
     int status = connection.getResponseCode();
 
     if (status != HttpURLConnection.HTTP_OK) {
@@ -634,7 +633,7 @@ public abstract class AbstractServerInstance implements Instance {
       if (message == null) {
         message = "Invalid HTTP Response";
       }
-      message = "Download Failed: " + message + " from " + uri;
+      message = "Download Failed: " + message + " from " + url;
       throw new IOException(message);
     }
 
@@ -647,12 +646,26 @@ public abstract class AbstractServerInstance implements Instance {
   @Override
   public ListenableFuture<Digest> fetchBlob(
       Iterable<String> uris, Digest expectedDigest, RequestMetadata requestMetadata) {
+    ImmutableList.Builder<URL> urls = ImmutableList.builder();
     for (String uri : uris) {
       try {
+        urls.add(new URL(new java.net.URL(uri)));
+      } catch (Exception e) {
+        return immediateFailedFuture(e);
+      }
+    }
+    return fetchBlobUrls(urls.build(), expectedDigest, requestMetadata);
+  }
+
+  @VisibleForTesting
+  ListenableFuture<Digest> fetchBlobUrls(
+      Iterable<URL> urls, Digest expectedDigest, RequestMetadata requestMetadata) {
+    for (URL url : urls) {
+      Digest.Builder actualDigestBuilder = expectedDigest.toBuilder();
+      try {
         // some minor abuse here, we want the download to set our built digest size as side effect
-        Digest.Builder actualDigestBuilder = expectedDigest.toBuilder();
-        downloadUri(
-            uri,
+        downloadUrl(
+            url,
             contentLength -> {
               Digest actualDigest = actualDigestBuilder.setSizeBytes(contentLength).build();
               if (expectedDigest.getSizeBytes() >= 0
@@ -663,6 +676,8 @@ public abstract class AbstractServerInstance implements Instance {
                       Compressor.Value.IDENTITY, actualDigest, UUID.randomUUID(), requestMetadata)
                   .getOutput(1, DAYS, () -> {});
             });
+        return immediateFuture(actualDigestBuilder.build());
+      } catch (Write.WriteCompleteException e) {
         return immediateFuture(actualDigestBuilder.build());
       } catch (Exception e) {
         log.log(Level.WARNING, "download attempt failed", e);


### PR DESCRIPTION
Ensure that completed writes when fetching http blobs are considered successful and delivered with content length responses.