### PR TITLE
[bug][discussion]  failure to setup exec dir: existing entry did not appear

### DIFF
--- a/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
+++ b/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
@@ -2804,6 +2804,9 @@ public abstract class CASFileCache implements ContentAddressableStorage {
       }
 
       void commit() throws IOException {
+        // Check some preconditions before committing the file to the CAS.
+        // 1. The filename must match the hash that we store.
+        // 2. The file must be read-only.
         String hash = hashSupplier.get().toString();
         String fileName = writePath.getFileName().toString();
         if (!fileName.startsWith(hash)) {
@@ -2819,7 +2822,11 @@ public abstract class CASFileCache implements ContentAddressableStorage {
           throw e;
         }
 
-        Entry entry = new Entry(key, blobSizeInBytes, Deadline.after(10, SECONDS));
+        // Create the new entry to track the file.
+        // FIXME: How is this deadline decided?
+        // FIXME: Could it get deleted before we finish committing?
+        // TEST: Bump it higher to see if it avoids failures setting up the exec dir.
+        Entry entry = new Entry(key, blobSizeInBytes, Deadline.after(5, MINUTES));
 
         Entry existingEntry = null;
         boolean inserted = false;
@@ -2828,7 +2835,15 @@ public abstract class CASFileCache implements ContentAddressableStorage {
           existingEntry = storage.putIfAbsent(key, entry);
           inserted = existingEntry == null;
         } catch (FileAlreadyExistsException e) {
-          log.log(Level.FINE, "file already exists for " + key + ", nonexistent entry will fail");
+          // FIXME: Why skip adding the entry to storage if the hardlink already exists?
+          // This seems like it would lead to the in-memory and disk storage being out of sync.
+          // TEST: To avoid failures setting up the exec dir, we will excuse the existing hardlink
+          // and register the entry in storage on behalf of the pre-existing file.  After all,
+          // these file names should be unique to their content, so I don't think the existing
+          // hardlink should contain different data than what we were attempting to link, right?
+          existingEntry = storage.putIfAbsent(key, entry);
+          inserted = existingEntry == null;
+          log.log(Level.INFO, "file already exists for " + key + ", nonexistent entry will fail");
         } finally {
           Files.delete(writePath);
           if (!inserted) {
@@ -2836,6 +2851,9 @@ public abstract class CASFileCache implements ContentAddressableStorage {
           }
         }
 
+        // FIXME: If our attempt to add it to storage failed,
+        // why would we iterate multiple times trying to get it from storage?
+        // Was there an expectation that another thread would add it?
         int attempts = 10;
         if (!inserted) {
           while (existingEntry == null && attempts-- != 0) {
@@ -2852,21 +2870,22 @@ public abstract class CASFileCache implements ContentAddressableStorage {
           }
         }
 
+        // FIXME: Why are we racing?
         if (existingEntry != null) {
-          log.log(Level.FINE, "lost the race to insert " + key);
+          log.log(Level.INFO, "lost the race to insert " + key);
           if (!referenceIfExists(key)) {
             // we would lose our accountability and have a presumed reference if we returned
             throw new IllegalStateException("storage conflict with existing key for " + key);
           }
         } else if (writeWinner.get()) {
-          log.log(Level.FINE, "won the race to insert " + key);
+          log.log(Level.INFO, "won the race to insert " + key);
           try {
             onInsert.run();
           } catch (RuntimeException e) {
             throw new IOException(e);
           }
         } else {
-          log.log(Level.FINE, "did not win the race to insert " + key);
+          log.log(Level.INFO, "did not win the race to insert " + key);
         }
       }
     };

--- a/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
+++ b/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
@@ -2828,7 +2828,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
         // TEST: Bump it higher to see if it avoids failures setting up the exec dir.
         Entry entry = new Entry(key, blobSizeInBytes, Deadline.after(5, MINUTES));
 
-        Entry existingEntry = null;
+        Entry existingEntry;
         boolean inserted = false;
         try {
           Files.createLink(CASFileCache.this.getPath(key), writePath);


### PR DESCRIPTION
Workers are failing to create the exec dir.  Here are the corresponding stack traces:
```
SEVERE: error creating exec dir for shard/operations/5c24cfb5-fd93-4b34-abaf-6cd18a77ffc9
```
```
at build.buildfarm.cas.cfc.CASFileCache.lambda$put$24(CASFileCache.java:2370)
at build.buildfarm.cas.cfc.CASFileCache.putAndCopy(CASFileCache.java:2396)
at build.buildfarm.cas.cfc.CASFileCache$7.close(CASFileCache.java:2506)
at build.buildfarm.cas.cfc.CASFileCache$7.withSingleTermination(CASFileCache.java:2512)
at build.buildfarm.cas.cfc.CASFileCache$8.close(CASFileCache.java:2842)
at build.buildfarm.cas.cfc.CASFileCache$8.commit(CASFileCache.java:2890)
```

```
Suppressed: build.buildfarm.cas.cfc.CASFileCache$PutDirectoryException: /app/data/cache/CAS/1ba55133db4dd15ddb67db62c7e11d0e53e9874dcdc6a2e6c75f1b5ee33e66b4_dir: 30 exceptions: 
[java.util.concurrent.ExecutionException: java.io.IOException: existing entry did not appear for 
a920461a3b6c4b9c64ac00cdb3351801cde1448e2f24ff703bebf28d7c62a2fc_exec, 
java.util.concurrent.ExecutionException: java.io.IOException: existing entry did not appear for 
a66972bf85885c9cc6cc5761131bd5c39ff54b6d586d8d83352175a355f3c9ab_exec, 
java.util.concurrent.ExecutionException: java.io.IOException: existing entry did not appear for 
5ee54ed6e481439a297be6460115ffc3ffba83b271e19feb130fce81a6edc655_exec, java.util.concurrent.ExecutionException: 
java.io.IOException: existing entry did not appear for 
adf5c88a8ee3ec222267798aecb1c53a9ff421ccf57c447c0e92464149d70586_exec, 
java.util.concurrent.ExecutionException: java.io.IOException: existing entry did not appear for 
767179a5354eb655e8deca24addc1e835f3200e3c13a632ecc621d442f9f8736_exec, 
java.util.concurrent.ExecutionException: java.io.IOException: existing entry did not appear for 
c4db39346782c39164baf0ac0004616e8383e0d47f951badd9de90c625c16e89_exec, 
java.util.concurrent.ExecutionException: java.io.IOException: existing entry did not appear for 
5b9c7157648f5098d4fce6531c72aa82eddb87c6ff2507f44765c2d2eb2a87f5_exec, 
java.util.concurrent.ExecutionException: java.io.IOException: existing entry did not appear for 
090044a902b58f540192f86000b8e157a9e97f4435977e5f172292fd89dcc02d_exec, 
java.util.concurrent.ExecutionException: java.io.IOException: existing entry did not appear for 
b9e1a3174c269d0fb8d314b02a0ec422389e80b9562bbc624001f52e221fe517_exec, 
java.util.concurrent.ExecutionException: java.io.IOException: existing entry did not appear for 
cd0cf4d0e0252611d90c69760e08df06b7c48db34db8699e7c8476be3b1d48b2_exec, 
java.util.concurrent.ExecutionException: java.io.IOException: existing entry did not appear for 
de67e9401bf1d23192b8a34345060608d1be7627910e1b6c21bf051ba74e8cea_exec, 
java.util.concurrent.ExecutionException: java.io.IOException: existing entry did not appear for 
c93778261e09f12684a1210ad7a9703f26604c9377a22cdea92632cb787a7d45_exec, 
java.util.concurrent.ExecutionException: java.io.IOException: existing entry did not appear for 
d985d8ea010ffbd2dd90d936a1cfd5ef863058181a3196622d3ca51d3ca92dc3_exec, 
java.util.concurrent.ExecutionException: java.io.IOException: existing entry did not appear for 
e9d7594c71cae866046c040cb7e8874692cbc58a4878a80bfd18de26e5c2fa9c_exec, 
java.util.concurrent.ExecutionException: java.io.IOException: existing entry did not appear for 
3d3f5b02ae8506b1bc9bdbac0c564803aff631b2660731299f096ed26d23e0ab_exec, 
java.util.concurrent.ExecutionException: java.io.IOException: existing entry did not appear for 
c88708cc116ecc0023f2081f937a70c6249b6b46e0231978b616879ac0269d4c_exec, 
java.util.concurrent.ExecutionException: java.io.IOException: existing entry did not appear for 
600adb92f1d6a2e60f2267191fb5d21301b567e8ebd2e39a2e6f3e0f3c02c51a_exec, 
java.util.concurrent.ExecutionException: java.io.IOException: existing entry did not appear for 
5ee5745a33a01af634b298763fc22b32a94d342027f199ed763dd9d341274b93_exec, 
java.util.concurrent.ExecutionException: java.io.IOException: existing entry did not appear for 
8997b0b1cf0b50b6c75b7a625b71ff913ee07fdab5e018e15788688801ae025f_exec, 
java.util.concurrent.ExecutionException: java.io.IOException: existing entry did not appear for 
6266581da7a151b428fb7cb774aef2c78aad0f901837c17e6a6455cf2cc709ca_exec, java.util.concurrent.ExecutionException: 
java.io.IOException: existing entry did not appear for 
ae32d2f482d71b801bcbe4bce321cfb66be53a4d2bbd12129179241cc0828fa7_exec, 
java.util.concurrent.ExecutionException: java.io.IOException: existing entry did not appear for 
cba9d00e3474ad8f1aa0c57c4494c0347cc6d6f0e0f27b6cf35485853c655c6e_exec, 
java.util.concurrent.ExecutionException: java.io.IOException: existing entry did not appear for 
d1d1d3c6ef3973cc1b11a7203a7fb1b12daa93db73a60278f7b366062860fd31_exec, java.util.concurrent.ExecutionException: 
java.io.IOException: existing entry did not appear for 
90ef23f6e917d6ac744a2a1d877ce3ebc17dc4b921669aa8351196bef67a2cbc_exec, 
java.util.concurrent.ExecutionException: java.io.IOException: existing entry did not appear for 
22118b6e34ad2ed6eb7b56b71d18476bc2130300363ca332e47b50ebdc7eadc6_exec, 
java.util.concurrent.ExecutionException: java.io.IOException: existing entry did not appear for 
1296bef567f9eac80e3d01b64cc714aa7d3fa881711d37c631d7aadb4dce2a9d_exec, 
java.util.concurrent.ExecutionException: java.io.IOException: existing entry did not appear for 
534b7c763a1faaa50c06aaf9fd06851f32bac330252877cd6595d9e7f068f63d_exec, 
java.util.concurrent.ExecutionException: java.io.IOException: existing entry did not appear for 
0b0e39080cc79c8af67d34d6e81600c7c8f8c83f67b0948d2df0c2856e621661_exec, 
java.util.concurrent.ExecutionException: java.io.IOException: existing entry did not appear for 
8143367c2ab5c9c0b0555a7997365f897cc60f00890e884b040c477bbd6f252c_exec, 
java.util.concurrent.ExecutionException: java.io.IOException: existing entry did not appear for 
35f2c2f151de70d690fc22970f426ce0c2bf3d415fc413a1b9e5c068f8e1badd_exec]
```

This PR is my attempt to understand the `commit()` method and to adjust it so that it avoids the `existing entry did not appear` error.  This is not intended to be a real fix, just adding comments to help discussion around our problem.