### PR TITLE
Enable custom latency buckets

### DIFF
--- a/examples/config.yml
+++ b/examples/config.yml
@@ -11,7 +11,7 @@ server:
   grpcMetrics:
     enabled: true
     provideLatencyHistograms: true
-    latencyBuckets: [0.001, 0.005, 0.01, 0.05, 0.075, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0]
+    latencyBuckets: [0.001, 0.01, 0.1, 1, 5, 10, 20, 40, 60, +Infinity]
   maxInboundMessageSizeBytes: 0
   maxInboundMetadataSize: 0
   casWriteTimeout: 3600

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -9,8 +9,9 @@ server:
   actionCacheReadOnly: false
   port: 8980
   grpcMetrics:
-    enabled: false
-    provideLatencyHistograms: false
+    enabled: true
+    provideLatencyHistograms: true
+    latencyBuckets: [0.001, 0.005, 0.01, 0.05, 0.075, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0]
   maxInboundMessageSizeBytes: 0
   maxInboundMetadataSize: 0
   casWriteTimeout: 3600
@@ -93,6 +94,7 @@ worker:
   grpcMetrics:
     enabled: false
     provideLatencyHistograms: false
+    latencyBuckets: [0.001, 0.005, 0.01, 0.05, 0.075, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0]
   capabilities:
     cas: true
     execution: true

--- a/src/main/java/build/buildfarm/common/config/GrpcMetrics.java
+++ b/src/main/java/build/buildfarm/common/config/GrpcMetrics.java
@@ -9,6 +9,7 @@ import me.dinowernli.grpc.prometheus.MonitoringServerInterceptor;
 public class GrpcMetrics {
   private boolean enabled = false;
   private boolean provideLatencyHistograms = false;
+  private double[] latencyBuckets;
 
   public static void handleGrpcMetricIntercepts(
       ServerBuilder<?> serverBuilder, GrpcMetrics grpcMetrics) {
@@ -21,7 +22,12 @@ public class GrpcMetrics {
 
       // Enable latency buckets.
       if (grpcMetrics.isProvideLatencyHistograms()) {
-        grpcConfig = grpcConfig.allMetrics();
+        grpcConfig = Configuration.allMetrics();
+      }
+
+      // provide custom latency buckets
+      if (grpcMetrics.getLatencyBuckets() != null) {
+        grpcConfig.withLatencyBuckets(grpcMetrics.getLatencyBuckets());
       }
 
       // Apply config to create an interceptor and apply it to the GRPC server.

--- a/src/test/java/build/buildfarm/common/config/BUILD
+++ b/src/test/java/build/buildfarm/common/config/BUILD
@@ -1,5 +1,3 @@
-load("//:jvm_flags.bzl", "ensure_accurate_metadata")
-
 java_test(
     name = "tests",
     srcs = glob(["*Test.java"]),

--- a/src/test/java/build/buildfarm/common/config/BUILD
+++ b/src/test/java/build/buildfarm/common/config/BUILD
@@ -1,0 +1,15 @@
+load("//:jvm_flags.bzl", "ensure_accurate_metadata")
+
+java_test(
+    name = "tests",
+    srcs = glob(["*Test.java"]),
+    test_class = "build.buildfarm.AllTests",
+    deps = [
+        "//src/main/java/build/buildfarm/common/config",
+        "//src/test/java/build/buildfarm:test_runner",
+        "@maven//:io_grpc_grpc_testing",
+        "@maven//:me_dinowernli_java_grpc_prometheus",
+        "@maven//:io_grpc_grpc_api",
+        "@maven//:org_mockito_mockito_core",
+    ],
+)

--- a/src/test/java/build/buildfarm/common/config/BUILD
+++ b/src/test/java/build/buildfarm/common/config/BUILD
@@ -5,9 +5,9 @@ java_test(
     deps = [
         "//src/main/java/build/buildfarm/common/config",
         "//src/test/java/build/buildfarm:test_runner",
+        "@maven//:io_grpc_grpc_api",
         "@maven//:io_grpc_grpc_testing",
         "@maven//:me_dinowernli_java_grpc_prometheus",
-        "@maven//:io_grpc_grpc_api",
         "@maven//:org_mockito_mockito_core",
     ],
 )

--- a/src/test/java/build/buildfarm/common/config/GrpcMetricsTest.java
+++ b/src/test/java/build/buildfarm/common/config/GrpcMetricsTest.java
@@ -1,5 +1,10 @@
 package build.buildfarm.common.config;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
 import io.grpc.ServerBuilder;
 import me.dinowernli.grpc.prometheus.MonitoringServerInterceptor;
 import org.junit.Test;
@@ -7,16 +12,9 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-
 @RunWith(MockitoJUnitRunner.class)
 public class GrpcMetricsTest {
-  @Mock
-  private ServerBuilder<?> serverBuilder;
+  @Mock private ServerBuilder<?> serverBuilder;
   private final GrpcMetrics grpcMetrics = new GrpcMetrics();
 
   @Test
@@ -31,7 +29,7 @@ public class GrpcMetricsTest {
   public void testHandleGrpcMetricIntercepts_withLatencyBucket() {
     grpcMetrics.setEnabled(true);
     grpcMetrics.setProvideLatencyHistograms(true);
-    grpcMetrics.setLatencyBuckets(new double[]{1, 2, 3});
+    grpcMetrics.setLatencyBuckets(new double[] {1, 2, 3});
 
     GrpcMetrics.handleGrpcMetricIntercepts(serverBuilder, grpcMetrics);
     verify(serverBuilder, times(1)).intercept(any(MonitoringServerInterceptor.class));

--- a/src/test/java/build/buildfarm/common/config/GrpcMetricsTest.java
+++ b/src/test/java/build/buildfarm/common/config/GrpcMetricsTest.java
@@ -1,0 +1,39 @@
+package build.buildfarm.common.config;
+
+import io.grpc.ServerBuilder;
+import me.dinowernli.grpc.prometheus.MonitoringServerInterceptor;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GrpcMetricsTest {
+  @Mock
+  private ServerBuilder<?> serverBuilder;
+  private final GrpcMetrics grpcMetrics = new GrpcMetrics();
+
+  @Test
+  public void testHandleGrpcMetricIntercepts_disabled() {
+    grpcMetrics.setEnabled(false);
+
+    GrpcMetrics.handleGrpcMetricIntercepts(serverBuilder, grpcMetrics);
+    verify(serverBuilder, never()).intercept(any(MonitoringServerInterceptor.class));
+  }
+
+  @Test
+  public void testHandleGrpcMetricIntercepts_withLatencyBucket() {
+    grpcMetrics.setEnabled(true);
+    grpcMetrics.setProvideLatencyHistograms(true);
+    grpcMetrics.setLatencyBuckets(new double[]{1, 2, 3});
+
+    GrpcMetrics.handleGrpcMetricIntercepts(serverBuilder, grpcMetrics);
+    verify(serverBuilder, times(1)).intercept(any(MonitoringServerInterceptor.class));
+  }
+}


### PR DESCRIPTION
Prometheus provides a default latency bucket, and that may not be helpful all use case. This change provide capability to define custom latency buckets.
