### PR TITLE
[bug] avoid NPE on null operation in ExecutionService

### DIFF
--- a/src/main/java/build/buildfarm/server/services/ExecutionService.java
+++ b/src/main/java/build/buildfarm/server/services/ExecutionService.java
@@ -122,9 +122,7 @@ public class ExecutionService extends ExecutionGrpc.ExecutionImplBase {
     public final synchronized void observe(Operation operation) {
       cancel();
       if (operation == null) {
-        throw Status.NOT_FOUND
-            .withDescription(String.format("Operation not found: %s", operation.getName()))
-            .asRuntimeException();
+        throw Status.NOT_FOUND.withDescription("Operation not found.").asRuntimeException();
       }
       deliver(operation);
       keepaliveFuture = scheduleKeepalive(operation.getName());


### PR DESCRIPTION
we should not call `operation.getName()` when `operation` is null.