### PR TITLE
Fix: custom latency buckets #1376

### DIFF
--- a/src/main/java/build/buildfarm/common/config/GrpcMetrics.java
+++ b/src/main/java/build/buildfarm/common/config/GrpcMetrics.java
@@ -27,7 +27,7 @@ public class GrpcMetrics {
 
       // provide custom latency buckets
       if (grpcMetrics.getLatencyBuckets() != null) {
-        grpcConfig.withLatencyBuckets(grpcMetrics.getLatencyBuckets());
+        grpcConfig = grpcConfig.withLatencyBuckets(grpcMetrics.getLatencyBuckets());
       }
 
       // Apply config to create an interceptor and apply it to the GRPC server.


### PR DESCRIPTION
`withLatencyBuckets` Creates a new copy and updates value for latency bucket.
https://github.com/grpc-ecosystem/java-grpc-prometheus/blob/master/src/main/java/me/dinowernli/grpc/prometheus/Configuration.java#L65