### PR TITLE
Skip isReadOnlyExecutable on symlinks

### DIFF
--- a/src/main/java/build/buildfarm/common/io/Utils.java
+++ b/src/main/java/build/buildfarm/common/io/Utils.java
@@ -291,7 +291,8 @@ public class Utils {
     boolean isReadOnlyExecutable;
     try {
       attributes = Files.readAttributes(path, BasicFileAttributes.class, linkOpts(followSymlinks));
-      isReadOnlyExecutable = EvenMoreFiles.isReadOnlyExecutable(path, fileStore);
+      isReadOnlyExecutable =
+          !attributes.isSymbolicLink() && EvenMoreFiles.isReadOnlyExecutable(path, fileStore);
     } catch (java.nio.file.FileSystemException e) {
       throw new NoSuchFileException(path + ERR_NO_SUCH_FILE_OR_DIR);
     }


### PR DESCRIPTION
The only presence of arbitrary symlinks in the CAS Filesystem is under directories. Symlinks are explicitly identified as non-readonly-executables. Prevent a dead symlink from throwing NSFE due to the readonly check.