### PR TITLE
Interpret ExecDirException to Status

### DIFF
--- a/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
+++ b/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
@@ -2159,39 +2159,6 @@ public abstract class CASFileCache implements ContentAddressableStorage {
     return false;
   }
 
-  static class PutDirectoryException extends IOException {
-    private final Path path;
-    private final Digest digest;
-    private final List<Throwable> exceptions;
-
-    PutDirectoryException(Path path, Digest digest, List<Throwable> exceptions) {
-      // When printing the exception, show the captured sub-exceptions.
-      super(getErrorMessage(path, exceptions));
-      this.path = path;
-      this.digest = digest;
-      this.exceptions = exceptions;
-      for (Throwable exception : exceptions) {
-        addSuppressed(exception);
-      }
-    }
-
-    Path getPath() {
-      return path;
-    }
-
-    Digest getDigest() {
-      return digest;
-    }
-
-    List<Throwable> getExceptions() {
-      return exceptions;
-    }
-  }
-
-  private static String getErrorMessage(Path path, List<Throwable> exceptions) {
-    return String.format("%s: %d %s: %s", path, exceptions.size(), "exceptions", exceptions);
-  }
-
   @SuppressWarnings("ConstantConditions")
   private ListenableFuture<Path> putDirectorySynchronized(
       Path path, Digest digest, Map<Digest, Directory> directoriesByDigest, ExecutorService service)

--- a/src/main/java/build/buildfarm/cas/cfc/PutDirectoryException.java
+++ b/src/main/java/build/buildfarm/cas/cfc/PutDirectoryException.java
@@ -1,0 +1,53 @@
+// Copyright 2023 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.cas.cfc;
+
+import build.bazel.remote.execution.v2.Digest;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+public class PutDirectoryException extends IOException {
+  private final Path path;
+  private final Digest digest;
+  private final List<Throwable> exceptions;
+
+  private static String getErrorMessage(Path path, List<Throwable> exceptions) {
+    return String.format("%s: %d %s: %s", path, exceptions.size(), "exceptions", exceptions);
+  }
+
+  public PutDirectoryException(Path path, Digest digest, List<Throwable> exceptions) {
+    // When printing the exception, show the captured sub-exceptions.
+    super(getErrorMessage(path, exceptions));
+    this.path = path;
+    this.digest = digest;
+    this.exceptions = exceptions;
+    for (Throwable exception : exceptions) {
+      addSuppressed(exception);
+    }
+  }
+
+  Path getPath() {
+    return path;
+  }
+
+  public Digest getDigest() {
+    return digest;
+  }
+
+  public List<Throwable> getExceptions() {
+    return exceptions;
+  }
+}

--- a/src/main/java/build/buildfarm/common/Errors.java
+++ b/src/main/java/build/buildfarm/common/Errors.java
@@ -19,5 +19,8 @@ public final class Errors {
 
   public static final String VIOLATION_TYPE_INVALID = "INVALID";
 
+  public static final String MISSING_INPUT =
+      "A requested input (or the `Action` or its `Command`) was not found in the CAS.";
+
   private Errors() {}
 }

--- a/src/main/java/build/buildfarm/instance/server/AbstractServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/server/AbstractServerInstance.java
@@ -16,6 +16,7 @@ package build.buildfarm.instance.server;
 
 import static build.buildfarm.common.Actions.asExecutionStatus;
 import static build.buildfarm.common.Actions.checkPreconditionFailure;
+import static build.buildfarm.common.Errors.MISSING_INPUT;
 import static build.buildfarm.common.Errors.VIOLATION_TYPE_INVALID;
 import static build.buildfarm.common.Errors.VIOLATION_TYPE_MISSING;
 import static build.buildfarm.common.Trees.enumerateTreeFileDigests;
