### PR TITLE
[CI] test buildfarm with the full config

### DIFF
--- a/.bazelci/integration_test.sh
+++ b/.bazelci/integration_test.sh
@@ -18,4 +18,5 @@ docker run \
     --env RUN_TEST=$RUN_TEST \
     --env TEST_ARG1=$TEST_ARG1 \
     --env EXECUTION_STAGE_WIDTH=$EXECUTION_STAGE_WIDTH \
+    --env BUILDFARM_CONFIG=$BUILDFARM_CONFIG \
     buildfarm buildfarm/.bazelci/test_buildfarm_container.sh

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -115,15 +115,28 @@ tasks:
     platform: ubuntu1804
     shell_commands:
     - export RUN_TEST=./.bazelci/run_generative_cc_many_test.sh
+    - export BUILDFARM_CONFIG="/buildfarm/examples/config.minimal.yml"
+    - export EXECUTION_STAGE_WIDTH=5
+    - ./.bazelci/integration_test.sh
+  
+  # Test the buildfarm deployment with the full config.
+  # More issues can be caught when using the fully defined configuration file.
+  integration_test_many_full_config:
+    name: "Integration Test (Full Config)"
+    platform: ubuntu1804
+    shell_commands:
+    - export RUN_TEST=./.bazelci/run_generative_cc_many_test.sh
+    - export BUILDFARM_CONFIG="/buildfarm/examples/config.yml"
     - export EXECUTION_STAGE_WIDTH=5
     - ./.bazelci/integration_test.sh
 
   # Test that buildfarm can work with zstd compression
-  compression_test_many_shard:
+  compression_test_many_compression:
     name: "Integration Test (Shard/Compression)"
     platform: ubuntu1804
     shell_commands:
     - export RUN_TEST=./.bazelci/run_generative_cc_many_test.sh
+    - export BUILDFARM_CONFIG="/buildfarm/examples/config.minimal.yml"
     - export TEST_ARG1=--experimental_remote_cache_compression
     - export EXECUTION_STAGE_WIDTH=5
     - ./.bazelci/integration_test.sh
@@ -148,6 +161,7 @@ tasks:
     platform: ubuntu1804
     shell_commands:
     - export RUN_TEST=./.bazelci/run_abseil_test.sh
+    - export BUILDFARM_CONFIG="/buildfarm/examples/config.minimal.yml"
     - export EXECUTION_STAGE_WIDTH=10
     - ./.bazelci/integration_test.sh
   integration_test_abseil_shard_compression:
@@ -155,6 +169,7 @@ tasks:
     platform: ubuntu1804
     shell_commands:
     - export RUN_TEST=./.bazelci/run_abseil_test.sh
+    - export BUILDFARM_CONFIG="/buildfarm/examples/config.minimal.yml"
     - export EXECUTION_STAGE_WIDTH=10
     - export TEST_ARG1=--experimental_remote_cache_compression
     - ./.bazelci/integration_test.sh

--- a/.bazelci/test_buildfarm_container.sh
+++ b/.bazelci/test_buildfarm_container.sh
@@ -11,8 +11,8 @@ BUILDFARM_SERVER_TARGET="//src/main/java/build/buildfarm:buildfarm-server"
 BUILDFARM_WORKER_TARGET="//src/main/java/build/buildfarm:buildfarm-shard-worker"
 
 #The configs used by the targets
-BUILDFARM_SERVER_CONFIG="/buildfarm/examples/config.minimal.yml"
-BUILDFARM_WORKER_CONFIG="/buildfarm/examples/config.minimal.yml"
+BUILDFARM_SERVER_CONFIG=$BUILDFARM_CONFIG
+BUILDFARM_WORKER_CONFIG=$BUILDFARM_CONFIG
 
 GRPC_LOGS1="/tmp/parsed-grpc.log"
 GRPC_LOGS2="/tmp/parsed-grpc2.log"


### PR DESCRIPTION
I noticed that particular startup failures could be missed if the configuration sections are left out.  We should test against the full config as well, since many people reference parts of it.