### PR TITLE
Missing directories not visited in validation

### DIFF
--- a/src/main/java/build/buildfarm/instance/server/AbstractServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/server/AbstractServerInstance.java
@@ -934,7 +934,10 @@ public abstract class AbstractServerInstance implements Instance {
           preconditionFailure);
     }
     pathDigests.pop();
-    visited.add(directoryDigest);
+    if (directory != null) {
+      // missing directories are not visited and will appear in violations list each time
+      visited.add(directoryDigest);
+    }
   }
 
   protected ListenableFuture<Tree> getTreeFuture(


### PR DESCRIPTION
A directory which is missing during the course of validation should not be identified as missing. This prevents a NPE and inspires validation to emit one MISSING violation per path to a missing directory for preconditions.

Fixes #1374