### PR TITLE
Restore DequeueMatchSettings Platform

### DIFF
--- a/src/main/java/build/buildfarm/common/config/DequeueMatchSettings.java
+++ b/src/main/java/build/buildfarm/common/config/DequeueMatchSettings.java
@@ -1,9 +1,11 @@
 package build.buildfarm.common.config;
 
+import build.bazel.remote.execution.v2.Platform;
 import lombok.Data;
 
 @Data
 public class DequeueMatchSettings {
   private boolean acceptEverything = true;
   private boolean allowUnmatched = false;
+  private Platform platform = Platform.getDefaultInstance();
 }

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -134,7 +134,7 @@ class ShardWorkerContext implements WorkerContext {
     ImmutableSetMultimap.Builder<String, String> provisions = ImmutableSetMultimap.builder();
     Platform matchPlatform =
         ExecutionPolicies.getMatchPlatform(
-            configs.getBackplane().getQueues()[0].getPlatform(), policies);
+            configs.getWorker().getDequeueMatchSettings().getPlatform(), policies);
     for (Platform.Property property : matchPlatform.getPropertiesList()) {
       provisions.put(property.getName(), property.getValue());
     }
@@ -277,7 +277,7 @@ class ShardWorkerContext implements WorkerContext {
     try {
       queueEntry =
           backplane.dispatchOperation(
-              configs.getBackplane().getQueues()[0].getPlatform().getPropertiesList());
+              configs.getWorker().getDequeueMatchSettings().getPlatform().getPropertiesList());
     } catch (IOException e) {
       Status status = Status.fromThrowable(e);
       switch (status.getCode()) {


### PR DESCRIPTION
The DequeueMatchSettings Platform before 0a6802e82f provided for selection or rejection of queue entries based on locally selectable platform properties that it provides, per worker. The config transition eliminated this capability, and left the workers only with the properties selected from the queue definition restrictions. Highlighting this was the elimination of use of the platform during ShardWorkerContext test creation, leaving a platform parameter orphaned.

Use the DMS Platform both in eligibility filtering and selection of the eligible queues to permit mildly heterogenous worker queue processing.

Fixes #1350