### PR TITLE
[execution] allow tmpfs and cgroups enforcement

### DIFF
--- a/_site/docs/configuration/configuration.md
+++ b/_site/docs/configuration/configuration.md
@@ -291,11 +291,12 @@ worker:
 
 ### Sandbox Settings
 
-| Configuration | Accepted and _Default_ Values | Description                                       |
-|---------------|-------------------------------|---------------------------------------------------|
-| alwaysUse             | boolean, _false_      | Enforce that the sandbox be used on every acion.  |
-| selectForBlockNetwork | boolean, _false_      | `block-network` enables sandbox action execution. |
-| selectForTmpFs        | boolean, _false_      | `tmpfs` enables sandbox action execution.         |
+| Configuration | Accepted and _Default_ Values | Description                                          |
+|---------------|-------------------------------|------------------------------------------------------|
+| alwaysUse             | boolean, _false_      | Enforce that the sandbox be used on every acion.     |
+| alwaysUseTmpFs        | boolean, _false_      | Enforce that the sandbox uses tmpfs on every acion.  |
+| selectForBlockNetwork | boolean, _false_      | `block-network` enables sandbox action execution.    |
+| selectForTmpFs        | boolean, _false_      | `tmpfs` enables sandbox action execution.            |
 
 Example:
 
@@ -303,6 +304,7 @@ Example:
 worker:
   sandboxSettings:
     alwaysUse: true
+    alwaysUseTmpFs: true
     selectForBlockNetwork: false
     selectForTmpFs: false
 ```

--- a/_site/docs/configuration/configuration.md
+++ b/_site/docs/configuration/configuration.md
@@ -293,7 +293,8 @@ worker:
 
 | Configuration | Accepted and _Default_ Values | Description                                          |
 |---------------|-------------------------------|------------------------------------------------------|
-| alwaysUse             | boolean, _false_      | Enforce that the sandbox be used on every acion.     |
+| alwaysUseSandbox      | boolean, _false_      | Enforce that the sandbox be used on every acion.     |
+| alwaysUseCgroups      | boolean, _true_       | Enforce that actions run under cgroups.              |
 | alwaysUseTmpFs        | boolean, _false_      | Enforce that the sandbox uses tmpfs on every acion.  |
 | selectForBlockNetwork | boolean, _false_      | `block-network` enables sandbox action execution.    |
 | selectForTmpFs        | boolean, _false_      | `tmpfs` enables sandbox action execution.            |
@@ -303,11 +304,14 @@ Example:
 ```yaml
 worker:
   sandboxSettings:
