### PR TITLE
[Worker] Catch all in ReportResultStage

### DIFF
--- a/src/main/java/build/buildfarm/worker/ReportResultStage.java
+++ b/src/main/java/build/buildfarm/worker/ReportResultStage.java
@@ -203,7 +203,7 @@ public class ReportResultStage extends PipelineStage {
       workerContext.destroyExecDir(operationContext.execDir);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-    } catch (IOException e) {
+    } catch (Exception e) {
       log.log(
           Level.SEVERE,
           String.format("error destroying exec dir %s", operationContext.execDir.toString()),

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -715,7 +715,8 @@ class ShardWorkerContext implements WorkerContext {
   // might want to split for removeDirectory and decrement references to avoid removing for streamed
   // output
   @Override
-  public void destroyExecDir(Path execDir) throws IOException, InterruptedException {
+  public void destroyExecDir(Path execDir)
+      throws IllegalStateException, IOException, InterruptedException {
     execFileSystem.destroyExecDir(execDir);
   }
 


### PR DESCRIPTION
I've got a situation where a worker is missing directories upon tearing down an action. When it throws an exception the worker becomes stuck forever. This makes it more resilient to benign errors and catches them all for safety to prevent a worker being wedged. Here, wedged meant that the pipeline stage, `ReportResultStage`, thread has exited due to the `IllegalStateException` and worker process remains running.

I get the stack:
```
SEVERE: ReportResultStage::run(): stage terminated due to exception
java.lang.IllegalStateException: inputDirectory dbbcb4da7a1858c1debab42054b872a60a64072fe34349b01047e5930d2e3721/79 is not in directoryStorage
        at build.buildfarm.cas.cfc.CASFileCache.decrementReferencesSynchronized(CASFileCache.java:1651)
        at build.buildfarm.cas.cfc.CASFileCache.decrementReferences(CASFileCache.java:1612)
        at build.buildfarm.worker.shard.CFCExecFileSystem.destroyExecDir(CFCExecFileSystem.java:444)
        at build.buildfarm.worker.shard.ShardWorkerContext.destroyExecDir(ShardWorkerContext.java:719)
        at build.buildfarm.worker.ReportResultStage.after(ReportResultStage.java:203)
        at build.buildfarm.worker.PipelineStage.iterate(PipelineStage.java:129)
        at build.buildfarm.worker.PipelineStage.runInterruptible(PipelineStage.java:44)
        at build.buildfarm.worker.PipelineStage.run(PipelineStage.java:51)
        at java.base/java.lang.Thread.run(Thread.java:1589)
```

As a side note, I've been looking to insulate against this case on a macOS VM based setup. The healthcheck endpoint seems like a possible place we could test pipeline status; for something like when the `ReportResultStage` threads or other vital threads exit but don't terminate the worker. 