### PR TITLE
Unwrap EEs on PutDirectoryException creation

### DIFF
--- a/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
+++ b/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
@@ -2275,7 +2275,10 @@ public abstract class CASFileCache implements ContentAddressableStorage {
                         try {
                           putFutures.get(i).get();
                           // should never get here
+                        } catch (ExecutionException e) {
+                          failures.add(e.getCause());
                         } catch (Throwable t) {
+                          // cancelled or interrupted during get
                           failures.add(t);
                         }
                       }


### PR DESCRIPTION
ExceutionExceptions wrap the actual exceptions of futures experienced during putDirectory, and add no tracing capacity. Unwrap these when thrown from failed futures.