### PR TITLE
[REAPI] fix buildfarm to support negative priority values

### DIFF
--- a/src/main/java/build/buildfarm/instance/server/AbstractServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/server/AbstractServerInstance.java
@@ -1897,8 +1897,20 @@ public abstract class AbstractServerInstance implements Instance {
         .setExecEnabled(true)
         .setExecutionPriorityCapabilities(
             PriorityCapabilities.newBuilder()
+
+                // The priority (relative importance) of this action. Generally, a lower value
+                // means that the action should be run sooner than actions having a greater
+                // priority value, but the interpretation of a given value is server-
+                // dependent. A priority of 0 means the *default* priority. Priorities may be
+                // positive or negative, and such actions should run later or sooner than
+                // actions having the default priority, respectively. The particular semantics
+                // of this field is up to the server. In particular, every server will have
+                // their own supported range of priorities, and will decide how these map into
+                // scheduling policy.
                 .addPriorities(
-                    PriorityRange.newBuilder().setMinPriority(0).setMaxPriority(Integer.MAX_VALUE)))
+                    PriorityRange.newBuilder()
+                        .setMinPriority(Integer.MIN_VALUE)
+                        .setMaxPriority(Integer.MAX_VALUE)))
         .build();
   }
 

--- a/src/test/java/build/buildfarm/common/redis/RedisPriorityQueueTest.java
+++ b/src/test/java/build/buildfarm/common/redis/RedisPriorityQueueTest.java
@@ -258,7 +258,7 @@ public class RedisPriorityQueueTest {
   // Reason for testing: The queue supports negative priorities.
   // Failure explanation: negative prioritizes are not handled in the correct order.
   @Test
-  public void checkPriorityOnDequeue() throws Exception {
+  public void checkNegativesInPriority() throws Exception {
     // ARRANGE
     RedisPriorityQueue queue = new RedisPriorityQueue("test");
     String val;

--- a/src/test/java/build/buildfarm/common/redis/RedisPriorityQueueTest.java
+++ b/src/test/java/build/buildfarm/common/redis/RedisPriorityQueueTest.java
@@ -254,6 +254,43 @@ public class RedisPriorityQueueTest {
     assertThat(queue.size(redis)).isEqualTo(0);
   }
 
+  // Function under test: dequeue
+  // Reason for testing: The queue supports negative priorities.
+  // Failure explanation: negative prioritizes are not handled in the correct order.
+  @Test
+  public void checkPriorityOnDequeue() throws Exception {
+    // ARRANGE
+    RedisPriorityQueue queue = new RedisPriorityQueue("test");
+    String val;
+
+    // ACT / ASSERT
+    queue.push(redis, "foo-6", 6);
+    queue.push(redis, "foo-5", 5);
+    queue.push(redis, "foo-3", 3);
+    queue.push(redis, "negative-50", -50);
+    queue.push(redis, "negative-1", -1);
+    queue.push(redis, "foo-1", 1);
+    queue.push(redis, "baz-2", 2);
+    queue.push(redis, "foo-4", 4);
+
+    val = queue.dequeue(redis, 1);
+    assertThat(val).isEqualTo("negative-50");
+    val = queue.dequeue(redis, 1);
+    assertThat(val).isEqualTo("negative-1");
+    val = queue.dequeue(redis, 1);
+    assertThat(val).isEqualTo("foo-1");
+    val = queue.dequeue(redis, 1);
+    assertThat(val).isEqualTo("baz-2");
+    val = queue.dequeue(redis, 1);
+    assertThat(val).isEqualTo("foo-3");
+    val = queue.dequeue(redis, 1);
+    assertThat(val).isEqualTo("foo-4");
+    val = queue.dequeue(redis, 1);
+    assertThat(val).isEqualTo("foo-5");
+    val = queue.dequeue(redis, 1);
+    assertThat(val).isEqualTo("foo-6");
+  }
+
   // Function under test: visit
   // Reason for testing: each element in the queue can be visited
   // Failure explanation: we are unable to visit each element in the queue


### PR DESCRIPTION
Negative priority values are supported according the [REAPI spec](https://github.com/bazelbuild/remote-apis/blob/64cc5e9e422c93e1d7f0545a146fd84fcc0e8b47/build/bazel/remote/execution/v2/remote_execution.proto#L1321).  Our implementation supports this, but we advertised it incorrectly to the client in our capabilities response.