### PR TITLE
Add context to NOT_FOUND responses

### DIFF
--- a/src/main/java/build/buildfarm/common/services/ByteStreamService.java
+++ b/src/main/java/build/buildfarm/common/services/ByteStreamService.java
@@ -306,7 +306,12 @@ public class ByteStreamService extends ByteStreamImplBase {
           limit,
           onErrorLogReadObserver(resourceName, Compressor.Value.IDENTITY, offset, target));
     } catch (NoSuchFileException e) {
-      responseObserver.onError(NOT_FOUND.asException());
+      responseObserver.onError(
+          NOT_FOUND
+              .withDescription(
+                  String.format(
+                      "Resource not found: %s, offset: %d, limit: %d", resourceName, offset, limit))
+              .asException());
     } catch (IOException e) {
       responseObserver.onError(Status.fromThrowable(e).asException());
     }

--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -2502,7 +2502,7 @@ public class ShardInstance extends AbstractServerInstance {
     if (operation == null) {
       return immediateFailedFuture(
           Status.NOT_FOUND
-              .withDescription(String.format("Could not find operation: %s", operationName))
+              .withDescription(String.format("Operation not found: %s", operationName))
               .asException());
     }
     return watchOperation(operation, watcher, /* initial=*/ true);

--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -1062,7 +1062,7 @@ public class ShardInstance extends AbstractServerInstance {
     @Override
     public void onSuccess(List<String> workersList) {
       if (workersList.isEmpty()) {
-        onFailure(Status.NOT_FOUND.asException());
+        onFailure(Status.NOT_FOUND.withDescription("No workers found.").asException());
       } else {
         Collections.shuffle(workersList, rand);
         onQueue(new ArrayDeque<String>(workersList));
@@ -2500,7 +2500,10 @@ public class ShardInstance extends AbstractServerInstance {
   public ListenableFuture<Void> watchOperation(String operationName, Watcher watcher) {
     Operation operation = getOperation(operationName);
     if (operation == null) {
-      return immediateFailedFuture(Status.NOT_FOUND.asException());
+      return immediateFailedFuture(
+          Status.NOT_FOUND
+              .withDescription(String.format("Could not find operation: %s", operationName))
+              .asException());
     }
     return watchOperation(operation, watcher, /* initial=*/ true);
   }

--- a/src/main/java/build/buildfarm/server/services/ExecutionService.java
+++ b/src/main/java/build/buildfarm/server/services/ExecutionService.java
@@ -122,7 +122,9 @@ public class ExecutionService extends ExecutionGrpc.ExecutionImplBase {
     public final synchronized void observe(Operation operation) {
       cancel();
       if (operation == null) {
-        throw Status.NOT_FOUND.asRuntimeException();
+        throw Status.NOT_FOUND
+            .withDescription(String.format("Operation not found: %s", operation.getName()))
+            .asRuntimeException();
       }
       deliver(operation);
       keepaliveFuture = scheduleKeepalive(operation.getName());


### PR DESCRIPTION
Add additional context to NOT_FOUND exceptions.
This is to help debug missing operations from this issue: https://github.com/bazelbuild/bazel-buildfarm/issues/1303