### PR TITLE
Adjust Server/Worker configs after parser

### DIFF
--- a/src/main/java/build/buildfarm/common/config/BuildfarmConfigs.java
+++ b/src/main/java/build/buildfarm/common/config/BuildfarmConfigs.java
@@ -68,7 +68,6 @@ public final class BuildfarmConfigs {
     ServerOptions options = parser.getOptions(ServerOptions.class);
     try {
       buildfarmConfigs = loadConfigs(getConfigurationPath(parser));
-      adjustServerConfigs(buildfarmConfigs);
     } catch (IOException e) {
       log.severe("Could not parse yml configuration file." + e);
       throw new RuntimeException(e);
@@ -79,6 +78,7 @@ public final class BuildfarmConfigs {
     if (options.port > 0) {
       buildfarmConfigs.getServer().setPort(options.port);
     }
+    adjustServerConfigs(buildfarmConfigs);
     return buildfarmConfigs;
   }
 
@@ -87,7 +87,6 @@ public final class BuildfarmConfigs {
     ShardWorkerOptions options = parser.getOptions(ShardWorkerOptions.class);
     try {
       buildfarmConfigs = loadConfigs(getConfigurationPath(parser));
-      adjustWorkerConfigs(buildfarmConfigs);
     } catch (IOException e) {
       log.severe("Could not parse yml configuration file." + e);
       throw new RuntimeException(e);
@@ -95,6 +94,7 @@ public final class BuildfarmConfigs {
     if (!Strings.isNullOrEmpty(options.publicName)) {
       buildfarmConfigs.getWorker().setPublicName(options.publicName);
     }
+    adjustWorkerConfigs(buildfarmConfigs);
     return buildfarmConfigs;
   }
 


### PR DESCRIPTION
Adjustments will make use of options. Ensure that they have the specified values from the commandline, and they have no checked exception throws.