### PR TITLE
Create separate grpc channel for write api and other Improvements

### DIFF
--- a/examples/config.yml
+++ b/examples/config.yml
@@ -135,6 +135,8 @@ worker:
       executionWrapper:
         path: "/"
         arguments:
+  maxConnectionAge: 3600
+  maxConnectionAgeGrace: 60
 executionWrappers:
   cgroups: /usr/bin/cgexec
   unshare: /usr/bin/unshare

--- a/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
+++ b/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
@@ -639,7 +639,8 @@ public abstract class CASFileCache implements ContentAddressableStorage {
             log.log(Level.SEVERE, "error closing input stream on cancel", e);
           } finally {
             if (!blobObserver.isCancelled()) {
-              blobObserver.onError(Status.CANCELLED.withDescription("client cancelled").asRuntimeException());
+              blobObserver.onError(
+                  Status.CANCELLED.withDescription("client cancelled").asRuntimeException());
             }
           }
         });

--- a/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
+++ b/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
@@ -89,6 +89,7 @@ import com.google.common.util.concurrent.SettableFuture;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.google.protobuf.ByteString;
 import io.grpc.Deadline;
+import io.grpc.Status;
 import io.grpc.StatusException;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.ServerCallStreamObserver;
@@ -636,6 +637,10 @@ public abstract class CASFileCache implements ContentAddressableStorage {
             in.close();
           } catch (IOException e) {
             log.log(Level.SEVERE, "error closing input stream on cancel", e);
+          } finally {
+            if (!blobObserver.isCancelled()) {
+              blobObserver.onError(Status.CANCELLED.withDescription("client cancelled").asRuntimeException());
+            }
           }
         });
     byte[] buffer = new byte[CHUNK_SIZE];

--- a/src/main/java/build/buildfarm/common/config/Worker.java
+++ b/src/main/java/build/buildfarm/common/config/Worker.java
@@ -37,6 +37,8 @@ public class Worker {
   private boolean errorOperationRemainingResources = false;
   private ExecutionPolicy[] executionPolicies = {};
   private SandboxSettings sandboxSettings = new SandboxSettings();
+  private long maxConnectionAge;
+  private long maxConnectionAgeGrace;
 
   public ExecutionPolicy[] getExecutionPolicies() {
     if (executionPolicies != null) {

--- a/src/main/java/build/buildfarm/common/grpc/StubWriteOutputStream.java
+++ b/src/main/java/build/buildfarm/common/grpc/StubWriteOutputStream.java
@@ -227,13 +227,14 @@ public class StubWriteOutputStream extends FeedbackOutputStream implements Write
 
                     @Override
                     public void onError(Throwable t) {
-                      String worker = bsStub.get().getChannel().authority();
-                      Status status = Status.fromThrowable(t);
                       log.log(
                           WARNING,
                           format(
                               "%s: write(%s) on worker %s after %d bytes of content",
-                              status.getCode().name(), resourceName, worker, writtenBytes));
+                              Status.fromThrowable(t).getCode().name(),
+                              resourceName,
+                              bsStub.get().getChannel().authority(),
+                              writtenBytes));
                       writeFuture.setException(exceptionTranslator.apply(t));
                     }
 

--- a/src/main/java/build/buildfarm/common/grpc/StubWriteOutputStream.java
+++ b/src/main/java/build/buildfarm/common/grpc/StubWriteOutputStream.java
@@ -227,6 +227,13 @@ public class StubWriteOutputStream extends FeedbackOutputStream implements Write
 
                     @Override
                     public void onError(Throwable t) {
+                      String worker = bsStub.get().getChannel().authority();
+                      Status status = Status.fromThrowable(t);
+                      log.log(
+                          WARNING,
+                          format(
+                              "%s: write(%s) on worker %s after %d bytes of content",
+                              status.getCode().name(), resourceName, worker, writtenBytes));
                       writeFuture.setException(exceptionTranslator.apply(t));
                     }
 

--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -920,7 +920,10 @@ public class ShardInstance extends AbstractServerInstance {
                       Level.WARNING,
                       format(
                           "%s: read(%s) on worker %s after %d bytes of content",
-                          status.getCode().name(), DigestUtil.toString(blobDigest), worker, received));
+                          status.getCode().name(),
+                          DigestUtil.toString(blobDigest),
+                          worker,
+                          received));
                   blobObserver.onError(t);
                   return;
                 }

--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -919,8 +919,8 @@ public class ShardInstance extends AbstractServerInstance {
                   log.log(
                       Level.WARNING,
                       format(
-                          "DEADLINE_EXCEEDED: read(%s) on worker %s after %d bytes of content",
-                          DigestUtil.toString(blobDigest), worker, received));
+                          "%s: read(%s) on worker %s after %d bytes of content",
+                          status.getCode().name(), DigestUtil.toString(blobDigest), worker, received));
                   blobObserver.onError(t);
                   return;
                 }

