### PR TITLE
Exit server on transform token exhaustion

### DIFF
--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -450,8 +450,7 @@ public class ShardInstance extends AbstractServerInstance {
                 public void run() {
                   log.log(Level.FINE, "OperationQueuer: Running");
                   try {
-                    for (; ; ) {
-                      transformTokensQueue.put(new Object());
+                    while (transformTokensQueue.offer(new Object(), 5, MINUTES)) {
                       stopwatch.start();
                       try {
                         iterate()
@@ -474,6 +473,7 @@ public class ShardInstance extends AbstractServerInstance {
                         stopwatch.reset();
                       }
                     }
+                    log.severe("OperationQueuer: Transform lease token timed out");
                   } catch (InterruptedException e) {
                     // treat with exit
                     operationQueuer = null;


### PR DESCRIPTION
When a server cannot acquire a transform token for an extended period of time, assume that it is malfunctioning and initiate a shutdown.