### PR TITLE
Require fileStore for Directories interactions

### DIFF
--- a/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
+++ b/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
@@ -1271,7 +1271,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
       loadResults = loadCache(onStartPut, removeDirectoryService);
     } else {
       // Skip loading the cache and ensure it is empty
-      Directories.remove(root, removeDirectoryService);
+      Directories.remove(root, fileStore, removeDirectoryService);
       initializeRootDirectory();
     }
 
@@ -1336,7 +1336,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
     try {
       for (Path path : files) {
         if (Files.isDirectory(path)) {
-          Directories.remove(path, removeDirectoryService);
+          Directories.remove(path, fileStore, removeDirectoryService);
         } else {
           Files.delete(path);
         }
@@ -1936,7 +1936,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
       return immediateFuture(null);
     }
 
-    return Directories.remove(getDirectoryPath(digest), service);
+    return Directories.remove(getDirectoryPath(digest), fileStore, service);
   }
 
   @SuppressWarnings("ConstantConditions")
@@ -2062,7 +2062,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
     if (Files.exists(path)) {
       if (Files.isDirectory(path)) {
         log.log(Level.FINE, "removing existing directory " + path + " for fetch");
-        Directories.remove(path);
+        Directories.remove(path, fileStore);
       } else {
         Files.delete(path);
       }
@@ -2295,7 +2295,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
             fetchFuture,
             (result) -> {
               try {
-                disableAllWriteAccess(path);
+                disableAllWriteAccess(path, fileStore);
               } catch (IOException e) {
                 log.log(Level.SEVERE, "error while disabling write permissions on " + path, e);
                 return immediateFailedFuture(e);
@@ -2326,7 +2326,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
               }
               try {
                 log.log(Level.FINE, "removing directory to roll back " + path);
-                Directories.remove(path);
+                Directories.remove(path, fileStore);
               } catch (IOException removeException) {
                 log.log(
                     Level.SEVERE,

--- a/src/main/java/build/buildfarm/worker/shard/CFCExecFileSystem.java
+++ b/src/main/java/build/buildfarm/worker/shard/CFCExecFileSystem.java
@@ -49,6 +49,7 @@ import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.ListenableFuture;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.FileStore;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.UserPrincipal;
@@ -80,6 +81,7 @@ class CFCExecFileSystem implements ExecFileSystem {
   private final ExecutorService fetchService = BuildfarmExecutors.getFetchServicePool();
   private final ExecutorService removeDirectoryService;
   private final ExecutorService accessRecorder;
+  private FileStore fileStore; // initialized with start
 
   CFCExecFileSystem(
       Path root,
@@ -102,9 +104,10 @@ class CFCExecFileSystem implements ExecFileSystem {
   @Override
   public void start(Consumer<List<Digest>> onDigests, boolean skipLoad)
       throws IOException, InterruptedException {
+    fileStore = Files.getFileStore(root);
     List<Dirent> dirents = null;
     try {
-      dirents = readdir(root, /* followSymlinks= */ false, Files.getFileStore(root));
+      dirents = readdir(root, /* followSymlinks= */ false, fileStore);
     } catch (IOException e) {
       log.log(Level.SEVERE, "error reading directory " + root.toString(), e);
     }
@@ -116,7 +119,8 @@ class CFCExecFileSystem implements ExecFileSystem {
       String name = dirent.getName();
       Path child = root.resolve(name);
       if (!child.equals(fileCache.getRoot())) {
-        removeDirectoryFutures.add(Directories.remove(root.resolve(name), removeDirectoryService));
+        removeDirectoryFutures.add(
+            Directories.remove(root.resolve(name), fileStore, removeDirectoryService));
       }
     }
 
@@ -364,7 +368,7 @@ class CFCExecFileSystem implements ExecFileSystem {
 
     Path execDir = root.resolve(operationName);
     if (Files.exists(execDir)) {
-      Directories.remove(execDir);
+      Directories.remove(execDir, fileStore);
     }
     Files.createDirectories(execDir);
 
@@ -416,7 +420,7 @@ class CFCExecFileSystem implements ExecFileSystem {
     } finally {
       if (!success) {
         fileCache.decrementReferences(inputFiles.build(), inputDirectories.build());
-        Directories.remove(execDir);
+        Directories.remove(execDir, fileStore);
       }
     }
 
@@ -451,7 +455,7 @@ class CFCExecFileSystem implements ExecFileSystem {
           inputDirectories == null ? ImmutableList.of() : inputDirectories);
     }
     if (Files.exists(execDir)) {
-      Directories.remove(execDir);
+      Directories.remove(execDir, fileStore);
     }
   }
 }

--- a/src/test/java/build/buildfarm/cas/cfc/CASFileCacheTest.java
+++ b/src/test/java/build/buildfarm/cas/cfc/CASFileCacheTest.java
@@ -175,10 +175,11 @@ class CASFileCacheTest {
 
   @After
   public void tearDown() throws IOException, InterruptedException {
+    FileStore fileStore = Files.getFileStore(root);
     // bazel appears to have a problem with us creating directories under
     // windows that are marked as no-delete. clean up after ourselves with
     // our utils
-    Directories.remove(root);
+    Directories.remove(root, fileStore);
     if (!shutdownAndAwaitTermination(putService, 1, SECONDS)) {
       throw new RuntimeException("could not shut down put service");
     }

--- a/src/test/java/build/buildfarm/common/io/UtilsTest.java
+++ b/src/test/java/build/buildfarm/common/io/UtilsTest.java
@@ -47,7 +47,8 @@ public class UtilsTest {
 
   @After
   public void tearDown() throws IOException {
-    Directories.remove(root);
+    fileStore = Files.getFileStore(root);
+    Directories.remove(root, fileStore);
   }
 
   @Test


### PR DESCRIPTION
Avoid fileStore recalculation for entire trees to be deleted, instead expect the callers to provide a fileStore, and that the entire tree exists within it.