--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -895,7 +895,7 @@ public class ShardInstance extends AbstractServerInstance {
               public void onNext(ByteString nextChunk) {
                 blobObserver.onNext(nextChunk);
                 received += nextChunk.size();
-                ioMetric.observe(received);
+                ioMetric.observe(nextChunk.size());
               }
 
               @Override

--- a/src/main/java/build/buildfarm/instance/shard/WorkerStubs.java
+++ b/src/main/java/build/buildfarm/instance/shard/WorkerStubs.java
@@ -57,6 +57,7 @@ public final class WorkerStubs {
         worker,
         digestUtil,
         createChannel(worker),
+        createChannel(worker), // seperate write channel
         timeout,
         newStubRetrier(),
         newStubRetryService());

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -84,6 +84,7 @@ import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import javax.annotation.Nullable;
 import javax.annotation.PostConstruct;
@@ -531,6 +532,10 @@ public class Worker {
   public void start() throws ConfigurationException, InterruptedException, IOException {
     String session = UUID.randomUUID().toString();
     ServerBuilder<?> serverBuilder = ServerBuilder.forPort(configs.getWorker().getPort());
+    if (configs.getWorker().getMaxConnectionAge() > 0) {
+      serverBuilder.maxConnectionAge(configs.getWorker().getMaxConnectionAge(), SECONDS);
+      serverBuilder.maxConnectionAgeGrace(configs.getWorker().getMaxConnectionAgeGrace(), SECONDS);
+    }
     String identifier = "buildfarm-worker-" + configs.getWorker().getPublicName() + "-" + session;
     root = configs.getWorker().getValidRoot();
     if (configs.getWorker().getPublicName().isEmpty()) {

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -84,7 +84,6 @@ import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import javax.annotation.Nullable;
 import javax.annotation.PostConstruct;


### PR DESCRIPTION
### Problem
Observed that the buildfarm availability occasionally drops due to timeouts, and even when the traffic decreases significantly, the system fails to recover. Upon investigation, it was discovered that the majority of timeouts are caused by a small group of Workers. Even under light loads, a substantial percentage of read and write requests to these affected workers experience timeouts.

This problem originates from a substantial backlog of pending data in the RECV-Q socket buffers of the Established connections on the Buildfarm worker. These hung-up connections are not appropriately cleared, leading to a high occurrence of timeouts for these connections. Sample connection:

| State  |  Recv-Q  | Send-Q | Local Address:Port  | Peer Address:Port | |
| - | - | - | - | - | -|
| ESTAB  | 2022741   | 0  | 172.17.0.2:8981   | <server_ip>:60296 |  (on worker)|
| ESTAB  | 0   | 531246  | 172.17.0.2:8980   | <worker_ip>:60296 |  (on server) |

In addition, during these incidents, the number of open file descriptors (FDs) on the affected workers also rises. This increase in open FDs is primarily caused by the TCP health check that we have configured for the worker cluster. The TCP health check operates by establishing and closing TCP connections. However, on the affected workers, around 5-10% of these TCP health check connections do not terminate correctly and remain stuck in the CLOSE_WAIT state. Each connection in the CLOSE_WAIT state contributes to the growing count of open file descriptors. (Q: why this happens?)

Analyzed multiple such incidents and found a common pattern that the problem starts occurring at very high write QPS. When there is a surge in write requests, the buildfarm worker is unable to process the data at the rate it is being pushed to the network layer. As a result, some data is left unread in the socket buffer because the application may have closed the call before all the requested data reached the worker. This accumulation of unread data in the socket buffers makes the connection very much unusable.


### Solution
1. Created seperate channel for read and write calls, so any issue with write call has no or minimum impact on the read call and vice-versa. This is inline with [Grpc performance best practice](https://grpc.io/docs/guides/performance/) recommendation to create a separate channel for each area of high load in the application.
2. Made gRPC maxconnection age configurable, previously it was using default value which is set to never expire. By setting a specific max connection age duration, if an issue arises with a connection, it will only persist for the designated period. With this configuration, gRPC will automatically close the connection after the max connection age, prompting the creation of a new connection. Additionally, set the maxConnectionAgeGrace to the max grpcTimeout, ensuring that pending RPCs on the connection are not impacted.

### Other improvements
1. Resolved missing prometheus metrics on read cancellation by invoking `blobObserver.onError` on call cancel This ensures that latency and status metrics for cancelled read calls are logged for buildfarm workers.
2. Fix `io_bytes_read` metrics for buildfarm:server. Previously a 1MB (16 * 64) blob logged as 8.5MB ( (16 * (16+1) / 2) * 64 ). 
3. Specify deadline for worker:read requests. 
4. Added and updated logging at few locations.