### PR TITLE
check null for wrapper arguments

### DIFF
--- a/src/main/java/build/buildfarm/worker/Executor.java
+++ b/src/main/java/build/buildfarm/worker/Executor.java
@@ -381,7 +381,7 @@ class Executor {
 
     arguments.add(wrapper.getPath());
 
-    if(wrapper.getArguments() != null) {
+    if (wrapper.getArguments() != null) {
       for (String argument : wrapper.getArguments()) {
         // If the argument is of the form <propertyName>, substitute the value of
         // the property from the platform specification.

--- a/src/main/java/build/buildfarm/worker/Executor.java
+++ b/src/main/java/build/buildfarm/worker/Executor.java
@@ -380,25 +380,29 @@ class Executor {
         uniqueIndex(operationContext.command.getPlatform().getPropertiesList(), Property::getName);
 
     arguments.add(wrapper.getPath());
-    for (String argument : wrapper.getArguments()) {
-      // If the argument is of the form <propertyName>, substitute the value of
-      // the property from the platform specification.
-      if (!argument.equals("<>")
-          && argument.charAt(0) == '<'
-          && argument.charAt(argument.length() - 1) == '>') {
-        // substitute with matching platform property content
-        // if this property is not present, the wrapper is ignored
-        String propertyName = argument.substring(1, argument.length() - 1);
-        Property property = properties.get(propertyName);
-        if (property == null) {
-          return ImmutableList.of();
+
+    if(wrapper.getArguments() != null) {
+      for (String argument : wrapper.getArguments()) {
+        // If the argument is of the form <propertyName>, substitute the value of
+        // the property from the platform specification.
+        if (!argument.equals("<>")
+            && argument.charAt(0) == '<'
+            && argument.charAt(argument.length() - 1) == '>') {
+          // substitute with matching platform property content
+          // if this property is not present, the wrapper is ignored
+          String propertyName = argument.substring(1, argument.length() - 1);
+          Property property = properties.get(propertyName);
+          if (property == null) {
+            return ImmutableList.of();
+          }
+          arguments.add(property.getValue());
+        } else {
+          // If the argument isn't of the form <propertyName>, add the argument directly:
+          arguments.add(argument);
         }
-        arguments.add(property.getValue());
-      } else {
-        // If the argument isn't of the form <propertyName>, add the argument directly:
-        arguments.add(argument);
       }
     }
+
     return arguments.build();
   }
 


### PR DESCRIPTION

I forgot to remove the `arguments:` attribute in my config file
```
  executionPolicies:
    - name: test
      executionWrapper:
        path: "/"
        arguments:
```
and I got this`NullPointerException`
```
Exception in thread "Thread-5093" java.lang.NullPointerException: Cannot read the array length because "<local4>" is null
        at build.buildfarm.worker.Executor.transformWrapper(Executor.java:383)
        at build.buildfarm.worker.Executor.executePolled(Executor.java:224)
        at build.buildfarm.worker.Executor.runInterruptible(Executor.java:162)
        at build.buildfarm.worker.Executor.run(Executor.java:330)
        at build.buildfarm.worker.ExecuteActionStage.lambda$iterate$0(ExecuteActionStage.java:138)
        at java.base/java.lang.Thread.run(Thread.java:833)
```

Check if the arguments are nil before the for-loop.