### PR TITLE
Output status code name on shard read error

### DIFF
--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -919,8 +919,11 @@ public class ShardInstance extends AbstractServerInstance {
                   log.log(
                       Level.WARNING,
                       format(
-                          "DEADLINE_EXCEEDED: read(%s) on worker %s after %d bytes of content",
-                          DigestUtil.toString(blobDigest), worker, received));
+                          "%s: read(%s) on worker %s after %d bytes of content",
+                          status.getCode().name(),
+                          DigestUtil.toString(blobDigest),
+                          worker,
+                          received));
                   blobObserver.onError(t);
                   return;
                 }


### PR DESCRIPTION
Use the proper name for a status code as presented when the read will not be retried.