### PR TITLE
Supply a basic retrier to remote cas writes

### DIFF
--- a/src/main/java/build/buildfarm/worker/ReportResultStage.java
+++ b/src/main/java/build/buildfarm/worker/ReportResultStage.java
@@ -35,6 +35,7 @@ import com.google.rpc.Code;
 import com.google.rpc.Status;
 import io.grpc.Deadline;
 import io.grpc.StatusException;
+import io.grpc.StatusRuntimeException;
 import io.grpc.protobuf.StatusProto;
 import java.io.IOException;
 import java.nio.channels.ClosedByInterruptException;
@@ -99,7 +100,7 @@ public class ReportResultStage extends PipelineStage {
           resultBuilder,
           operationContext.execDir,
           operationContext.command);
-    } catch (StatusException e) {
+    } catch (StatusException | StatusRuntimeException e) {
       ExecuteResponse executeResponse = operationContext.executeResponse.build();
       if (executeResponse.getStatus().getCode() == Code.OK.getNumber()
           && executeResponse.getResult().getExitCode() == 0) {

--- a/src/main/java/build/buildfarm/worker/shard/RemoteCasWriter.java
+++ b/src/main/java/build/buildfarm/worker/shard/RemoteCasWriter.java
@@ -23,6 +23,8 @@ import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.RequestMetadata;
 import build.buildfarm.common.Size;
 import build.buildfarm.common.Write;
+import build.buildfarm.common.grpc.Retrier;
+import build.buildfarm.common.grpc.RetryException;
 import build.buildfarm.common.io.FeedbackOutputStream;
 import build.buildfarm.instance.Instance;
 import com.google.common.base.Throwables;
@@ -46,12 +48,15 @@ import lombok.extern.java.Log;
 
 @Log
 public class RemoteCasWriter implements CasWriter {
-  private Set<String> workerSet;
-  private LoadingCache<String, Instance> workerStubs;
+  private final Set<String> workerSet;
+  private final LoadingCache<String, Instance> workerStubs;
+  private final Retrier retrier;
 
-  public RemoteCasWriter(Set<String> workerSet, LoadingCache<String, Instance> workerStubs) {
+  public RemoteCasWriter(
+      Set<String> workerSet, LoadingCache<String, Instance> workerStubs, Retrier retrier) {
     this.workerSet = workerSet;
     this.workerStubs = workerStubs;
+    this.retrier = retrier;
   }
 
   public void write(Digest digest, Path file) throws IOException, InterruptedException {
@@ -63,19 +68,30 @@ public class RemoteCasWriter implements CasWriter {
   private void insertFileToCasMember(Digest digest, Path file)
       throws IOException, InterruptedException {
     try (InputStream in = Files.newInputStream(file)) {
-      writeToCasMember(digest, in);
-    } catch (ExecutionException e) {
-      throw new IOException(Status.RESOURCE_EXHAUSTED.withCause(e).asRuntimeException());
+      retrier.execute(() -> writeToCasMember(digest, in));
+    } catch (RetryException e) {
+      Throwable cause = e.getCause();
+      Throwables.throwIfInstanceOf(cause, IOException.class);
+      Throwables.throwIfUnchecked(cause);
+      throw new RuntimeException(cause);
     }
   }
 
-  private void writeToCasMember(Digest digest, InputStream in)
-      throws IOException, InterruptedException, ExecutionException {
+  private long writeToCasMember(Digest digest, InputStream in)
+      throws IOException, InterruptedException {
     // create a write for inserting into another CAS member.
     String workerName = getRandomWorker();
     Write write = getCasMemberWrite(digest, workerName);
 
-    streamIntoWriteFuture(in, write, digest).get();
+    try {
+      return streamIntoWriteFuture(in, write, digest).get();
+    } catch (ExecutionException e) {
+      Throwable cause = e.getCause();
+      Throwables.throwIfInstanceOf(cause, IOException.class);
+      // prevent a discard of this frame
+      Status status = Status.fromThrowable(cause);
+      throw status.asRuntimeException();
+    }
   }
 
   private Write getCasMemberWrite(Digest digest, String workerName) throws IOException {
@@ -93,13 +109,12 @@ public class RemoteCasWriter implements CasWriter {
   private void insertBlobToCasMember(Digest digest, ByteString content)
       throws IOException, InterruptedException {
     try (InputStream in = content.newInput()) {
-      writeToCasMember(digest, in);
-    } catch (ExecutionException e) {
+      retrier.execute(() -> writeToCasMember(digest, in));
+    } catch (RetryException e) {
       Throwable cause = e.getCause();
-      Throwables.throwIfUnchecked(cause);
       Throwables.throwIfInstanceOf(cause, IOException.class);
-      Status status = Status.fromThrowable(cause);
-      throw new IOException(status.asException());
+      Throwables.throwIfUnchecked(cause);
+      throw new RuntimeException(cause);
     }
   }
 

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -39,6 +39,8 @@ import build.buildfarm.common.InputStreamFactory;
 import build.buildfarm.common.config.BuildfarmConfigs;
 import build.buildfarm.common.config.Cas;
 import build.buildfarm.common.config.GrpcMetrics;
+import build.buildfarm.common.grpc.Retrier;
+import build.buildfarm.common.grpc.Retrier.Backoff;
 import build.buildfarm.common.services.ByteStreamService;
 import build.buildfarm.common.services.ContentAddressableStorageService;
 import build.buildfarm.instance.Instance;
@@ -577,7 +579,8 @@ public class Worker {
     // Create the appropriate writer for the context
     CasWriter writer;
     if (!configs.getWorker().getCapabilities().isCas()) {
-      writer = new RemoteCasWriter(backplane.getStorageWorkers(), workerStubs);
+      Retrier retrier = new Retrier(Backoff.sequential(5), Retrier.DEFAULT_IS_RETRIABLE);
+      writer = new RemoteCasWriter(backplane.getStorageWorkers(), workerStubs, retrier);
     } else {
       writer = new LocalCasWriter(execFileSystem);
     }


### PR DESCRIPTION
Worker loss can signal cascading failure and shutdown for execute-only peers. Ensure that a ReportResultStage seeing an SRE does not close the stage, and that there are basic retries for remote uploads.