### PR TITLE
[redis] allow the client to reconnect on redis exceptions

### DIFF
--- a/src/main/java/build/buildfarm/common/config/Backplane.java
+++ b/src/main/java/build/buildfarm/common/config/Backplane.java
@@ -42,6 +42,7 @@ public class Backplane {
   private int timeout = 10000;
   private String[] redisNodes = {};
   private int maxAttempts = 20;
+  private boolean reconnectClient = true;
   private boolean cacheCas = false;
 
   public String getRedisUri() {

--- a/src/main/java/build/buildfarm/common/redis/BUILD
+++ b/src/main/java/build/buildfarm/common/redis/BUILD
@@ -9,8 +9,8 @@ java_library(
         "//third_party/jedis",
         "@maven//:com_google_guava_guava",
         "@maven//:io_grpc_grpc_api",
-        "@maven//:org_redisson_redisson",
-        "@maven//:org_projectlombok_lombok",
         "@maven//:io_prometheus_simpleclient",
+        "@maven//:org_projectlombok_lombok",
+        "@maven//:org_redisson_redisson",
     ],
 )

--- a/src/main/java/build/buildfarm/common/redis/BUILD
+++ b/src/main/java/build/buildfarm/common/redis/BUILD
@@ -10,5 +10,7 @@ java_library(
         "@maven//:com_google_guava_guava",
         "@maven//:io_grpc_grpc_api",
         "@maven//:org_redisson_redisson",
+        "@maven//:org_projectlombok_lombok",
+        "@maven//:io_prometheus_simpleclient",
     ],
 )

--- a/src/main/java/build/buildfarm/common/redis/RedisClient.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisClient.java
@@ -85,11 +85,6 @@ public class RedisClient implements Closeable {
     this.jedis = jedis;
   }
 
