### PR TITLE
[deployment] [cleanup] remove unused container_image targets

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -4,6 +4,7 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@rules_oss_audit//oss_audit:java/oss_audit.bzl", "oss_audit")
+load("//:defs.bzl", "ensure_accurate_metadata")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -147,7 +148,7 @@ java_image(
         "//examples:example_configs",
         "//src/main/java/build/buildfarm:configs",
     ],
-    jvm_flags = [
+    jvm_flags = ensure_accurate_metadata() + [
         "-Dlogging.config=file:/app/build_buildfarm/src/main/java/build/buildfarm/logging.properties",
     ] + select({
         "//config:open_telemetry": SERVER_TELEMETRY_JVM_FLAGS,
@@ -204,7 +205,7 @@ java_image(
         "//examples:example_configs",
         "//src/main/java/build/buildfarm:configs",
     ],
-    jvm_flags = [
+    jvm_flags = ensure_accurate_metadata() + [
         "-Dlogging.config=file:/app/build_buildfarm/src/main/java/build/buildfarm/logging.properties",
     ] + select({
         "//config:open_telemetry": WORKER_TELEMETRY_JVM_FLAGS,

--- a/src/main/java/build/buildfarm/BUILD
+++ b/src/main/java/build/buildfarm/BUILD
@@ -11,13 +11,6 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
-genrule(
-    name = "tini.binary",
-    srcs = ["@tini//file"],
-    outs = ["tini"],
-    cmd = "cp $< $@ && chmod +x $@",
-)
-
 java_binary(
     name = "buildfarm-server",
     classpath_resources = [
@@ -32,26 +25,6 @@ java_binary(
     ],
 )
 
-container_image(
-    name = "server.container",
-    base = "@java_image_base//image",
-    cmd = [
-        "buildfarm-server_deploy.jar",
-        "/config/server.config",
-        "--port",
-        "8980",
-    ],
-    # leverage the implicit target of the buildfarm-server to get a fat jar.
-    # this is simply a workaround for the fact that we have so many dependencies,
-    # so we'd want some wrappy script. This seemed more straightforward.
-    # https://docs.bazel.build/versions/master/be/java.html#java_binary_implicit_outputs
-    files = [
-        ":buildfarm-server_deploy.jar",
-    ],
-    tags = ["container"],
-    visibility = ["//visibility:public"],
-)
-
 java_binary(
     name = "buildfarm-shard-worker",
     classpath_resources = [
@@ -64,18 +37,4 @@ java_binary(
         "//src/main/java/build/buildfarm/worker/shard",
         "@maven//:org_slf4j_slf4j_simple",
     ],
-)
-
-container_image(
-    name = "buildfarm-shard-worker.container",
-    base = "@java_image_base//image",
-    # leverage the implicit target of the buildfarm-shard-worker to get a fat jar.
-    # this is simply a workaround for the fact that we have so many dependencies,
-    # so we'd want some wrappy script. This seemed more straightforward.
-    # https://docs.bazel.build/versions/master/be/java.html#java_binary_implicit_outputs
-    files = [
-        ":buildfarm-shard-worker_deploy.jar",
-    ],
-    tags = ["container"],
-    visibility = ["//visibility:public"],
 )

--- a/src/main/java/build/buildfarm/BUILD
+++ b/src/main/java/build/buildfarm/BUILD
@@ -1,4 +1,3 @@
-load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("//:defs.bzl", "ensure_accurate_metadata")
 
 package(


### PR DESCRIPTION
Let's remove the following `container_image` targets because they are older and no longer referenced in the documentation or the CI.  They also should not be used because they are missing other elements such as execution_wrappers, telemetry, and additional jvm flags.  Keeping them will only create confusion with the other image targets that we have. 

The primary images we want developers to use and reference when building from source are found in the root `BUILD` file.
 - We can also remove tini here because it's built and used from the root BUILD file.