### PR TITLE
Initialize fileStore when skipping load

### DIFF
--- a/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
+++ b/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
@@ -1275,6 +1275,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
       loadResults = loadCache(onStartPut, removeDirectoryService);
     } else {
       // Skip loading the cache and ensure it is empty
+      fileStore = Files.getFileStore(root);
       Directories.remove(root, fileStore, removeDirectoryService);
       initializeRootDirectory();
     }


### PR DESCRIPTION
Prevents a null fileStore reference when removing directories.