### PR TITLE
Support UTF8 Strings in ffiReaddir

### DIFF
--- a/src/main/java/build/buildfarm/common/io/FFIdirent.java
+++ b/src/main/java/build/buildfarm/common/io/FFIdirent.java
@@ -32,5 +32,5 @@ public class FFIdirent extends Struct {
   public final Signed64 d_off = new Signed64();
   public final Unsigned16 d_reclen = new Unsigned16();
   public final Unsigned8 d_type = new Unsigned8();
-  public final AsciiString d_name = new AsciiString(MAX_NAME_LEN);
+  public final UTF8String d_name = new UTF8String(MAX_NAME_LEN);
 }


### PR DESCRIPTION
Files are delivered via readdir in utf8 encoding (on linux for xfs at least), assume that posix will mandate this.