-  public RedisClient(JedisCluster jedis, Supplier<JedisCluster> jedisClusterFactory) {
-    this.jedis = jedis;
-    this.jedisClusterFactory = jedisClusterFactory;
-  }
-
   public RedisClient(
       JedisCluster jedis,
       Supplier<JedisCluster> jedisClusterFactory,
@@ -168,8 +163,7 @@ public class RedisClient implements Closeable {
     // or a redis cluster that goes down.
     while (true) {
       try {
-        T result = defaultCall(withJedis);
-        return result;
+        return defaultCall(withJedis);
       } catch (Exception e) {
         redisErrorCounter.inc();
         System.out.println("Failure in RedisClient::call");

--- a/src/main/java/build/buildfarm/common/redis/RedisClient.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisClient.java
@@ -16,6 +16,7 @@ package build.buildfarm.common.redis;
 
 import io.grpc.Status;
 import io.grpc.Status.Code;
+import io.prometheus.client.Counter;
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.ConnectException;
@@ -23,29 +24,29 @@ import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.exceptions.JedisDataException;
 import redis.clients.jedis.exceptions.JedisException;
 import redis.clients.jedis.exceptions.JedisNoReachableClusterNodeException;
-import java.util.function.Supplier;
-import io.prometheus.client.Counter;
-import lombok.extern.java.Log;
-import java.util.logging.Level;
-import lombok.extern.java.Log;
 
 /**
  * @class RedisClient
  * @brief Responsible for making calls to redis.
  */
-@Log
 public class RedisClient implements Closeable {
-
   // Metrics to detect any kind of redis failures.
   // Often due to network issues are the redis cluster going down.
-  private static final Counter redisErrorCounter = Counter.build().name("redis_client_error").help("Count of redis client failures").register();
-  private static final Counter redisClientRebuildErrorCounter = Counter.build().name("redis_client_rebuild_error").help("Count of failures rebuilding redis client").register();
-      
+  private static final Counter redisErrorCounter =
+      Counter.build().name("redis_client_error").help("Count of redis client failures").register();
+  private static final Counter redisClientRebuildErrorCounter =
+      Counter.build()
+          .name("redis_client_rebuild_error")
+          .help("Count of failures rebuilding redis client")
+          .register();
+  private boolean restablishClientOnFailures = false;
+
   private static final String MISCONF_RESPONSE = "MISCONF";
 
   @FunctionalInterface
@@ -83,10 +84,19 @@ public class RedisClient implements Closeable {
   public RedisClient(JedisCluster jedis) {
     this.jedis = jedis;
   }
-  
+
   public RedisClient(JedisCluster jedis, Supplier<JedisCluster> jedisClusterFactory) {
     this.jedis = jedis;
     this.jedisClusterFactory = jedisClusterFactory;
+  }
+
+  public RedisClient(
+      JedisCluster jedis,
+      Supplier<JedisCluster> jedisClusterFactory,
+      boolean restablishClientOnFailures) {
+    this.jedis = jedis;
+    this.jedisClusterFactory = jedisClusterFactory;
+    this.restablishClientOnFailures = restablishClientOnFailures;
   }
 
   @Override
@@ -106,25 +116,24 @@ public class RedisClient implements Closeable {
   }
 
   public void run(Consumer<JedisCluster> withJedis) throws IOException {
-    callEnsureSuccess(
+    callImpl(
         (JedisContext<Void>)
             jedis -> {
               withJedis.accept(jedis);
               return null;
             });
   }
-  
 
   public <T> T blockingCall(JedisInterruptibleContext<T> withJedis)
       throws IOException, InterruptedException {
     return defaultBlockingCall(withJedis);
   }
-  
+
   private <T> T defaultBlockingCall(JedisInterruptibleContext<T> withJedis)
       throws IOException, InterruptedException {
     AtomicReference<InterruptedException> interruption = new AtomicReference<>(null);
     T result =
-        callEnsureSuccess(
+        callImpl(
             jedis -> {
               try {
                 return withJedis.run(jedis);
@@ -141,38 +150,45 @@ public class RedisClient implements Closeable {
   }
 
   public <T> T call(JedisContext<T> withJedis) throws IOException {
-    return callEnsureSuccess(withJedis);
+    return callImpl(withJedis);
   }
-  
-  private <T> T callEnsureSuccess(JedisContext<T> withJedis) {
-    while(true){
+
+  private <T> T callImpl(JedisContext<T> withJedis) throws IOException {
+    // Typical configuration that does not handle exceptions
+    // or try to restablish the jedis client on failures.
+    if (!restablishClientOnFailures) {
+      return defaultCall(withJedis);
+    }
+
+    // Alternatively,
+    // Capture all redis problems at the client level.
+    // Try to re-establish the client and log all issues.
+    // This will block the overall thread until redis can be connected to.
+    // It may be a useful strategy for gaining stability on a poorly performing network,
+    // or a redis cluster that goes down.
+    while (true) {
       try {
         T result = defaultCall(withJedis);
         return result;
-      }
-      catch (Exception e){
+      } catch (Exception e) {
         redisErrorCounter.inc();
-        log.log(Level.SEVERE,"Failure in RedisClient::call");
-        log.log(Level.SEVERE,e.toString());
+        System.out.println("Failure in RedisClient::call");
+        System.out.println(e.toString());
         rebuildJedisCluser();
       }
     }
-    
-  }
-  
-  private void rebuildJedisCluser(){
-        try {
-          log.log(Level.SEVERE,"Rebuilding redis client");
-           jedis = jedisClusterFactory.get();
-        }
-        catch (Exception e){
-          redisClientRebuildErrorCounter.inc();
-          log.log(Level.SEVERE,"Failed to rebuild redis client");
-          log.log(Level.SEVERE,e.toString());
-        }
-    
   }
 
+  private void rebuildJedisCluser() {
+    try {
+      System.out.println("Rebuilding redis client");
+      jedis = jedisClusterFactory.get();
+    } catch (Exception e) {
+      redisClientRebuildErrorCounter.inc();
+      System.out.println("Failed to rebuild redis client");
+      System.out.println(e.toString());
+    }
+  }
 
   private <T> T defaultCall(JedisContext<T> withJedis) throws IOException {
     throwIfClosed();

--- a/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
@@ -497,7 +497,11 @@ public class RedisShardBackplane implements Backplane {
     // Construct a single redis client to be used throughout the entire backplane.
     // We wish to avoid various synchronous and error handling issues that could occur when using
     // multiple clients.
-    client = new RedisClient(jedisClusterFactory.get());
+    client =
+        new RedisClient(
+            jedisClusterFactory.get(),
+            jedisClusterFactory,
+            configs.getBackplane().isReconnectClient());
     // Create containers that make up the backplane
     state = DistributedStateCreator.create(client);
 


### PR DESCRIPTION
 - allow the client to reconnect on redis exceptions
 - prevent exceptions from surfacing to other code getting servers / workers stuck.
 - print metrics on redis failures so we can track their occurrence 