### PR TITLE
Update tools_remote commit for bazel 6.2 support

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -151,7 +151,7 @@ tasks:
     - export BUILDFARM_CONFIG="/buildfarm/examples/config.minimal.yml"
     - export TEST_ARG1=--experimental_remote_grpc_log='./grpc.log'
     - export TEST_ARG2=--experimental_remote_grpc_log='./grpc2.log'
-    - export SHA1_TOOLS_REMOTE=9969ed6911aea04f7e896cd3958ea933547f933c
+    - export SHA1_TOOLS_REMOTE=eeddeff416118c86856fd76c95733307256dc855
     - export EXECUTION_STAGE_WIDTH=5
     - ./.bazelci/cache_test.sh
 


### PR DESCRIPTION
Use an updated tools_remote which now supports bazel 6.2 and pins its supported version in the case of future releases with incompatibilities resulting from the use of bazelisk as the bazel binary.

Fixes #1338