### PR TITLE
[CI] Run unit tests on ubuntu 20.04

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -55,6 +55,13 @@ tasks:
     - "--test_tag_filters=-integration,-redis"
     test_targets:
     - "..."
+  ubuntu2004:
+    name: "Unit Tests"
+    build_targets:
+    - "..."
+    test_flags:
+    - "--test_tag_filters=-integration,-redis"
+    test_targets:
   macos:
     name: "Unit Tests"
     build_flags:


### PR DESCRIPTION
Let's start running unit tests on ubuntu 20.04 LTS.
We may consider updating other integration tests to use new versions of ubuntu next.