### PR TITLE
SEVERE for app.run failure

### DIFF
--- a/src/main/java/build/buildfarm/server/BuildFarmServer.java
+++ b/src/main/java/build/buildfarm/server/BuildFarmServer.java
@@ -218,6 +218,10 @@ public class BuildFarmServer {
     springConfig.put("server.port", configs.getUi().getPort());
     app.setDefaultProperties(springConfig);
 
-    app.run(args);
+    try {
+      app.run(args);
+    } catch (Throwable t) {
+      log.log(SEVERE, "Error running application", t);
+    }
   }
 }


### PR DESCRIPTION
An invocation of app.run which fails for any reason in the spring framework will exit silently. Ensure that errors are presented before exiting the application.