### PR TITLE
Restore storage-only worker registration.

### DIFF
--- a/src/main/java/build/buildfarm/backplane/Backplane.java
+++ b/src/main/java/build/buildfarm/backplane/Backplane.java
@@ -98,8 +98,8 @@ public interface Backplane {
 
   Iterable<Map.Entry<String, String>> getOperations(Set<String> operationIds) throws IOException;
 
-  /** Returns a set of the names of all active workers. */
-  Set<String> getWorkers() throws IOException;
+  /** Returns a set of the names of all active storage workers. */
+  Set<String> getStorageWorkers() throws IOException;
 
   /**
    * The AC stores full ActionResult objects in a hash map where the key is the digest of the action

--- a/src/main/java/build/buildfarm/common/config/Worker.java
+++ b/src/main/java/build/buildfarm/common/config/Worker.java
@@ -46,14 +46,15 @@ public class Worker {
     }
   }
 
-  public WorkerType getWorkerType() {
-    if (getCapabilities().isCas() && getCapabilities().isExecution()) {
-      return WorkerType.EXECUTE_AND_STORAGE;
-    }
+  public int getWorkerType() {
+    int workerType = 0;
     if (getCapabilities().isCas()) {
-      return WorkerType.STORAGE;
+      workerType |= WorkerType.STORAGE.getNumber();
     }
-    return WorkerType.EXECUTE;
+    if (getCapabilities().isExecution()) {
+      workerType |= WorkerType.EXECUTE.getNumber();
+    }
+    return workerType;
   }
 
   public Path getValidRoot() throws ConfigurationException {

--- a/src/main/java/build/buildfarm/instance/shard/DistributedState.java
+++ b/src/main/java/build/buildfarm/instance/shard/DistributedState.java
@@ -28,7 +28,7 @@ import build.buildfarm.common.redis.RedisMap;
 public class DistributedState {
   /**
    * @field executeWorkers
-   * @brief All of the execute-only workers register themselves to the cluster.
+   * @brief All of the execute-capable workers register themselves to the cluster.
    * @details This is done to keep track of which machines are online and known by the rest of the
    *     cluster.
    */
@@ -36,19 +36,11 @@ public class DistributedState {
 
   /**
    * @field storageWorkers
-   * @brief All of the storage-only workers register themselves to the cluster.
+   * @brief All of the storage-capable workers register themselves to the cluster.
    * @details This is done to keep track of which machines are online and known by the rest of the
    *     cluster.
    */
   public RedisHashMap storageWorkers;
-
-  /**
-   * @field executeAndStorageWorkers
-   * @brief All of the workers with both execute and storage register themselves to the cluster.
-   * @details This is done to keep track of which machines are online and known by the rest of the
-   *     cluster.
-   */
-  public RedisHashMap executeAndStorageWorkers;
 
   /**
    * @field prequeue

--- a/src/main/java/build/buildfarm/instance/shard/DistributedStateCreator.java
+++ b/src/main/java/build/buildfarm/instance/shard/DistributedStateCreator.java
@@ -58,7 +58,6 @@ public class DistributedStateCreator {
         new RedisHashMap(configs.getBackplane().getWorkersHashName() + "_execute");
     state.storageWorkers =
         new RedisHashMap(configs.getBackplane().getWorkersHashName() + "_storage");
-    state.executeAndStorageWorkers = new RedisHashMap(configs.getBackplane().getWorkersHashName());
 
     return state;
   }

--- a/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
@@ -141,7 +141,7 @@ public class RedisShardBackplane implements Backplane {
   private ExecutorService subscriberService = null;
   private @Nullable RedisClient client = null;
 
-  private final Set<String> workerSet = Collections.synchronizedSet(new HashSet<>());
+  private final Set<String> storageWorkerSet = Collections.synchronizedSet(new HashSet<>());
   private long workerSetExpiresAt = 0;
 
   private DistributedState state = new DistributedState();
@@ -452,7 +452,10 @@ public class RedisShardBackplane implements Backplane {
     subscriberService = BuildfarmExecutors.getSubscriberPool();
     subscriber =
         new RedisShardSubscriber(
-            watchers, workerSet, configs.getBackplane().getWorkerChannel(), subscriberService);
+            watchers,
+            storageWorkerSet,
+            configs.getBackplane().getWorkerChannel(),
+            subscriberService);
 
     operationSubscription =
         new RedisShardSubscription(
@@ -586,19 +589,22 @@ public class RedisShardBackplane implements Backplane {
   }
 
   private boolean addWorkerByType(JedisCluster jedis, ShardWorker shardWorker, String json) {
-    if (shardWorker.getWorkerType() == WorkerType.EXECUTE) {
-      return state.executeWorkers.insert(jedis, shardWorker.getEndpoint(), json);
-    } else if (shardWorker.getWorkerType() == WorkerType.STORAGE) {
-      return state.storageWorkers.insert(jedis, shardWorker.getEndpoint(), json);
+    int type = shardWorker.getWorkerType();
+    if (type == 0) {
+      return false; // no destination
     }
-
-    return state.executeAndStorageWorkers.insert(jedis, shardWorker.getEndpoint(), json);
+    boolean result = true;
+    if ((type & WorkerType.EXECUTE.getNumber()) == WorkerType.EXECUTE.getNumber()) {
+      result = state.executeWorkers.insert(jedis, shardWorker.getEndpoint(), json) && result;
+    }
+    if ((type & WorkerType.STORAGE.getNumber()) == WorkerType.STORAGE.getNumber()) {
+      result = state.storageWorkers.insert(jedis, shardWorker.getEndpoint(), json) && result;
+    }
+    return result;
   }
 
   private boolean removeWorkerAndPublish(JedisCluster jedis, String name, String changeJson) {
-    if (state.executeAndStorageWorkers.remove(jedis, name)
-        || state.storageWorkers.remove(jedis, name)
-        || state.executeWorkers.remove(jedis, name)) {
+    if (state.storageWorkers.remove(jedis, name) || state.executeWorkers.remove(jedis, name)) {
       jedis.publish(configs.getBackplane().getWorkerChannel(), changeJson);
       return true;
     }
@@ -664,21 +670,21 @@ public class RedisShardBackplane implements Backplane {
 
   @SuppressWarnings("ConstantConditions")
   @Override
-  public synchronized Set<String> getWorkers() throws IOException {
+  public synchronized Set<String> getStorageWorkers() throws IOException {
     long now = System.currentTimeMillis();
     if (now < workerSetExpiresAt) {
-      return workerSet;
+      return storageWorkerSet;
     }
 
-    synchronized (workerSet) {
-      Set<String> newWorkerSet = client.call(jedis -> fetchAndExpireWorkers(jedis, now));
-      workerSet.clear();
-      workerSet.addAll(newWorkerSet);
+    synchronized (storageWorkerSet) {
+      Set<String> newWorkerSet = client.call(jedis -> fetchAndExpireStorageWorkers(jedis, now));
+      storageWorkerSet.clear();
+      storageWorkerSet.addAll(newWorkerSet);
     }
 
     // fetch every 3 seconds
     workerSetExpiresAt = now + 3000;
-    return workerSet;
+    return storageWorkerSet;
   }
 
   // When performing a graceful scale down of workers, the backplane can provide worker names to the
@@ -686,7 +692,7 @@ public class RedisShardBackplane implements Backplane {
   // sophisticated in the future. But for now, we'll give back n random workers.
   public List<String> suggestedWorkersToScaleDown(int numWorkers) throws IOException {
     // get all workers
-    List<String> allWorkers = new ArrayList<>(getWorkers());
+    List<String> allWorkers = new ArrayList<>(getStorageWorkers());
 
     // ensure selection amount is in range [0 - size]
     numWorkers = Math.max(0, Math.min(numWorkers, allWorkers.size()));
@@ -724,10 +730,10 @@ public class RedisShardBackplane implements Backplane {
     }
   }
 
-  private Set<String> fetchAndExpireWorkers(JedisCluster jedis, long now) {
+  private Set<String> fetchAndExpireStorageWorkers(JedisCluster jedis, long now) {
     Set<String> returnWorkers = Sets.newConcurrentHashSet();
     ImmutableList.Builder<ShardWorker> invalidWorkers = ImmutableList.builder();
-    for (Map.Entry<String, String> entry : state.executeAndStorageWorkers.asMap(jedis).entrySet()) {
+    for (Map.Entry<String, String> entry : state.storageWorkers.asMap(jedis).entrySet()) {
       String json = entry.getValue();
       String name = entry.getKey();
       try {
@@ -1390,7 +1396,10 @@ public class RedisShardBackplane implements Backplane {
   @Override
   public BackplaneStatus backplaneStatus() throws IOException {
     BackplaneStatus.Builder builder = BackplaneStatus.newBuilder();
-    builder.addAllActiveWorkers(client.call(jedis -> state.executeAndStorageWorkers.keys(jedis)));
+    builder.addAllActiveWorkers(
+        client.call(
+            jedis ->
+                Sets.union(state.executeWorkers.keys(jedis), state.storageWorkers.keys(jedis))));
     builder.setDispatchedSize(client.call(jedis -> state.dispatchedOperations.size(jedis)));
     builder.setOperationQueue(state.operationQueue.status(client.call(jedis -> jedis)));
     builder.setPrequeue(state.prequeue.status(client.call(jedis -> jedis)));

--- a/src/main/java/build/buildfarm/instance/shard/RemoteInputStreamFactory.java
+++ b/src/main/java/build/buildfarm/instance/shard/RemoteInputStreamFactory.java
@@ -160,7 +160,7 @@ public class RemoteInputStreamFactory implements InputStreamFactory {
     Set<String> remoteWorkers;
     Set<String> locationSet;
     try {
-      Set<String> workers = backplane.getWorkers();
+      Set<String> workers = backplane.getStorageWorkers();
       if (publicName == null) {
         remoteWorkers = workers;
       } else {

--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -678,7 +678,7 @@ public class ShardInstance extends AbstractServerInstance {
     // blobs are missing.
     Deque<String> workers;
     try {
-      Set<String> workerSet = backplane.getWorkers();
+      Set<String> workerSet = backplane.getStorageWorkers();
       List<String> workersList;
       synchronized (workerSet) {
         workersList = new ArrayList<>(workerSet);
@@ -942,7 +942,7 @@ public class ShardInstance extends AbstractServerInstance {
     Set<String> workerSet;
     Set<String> locationSet;
     try {
-      workerSet = backplane.getWorkers();
+      workerSet = backplane.getStorageWorkers();
       locationSet = backplane.getBlobLocationSet(blobDigest);
       synchronized (workerSet) {
         workersList = new ArrayList<>(Sets.intersection(locationSet, workerSet));
@@ -1112,7 +1112,7 @@ public class ShardInstance extends AbstractServerInstance {
   String getRandomWorker() {
     Set<String> workerSet;
     try {
-      workerSet = backplane.getWorkers();
+      workerSet = backplane.getStorageWorkers();
     } catch (IOException e) {
       throw Status.fromThrowable(e).asRuntimeException();
     }

--- a/src/main/java/build/buildfarm/tools/WorkerProfile.java
+++ b/src/main/java/build/buildfarm/tools/WorkerProfile.java
@@ -123,7 +123,7 @@ class WorkerProfile {
   private static Set<String> fetchWorkers(JedisCluster jedis, long now) {
     Set<String> workers = Sets.newConcurrentHashSet();
     for (Map.Entry<String, String> entry :
-        jedis.hgetAll(configs.getBackplane().getWorkersHashName()).entrySet()) {
+        jedis.hgetAll(configs.getBackplane().getWorkersHashName() + "_storage").entrySet()) {
       String json = entry.getValue();
       try {
         if (json != null) {

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -562,7 +562,7 @@ public class Worker {
     // Create the appropriate writer for the context
     CasWriter writer;
     if (!configs.getWorker().getCapabilities().isCas()) {
-      writer = new RemoteCasWriter(backplane.getWorkers(), workerStubs);
+      writer = new RemoteCasWriter(backplane.getStorageWorkers(), workerStubs);
     } else {
       writer = new LocalCasWriter(execFileSystem);
     }
@@ -604,14 +604,7 @@ public class Worker {
     healthStatusManager.setStatus(
         HealthStatusManager.SERVICE_NAME_ALL_SERVICES, ServingStatus.SERVING);
     PrometheusPublisher.startHttpServer(configs.getPrometheusPort());
-    // Not all workers need to be registered and visible in the backplane.
-    // For example, a GPU worker may wish to perform work that we do not want to cache locally for
-    // other workers.
-    if (configs.getWorker().getCapabilities().isCas()) {
-      startFailsafeRegistration();
-    } else {
-      log.log(INFO, "Skipping worker registration");
-    }
+    startFailsafeRegistration();
 
     pipeline.start();
     healthCheckMetric.labels("start").inc();

--- a/src/main/java/build/buildfarm/worker/shard/WorkerProfileService.java
+++ b/src/main/java/build/buildfarm/worker/shard/WorkerProfileService.java
@@ -111,7 +111,7 @@ public class WorkerProfileService extends WorkerProfileGrpc.WorkerProfileImplBas
       WorkerListRequest request, StreamObserver<WorkerListMessage> responseObserver) {
     WorkerListMessage.Builder replyBuilder = WorkerListMessage.newBuilder();
     try {
-      replyBuilder.addAllWorkers(backplane.getWorkers());
+      replyBuilder.addAllWorkers(backplane.getStorageWorkers());
     } catch (IOException e) {
       responseObserver.onError(e);
     }

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -257,11 +257,11 @@ message S3BucketConfig {
 }
 
 enum WorkerType {
-  EXECUTE = 0;
+  NONE = 0;
 
-  STORAGE = 1;
+  EXECUTE = 1;
 
-  EXECUTE_AND_STORAGE = 2;
+  STORAGE = 2;
 }
 
 message ShardWorker {
@@ -269,7 +269,7 @@ message ShardWorker {
 
   int64 expire_at = 2;
 
-  WorkerType worker_type = 3;
+  int32 worker_type = 3;
 }
 
 message WorkerChange {

--- a/src/test/java/build/buildfarm/instance/shard/ShardInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/shard/ShardInstanceTest.java
@@ -193,7 +193,7 @@ public class ShardInstanceTest {
     when(mockInstanceLoader.load(eq(workerName))).thenReturn(mockWorkerInstance);
 
     ImmutableSet<String> workers = ImmutableSet.of(workerName);
-    when(mockBackplane.getWorkers()).thenReturn(workers);
+    when(mockBackplane.getStorageWorkers()).thenReturn(workers);
 
     ByteString commandBlob = command.toByteString();
     Digest commandDigest = DIGEST_UTIL.compute(commandBlob);
@@ -816,7 +816,7 @@ public class ShardInstanceTest {
 
   @Test
   public void blobsAreMissingWhenWorkersIsEmpty() throws Exception {
-    when(mockBackplane.getWorkers()).thenReturn(ImmutableSet.of());
+    when(mockBackplane.getStorageWorkers()).thenReturn(ImmutableSet.of());
     Digest digest = Digest.newBuilder().setHash("hash").setSizeBytes(1).build();
     Iterable<Digest> missingDigests =
         instance
@@ -831,7 +831,7 @@ public class ShardInstanceTest {
     when(mockInstanceLoader.load(eq(workerName))).thenReturn(mockWorkerInstance);
 
     ImmutableSet<String> workers = ImmutableSet.of(workerName);
-    when(mockBackplane.getWorkers()).thenReturn(workers);
+    when(mockBackplane.getStorageWorkers()).thenReturn(workers);
 
     Digest digest = Digest.newBuilder().setHash("hash").setSizeBytes(1).build();
     List<Digest> queryDigests = ImmutableList.of(digest);
@@ -998,7 +998,7 @@ public class ShardInstanceTest {
     when(mockInstanceLoader.load(eq(workerName))).thenReturn(mockWorkerInstance);
 
     ImmutableSet<String> workers = ImmutableSet.of(workerName);
-    when(mockBackplane.getWorkers()).thenReturn(workers);
+    when(mockBackplane.getStorageWorkers()).thenReturn(workers);
 
     ByteString blob = ByteString.copyFromUtf8("blobOnWorker");
     Digest actualDigest = DIGEST_UTIL.compute(blob);
@@ -1039,7 +1039,7 @@ public class ShardInstanceTest {
     assertThat(containsAfterAdding).isTrue();
     assertThat(result.build()).isEqualTo(actualDigest);
 
-    verify(mockBackplane, atLeastOnce()).getWorkers();
+    verify(mockBackplane, atLeastOnce()).getStorageWorkers();
     verify(mockInstanceLoader, atLeastOnce()).load(eq(workerName));
   }
 }


### PR DESCRIPTION
Storage workers were not considered part of the available pool of write targets. Workers in general will be considered at once one or more of EXECUTE, or STORAGE types. This restores functionality, registers execute workers for the first time, and paves the way for cluster awareness of execution.

Of note, execute workers will not be presented currently through the backplane. Further changes to non-read/write behaviors will follow for them once storage-only is proven working.