-    alwaysUse: true
+    alwaysUseSandbox: true
+    alwaysUseCgroups: true
     alwaysUseTmpFs: true
     selectForBlockNetwork: false
     selectForTmpFs: false
 ```
+
+Note: In order for these settings to take effect, you must also configure `limitGlobalExecution: true`.
 
 ### Dequeue Match
 

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -129,7 +129,8 @@ worker:
   errorOperationOutputSizeExceeded: false
   gracefulShutdownSeconds: 0
   sandboxSettings:
-    alwaysUse: false
+    alwaysUseSandbox: false
+    alwaysUseCgroups: false
     alwaysUseTmpFs: false
     selectForBlockNetwork: false
     selectForTmpFs: false

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -130,6 +130,7 @@ worker:
   gracefulShutdownSeconds: 0
   sandboxSettings:
     alwaysUse: false
+    alwaysUseTmpFs: false
     selectForBlockNetwork: false
     selectForTmpFs: false
   createSymlinkOutputs: false

--- a/src/main/java/build/buildfarm/common/config/SandboxSettings.java
+++ b/src/main/java/build/buildfarm/common/config/SandboxSettings.java
@@ -33,6 +33,13 @@ public class SandboxSettings {
   public boolean alwaysUse = false;
 
   /**
+   * @field alwaysUseTmpFs
+   * @brief Whether or not to always use tmpfs when using the sandbox.
+   * @details It may be preferred to enforce sandbox usage than rely on client selection.
+   */
+  public boolean alwaysUseTmpFs = false;
+
+  /**
    * @field selectForBlockNetwork
    * @brief If the action requires "block network" use the sandbox to fulfill this request.
    * @details Otherwise, there may be no alternative solution and the "block network" request will

--- a/src/main/java/build/buildfarm/common/config/SandboxSettings.java
+++ b/src/main/java/build/buildfarm/common/config/SandboxSettings.java
@@ -37,7 +37,7 @@ public class SandboxSettings {
    * @brief Whether or not to use cgroups when sandboxing actions.
    * @details It may be preferred to enforce cgroup usage.
    */
-  public boolean alwaysUseCgroups = false;
+  public boolean alwaysUseCgroups = true;
 
   /**
    * @field alwaysUseTmpFs

--- a/src/main/java/build/buildfarm/common/config/SandboxSettings.java
+++ b/src/main/java/build/buildfarm/common/config/SandboxSettings.java
@@ -33,6 +33,13 @@ public class SandboxSettings {
   public boolean alwaysUse = false;
 
   /**
+   * @field alwaysUseCgroups
+   * @brief Whether or not to use cgroups when sandboxing actions.
+   * @details It may be preferred to enforce cgroup usage.
+   */
+  public boolean alwaysUseCgroups = false;
+
+  /**
    * @field alwaysUseTmpFs
    * @brief Whether or not to always use tmpfs when using the sandbox.
    * @details It may be preferred to enforce sandbox usage than rely on client selection.

--- a/src/main/java/build/buildfarm/common/config/SandboxSettings.java
+++ b/src/main/java/build/buildfarm/common/config/SandboxSettings.java
@@ -26,11 +26,11 @@ import lombok.Data;
 @Data
 public class SandboxSettings {
   /**
-   * @field alwaysUse
+   * @field alwaysUseSandbox
    * @brief Whether or not to always use the sandbox when running actions.
    * @details It may be preferred to enforce sandbox usage than rely on client selection.
    */
-  public boolean alwaysUse = false;
+  public boolean alwaysUseSandbox = false;
 
   /**
    * @field alwaysUseCgroups

--- a/src/main/java/build/buildfarm/worker/resources/ResourceDecider.java
+++ b/src/main/java/build/buildfarm/worker/resources/ResourceDecider.java
@@ -200,10 +200,9 @@ public final class ResourceDecider {
   }
 
   private static void decideSandboxUsage(ResourceLimits limits, SandboxSettings sandbox) {
-
     // Decide which sandbox limitations are enabled by default acording to the deployment's
     // configuration.
-    if (sandbox.isAlwaysUse()) {
+    if (sandbox.isAlwaysUseSandbox()) {
       limits.useLinuxSandbox = true;
       limits.description.add("enabled sandbox by default");
     }

--- a/src/main/java/build/buildfarm/worker/resources/ResourceDecider.java
+++ b/src/main/java/build/buildfarm/worker/resources/ResourceDecider.java
@@ -203,8 +203,14 @@ public final class ResourceDecider {
     // configured on
     if (sandbox.isAlwaysUse()) {
       limits.useLinuxSandbox = true;
-      limits.description.add("enabled");
+      limits.description.add("enabled sandbox by default");
       return;
+    }
+
+    // configured on
+    if (sandbox.isAlwaysUseTmpFs()) {
+      limits.tmpFs = true;
+      limits.description.add("enabled tmpfs by default");
     }
 
     // selected based on other features

--- a/src/main/java/build/buildfarm/worker/resources/ResourceDecider.java
+++ b/src/main/java/build/buildfarm/worker/resources/ResourceDecider.java
@@ -200,14 +200,17 @@ public final class ResourceDecider {
   }
 
   private static void decideSandboxUsage(ResourceLimits limits, SandboxSettings sandbox) {
-    // configured on
+
+    // Decide which sandbox limitations are enabled by default acording to the deployment's
+    // configuration.
     if (sandbox.isAlwaysUse()) {
       limits.useLinuxSandbox = true;
       limits.description.add("enabled sandbox by default");
-      return;
     }
-
-    // configured on
+    if (sandbox.isAlwaysUseCgroups()) {
+      limits.cgroups = true;
+      limits.description.add("enabled cgroups by default");
+    }
     if (sandbox.isAlwaysUseTmpFs()) {
       limits.tmpFs = true;
       limits.description.add("enabled tmpfs by default");

--- a/src/main/java/build/buildfarm/worker/resources/ResourceLimits.java
+++ b/src/main/java/build/buildfarm/worker/resources/ResourceLimits.java
@@ -76,6 +76,13 @@ public class ResourceLimits {
   public ContainerSettings containerSettings = new ContainerSettings();
 
   /**
+   * @field cgroups
+   * @brief Whether to use cgroups for resource limitation.
+   * @details Decides whether to use cgroups for restricting cores, mem, etc.
+   */
+  public boolean cgroups = true;
+
+  /**
    * @field cpu
    * @brief Resource limitations on CPUs.
    * @details Decides specific CPU limitations and whether to apply them for a given action.

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -922,28 +922,31 @@ class ShardWorkerContext implements WorkerContext {
     // ResourceLimits object. We apply the cgroup settings to file resources
     // and collect group names to use on the CLI.
     String operationId = getOperationId(operationName);
-    final Group group = operationsGroup.getChild(operationId);
     ArrayList<IOResource> resources = new ArrayList<>();
-    ArrayList<String> usedGroups = new ArrayList<>();
 
-    // Possibly set core restrictions.
-    if (limits.cpu.limit) {
-      applyCpuLimits(group, limits, resources);
-      usedGroups.add(group.getCpu().getName());
-    }
+    if (limits.cgroups) {
+      final Group group = operationsGroup.getChild(operationId);
+      ArrayList<String> usedGroups = new ArrayList<>();
 
-    // Possibly set memory restrictions.
-    if (limits.mem.limit) {
-      applyMemLimits(group, limits, resources);
-      usedGroups.add(group.getMem().getName());
-    }
+      // Possibly set core restrictions.
+      if (limits.cpu.limit) {
+        applyCpuLimits(group, limits, resources);
+        usedGroups.add(group.getCpu().getName());
+      }
 
-    // Decide the CLI for running under cgroups
-    if (!usedGroups.isEmpty()) {
-      arguments.add(
-          configs.getExecutionWrappers().getCgroups(),
-          "-g",
-          String.join(",", usedGroups) + ":" + group.getHierarchy());
+      // Possibly set memory restrictions.
+      if (limits.mem.limit) {
+        applyMemLimits(group, limits, resources);
+        usedGroups.add(group.getMem().getName());
+      }
+
+      // Decide the CLI for running under cgroups
+      if (!usedGroups.isEmpty()) {
+        arguments.add(
+            configs.getExecutionWrappers().getCgroups(),
+            "-g",
+            String.join(",", usedGroups) + ":" + group.getHierarchy());
+      }
     }
 
     // Possibly set network restrictions.

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -829,7 +829,9 @@ class ShardWorkerContext implements WorkerContext {
   @Override
   public void createExecutionLimits() {
     if (shouldLimitCoreUsage()) {
-      createOperationExecutionLimits();
+      if (configs.getWorker().getSandboxSettings().isAlwaysUseCgroups()) {
+        createOperationExecutionLimits();
+      }
     }
   }
 
@@ -860,11 +862,13 @@ class ShardWorkerContext implements WorkerContext {
 
   @Override
   public void destroyExecutionLimits() {
-    try {
-      operationsGroup.getCpu().close();
-      executionsGroup.getCpu().close();
-    } catch (IOException e) {
-      throw new RuntimeException(e);
+    if (configs.getWorker().getSandboxSettings().isAlwaysUseCgroups()) {
+      try {
+        operationsGroup.getCpu().close();
+        executionsGroup.getCpu().close();
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
     }
   }
 

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -828,8 +828,8 @@ class ShardWorkerContext implements WorkerContext {
 
   @Override
   public void createExecutionLimits() {
-   if (shouldLimitCoreUsage() && configs.getWorker().getSandboxSettings().isAlwaysUseCgroups()) {
-        createOperationExecutionLimits();
+    if (shouldLimitCoreUsage() && configs.getWorker().getSandboxSettings().isAlwaysUseCgroups()) {
+      createOperationExecutionLimits();
     }
   }
 

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -828,10 +828,8 @@ class ShardWorkerContext implements WorkerContext {
 
   @Override
   public void createExecutionLimits() {
-    if (shouldLimitCoreUsage()) {
-      if (configs.getWorker().getSandboxSettings().isAlwaysUseCgroups()) {
+   if (shouldLimitCoreUsage() && configs.getWorker().getSandboxSettings().isAlwaysUseCgroups()) {
         createOperationExecutionLimits();
-      }
     }
   }
 

--- a/src/test/java/build/buildfarm/worker/resources/ResourceDeciderTest.java
+++ b/src/test/java/build/buildfarm/worker/resources/ResourceDeciderTest.java
@@ -726,7 +726,7 @@ public class ResourceDeciderTest {
     // ARRANGE
     Command command = Command.newBuilder().build();
     SandboxSettings sandboxSettings = new SandboxSettings();
-    sandboxSettings.alwaysUse = true;
+    sandboxSettings.alwaysUseSandbox = true;
 
     // ACT
     ResourceLimits limits =


### PR DESCRIPTION
### tmpfs
Previously we required bazel clients to opt-in with an exec_property.  Now buildfarm has the ability to enforce tmpfs usage as part of deployment configuration.
See:  `alwaysUseTmpFs: true`

### cgroups
cgroups was previously enabled via `limitGlobalExecution`.  However, there was no way to opt-out of cgroups and opt-in to other restrictions.  limitGlobalExecution is still required for accessing restrictions, but it will no longer guarantee cgroups is used.  For that, deployments must set:
See:  `alwaysUseCgroups: true`


### Additional context
We may also want to experiment with sandbox, but not cgroups in our deployment.  There is currently no way to do this because enabling sandbox also requires enabling  `limitGlobalExecution`, but doing so enables cgroups.   By making these settings more granular we are able opt into and enforce particular execution wrappers.