### PR TITLE
Revert context deadline guarantee from (#1377)"

### DIFF
--- a/src/test/java/build/buildfarm/instance/stub/StubInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/stub/StubInstanceTest.java
@@ -64,7 +64,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -99,7 +98,7 @@ public class StubInstanceTest {
     fakeServer.awaitTermination();
   }
 
-  private StubInstance newStubInstance(String instanceName) {
+  private Instance newStubInstance(String instanceName) {
     return new StubInstance(
         instanceName,
         DIGEST_UTIL,
@@ -195,38 +194,6 @@ public class StubInstanceTest {
         ImmutableList.of(Digest.newBuilder().setHash("present").setSizeBytes(1).build());
     assertThat(instance.findMissingBlobs(digests, RequestMetadata.getDefaultInstance()).get())
         .isEmpty();
-    instance.stop();
-  }
-
-  @Test
-  public void findMissingBlobsOverSizeLimitRecombines()
-      throws ExecutionException, InterruptedException {
-    AtomicReference<FindMissingBlobsRequest> reference = new AtomicReference<>();
-    serviceRegistry.addService(
-        new ContentAddressableStorageImplBase() {
-          @Override
-          public void findMissingBlobs(
-              FindMissingBlobsRequest request,
-              StreamObserver<FindMissingBlobsResponse> responseObserver) {
-            reference.set(request);
-            responseObserver.onNext(
-                FindMissingBlobsResponse.newBuilder()
-                    .addAllMissingBlobDigests(request.getBlobDigestsList())
-                    .build());
-            responseObserver.onCompleted();
-          }
-        });
-    StubInstance instance = newStubInstance("findMissingBlobs-test");
-    instance.maxRequestSize = 1024;
-    ImmutableList.Builder<Digest> builder = ImmutableList.builder();
-    // generates digest size * 1024 serialized size at least
-    for (int i = 0; i < 1024; i++) {
-      ByteString content = ByteString.copyFromUtf8("Hello, World! " + UUID.randomUUID());
-      builder.add(DIGEST_UTIL.compute(content));
-    }
-    ImmutableList<Digest> digests = builder.build();
-    assertThat(instance.findMissingBlobs(digests, RequestMetadata.getDefaultInstance()).get())
-        .containsExactlyElementsIn(digests);
     instance.stop();
   }
 


### PR DESCRIPTION
This reverts mistakenly added checks for non-null deadlines in StubInstance.