### PR TITLE
Return early on existing blob match

### DIFF
--- a/src/main/java/build/buildfarm/server/services/FetchService.java
+++ b/src/main/java/build/buildfarm/server/services/FetchService.java
@@ -58,14 +58,23 @@ public class FetchService extends FetchImplBase {
         if (instance.containsBlob(expectedDigest, result, requestMetadata)) {
           responseObserver.onNext(
               FetchBlobResponse.newBuilder().setBlobDigest(result.build()).build());
+          responseObserver.onCompleted();
+          return;
         }
       } else {
-        throw Status.INVALID_ARGUMENT
-            .withDescription(format("Invalid qualifier '%s'", name))
-            .asRuntimeException();
+        responseObserver.onError(
+            Status.INVALID_ARGUMENT
+                .withDescription(format("Invalid qualifier '%s'", name))
+                .asException());
+        return;
       }
     }
-    if (request.getUrisCount() != 0) {
+    if (expectedDigest == null) {
+      responseObserver.onError(
+          Status.INVALID_ARGUMENT
+              .withDescription(format("Missing qualifier 'checksum.sri'"))
+              .asException());
+    } else if (request.getUrisCount() != 0) {
       addCallback(
           instance.fetchBlob(request.getUrisList(), expectedDigest, requestMetadata),
           new FutureCallback<Digest>() {

--- a/src/test/java/build/buildfarm/server/services/BUILD
+++ b/src/test/java/build/buildfarm/server/services/BUILD
@@ -1,12 +1,7 @@
 java_test(
     name = "tests",
     size = "small",
-    srcs = [
-        "ActionCacheServiceTest.java",
-        "ByteStreamServiceTest.java",
-        "ExecutionServiceTest.java",
-        "FutureWriteResponseObserver.java",
-    ],
+    srcs = glob(["*.java"]),
     data = ["//examples:example_configs"],
     test_class = "build.buildfarm.AllTests",
     deps = [
@@ -40,6 +35,8 @@ java_test(
         "@maven//:io_grpc_grpc_stub",
         "@maven//:me_dinowernli_java_grpc_prometheus",
         "@maven//:org_mockito_mockito_core",
+        "@remote_apis//:build_bazel_remote_asset_v1_remote_asset_java_grpc",
+        "@remote_apis//:build_bazel_remote_asset_v1_remote_asset_java_proto",
         "@remote_apis//:build_bazel_remote_execution_v2_remote_execution_java_grpc",
         "@remote_apis//:build_bazel_remote_execution_v2_remote_execution_java_proto",
     ],

--- a/src/test/java/build/buildfarm/server/services/FetchServiceTest.java
+++ b/src/test/java/build/buildfarm/server/services/FetchServiceTest.java
@@ -1,0 +1,84 @@
+// Copyright 2023 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.server.services;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import build.bazel.remote.asset.v1.FetchBlobRequest;
+import build.bazel.remote.asset.v1.FetchBlobResponse;
+import build.bazel.remote.asset.v1.Qualifier;
+import build.bazel.remote.execution.v2.Digest;
+import build.bazel.remote.execution.v2.RequestMetadata;
+import build.buildfarm.common.DigestUtil;
+import build.buildfarm.common.DigestUtil.HashFunction;
+import build.buildfarm.instance.Instance;
+import com.google.common.io.BaseEncoding;
+import com.google.protobuf.ByteString;
+import io.grpc.stub.StreamObserver;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.stubbing.Answer;
+
+@RunWith(JUnit4.class)
+public class FetchServiceTest {
+  private static final DigestUtil DIGEST_UTIL = new DigestUtil(HashFunction.SHA256);
+
+  @Test
+  public void existingEntryShouldCompleteWithoutFetch() throws InterruptedException {
+    Instance instance = mock(Instance.class);
+    FetchService service = new FetchService(instance);
+
+    ByteString content = ByteString.copyFromUtf8("Fetch Blob Content");
+    Digest contentDigest = DIGEST_UTIL.compute(content);
+    Digest containsDigest = contentDigest.toBuilder().setSizeBytes(-1).build();
+
+    FetchBlobRequest request =
+        FetchBlobRequest.newBuilder()
+            .addQualifiers(
+                Qualifier.newBuilder()
+                    .setName("checksum.sri")
+                    .setValue(hashChecksumSRI(contentDigest.getHash()))
+                    .build())
+            .build();
+
+    doAnswer(
+            (Answer<Boolean>)
+                invocation -> {
+                  Digest.Builder result = (Digest.Builder) invocation.getArguments()[1];
+                  result.mergeFrom(contentDigest);
+                  return true;
+                })
+        .when(instance)
+        .containsBlob(eq(containsDigest), any(Digest.Builder.class), any(RequestMetadata.class));
+    StreamObserver<FetchBlobResponse> response = mock(StreamObserver.class);
+    service.fetchBlob(request, response);
+    verify(instance, never())
+        .fetchBlob(any(Iterable.class), any(Digest.class), any(RequestMetadata.class));
+    verify(response, times(1)).onCompleted();
+    verify(response, times(1))
+        .onNext(FetchBlobResponse.newBuilder().setBlobDigest(contentDigest).build());
+  }
+
+  private String hashChecksumSRI(String hash) {
+    return "sha256-" + BaseEncoding.base64().encode(BaseEncoding.base16().lowerCase().decode(hash));
+  }
+}


### PR DESCRIPTION
The FetchService should not continue to process URIs for existing entries.