### PR TITLE
[config] allow configuration of server cache sizes

### DIFF
--- a/_site/docs/configuration/configuration.md
+++ b/_site/docs/configuration/configuration.md
@@ -22,6 +22,7 @@ worker:
 ```
 
 The configuration can be provided to the server and worker as a CLI argument or through the env variable `CONFIG_PATH`
+For an example config containing all of the configuration values, see `examples/config.yml`.
 
 ## All Configurations
 

--- a/_site/docs/configuration/configuration.md
+++ b/_site/docs/configuration/configuration.md
@@ -100,6 +100,26 @@ server:
     provideLatencyHistograms: false
 ```
 
+### Server Caches
+
+| Configuration            | Accepted and _Default_ Values | Description                                            |
+|--------------------------|-------------------------------|--------------------------------------------------------|
+| directoryCacheMaxEntries                  | Long, _64 * 1024_              | The max number of entries that the directory cache will hold.    |
+| commandCacheMaxEntries                  | Long, _64 * 1024_              | The max number of entries that the command cache will hold.    |
+| digestToActionCacheMaxEntries                  | Long, _64 * 1024_              | The max number of entries that the digest-to-action cache will hold.    |
+| recentServedExecutionsCacheMaxEntries                  | Long, _64 * 1024_              | The max number of entries that the executions cache will hold.    |
+
+Example:
+
+```
+server:
+  caches:
+    directoryCacheMaxEntries: 10000
+    commandCacheMaxEntries: 10000
+    digestToActionCacheMaxEntries: 10000
+    recentServedExecutionsCacheMaxEntries: 10000
+```
+
 ### Admin
 
 | Configuration         | Accepted and _Default_ Values | Description                                                                    |

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -27,6 +27,11 @@ server:
   recordBesEvents: false
   clusterId: local
   cloudRegion: us-east-1
+  caches:
+    directoryCacheMaxEntries: 10000
+    commandCacheMaxEntries: 10000
+    digestToActionCacheMaxEntries: 10000
+    recentServedExecutionsCacheMaxEntries: 10000
   admin:
     deploymentEnvironment: AWS
     clusterEndpoint: "grpc://localhost"

--- a/src/main/java/build/buildfarm/common/config/Server.java
+++ b/src/main/java/build/buildfarm/common/config/Server.java
@@ -40,6 +40,8 @@ public class Server {
   private String cloudRegion;
   private String publicName;
 
+  private ServerCacheConfigs caches = new ServerCacheConfigs();
+
   public String getPublicName() {
     // use environment override (useful for containerized deployment)
     if (!Strings.isNullOrEmpty(System.getenv("INSTANCE_NAME"))) {

--- a/src/main/java/build/buildfarm/common/config/ServerCacheConfigs.java
+++ b/src/main/java/build/buildfarm/common/config/ServerCacheConfigs.java
@@ -1,0 +1,55 @@
+// Copyright 2023 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.common.config;
+
+import lombok.Data;
+
+/**
+ * @class Server Cache Configs
+ * @brief Configuration for the server's in memory caches.
+ * @details The servers can cache different responses and REPAI data to provide better performance
+ *     to the clients. It may come up at a cost of increased memory usage on the servers. Here we
+ *     provide configuration on how large these caches can grow.
+ */
+@Data
+public class ServerCacheConfigs {
+  /**
+   * @field directoryCacheMaxEntries
+   * @brief The max number of entries that the directory cache will hold.
+   * @details This will not dictate the max memory used.
+   */
+  public long directoryCacheMaxEntries = 64 * 1024;
+
+  /**
+   * @field commandCacheMaxEntries
+   * @brief The max number of entries that the command cache will hold.
+   * @details This will not dictate the max memory used.
+   */
+  public long commandCacheMaxEntries = 64 * 1024;
+
+  /**
+   * @field digestToActionCacheMaxEntries
+   * @brief The max number of entries that the digest-to-action cache will hold.
+   * @details This will not dictate the max memory used.
+   */
+  public long digestToActionCacheMaxEntries = 64 * 1024;
+
+  /**
+   * @field recentServedExecutionsCacheMaxEntries
+   * @brief The max number of entries that the executions cache will hold.
+   * @details This will not dictate the max memory used.
+   */
+  public long recentServedExecutionsCacheMaxEntries = 64 * 1024;
+}


### PR DESCRIPTION
Allow these constants to be overridden in the config.  Backwards compatible; the existing values are set by default.