### PR TITLE
Use a centos version with newer toolchains

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -75,7 +75,7 @@ tasks:
     - "..."
   rpm_builds:
     name: "Rpm Builds"
-    platform: centos7
+    platform: centos7_java11_devtoolset10
     shell_commands:
     - bazel build //src/main/java/build/buildfarm/rpms/server:buildfarm-server-rpm //src/main/java/build/buildfarm/rpms/worker:buildfarm-worker-rpm
 


### PR DESCRIPTION
Fixing https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/3015#01880e23-5928-4838-8574-95e1e698c94a where https://github.com/bazelbuild/bazel/commit/978cd23e80f202a03e99a87f2089a9a0622b5d5d is probably the culprit.