### PR TITLE
Giving names to worker threads

### DIFF
--- a/src/main/java/build/buildfarm/worker/ExecuteActionStage.java
+++ b/src/main/java/build/buildfarm/worker/ExecuteActionStage.java
@@ -135,7 +135,7 @@ public class ExecuteActionStage extends SuperscalarPipelineStage {
     OperationContext operationContext = take();
     ResourceLimits limits = workerContext.commandExecutionSettings(operationContext.command);
     Executor executor = new Executor(workerContext, operationContext, this);
-    Thread executorThread = new Thread(() -> executor.run(limits));
+    Thread executorThread = new Thread(() -> executor.run(limits), "ExecuteActionStage.executor");
 
     synchronized (this) {
       executors.add(executorThread);

--- a/src/main/java/build/buildfarm/worker/Executor.java
+++ b/src/main/java/build/buildfarm/worker/Executor.java
@@ -486,8 +486,8 @@ class Executor {
         new ByteStringWriteReader(
             process.getErrorStream(), stderrWrite, (int) workerContext.getStandardErrorLimit());
 
-    Thread stdoutReaderThread = new Thread(stdoutReader);
-    Thread stderrReaderThread = new Thread(stderrReader);
+    Thread stdoutReaderThread = new Thread(stdoutReader, "Executor.stdoutReader");
+    Thread stderrReaderThread = new Thread(stderrReader, "Executor.stderrReader");
     stdoutReaderThread.start();
     stderrReaderThread.start();
 

--- a/src/main/java/build/buildfarm/worker/InputFetchStage.java
+++ b/src/main/java/build/buildfarm/worker/InputFetchStage.java
@@ -98,7 +98,9 @@ public class InputFetchStage extends SuperscalarPipelineStage {
   @Override
   protected void iterate() throws InterruptedException {
     OperationContext operationContext = take();
-    Thread fetcher = new Thread(new InputFetcher(workerContext, operationContext, this), "InputFetchStage.fetcher");
+    Thread fetcher =
+        new Thread(
+            new InputFetcher(workerContext, operationContext, this), "InputFetchStage.fetcher");
 
     synchronized (this) {
       fetchers.add(fetcher);

--- a/src/main/java/build/buildfarm/worker/InputFetchStage.java
+++ b/src/main/java/build/buildfarm/worker/InputFetchStage.java
@@ -98,7 +98,7 @@ public class InputFetchStage extends SuperscalarPipelineStage {
   @Override
   protected void iterate() throws InterruptedException {
     OperationContext operationContext = take();
-    Thread fetcher = new Thread(new InputFetcher(workerContext, operationContext, this));
+    Thread fetcher = new Thread(new InputFetcher(workerContext, operationContext, this), "InputFetchStage.fetcher");
 
     synchronized (this) {
       fetchers.add(fetcher);

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -507,7 +507,8 @@ public class Worker {
                   }
                 }
               }
-            }, "Worker.failsafeRegistration")
+            },
+            "Worker.failsafeRegistration")
         .start();
   }
 

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -507,7 +507,7 @@ public class Worker {
                   }
                 }
               }
-            })
+            }, "Worker.failsafeRegistration")
         .start();
   }
 


### PR DESCRIPTION
Use a schema where the thread is named by the class that owns it and a brief description about what it does, based on what people called the variables.

The context is I've been trailing a bug from time to time and this makes it easier to look at dumps. If we like the format I'd be happy to go through and name other threads in the repo using this convention