### PR TITLE
[bugfix] [containers] Disable logback to avoid server crashes on startup.

### DIFF
--- a/src/main/java/build/buildfarm/server/BuildFarmServer.java
+++ b/src/main/java/build/buildfarm/server/BuildFarmServer.java
@@ -211,6 +211,9 @@ public class BuildFarmServer {
     SpringApplication app = new SpringApplication(BuildFarmServer.class);
     Map<String, Object> springConfig = new HashMap<>();
 
+    // Disable Logback
+    System.setProperty("org.springframework.boot.logging.LoggingSystem", "none");
+
     springConfig.put("ui.frontend.enable", configs.getUi().isEnable());
     springConfig.put("server.port", configs.getUi().getPort());
     app.setDefaultProperties(springConfig);


### PR DESCRIPTION
By introducing either of these dependencies (as was done in https://github.com/bazelbuild/bazel-buildfarm/pull/1325): 
```
"@maven//:org_springframework_boot_spring_boot_starter_thymeleaf",
"@maven//:org_springframework_boot_spring_boot_starter_web",
```

Spring will inherit a sub-dependency called [Logback](https://logback.qos.ch/), which it will use by default.  Logback expects its own xml configuration during startup.  This causes the buildfarm-server to fail during startup with:
```
Logging system failed to initialize using configuration from 'file:/app/build_buildfarm/src/main/java/build/buildfarm/logging.properties'
java.lang.IllegalStateException: Could not initialize Logback logging from file:/app/build_buildfarm/src/main/java/build/buildfarm/logging.properties
	at org.springframework.boot.logging.logback.LogbackLoggingSystem.loadConfiguration(LogbackLoggingSystem.java:168)
	at org.springframework.boot.logging.AbstractLoggingSystem.initializeWithSpecificConfig(AbstractLoggingSystem.java:66)
	at org.springframework.boot.logging.AbstractLoggingSystem.initialize(AbstractLoggingSystem.java:57)
	at org.springframework.boot.logging.logback.LogbackLoggingSystem.initialize(LogbackLoggingSystem.java:132)
	at org.springframework.boot.context.logging.LoggingApplicationListener.initializeSystem(LoggingApplicationListener.java:332)
	at org.springframework.boot.context.logging.LoggingApplicationListener.initialize(LoggingApplicationListener.java:298)
	at org.springframework.boot.context.logging.LoggingApplicationListener.onApplicationEnvironmentPreparedEvent(LoggingApplicationListener.java:246)
	at org.springframework.boot.context.logging.LoggingApplicationListener.onApplicationEvent(LoggingApplicationListener.java:223)
	at org.springframework.context.event.SimpleApplicationEventMulticaster.doInvokeListener(SimpleApplicationEventMulticaster.java:176)
	at org.springframework.context.event.SimpleApplicationEventMulticaster.invokeListener(SimpleApplicationEventMulticaster.java:169)
	at org.springframework.context.event.SimpleApplicationEventMulticaster.multicastEvent(SimpleApplicationEventMulticaster.java:143)
	at org.springframework.context.event.SimpleApplicationEventMulticaster.multicastEvent(SimpleApplicationEventMulticaster.java:131)
	at org.springframework.boot.context.event.EventPublishingRunListener.environmentPrepared(EventPublishingRunListener.java:85)
	at org.springframework.boot.SpringApplicationRunListeners.lambda$environmentPrepared$2(SpringApplicationRunListeners.java:66)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at org.springframework.boot.SpringApplicationRunListeners.doWithListeners(SpringApplicationRunListeners.java:120)
	at org.springframework.boot.SpringApplicationRunListeners.doWithListeners(SpringApplicationRunListeners.java:114)
	at org.springframework.boot.SpringApplicationRunListeners.environmentPrepared(SpringApplicationRunListeners.java:65)
	at org.springframework.boot.SpringApplication.prepareEnvironment(SpringApplication.java:344)
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:302)
	at build.buildfarm.server.BuildFarmServer.main(BuildFarmServer.java:221)
Caused by: ch.qos.logback.core.LogbackException: Unexpected filename extension of file [file:/app/build_buildfarm/src/main/java/build/buildfarm/logging.properties]. Should be .xml
	at ch.qos.logback.classic.util.ContextInitializer.configureByResource(ContextInitializer.java:66)
	at org.springframework.boot.logging.logback.LogbackLoggingSystem.configureByResourceUrl(LogbackLoggingSystem.java:191)
	at org.springframework.boot.logging.logback.LogbackLoggingSystem.loadConfiguration(LogbackLoggingSystem.java:165)
	... 20 more
Exception in thread "main" java.lang.IllegalStateException: java.lang.IllegalStateException: Could not initialize Logback logging from file:/app/build_buildfarm/src/main/java/build/buildfarm/logging.properties
	at org.springframework.boot.context.logging.LoggingApplicationListener.initializeSystem(LoggingApplicationListener.java:344)
	at org.springframework.boot.context.logging.LoggingApplicationListener.initialize(LoggingApplicationListener.java:298)
	at org.springframework.boot.context.logging.LoggingApplicationListener.onApplicationEnvironmentPreparedEvent(LoggingApplicationListener.java:246)
	at org.springframework.boot.context.logging.LoggingApplicationListener.onApplicationEvent(LoggingApplicationListener.java:223)
	at org.springframework.context.event.SimpleApplicationEventMulticaster.doInvokeListener(SimpleApplicationEventMulticaster.java:176)
	at org.springframework.context.event.SimpleApplicationEventMulticaster.invokeListener(SimpleApplicationEventMulticaster.java:169)
	at org.springframework.context.event.SimpleApplicationEventMulticaster.multicastEvent(SimpleApplicationEventMulticaster.java:143)
	at org.springframework.context.event.SimpleApplicationEventMulticaster.multicastEvent(SimpleApplicationEventMulticaster.java:131)
	at org.springframework.boot.context.event.EventPublishingRunListener.environmentPrepared(EventPublishingRunListener.java:85)
	at org.springframework.boot.SpringApplicationRunListeners.lambda$environmentPrepared$2(SpringApplicationRunListeners.java:66)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at org.springframework.boot.SpringApplicationRunListeners.doWithListeners(SpringApplicationRunListeners.java:120)
	at org.springframework.boot.SpringApplicationRunListeners.doWithListeners(SpringApplicationRunListeners.java:114)
	at org.springframework.boot.SpringApplicationRunListeners.environmentPrepared(SpringApplicationRunListeners.java:65)
	at org.springframework.boot.SpringApplication.prepareEnvironment(SpringApplication.java:344)
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:302)
	at build.buildfarm.server.BuildFarmServer.main(BuildFarmServer.java:221)
Caused by: java.lang.IllegalStateException: Could not initialize Logback logging from file:/app/build_buildfarm/src/main/java/build/buildfarm/logging.properties
	at org.springframework.boot.logging.logback.LogbackLoggingSystem.loadConfiguration(LogbackLoggingSystem.java:168)
	at org.springframework.boot.logging.AbstractLoggingSystem.initializeWithSpecificConfig(AbstractLoggingSystem.java:66)
	at org.springframework.boot.logging.AbstractLoggingSystem.initialize(AbstractLoggingSystem.java:57)
	at org.springframework.boot.logging.logback.LogbackLoggingSystem.initialize(LogbackLoggingSystem.java:132)
	at org.springframework.boot.context.logging.LoggingApplicationListener.initializeSystem(LoggingApplicationListener.java:332)
	... 16 more
Caused by: ch.qos.logback.core.LogbackException: Unexpected filename extension of file [file:/app/build_buildfarm/src/main/java/build/buildfarm/logging.properties]. Should be .xml
	at ch.qos.logback.classic.util.ContextInitializer.configureByResource(ContextInitializer.java:66)
	at org.springframework.boot.logging.logback.LogbackLoggingSystem.configureByResourceUrl(LogbackLoggingSystem.java:191)
	at org.springframework.boot.logging.logback.LogbackLoggingSystem.loadConfiguration(LogbackLoggingSystem.java:165)
	... 20 more

```

For some reason, this problem is specific to java built images.  The problem does not manifest if you run `//src/main/java/build/buildfarm:buildfarm-server` directly.  It is a shortcoming of our CI that it does not validate container startup.  A solution to this problem is to configure Spring not to use logback on startup-- which I presume was the previous case.
