### PR TITLE
Dropping ubuntu1604 support

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -37,16 +37,6 @@ tasks:
     - ./generate_coverage.sh
 
   # Typical unit tests that run across a variety of operating systems.
-  ubuntu1604:
-    name: "Unit Tests"
-    build_flags:
-    - "--build_tag_filters=-audit"
-    build_targets:
-    - "..."
-    test_flags:
-    - "--test_tag_filters=-integration,-redis"
-    test_targets:
-    - "..."
   ubuntu1804:
     name: "Unit Tests"
     build_targets:


### PR DESCRIPTION
Bazel no longer builds successfully under ubuntu1604. Removing it as a target as a partial solution for green unit test builds under bazel.