@@ -176,9 +177,6 @@ public abstract class AbstractServerInstance implements Instance {
 
   public static final String ENVIRONMENT_VARIABLES_NOT_SORTED =
       "The `Command`'s `environment_variables` are not correctly sorted by `name`.";
-
-  public static final String MISSING_INPUT =
-      "A requested input (or the `Action` or its `Command`) was not found in the CAS.";
 
   public static final String MISSING_ACTION = "The action was not found in the CAS.";
 

--- a/src/main/java/build/buildfarm/worker/BUILD
+++ b/src/main/java/build/buildfarm/worker/BUILD
@@ -4,6 +4,7 @@ java_library(
     plugins = ["//src/main/java/build/buildfarm/common:lombok"],
     visibility = ["//visibility:public"],
     deps = [
+        "//src/main/java/build/buildfarm/cas",
         "//src/main/java/build/buildfarm/common",
         "//src/main/java/build/buildfarm/common/config",
         "//src/main/java/build/buildfarm/instance",

--- a/src/main/java/build/buildfarm/worker/ExecDirException.java
+++ b/src/main/java/build/buildfarm/worker/ExecDirException.java
@@ -1,0 +1,139 @@
+// Copyright 2023 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.worker;
+
+import static build.buildfarm.common.Errors.MISSING_INPUT;
+import static build.buildfarm.common.Errors.VIOLATION_TYPE_INVALID;
+import static build.buildfarm.common.Errors.VIOLATION_TYPE_MISSING;
+import static java.util.logging.Level.SEVERE;
+
+import build.bazel.remote.execution.v2.Digest;
+import build.buildfarm.cas.cfc.PutDirectoryException;
+import build.buildfarm.common.DigestUtil;
+import com.google.protobuf.Any;
+import com.google.rpc.Code;
+import com.google.rpc.PreconditionFailure;
+import com.google.rpc.PreconditionFailure.Violation;
+import com.google.rpc.Status;
+import java.io.IOException;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.util.List;
+import lombok.extern.java.Log;
+
+@Log
+public class ExecDirException extends IOException {
+  private final Path path;
+  private final List<Throwable> exceptions;
+
+  public static class ViolationException extends Exception {
+    private final Digest digest;
+    private final Path path;
+    private final boolean isExecutable;
+
+    public ViolationException(Digest digest, Path path, boolean isExecutable, Throwable cause) {
+      super(cause);
+      this.digest = digest;
+      this.path = path;
+      this.isExecutable = isExecutable;
+    }
+
+    private static String getDescription(Path path, boolean isExecutable) {
+      if (path != null) {
+        return "The file `/" + path + (isExecutable ? "*" : "") + "` was not found in the CAS.";
+      }
+      return MISSING_INPUT;
+    }
+
+    static void toViolation(
+        Violation.Builder violation, Throwable cause, Path path, boolean isExecutable) {
+      if (cause instanceof NoSuchFileException) {
+        violation
+            .setType(VIOLATION_TYPE_MISSING)
+            .setDescription(getDescription(path, isExecutable));
+      } else {
+        violation.setType(VIOLATION_TYPE_INVALID).setDescription(cause.getMessage());
+      }
+    }
+
+    public Violation getViolation() {
+      Violation.Builder violation = Violation.newBuilder();
+      toViolation(violation, getCause(), path, isExecutable);
+      violation.setSubject("blobs/" + DigestUtil.toString(digest));
+      return violation.build();
+    }
+  }
+
+  private static String getErrorMessage(Path path, List<Throwable> exceptions) {
+    return String.format("%s: %d %s: %s", path, exceptions.size(), "exceptions", exceptions);
+  }
+
+  public ExecDirException(Path path, List<Throwable> exceptions) {
+    // When printing the exception, show the captured sub-exceptions.
+    super(getErrorMessage(path, exceptions));
+    this.path = path;
+    this.exceptions = exceptions;
+    for (Throwable exception : exceptions) {
+      addSuppressed(exception);
+    }
+  }
+
+  Path getPath() {
+    return path;
+  }
+
+  List<Throwable> getExceptions() {
+    return exceptions;
+  }
+
+  Status.Builder toStatus(Status.Builder status) {
+    status.setCode(Code.FAILED_PRECONDITION.getNumber());
+
+    // aggregate into a single preconditionFailure
+    PreconditionFailure.Builder preconditionFailure = PreconditionFailure.newBuilder();
+    for (Throwable exception : exceptions) {
+      if (exception instanceof ViolationException) {
+        ViolationException violationException = (ViolationException) exception;
+        preconditionFailure.addViolations(violationException.getViolation());
+      } else if (exception instanceof PutDirectoryException) {
+        PutDirectoryException putDirException = (PutDirectoryException) exception;
+        for (Throwable putDirCause : putDirException.getExceptions()) {
+          if (putDirCause instanceof IOException) {
+            Violation.Builder violation = preconditionFailure.addViolationsBuilder();
+            ViolationException.toViolation(
+                violation, putDirCause, /* path=*/ null, /* isExecutable=*/ false);
+            if (putDirCause instanceof NoSuchFileException) {
+              violation.setSubject("blobs/" + putDirCause.getMessage());
+            } else {
+              log.log(SEVERE, "unrecognized put dir cause exception", putDirCause);
+              violation.setSubject("blobs/" + DigestUtil.toString(putDirException.getDigest()));
+            }
+          } else {
+            log.log(SEVERE, "unrecognized put dir exception", putDirCause);
+            status.setCode(Code.INTERNAL.getNumber());
+          }
+        }
+      } else {
+        log.log(SEVERE, "unrecognized exec dir exception", exception);
+        status.setCode(Code.INTERNAL.getNumber());
+      }
+    }
+    if (preconditionFailure.getViolationsCount() > 0) {
+      status.addDetails(Any.pack(preconditionFailure.build()));
+    }
+
+    return status;
+  }
+}

--- a/src/main/java/build/buildfarm/worker/InputFetcher.java
+++ b/src/main/java/build/buildfarm/worker/InputFetcher.java
@@ -15,7 +15,6 @@
 package build.buildfarm.worker;
 
 import static build.bazel.remote.execution.v2.ExecutionStage.Value.QUEUED;
-import static build.buildfarm.common.Errors.VIOLATION_TYPE_INVALID;
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
@@ -30,13 +29,17 @@ import build.bazel.remote.execution.v2.ExecutedActionMetadata;
 import build.bazel.remote.execution.v2.FileNode;
 import build.buildfarm.common.OperationFailer;
 import build.buildfarm.common.ProxyDirectoriesIndex;
+import build.buildfarm.v1test.ExecuteEntry;
 import build.buildfarm.v1test.QueuedOperation;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.Iterables;
 import com.google.longrunning.Operation;
 import com.google.protobuf.Duration;
 import com.google.protobuf.util.Durations;
 import com.google.protobuf.util.Timestamps;
+import com.google.rpc.Code;
+import com.google.rpc.Status;
 import io.grpc.Deadline;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -162,7 +165,8 @@ public class InputFetcher implements Runnable {
     return null;
   }
 
-  private long fetchPolled(Stopwatch stopwatch) throws InterruptedException {
+  @VisibleForTesting
+  long fetchPolled(Stopwatch stopwatch) throws InterruptedException {
     String operationName = operationContext.queueEntry.getExecuteEntry().getOperationName();
     log.log(Level.FINE, format("fetching inputs: %s", operationName));
 
@@ -196,8 +200,15 @@ public class InputFetcher implements Runnable {
               queuedOperation.getAction(),
               queuedOperation.getCommand());
     } catch (IOException e) {
-      log.log(Level.SEVERE, format("error creating exec dir for %s", operationName), e);
-      failOperation("Error creating exec dir", e.toString());
+      Status.Builder status = Status.newBuilder().setMessage("Error creating exec dir");
+      if (e instanceof ExecDirException) {
+        ExecDirException execDirEx = (ExecDirException) e;
+        execDirEx.toStatus(status);
+      } else {
+        status.setCode(Code.INTERNAL.getNumber());
+        log.log(Level.SEVERE, format("error creating exec dir for %s", operationName), e);
+      }
+      failOperation(status.build());
       return 0;
     }
     success = true;
@@ -311,15 +322,10 @@ public class InputFetcher implements Runnable {
     }
   }
 
-  private void failOperation(String failureMessage, String failureDetails)
-      throws InterruptedException {
+  private void failOperation(Status status) throws InterruptedException {
+    ExecuteEntry executeEntry = operationContext.queueEntry.getExecuteEntry();
     Operation failedOperation =
-        OperationFailer.get(
-            operationContext.operation,
-            operationContext.queueEntry.getExecuteEntry(),
-            VIOLATION_TYPE_INVALID,
-            failureMessage,
-            failureDetails);
+        OperationFailer.get(operationContext.operation, executeEntry, status);
 
     try {
       workerContext.putOperation(failedOperation);
@@ -327,7 +333,7 @@ public class InputFetcher implements Runnable {
           operationContext.toBuilder().setOperation(failedOperation).build();
       owner.error().put(newOperationContext);
     } catch (Exception e) {
-      String operationName = operationContext.queueEntry.getExecuteEntry().getOperationName();
+      String operationName = executeEntry.getOperationName();
       log.log(Level.SEVERE, format("Cannot report failed operation %s", operationName), e);
     }
   }

--- a/src/main/java/build/buildfarm/worker/shard/CFCExecFileSystem.java
+++ b/src/main/java/build/buildfarm/worker/shard/CFCExecFileSystem.java
@@ -21,10 +21,12 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.Iterables.concat;
 import static com.google.common.collect.Iterables.filter;
 import static com.google.common.util.concurrent.Futures.allAsList;
+import static com.google.common.util.concurrent.Futures.catchingAsync;
 import static com.google.common.util.concurrent.Futures.immediateFailedFuture;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static com.google.common.util.concurrent.Futures.transform;
 import static com.google.common.util.concurrent.Futures.transformAsync;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static com.google.common.util.concurrent.MoreExecutors.listeningDecorator;
 import static com.google.common.util.concurrent.MoreExecutors.shutdownAndAwaitTermination;
 import static java.util.concurrent.TimeUnit.MINUTES;
@@ -35,7 +37,6 @@ import build.bazel.remote.execution.v2.Compressor;
 import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.Directory;
 import build.bazel.remote.execution.v2.DirectoryNode;
-import build.bazel.remote.execution.v2.FileNode;
 import build.bazel.remote.execution.v2.SymlinkNode;
 import build.buildfarm.cas.ContentAddressableStorage;
 import build.buildfarm.cas.cfc.CASFileCache;
@@ -43,6 +44,8 @@ import build.buildfarm.common.BuildfarmExecutors;
 import build.buildfarm.common.DigestUtil;
 import build.buildfarm.common.io.Directories;
 import build.buildfarm.common.io.Dirent;
+import build.buildfarm.worker.ExecDirException;
+import build.buildfarm.worker.ExecDirException.ViolationException;
 import build.buildfarm.worker.OutputDirectory;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -181,30 +184,26 @@ class CFCExecFileSystem implements ExecFileSystem {
 
   @SuppressWarnings("ConstantConditions")
   private ListenableFuture<Void> put(
-      Path path, FileNode fileNode, ImmutableList.Builder<String> inputFiles) {
-    Path filePath = path.resolve(fileNode.getName());
-    Digest digest = fileNode.getDigest();
+      Digest digest, Path path, boolean isExecutable, Consumer<String> onKey) {
     if (digest.getSizeBytes() == 0) {
       return listeningDecorator(fetchService)
           .submit(
               () -> {
-                Files.createFile(filePath);
+                Files.createFile(path);
                 // ignore executable
                 return null;
               });
     }
-    String key = fileCache.getKey(digest, fileNode.getIsExecutable());
+    String key = fileCache.getKey(digest, isExecutable);
     return transformAsync(
-        fileCache.put(digest, fileNode.getIsExecutable(), fetchService),
+        fileCache.put(digest, isExecutable, fetchService),
         (fileCachePath) -> {
           checkNotNull(key);
           // we saw null entries in the built immutable list without synchronization
-          synchronized (inputFiles) {
-            inputFiles.add(key);
-          }
-          if (fileNode.getDigest().getSizeBytes() != 0) {
+          onKey.accept(key);
+          if (digest.getSizeBytes() != 0) {
             try {
-              Files.createLink(filePath, fileCachePath);
+              Files.createLink(path, fileCachePath);
             } catch (IOException e) {
               return immediateFailedFuture(e);
             }
@@ -214,12 +213,29 @@ class CFCExecFileSystem implements ExecFileSystem {
         fetchService);
   }
 
+  private ListenableFuture<Void> catchingPut(
+      Digest digest, Path root, Path path, boolean isExecutable, Consumer<String> onKey) {
+    return catchingAsync(
+        put(digest, path, isExecutable, onKey),
+        Throwable.class, // required per docs
+        t -> {
+          if (t instanceof IOException) {
+            return immediateFailedFuture(
+                new ViolationException(
+                    digest, root.relativize(path), isExecutable, (IOException) t));
+          }
+          return immediateFailedFuture(t);
+        },
+        directExecutor());
+  }
+
   private Iterable<ListenableFuture<Void>> fetchInputs(
+      Path root,
       Path path,
       Digest directoryDigest,
       Map<Digest, Directory> directoriesIndex,
       OutputDirectory outputDirectory,
-      ImmutableList.Builder<String> inputFiles,
+      Consumer<String> onKey,
       ImmutableList.Builder<Digest> inputDirectories)
       throws IOException {
     Directory directory = directoriesIndex.get(directoryDigest);
@@ -231,7 +247,14 @@ class CFCExecFileSystem implements ExecFileSystem {
 
     Iterable<ListenableFuture<Void>> downloads =
         directory.getFilesList().stream()
-            .map(fileNode -> put(path, fileNode, inputFiles))
+            .map(
+                fileNode ->
+                    catchingPut(
+                        fileNode.getDigest(),
+                        root,
+                        path.resolve(fileNode.getName()),
+                        fileNode.getIsExecutable(),
+                        onKey))
             .collect(ImmutableList.toImmutableList());
 
     downloads =
@@ -253,11 +276,12 @@ class CFCExecFileSystem implements ExecFileSystem {
             concat(
                 downloads,
                 fetchInputs(
+                    root,
                     dirPath,
                     digest,
                     directoriesIndex,
                     childOutputDirectory,
-                    inputFiles,
+                    onKey,
                     inputDirectories));
       } else {
         downloads =
@@ -292,33 +316,6 @@ class CFCExecFileSystem implements ExecFileSystem {
           return immediateFuture(null);
         },
         fetchService);
-  }
-
-  private static class ExecDirException extends IOException {
-    private final Path path;
-    private final List<Throwable> exceptions;
-
-    ExecDirException(Path path, List<Throwable> exceptions) {
-      // When printing the exception, show the captured sub-exceptions.
-      super(getErrorMessage(path, exceptions));
-      this.path = path;
-      this.exceptions = exceptions;
-      for (Throwable exception : exceptions) {
-        addSuppressed(exception);
-      }
-    }
-
-    Path getPath() {
-      return path;
-    }
-
-    List<Throwable> getExceptions() {
-      return exceptions;
-    }
-  }
-
-  private static String getErrorMessage(Path path, List<Throwable> exceptions) {
-    return String.format("%s: %d %s: %s", path, exceptions.size(), "exceptions", exceptions);
   }
 
   private static void checkExecErrors(Path path, List<Throwable> errors) throws ExecDirException {
@@ -379,10 +376,15 @@ class CFCExecFileSystem implements ExecFileSystem {
     Iterable<ListenableFuture<Void>> fetchedFutures =
         fetchInputs(
             execDir,
+            execDir,
             inputRootDigest,
             directoriesIndex,
             outputDirectory,
-            inputFiles,
+            key -> {
+              synchronized (inputFiles) {
+                inputFiles.add(key);
+              }
+            },
             inputDirectories);
     boolean success = false;
     try {

--- a/src/test/java/build/buildfarm/cas/cfc/CASFileCacheTest.java
+++ b/src/test/java/build/buildfarm/cas/cfc/CASFileCacheTest.java
@@ -43,7 +43,6 @@ import build.buildfarm.cas.ContentAddressableStorage.Blob;
 import build.buildfarm.cas.DigestMismatchException;
 import build.buildfarm.cas.cfc.CASFileCache.CancellableOutputStream;
 import build.buildfarm.cas.cfc.CASFileCache.Entry;
-import build.buildfarm.cas.cfc.CASFileCache.PutDirectoryException;
 import build.buildfarm.cas.cfc.CASFileCache.StartupCacheResults;
 import build.buildfarm.common.DigestUtil;
 import build.buildfarm.common.DigestUtil.HashFunction;

--- a/src/test/java/build/buildfarm/worker/BUILD
+++ b/src/test/java/build/buildfarm/worker/BUILD
@@ -17,6 +17,7 @@ java_test(
     plugins = ["//src/main/java/build/buildfarm/common:lombok"],
     test_class = "build.buildfarm.AllTests",
     deps = [
+        "//src/main/java/build/buildfarm/cas",
         "//src/main/java/build/buildfarm/common",
         "//src/main/java/build/buildfarm/common/config",
         "//src/main/java/build/buildfarm/instance",
@@ -25,6 +26,7 @@ java_test(
         "//src/main/protobuf:build_buildfarm_v1test_buildfarm_java_proto",
         "//src/test/java/build/buildfarm:test_runner",
         "@googleapis//:google_rpc_code_java_proto",
+        "@googleapis//:google_rpc_error_details_java_proto",
         "@maven//:com_github_jnr_jnr_constants",
         "@maven//:com_github_jnr_jnr_ffi",
         "@maven//:com_github_serceman_jnr_fuse",

--- a/src/test/java/build/buildfarm/worker/InputFetcherTest.java
+++ b/src/test/java/build/buildfarm/worker/InputFetcherTest.java
@@ -1,0 +1,135 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.worker;
+
+import static build.buildfarm.common.Errors.VIOLATION_TYPE_MISSING;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import build.bazel.remote.execution.v2.Action;
+import build.bazel.remote.execution.v2.Command;
+import build.bazel.remote.execution.v2.Digest;
+import build.bazel.remote.execution.v2.Directory;
+import build.bazel.remote.execution.v2.ExecuteResponse;
+import build.buildfarm.cas.cfc.PutDirectoryException;
+import build.buildfarm.v1test.ExecuteEntry;
+import build.buildfarm.v1test.QueueEntry;
+import build.buildfarm.v1test.QueuedOperation;
+import build.buildfarm.worker.ExecDirException.ViolationException;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.longrunning.Operation;
+import com.google.protobuf.Any;
+import com.google.rpc.Code;
+import com.google.rpc.DebugInfo;
+import com.google.rpc.Help;
+import com.google.rpc.LocalizedMessage;
+import com.google.rpc.PreconditionFailure;
+import com.google.rpc.RequestInfo;
+import com.google.rpc.ResourceInfo;
+import com.google.rpc.Status;
+import java.io.IOException;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class InputFetcherTest {
+  @Test
+  public void onlyMissingFilesIsViolationMissingFailedPrecondition() throws Exception {
+    PipelineStage error = mock(PipelineStage.class);
+    Operation operation = Operation.newBuilder().setName("missing-inputs").build();
+    ExecuteEntry executeEntry =
+        ExecuteEntry.newBuilder().setOperationName(operation.getName()).build();
+    QueueEntry queueEntry = QueueEntry.newBuilder().setExecuteEntry(executeEntry).build();
+    OperationContext operationContext =
+        OperationContext.newBuilder().setQueueEntry(queueEntry).setOperation(operation).build();
+    Command command = Command.newBuilder().addArguments("/bin/false").build();
+    QueuedOperation queuedOperation = QueuedOperation.newBuilder().setCommand(command).build();
+    AtomicReference<Operation> failedOperationRef = new AtomicReference<>();
+    WorkerContext workerContext =
+        new StubWorkerContext() {
+          @Override
+          public QueuedOperation getQueuedOperation(QueueEntry queueEntry) {
+            return queuedOperation;
+          }
+
+          @Override
+          public boolean putOperation(Operation operation) {
+            return failedOperationRef.compareAndSet(null, operation);
+          }
+
+          @Override
+          public Path createExecDir(
+              String operationName,
+              Map<Digest, Directory> directoriesIndex,
+              Action action,
+              Command command)
+              throws IOException {
+            Path root = Paths.get(operationName);
+            throw new ExecDirException(
+                Paths.get(operationName),
+                ImmutableList.of(
+                    new ViolationException(
+                        Digest.getDefaultInstance(),
+                        root.resolve("input"),
+                        /* isExecutable=*/ false,
+                        new NoSuchFileException("input-digest")),
+                    new PutDirectoryException(
+                        root.resolve("dir"),
+                        Digest.getDefaultInstance(),
+                        ImmutableList.of(new NoSuchFileException("dir/input-digest")))));
+          }
+
+          @Override
+          public int getInputFetchStageWidth() {
+            return 1;
+          }
+        };
+    InputFetchStage owner = new InputFetchStage(workerContext, /* output=*/ null, error);
+    InputFetcher inputFetcher = new InputFetcher(workerContext, operationContext, owner);
+    inputFetcher.fetchPolled(/* stopwatch=*/ null);
+    Operation failedOperation = checkNotNull(failedOperationRef.get());
+    verify(error, times(1)).put(any(OperationContext.class));
+    ExecuteResponse executeResponse = failedOperation.getResponse().unpack(ExecuteResponse.class);
+    Status status = executeResponse.getStatus();
+    assertThat(status.getCode()).isEqualTo(Code.FAILED_PRECONDITION.getNumber());
+    for (Any detail : status.getDetailsList()) {
+      if (!(detail.is(DebugInfo.class)
+          || detail.is(Help.class)
+          || detail.is(LocalizedMessage.class)
+          || detail.is(RequestInfo.class)
+          || detail.is(ResourceInfo.class))) {
+        assertThat(detail.is(PreconditionFailure.class)).isTrue();
+        PreconditionFailure preconditionFailure = detail.unpack(PreconditionFailure.class);
+        assertThat(preconditionFailure.getViolationsCount()).isGreaterThan(0);
+        assertThat(
+                Iterables.all(
+                    preconditionFailure.getViolationsList(),
+                    violation -> violation.getType().equals(VIOLATION_TYPE_MISSING)))
+            .isTrue();
+      }
+    }
+  }
+}

--- a/src/test/java/build/buildfarm/worker/StubWorkerContext.java
+++ b/src/test/java/build/buildfarm/worker/StubWorkerContext.java
@@ -34,6 +34,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.longrunning.Operation;
 import com.google.protobuf.Duration;
 import io.grpc.Deadline;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -142,10 +143,8 @@ class StubWorkerContext implements WorkerContext {
 
   @Override
   public Path createExecDir(
-      String operationName,
-      Map<Digest, Directory> directoriesIndex,
-      Action action,
-      Command command) {
+      String operationName, Map<Digest, Directory> directoriesIndex, Action action, Command command)
+      throws IOException, InterruptedException {
     throw new UnsupportedOperationException();
   }
 


### PR DESCRIPTION
Handle ExecDirExceptions in InputFetcher such that the client can observe a FAILED_PRECONDITION with PreconditionFailures that include Violations with VIOLATION_TYPE_MISSING to inspire virtuous loop reestablishment. A ViolationException acts as a container for this, and can be extended to include the components of a putDirectory. Interpret PutDirectoryExceptions with their imposed violations. Missing inputs at the time of execute, whether linked as immediate files or through the directory cache, will be interpreted as VIOLATION_TYPE_MISSING.