### PR TITLE
[Config] Better error when yaml.load fails

### DIFF
--- a/src/main/java/build/buildfarm/common/config/BuildfarmConfigs.java
+++ b/src/main/java/build/buildfarm/common/config/BuildfarmConfigs.java
@@ -45,6 +45,9 @@ public final class BuildfarmConfigs {
     try (InputStream inputStream = Files.newInputStream(configLocation)) {
       Yaml yaml = new Yaml(new Constructor(buildfarmConfigs.getClass()));
       buildfarmConfigs = yaml.load(inputStream);
+      if (buildfarmConfigs == null) {
+          throw new RuntimeException("Could not load configs from path: " + configLocation);
+      }
       log.info(buildfarmConfigs.toString());
       return buildfarmConfigs;
     }

--- a/src/main/java/build/buildfarm/common/config/BuildfarmConfigs.java
+++ b/src/main/java/build/buildfarm/common/config/BuildfarmConfigs.java
@@ -46,7 +46,7 @@ public final class BuildfarmConfigs {
       Yaml yaml = new Yaml(new Constructor(buildfarmConfigs.getClass()));
       buildfarmConfigs = yaml.load(inputStream);
       if (buildfarmConfigs == null) {
-          throw new RuntimeException("Could not load configs from path: " + configLocation);
+        throw new RuntimeException("Could not load configs from path: " + configLocation);
       }
       log.info(buildfarmConfigs.toString());
       return buildfarmConfigs;


### PR DESCRIPTION
Today when yaml.load returns a null, it raises a `NullPointerException` when trying to log the config

This gives a better error to make it a bit easier to debug and futher print the path it loaded.