### PR TITLE
[redis] Actually respect dequeue timeout in priortyqueue dequeue

### DIFF
--- a/examples/config.yml
+++ b/examples/config.yml
@@ -75,6 +75,7 @@ backplane:
   maxQueueDepth: 100000
   maxPreQueueDepth: 1000000
   priorityQueue: false
+  priorityPollIntervalMillis: 100
   timeout: 10000
   maxAttempts: 20
   cacheCas: false

--- a/src/main/java/build/buildfarm/common/config/Backplane.java
+++ b/src/main/java/build/buildfarm/common/config/Backplane.java
@@ -43,6 +43,7 @@ public class Backplane {
   private String[] redisNodes = {};
   private int maxAttempts = 20;
   private boolean cacheCas = false;
+  private long priorityPollIntervalMillis = 100;
 
   public String getRedisUri() {
     // use environment override (useful for containerized deployment)

--- a/src/main/java/build/buildfarm/common/redis/RedisQueueFactory.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisQueueFactory.java
@@ -14,6 +14,7 @@
 
 package build.buildfarm.common.redis;
 
+import build.buildfarm.common.config.BuildfarmConfigs;
 import build.buildfarm.common.config.Queue;
 
 /**
@@ -21,6 +22,8 @@ import build.buildfarm.common.config.Queue;
  * @brief A redis queue factory.
  */
 public class RedisQueueFactory {
+  private static BuildfarmConfigs configs = BuildfarmConfigs.getInstance();
+
   public QueueInterface getQueue(Queue.QUEUE_TYPE queueType, String name) {
     if (queueType == null) {
       return null;
@@ -28,7 +31,7 @@ public class RedisQueueFactory {
     if (queueType.equals(Queue.QUEUE_TYPE.standard)) {
       return new RedisQueue(name);
     } else if (queueType.equals(Queue.QUEUE_TYPE.priority)) {
-      return new RedisPriorityQueue(name);
+      return new RedisPriorityQueue(name, configs.getBackplane().getPriorityPollIntervalMillis());
     }
     return null;
   }

--- a/src/test/java/build/buildfarm/common/redis/RedisPriorityQueueTest.java
+++ b/src/test/java/build/buildfarm/common/redis/RedisPriorityQueueTest.java
@@ -19,6 +19,8 @@ import static com.google.common.truth.Truth.assertThat;
 import build.buildfarm.common.StringVisitor;
 import build.buildfarm.common.config.BuildfarmConfigs;
 import build.buildfarm.instance.shard.JedisClusterFactory;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.After;
@@ -252,6 +254,23 @@ public class RedisPriorityQueueTest {
     val = queue.dequeue(redis, 1);
     assertThat(val).isEqualTo("baz");
     assertThat(queue.size(redis)).isEqualTo(0);
+  }
+
+  // Function under test: dequeue
+  // Reason for testing: Test dequeue times out correctly
+  // Failure explanation: dequeue does not spend the full time waiting for response
+  @Test
+  public void checkDequeueTimeout() throws Exception {
+    // ARRANGE
+    RedisPriorityQueue queue = new RedisPriorityQueue("test");
+
+    Instant start = Instant.now();
+    String val = queue.dequeue(redis, 1);
+    Instant finish = Instant.now();
+
+    long timeElapsed = Duration.between(start, finish).toMillis();
+    assertThat(timeElapsed).isGreaterThan(1000L);
+    assertThat(val).isEqualTo(null);
   }
 
   // Function under test: dequeue


### PR DESCRIPTION
The dequeue function in the RedisPriorityQueue wasn't actually waiting for the full timeout.   It was also hitting redis up to 1k evals / second in our environment.

related to #1304 