### PR TITLE
Incorporate rules_{python,proto} for bazel_tools

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,23 +8,14 @@ load(":defs.bzl", "buildfarm_init")
 
 buildfarm_init()
 
-load("@rules_oss_audit//oss_audit:repositories.bzl", "rules_oss_audit_dependencies")
+load(":generated.bzl", "buildfarm_generated")
 
-rules_oss_audit_dependencies()
+buildfarm_generated()
 
-load("@rules_oss_audit//oss_audit:setup.bzl", "rules_oss_audit_setup")
+load("@oss_audit_deps//:requirements.bzl", "install_deps")
 
-rules_oss_audit_setup()
-
-load("@maven//:compat.bzl", "compat_repositories")
-
-compat_repositories()
+install_deps()
 
 load(":images.bzl", "buildfarm_images")
 
 buildfarm_images()
-
-# Find rpmbuild if it exists.
-load("@rules_pkg//toolchains/rpm:rpmbuild_configure.bzl", "find_system_rpmbuild")
-
-find_system_rpmbuild(name = "rules_pkg_rpmbuild")

--- a/defs.bzl
+++ b/defs.bzl
@@ -2,16 +2,19 @@
 buildfarm definitions that can be imported into other WORKSPACE files
 """
 
-load("@rules_jvm_external//:defs.bzl", "maven_install")
-load("@remote_apis//:repository_rules.bzl", "switched_rules_by_language")
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+load("@com_grail_bazel_toolchain//toolchain:rules.bzl", "llvm_toolchain")
 load(
     "@io_bazel_rules_docker//repositories:repositories.bzl",
     container_repositories = "repositories",
 )
-load("@io_grpc_grpc_java//:repositories.bzl", "grpc_java_repositories")
-load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
-load("@com_grail_bazel_toolchain//toolchain:rules.bzl", "llvm_toolchain")
 load("@io_bazel_rules_k8s//k8s:k8s.bzl", "k8s_repositories")
+load("@io_grpc_grpc_java//:repositories.bzl", "grpc_java_repositories")
+load("@remote_apis//:repository_rules.bzl", "switched_rules_by_language")
+load("@rules_jvm_external//:defs.bzl", "maven_install")
+load("@rules_oss_audit//oss_audit:setup.bzl", "rules_oss_audit_setup")
+load("@rules_pkg//toolchains/rpm:rpmbuild_configure.bzl", "find_system_rpmbuild")
+load("@rules_python//python:repositories.bzl", "python_register_toolchains")
 
 IO_NETTY_MODULES = [
     "buffer",
@@ -161,4 +164,16 @@ def buildfarm_init(name = "buildfarm"):
     llvm_toolchain(
         name = "llvm_toolchain",
         llvm_version = "10.0.0",
+    )
+
+    rules_oss_audit_setup()
+
+    # Find rpmbuild if it exists.
+    find_system_rpmbuild(name = "rules_pkg_rpmbuild")
+
+    python_register_toolchains(
+        name = "python3_9",
+        # Available versions are listed in @rules_python//python:versions.bzl.
+        # We recommend using the same version your team is already standardized on.
+        python_version = "3.9",
     )

--- a/deps.bzl
+++ b/deps.bzl
@@ -121,6 +121,20 @@ def archive_dependencies(third_party):
             "patch_args": ["-p1"],
             "patches": ["%s/bazel:bazel_visibility.patch" % third_party],
         },
+        {
+            "name": "rules_python",
+            "sha256": "a644da969b6824cc87f8fe7b18101a8a6c57da5db39caa6566ec6109f37d2141",
+            "strip_prefix": "rules_python-0.20.0",
+            "urls": ["https://github.com/bazelbuild/rules_python/releases/download/0.20.0/rules_python-0.20.0.tar.gz"],
+        },
+        {
+            "name": "rules_proto",
+            "sha256": "dc3fb206a2cb3441b485eb1e423165b231235a1ea9b031b4433cf7bc1fa460dd",
+            "strip_prefix": "rules_proto-5.3.0-21.7",
+            "urls": [
+                "https://github.com/bazelbuild/rules_proto/archive/refs/tags/5.3.0-21.7.tar.gz",
+            ],
+        },
 
         # Optional execution wrappers
         {
@@ -135,6 +149,14 @@ def archive_dependencies(third_party):
             "sha256": "02962810bcf82d0c66f929ccc163423f53773b8b154574ca956345523243e70d",
             "strip_prefix": "rules_oss_audit-1b2690cefd5a960c181e0d89bf3c076294a0e6f4",
             "url": "https://github.com/vmware/rules_oss_audit/archive/1b2690cefd5a960c181e0d89bf3c076294a0e6f4.zip",
+        },
+        {
+            "name": "bazel_skylib",
+            "sha256": "1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c",
+            "urls": [
+                "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
+                "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
+            ],
         },
     ]
 

--- a/generated.bzl
+++ b/generated.bzl
@@ -1,0 +1,16 @@
+"""
+buildfarm generated definitions that can be imported into other WORKSPACE files
+"""
+
+load("@maven//:compat.bzl", "compat_repositories")
+load("@python3_9//:defs.bzl", "interpreter")
+load("@rules_python//python:pip.bzl", "pip_parse")
+
+def buildfarm_generated():
+    compat_repositories()
+
+    pip_parse(
+        name = "oss_audit_deps",
+        python_interpreter_target = interpreter,
+        requirements = "@rules_oss_audit//oss_audit/tools:requirements.txt",
+    )


### PR DESCRIPTION
Since bazelbuild/bazel#17545, bazel_tools apparantly requires rules_python and rules_proto to successfully parse under bazel (load lines only). We only use affected bazel_tools (src/main/protobuf) in persistentworkers. Import these repositories to reinstate downstream CI passing.