### PR TITLE
Output additions to RequestMetadata

### DIFF
--- a/src/main/java/build/buildfarm/tools/Cat.java
+++ b/src/main/java/build/buildfarm/tools/Cat.java
@@ -483,6 +483,9 @@ class Cat {
     System.out.println("ActionId: " + metadata.getActionId());
     System.out.println("ToolInvocationId: " + metadata.getToolInvocationId());
     System.out.println("CorrelatedInvocationsId: " + metadata.getCorrelatedInvocationsId());
+    System.out.println("ActionMnemonic: " + metadata.getActionMnemonic());
+    System.out.println("TargetId: " + metadata.getTargetId());
+    System.out.println("ConfigurationId: " + metadata.getConfigurationId());
   }
 
   private static void printStatus(com.google.rpc.Status status)


### PR DESCRIPTION
Include Action Mnemonic, Target Id, and Configuration Id in the bf-cat output suite for RequestMetadata.