### PR TITLE
Reduce log levels to make log files more meaningful

### DIFF
--- a/src/main/java/build/buildfarm/admin/aws/AwsAdmin.java
+++ b/src/main/java/build/buildfarm/admin/aws/AwsAdmin.java
@@ -127,7 +127,7 @@ public class AwsAdmin implements Admin {
     }
     resultBuilder.addAllHosts(hosts);
     resultBuilder.setNumHosts(hosts.size());
-    log.log(Level.FINE, String.format("Got %d hosts for filter: %s", hosts.size(), filter));
+    log.log(Level.FINER, String.format("Got %d hosts for filter: %s", hosts.size(), filter));
     return resultBuilder.build();
   }
 

--- a/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
+++ b/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
@@ -550,7 +550,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
   @SuppressWarnings("ResultOfMethodCallIgnored")
   InputStream newLocalInput(Compressor.Value compressor, Digest digest, long offset)
       throws IOException {
-    log.log(Level.FINE, format("getting input stream for %s", DigestUtil.toString(digest)));
+    log.log(Level.FINER, format("getting input stream for %s", DigestUtil.toString(digest)));
     boolean isExecutable = false;
     do {
       String key = getKey(digest, isExecutable);
@@ -724,7 +724,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
   public void put(Blob blob, Runnable onExpiration) throws InterruptedException {
     String key = getKey(blob.getDigest(), false);
     try {
-      log.log(Level.FINE, format("put: %s", key));
+      log.log(Level.FINER, format("put: %s", key));
       OutputStream out =
           putImpl(
               Compressor.Value.IDENTITY,
@@ -1050,7 +1050,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
     String key = getKey(digest, false);
     final CancellableOutputStream cancellableOut;
     try {
-      log.log(Level.FINE, format("getWrite: %s", key));
+      log.log(Level.FINER, format("getWrite: %s", key));
       cancellableOut =
           putImpl(
               compressor,
@@ -2140,7 +2140,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
   private void removeFilePath(Path path) throws IOException {
     if (Files.exists(path)) {
       if (Files.isDirectory(path)) {
-        log.log(Level.FINE, "removing existing directory " + path + " for fetch");
+        log.log(Level.FINER, "removing existing directory " + path + " for fetch");
         Directories.remove(path, fileStore);
       } else {
         Files.delete(path);
@@ -2169,14 +2169,14 @@ public abstract class CASFileCache implements ContentAddressableStorage {
     // Claim the directory path so no other threads try to create/delete it.
     Path path = getDirectoryPath(digest);
     Lock l = locks.acquire(path);
-    log.log(Level.FINE, format("locking directory %s", path.getFileName()));
+    log.log(Level.FINER, format("locking directory %s", path.getFileName()));
     try {
       l.lockInterruptibly();
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       return immediateFailedFuture(e);
     }
-    log.log(Level.FINE, format("locked directory %s", path.getFileName()));
+    log.log(Level.FINER, format("locked directory %s", path.getFileName()));
 
     // Now that a lock has been claimed, we can proceed to create the directory.
     ListenableFuture<Path> putFuture;
@@ -2190,7 +2190,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
     putFuture.addListener(
         () -> {
           l.unlock();
-          log.log(Level.FINE, format("directory %s has been unlocked", path.getFileName()));
+          log.log(Level.FINER, format("directory %s has been unlocked", path.getFileName()));
         },
         service);
     return putFuture;
@@ -2238,7 +2238,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
   private ListenableFuture<Path> putDirectorySynchronized(
       Path path, Digest digest, Map<Digest, Directory> directoriesByDigest, ExecutorService service)
       throws IOException {
-    log.log(Level.FINE, format("directory %s has been locked", path.getFileName()));
+    log.log(Level.FINER, format("directory %s has been locked", path.getFileName()));
     ListenableFuture<Void> expireFuture;
     synchronized (this) {
       DirectoryEntry e = directoryStorage.get(digest);
@@ -2265,7 +2265,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
         }
 
         if (e != null) {
-          log.log(Level.FINE, format("found existing entry for %s", path.getFileName()));
+          log.log(Level.FINER, format("found existing entry for %s", path.getFileName()));
           if (directoryEntryExists(path, e, directoriesByDigest)) {
             return immediateFuture(path);
           }
@@ -2278,7 +2278,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
 
         decrementReferencesSynchronized(inputsBuilder.build(), ImmutableList.of());
         expireFuture = expireDirectory(digest, service);
-        log.log(Level.FINE, format("expiring existing entry for %s", path.getFileName()));
+        log.log(Level.FINER, format("expiring existing entry for %s", path.getFileName()));
       }
     }
 
@@ -2300,7 +2300,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
         transformAsync(
             deindexFuture,
             result -> {
-              log.log(Level.FINE, format("expiry complete, fetching %s", path.getFileName()));
+              log.log(Level.FINER, format("expiry complete, fetching %s", path.getFileName()));
               ImmutableList.Builder<ListenableFuture<Path>> putFuturesBuilder =
                   ImmutableList.builder();
               fetchDirectory(
@@ -2374,7 +2374,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
                 }
               }
               try {
-                log.log(Level.FINE, "removing directory to roll back " + path);
+                log.log(Level.FINER, "removing directory to roll back " + path);
                 Directories.remove(path, fileStore);
               } catch (IOException removeException) {
                 log.log(
@@ -2390,7 +2390,8 @@ public abstract class CASFileCache implements ContentAddressableStorage {
     return transform(
         rollbackFuture,
         (results) -> {
-          log.log(Level.FINE, format("directory fetch complete, inserting %s", path.getFileName()));
+          log.log(
+              Level.FINER, format("directory fetch complete, inserting %s", path.getFileName()));
           DirectoryEntry e =
               new DirectoryEntry(
                   // might want to have this treatment ahead of this
@@ -2442,13 +2443,13 @@ public abstract class CASFileCache implements ContentAddressableStorage {
         complete = true;
       } finally {
         try {
-          log.log(Level.FINE, format("closing output stream for %s", DigestUtil.toString(digest)));
+          log.log(Level.FINER, format("closing output stream for %s", DigestUtil.toString(digest)));
           if (complete) {
             out.close();
           } else {
             out.cancel();
           }
-          log.log(Level.FINE, format("output stream closed for %s", DigestUtil.toString(digest)));
+          log.log(Level.FINER, format("output stream closed for %s", DigestUtil.toString(digest)));
         } catch (IOException e) {
           if (Thread.interrupted()) {
             log.log(
@@ -2460,7 +2461,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
             throw new InterruptedException();
           } else {
             log.log(
-                Level.FINE,
+                Level.FINER,
                 format("failed output stream close for %s", DigestUtil.toString(digest)),
                 e);
           }
@@ -2492,7 +2493,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
   private void copyExternalInput(Digest digest, CancellableOutputStream out)
       throws IOException, InterruptedException {
     Retrier retrier = new Retrier(Backoff.sequential(5), Retrier.DEFAULT_IS_RETRIABLE);
-    log.log(Level.FINE, format("downloading %s", DigestUtil.toString(digest)));
+    log.log(Level.FINER, format("downloading %s", DigestUtil.toString(digest)));
     try {
       retrier.execute(
           () -> {
@@ -2513,7 +2514,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
           e); // prevent burial by early end of stream during close
       throw e;
     }
-    log.log(Level.FINE, format("download of %s complete", DigestUtil.toString(digest)));
+    log.log(Level.FINER, format("download of %s complete", DigestUtil.toString(digest)));
   }
 
   @FunctionalInterface
@@ -2567,7 +2568,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
     if (out == DUPLICATE_OUTPUT_STREAM) {
       return null;
     }
-    log.log(Level.FINE, format("entry %s is missing, downloading and populating", key));
+    log.log(Level.FINER, format("entry %s is missing, downloading and populating", key));
     return newCancellableOutputStream(out);
   }
 
@@ -2752,7 +2753,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
                         return immediateFuture(null);
                       }
                       expiredKeyCounter.inc();
-                      log.log(Level.INFO, format("expired key %s", expiredKey));
+                      log.log(Level.FINE, format("expired key %s", expiredKey));
                       return immediateFuture(fileEntryKey.getDigest());
                     },
                     expireService));
@@ -2955,7 +2956,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
           existingEntry = safeStorageInsertion(key, entry);
           inserted = existingEntry == null;
         } catch (FileAlreadyExistsException e) {
-          log.log(Level.FINE, "file already exists for " + key + ", nonexistent entry will fail");
+          log.log(Level.FINER, "file already exists for " + key + ", nonexistent entry will fail");
         } finally {
           Files.delete(writePath);
           if (!inserted) {
@@ -2980,20 +2981,20 @@ public abstract class CASFileCache implements ContentAddressableStorage {
         }
 
         if (existingEntry != null) {
-          log.log(Level.FINE, "lost the race to insert " + key);
+          log.log(Level.FINER, "lost the race to insert " + key);
           if (!referenceIfExists(key)) {
             // we would lose our accountability and have a presumed reference if we returned
             throw new IllegalStateException("storage conflict with existing key for " + key);
           }
         } else if (writeWinner.get()) {
-          log.log(Level.FINE, "won the race to insert " + key);
+          log.log(Level.FINER, "won the race to insert " + key);
           try {
             onInsert.run();
           } catch (RuntimeException e) {
             throw new IOException(e);
           }
         } else {
-          log.log(Level.FINE, "did not win the race to insert " + key);
+          log.log(Level.FINER, "did not win the race to insert " + key);
         }
       }
     };
@@ -3047,7 +3048,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
             "entry " + key + " has " + referenceCount + " references and is being incremented...");
       }
       log.log(
-          Level.FINER,
+          Level.FINEST,
           "incrementing references to "
               + key
               + " from "
@@ -3077,7 +3078,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
             "entry " + key + " has 0 references and is being decremented...");
       }
       log.log(
-          Level.FINER,
+          Level.FINEST,
           "decrementing references to "
               + key
               + " from "

--- a/src/main/java/build/buildfarm/common/services/ByteStreamService.java
+++ b/src/main/java/build/buildfarm/common/services/ByteStreamService.java
@@ -342,7 +342,7 @@ public class ByteStreamService extends ByteStreamImplBase {
     long offset = request.getReadOffset();
     long limit = request.getReadLimit();
     log.log(
-        Level.FINER,
+        Level.FINEST,
         format("read resource_name=%s offset=%d limit=%d", resourceName, offset, limit));
 
     try {
@@ -357,7 +357,7 @@ public class ByteStreamService extends ByteStreamImplBase {
       QueryWriteStatusRequest request, StreamObserver<QueryWriteStatusResponse> responseObserver) {
     String resourceName = request.getResourceName();
     try {
-      log.log(Level.FINE, format("queryWriteStatus(%s)", resourceName));
+      log.log(Level.FINER, format("queryWriteStatus(%s)", resourceName));
       Write write = getWrite(resourceName);
       responseObserver.onNext(
           QueryWriteStatusResponse.newBuilder()
@@ -366,7 +366,7 @@ public class ByteStreamService extends ByteStreamImplBase {
               .build());
       responseObserver.onCompleted();
       log.log(
-          Level.FINE,
+          Level.FINER,
           format(
               "queryWriteStatus(%s) => committed_size = %d, complete = %s",
               resourceName, write.getCommittedSize(), write.isComplete()));

--- a/src/main/java/build/buildfarm/common/services/ContentAddressableStorageService.java
+++ b/src/main/java/build/buildfarm/common/services/ContentAddressableStorageService.java
@@ -109,7 +109,7 @@ public class ContentAddressableStorageService
               long elapsedMicros = stopwatch.elapsed(MICROSECONDS);
               missingBlobs.observe(request.getBlobDigestsList().size());
               log.log(
-                  Level.FINE,
+                  Level.FINER,
                   "FindMissingBlobs("
                       + instance.getName()
                       + ") for "

--- a/src/main/java/build/buildfarm/common/services/WriteStreamObserver.java
+++ b/src/main/java/build/buildfarm/common/services/WriteStreamObserver.java
@@ -110,7 +110,7 @@ public class WriteStreamObserver implements StreamObserver<WriteRequest> {
         Status status = Status.fromThrowable(e);
         if (errorResponse(status.asException())) {
           log.log(
-              status.getCode() == Status.Code.CANCELLED ? Level.FINE : Level.SEVERE,
+              status.getCode() == Status.Code.CANCELLED ? Level.FINER : Level.SEVERE,
               format("error writing %s", (name == null ? request.getResourceName() : name)),
               e);
         }
@@ -160,7 +160,7 @@ public class WriteStreamObserver implements StreamObserver<WriteRequest> {
 
     if (Context.current().isCancelled()) {
       log.log(
-          Level.FINER,
+          Level.FINEST,
           format("skipped delivering committed_size to %s for cancelled context", name));
     } else {
       try {
@@ -182,7 +182,7 @@ public class WriteStreamObserver implements StreamObserver<WriteRequest> {
         Status status = Status.fromThrowable(e);
         if (errorResponse(status.asException())) {
           log.log(
-              status.getCode() == Status.Code.CANCELLED ? Level.FINE : Level.SEVERE,
+              status.getCode() == Status.Code.CANCELLED ? Level.FINER : Level.SEVERE,
               format(
                   "%s-%s: %s -> %s -> %s: error committing %s",
                   requestMetadata.getToolDetails().getToolName(),
@@ -202,7 +202,8 @@ public class WriteStreamObserver implements StreamObserver<WriteRequest> {
 
     if (exception.compareAndSet(null, null)) {
       try {
-        log.log(Level.FINER, format("delivering committed_size for %s of %d", name, committedSize));
+        log.log(
+            Level.FINEST, format("delivering committed_size for %s of %d", name, committedSize));
         responseObserver.onNext(response);
         responseObserver.onCompleted();
       } catch (Exception e) {
@@ -221,9 +222,9 @@ public class WriteStreamObserver implements StreamObserver<WriteRequest> {
       name = resourceName;
       try {
         write = getWrite(resourceName);
-        if (log.isLoggable(Level.FINER)) {
+        if (log.isLoggable(Level.FINEST)) {
           log.log(
-              Level.FINER,
+              Level.FINEST,
               format(
                   "registering callback for %s: committed_size = %d (transient), complete = %s",
                   resourceName, write.getCommittedSize(), write.isComplete()));
@@ -365,7 +366,7 @@ public class WriteStreamObserver implements StreamObserver<WriteRequest> {
           data = data.substring(skipBytes);
         }
         log.log(
-            Level.FINER,
+            Level.FINEST,
             format(
                 "writing %d to %s at %d%s",
                 bytesToWrite, name, offset, finishWrite ? " with finish_write" : ""));
@@ -381,7 +382,7 @@ public class WriteStreamObserver implements StreamObserver<WriteRequest> {
 
   @GuardedBy("this")
   private void close() {
-    log.log(Level.FINER, format("closing stream due to finishWrite for %s", name));
+    log.log(Level.FINEST, format("closing stream due to finishWrite for %s", name));
     try {
       getOutput().close();
     } catch (DigestMismatchException e) {
@@ -464,11 +465,11 @@ public class WriteStreamObserver implements StreamObserver<WriteRequest> {
 
   @Override
   public void onError(Throwable t) {
-    log.log(Level.FINE, format("write error for %s", name), t);
+    log.log(Level.FINER, format("write error for %s", name), t);
   }
 
   @Override
   public void onCompleted() {
-    log.log(Level.FINE, format("write completed for %s", name));
+    log.log(Level.FINER, format("write completed for %s", name));
   }
 }

--- a/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
@@ -206,7 +206,7 @@ public class RedisShardBackplane implements Backplane {
         JsonFormat.parser().merge(entry, executeEntry);
         visit(executeEntry.build(), entry);
       } catch (InvalidProtocolBufferException e) {
-        log.log(Level.FINE, "invalid ExecuteEntry json: " + entry, e);
+        log.log(Level.FINER, "invalid ExecuteEntry json: " + entry, e);
       }
     }
   }
@@ -330,10 +330,10 @@ public class RedisShardBackplane implements Backplane {
 
     if (!expiringChannels.isEmpty()) {
       log.log(
-          Level.FINE,
+          Level.FINER,
           format("Scan %d watches, %s, expiresAt: %s", expiringChannels.size(), now, expiresAt));
 
-      log.log(Level.FINE, "Scan prequeue");
+      log.log(Level.FINER, "Scan prequeue");
       // scan prequeue, pet watches
       scanPrequeue(jedis, resetChannel);
     }
@@ -342,7 +342,7 @@ public class RedisShardBackplane implements Backplane {
     scanProcessing(jedis, resetChannel, now);
 
     if (!expiringChannels.isEmpty()) {
-      log.log(Level.FINE, "Scan queue");
+      log.log(Level.FINER, "Scan queue");
       // scan queue, pet watches
       scanQueue(jedis, resetChannel);
     }
@@ -351,7 +351,7 @@ public class RedisShardBackplane implements Backplane {
     scanDispatching(jedis, resetChannel, now);
 
     if (!expiringChannels.isEmpty()) {
-      log.log(Level.FINE, "Scan dispatched");
+      log.log(Level.FINER, "Scan dispatched");
       // scan dispatched pet watches
       scanDispatched(jedis, resetChannel);
     }
@@ -445,7 +445,7 @@ public class RedisShardBackplane implements Backplane {
         }
         subscriber.onOperation(operationChannel(operationName), operation, nextExpiresAt(now));
         log.log(
-            Level.FINE,
+            Level.FINER,
             format(
                 "operation %s done due to %s",
                 operationName, operation == null ? "null" : "completed"));
@@ -537,24 +537,24 @@ public class RedisShardBackplane implements Backplane {
     if (failsafeOperationThread != null) {
       failsafeOperationThread.interrupt();
       failsafeOperationThread.join();
-      log.log(Level.FINE, "failsafeOperationThread has been stopped");
+      log.log(Level.FINER, "failsafeOperationThread has been stopped");
     }
     if (operationSubscription != null) {
       operationSubscription.stop();
       if (subscriptionThread != null) {
         subscriptionThread.join();
       }
-      log.log(Level.FINE, "subscriptionThread has been stopped");
+      log.log(Level.FINER, "subscriptionThread has been stopped");
     }
     if (subscriberService != null) {
       subscriberService.shutdown();
       subscriberService.awaitTermination(10, SECONDS);
-      log.log(Level.FINE, "subscriberService has been stopped");
+      log.log(Level.FINER, "subscriberService has been stopped");
     }
     if (client != null) {
       client.close();
       client = null;
-      log.log(Level.FINE, "client has been closed");
+      log.log(Level.FINER, "client has been closed");
     }
   }
 

--- a/src/main/java/build/buildfarm/instance/shard/RedisShardSubscriber.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardSubscriber.java
@@ -137,7 +137,7 @@ class RedisShardSubscriber extends JedisPubSub {
         new TimedWatchFuture(watcher) {
           @Override
           public void unwatch() {
-            log.log(Level.FINE, format("unwatching %s", channel));
+            log.log(Level.FINER, format("unwatching %s", channel));
             RedisShardSubscriber.this.unwatch(channel, this);
           }
         };
@@ -199,7 +199,7 @@ class RedisShardSubscriber extends JedisPubSub {
       @Nullable Instant expiresAt) {
     List<TimedWatchFuture> operationWatchers = watchers.get(channel);
     boolean observe = operation == null || operation.hasMetadata() || operation.getDone();
-    log.log(Level.FINE, format("onOperation %s: %s", channel, operation));
+    log.log(Level.FINER, format("onOperation %s: %s", channel, operation));
     synchronized (watchers) {
       ImmutableList.Builder<Consumer<Operation>> observers = ImmutableList.builder();
       for (TimedWatchFuture watchFuture : operationWatchers) {
@@ -215,7 +215,7 @@ class RedisShardSubscriber extends JedisPubSub {
         executor.execute(
             () -> {
               if (observe) {
-                log.log(Level.FINE, "observing " + operation);
+                log.log(Level.FINER, "observing " + operation);
                 observer.accept(operation);
               }
             });

--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -412,14 +412,14 @@ public class ShardInstance extends AbstractServerInstance {
                       () -> {},
                       Deadline.after(5, MINUTES));
                   try {
-                    log.log(Level.FINE, "queueing " + operationName);
+                    log.log(Level.FINER, "queueing " + operationName);
                     ListenableFuture<Void> queueFuture = queue(executeEntry, poller, queueTimeout);
                     addCallback(
                         queueFuture,
                         new FutureCallback<Void>() {
                           @Override
                           public void onSuccess(Void result) {
-                            log.log(Level.FINE, "successfully queued " + operationName);
+                            log.log(Level.FINER, "successfully queued " + operationName);
                             // nothing
                           }
 
@@ -433,7 +433,7 @@ public class ShardInstance extends AbstractServerInstance {
                     long operationTransformDispatchUSecs =
                         stopwatch.elapsed(MICROSECONDS) - canQueueUSecs;
                     log.log(
-                        Level.FINE,
+                        Level.FINER,
                         format(
                             "OperationQueuer: Dispatched To Transform %s: %dus in canQueue, %dus in transform dispatch",
                             operationName, canQueueUSecs, operationTransformDispatchUSecs));
@@ -448,7 +448,7 @@ public class ShardInstance extends AbstractServerInstance {
 
                 @Override
                 public void run() {
-                  log.log(Level.FINE, "OperationQueuer: Running");
+                  log.log(Level.FINER, "OperationQueuer: Running");
                   try {
                     while (transformTokensQueue.offer(new Object(), 5, MINUTES)) {
                       stopwatch.start();
@@ -481,7 +481,7 @@ public class ShardInstance extends AbstractServerInstance {
                   } catch (Exception t) {
                     log.log(Level.SEVERE, "OperationQueuer: fatal exception during iteration", t);
                   } finally {
-                    log.log(Level.FINE, "OperationQueuer: Exiting");
+                    log.log(Level.FINER, "OperationQueuer: Exiting");
                   }
                   operationQueuer = null;
                   try {
@@ -566,7 +566,7 @@ public class ShardInstance extends AbstractServerInstance {
       return;
     }
     stopping = true;
-    log.log(Level.FINE, format("Instance %s is stopping", getName()));
+    log.log(Level.FINER, format("Instance %s is stopping", getName()));
     if (operationQueuer != null) {
       operationQueuer.stop();
     }
@@ -602,7 +602,7 @@ public class ShardInstance extends AbstractServerInstance {
     }
     actionCacheFetchService.shutdownNow();
     workerStubs.invalidateAll();
-    log.log(Level.FINE, format("Instance %s has been stopped", getName()));
+    log.log(Level.FINER, format("Instance %s has been stopped", getName()));
     stopping = false;
     stopped = true;
   }
@@ -908,7 +908,7 @@ public class ShardInstance extends AbstractServerInstance {
                 } else if (status.getCode() == Code.NOT_FOUND) {
                   casMissCounter.inc();
                   log.log(
-                      configs.getServer().isEnsureOutputsPresent() ? Level.WARNING : Level.FINE,
+                      configs.getServer().isEnsureOutputsPresent() ? Level.WARNING : Level.FINER,
                       worker + " did not contain " + DigestUtil.toString(blobDigest));
                   // ignore this, the worker will update the backplane eventually
                 } else if (status.getCode() != Code.DEADLINE_EXCEEDED
@@ -1019,7 +1019,7 @@ public class ShardInstance extends AbstractServerInstance {
     final ListenableFuture<List<String>> populatedWorkerListFuture;
     if (emptyWorkerList) {
       log.log(
-          Level.FINE,
+          Level.FINER,
           format(
               "worker list was initially empty for %s, attempting to correct",
               DigestUtil.toString(blobDigest)));
@@ -1035,7 +1035,7 @@ public class ShardInstance extends AbstractServerInstance {
                   RequestMetadata.getDefaultInstance()),
               (foundOnWorkers) -> {
                 log.log(
-                    Level.FINE,
+                    Level.FINER,
                     format(
                         "worker list was corrected for %s to be %s",
                         DigestUtil.toString(blobDigest), foundOnWorkers.toString()));
@@ -1065,7 +1065,7 @@ public class ShardInstance extends AbstractServerInstance {
               workersList.clear();
               final ListenableFuture<List<String>> workersListFuture;
               log.log(
-                  Level.FINE,
+                  Level.FINER,
                   format(
                       "worker list was depleted for %s, attempting to correct",
                       DigestUtil.toString(blobDigest)));
@@ -1081,7 +1081,7 @@ public class ShardInstance extends AbstractServerInstance {
                           RequestMetadata.getDefaultInstance()),
                       (foundOnWorkers) -> {
                         log.log(
-                            Level.FINE,
+                            Level.FINER,
                             format(
                                 "worker list was corrected after depletion for %s to be %s",
                                 DigestUtil.toString(blobDigest), foundOnWorkers.toString()));
@@ -1380,7 +1380,7 @@ public class ShardInstance extends AbstractServerInstance {
           @Override
           public CompletableFuture<Directory> apply(Digest digest, Executor executor) {
             log.log(
-                Level.FINE,
+                Level.FINER,
                 format(
                     "transformQueuedOperation(%s): fetching directory %s",
                     reason, DigestUtil.toString(directoryBlobDigest)));
@@ -1515,7 +1515,7 @@ public class ShardInstance extends AbstractServerInstance {
                 expectCommand(commandDigest, requestMetadata),
                 (command) -> {
                   log.log(
-                      Level.FINE,
+                      Level.FINER,
                       format("transformQueuedOperation(%s): fetched command", operationName));
                   if (command != null) {
                     queuedOperationBuilder.setCommand(command);
@@ -2000,7 +2000,7 @@ public class ShardInstance extends AbstractServerInstance {
 
       executionSuccess.inc();
       log.log(
-          Level.FINE,
+          Level.FINER,
           new StringBuilder()
               .append("ExecutionSuccess: ")
               .append(requestMetadata.getToolInvocationId())
@@ -2013,7 +2013,7 @@ public class ShardInstance extends AbstractServerInstance {
       actionCache.invalidate(DigestUtil.asActionKey(actionDigest));
       if (!skipCacheLookup && recentCacheServedExecutions.getIfPresent(requestMetadata) != null) {
         log.log(
-            Level.FINE,
+            Level.FINER,
             format("Operation %s will have skip_cache_lookup = true due to retry", operationName));
         skipCacheLookup = true;
       }
@@ -2238,7 +2238,7 @@ public class ShardInstance extends AbstractServerInstance {
             poller.pause();
             long checkCacheUSecs = stopwatch.elapsed(MICROSECONDS);
             log.log(
-                Level.FINE,
+                Level.FINER,
                 format(
                     "ShardInstance(%s): checkCache(%s): %sus elapsed",
                     getName(), operation.getName(), checkCacheUSecs));
@@ -2265,7 +2265,7 @@ public class ShardInstance extends AbstractServerInstance {
     Digest actionDigest = metadata.getActionDigest();
     SettableFuture<Void> queueFuture = SettableFuture.create();
     log.log(
-        Level.FINE,
+        Level.FINER,
         format(
             "ShardInstance(%s): queue(%s): fetching action %s",
             getName(), operation.getName(), actionDigest.getHash()));
@@ -2308,7 +2308,7 @@ public class ShardInstance extends AbstractServerInstance {
             actionFuture,
             (action) -> {
               log.log(
-                  Level.FINE,
+                  Level.FINER,
                   format(
                       "ShardInstance(%s): queue(%s): fetched action %s transforming queuedOperation",
                       getName(), operation.getName(), actionDigest.getHash()));
@@ -2338,7 +2338,7 @@ public class ShardInstance extends AbstractServerInstance {
             queuedFuture,
             (profiledQueuedMetadata) -> {
               log.log(
-                  Level.FINE,
+                  Level.FINER,
                   format(
                       "ShardInstance(%s): queue(%s): queuedOperation %s transformed, validating",
                       getName(),
@@ -2360,7 +2360,7 @@ public class ShardInstance extends AbstractServerInstance {
             validatedFuture,
             (profiledQueuedMetadata) -> {
               log.log(
-                  Level.FINE,
+                  Level.FINER,
                   format(
                       "ShardInstance(%s): queue(%s): queuedOperation %s validated, uploading",
                       getName(),
@@ -2412,7 +2412,7 @@ public class ShardInstance extends AbstractServerInstance {
               long elapsedUSecs = stopwatch.elapsed(MICROSECONDS);
               long queueUSecs = elapsedUSecs - startQueueUSecs;
               log.log(
-                  Level.FINE,
+                  Level.FINER,
                   format(
                       "ShardInstance(%s): queue(%s): %dus checkCache, %dus transform, %dus validate, %dus upload, %dus queue, %dus elapsed",
                       getName(),

--- a/src/main/java/build/buildfarm/instance/shard/Util.java
+++ b/src/main/java/build/buildfarm/instance/shard/Util.java
@@ -141,7 +141,7 @@ public class Util {
           }
         };
     log.log(
-        Level.FINE,
+        Level.FINER,
         format(
             "scanning through %d workers to find %s",
             workerSet.size(), DigestUtil.toString(digest)));
@@ -184,7 +184,7 @@ public class Util {
           public void onSuccess(Iterable<Digest> missingDigests) {
             boolean found = Iterables.isEmpty(missingDigests);
             log.log(
-                Level.FINE,
+                Level.FINER,
                 format(
                     "check missing response for %s to %s was %sfound",
                     DigestUtil.toString(digest), worker, found ? "" : "not "));
@@ -197,7 +197,7 @@ public class Util {
             Status status = Status.fromThrowable(t);
             if (status.getCode() == Code.UNAVAILABLE) {
               log.log(
-                  Level.FINE,
+                  Level.FINER,
                   format(
                       "check missing response for %s to %s was not found for unavailable",
                       DigestUtil.toString(digest), worker));

--- a/src/main/java/build/buildfarm/metrics/AbstractMetricsPublisher.java
+++ b/src/main/java/build/buildfarm/metrics/AbstractMetricsPublisher.java
@@ -172,7 +172,7 @@ public abstract class AbstractMetricsPublisher implements MetricsPublisher {
             .usingTypeRegistry(typeRegistry)
             .omittingInsignificantWhitespace()
             .print(operationRequestMetadata);
-    log.log(Level.FINE, "{}", formattedRequestMetadata);
+    log.log(Level.FINER, "{}", formattedRequestMetadata);
     return formattedRequestMetadata;
   }
 }

--- a/src/main/java/build/buildfarm/worker/Executor.java
+++ b/src/main/java/build/buildfarm/worker/Executor.java
@@ -199,7 +199,7 @@ class Executor {
       Stopwatch stopwatch)
       throws InterruptedException {
     /* execute command */
-    log.log(Level.FINE, "Executor: Operation " + operation.getName() + " Executing command");
+    log.log(Level.FINER, "Executor: Operation " + operation.getName() + " Executing command");
 
     ActionResult.Builder resultBuilder = operationContext.executeResponse.getResultBuilder();
     resultBuilder
@@ -291,7 +291,7 @@ class Executor {
     long executeUSecs = stopwatch.elapsed(MICROSECONDS);
 
     log.log(
-        Level.FINE,
+        Level.FINER,
         String.format(
             "Executor::executeCommand(%s): Completed command: exit code %d",
             operationName, resultBuilder.getExitCode()));
@@ -309,7 +309,7 @@ class Executor {
         throw e;
       }
     } else {
-      log.log(Level.FINE, "Executor: Operation " + operationName + " Failed to claim output");
+      log.log(Level.FINER, "Executor: Operation " + operationName + " Failed to claim output");
       boolean wasInterrupted = Thread.interrupted();
       try {
         putError();

--- a/src/main/java/build/buildfarm/worker/InputFetcher.java
+++ b/src/main/java/build/buildfarm/worker/InputFetcher.java
@@ -168,7 +168,7 @@ public class InputFetcher implements Runnable {
   @VisibleForTesting
   long fetchPolled(Stopwatch stopwatch) throws InterruptedException {
     String operationName = operationContext.queueEntry.getExecuteEntry().getOperationName();
-    log.log(Level.FINE, format("fetching inputs: %s", operationName));
+    log.log(Level.FINER, format("fetching inputs: %s", operationName));
 
     ExecutedActionMetadata.Builder executedAction =
         operationContext
@@ -278,7 +278,7 @@ public class InputFetcher implements Runnable {
       }
     } else {
       String operationName = operationContext.queueEntry.getExecuteEntry().getOperationName();
-      log.log(Level.FINE, "InputFetcher: Operation " + operationName + " Failed to claim output");
+      log.log(Level.FINER, "InputFetcher: Operation " + operationName + " Failed to claim output");
 
       owner.error().put(operationContext);
     }

--- a/src/main/java/build/buildfarm/worker/Pipeline.java
+++ b/src/main/java/build/buildfarm/worker/Pipeline.java
@@ -134,7 +134,7 @@ public class Pipeline {
             }
           }
           if (stageToClose != null && !stageToClose.isClosed()) {
-            log.log(Level.FINE, "Closing stage at priority " + maxPriority);
+            log.log(Level.FINER, "Closing stage at priority " + maxPriority);
             stageToClose.close();
           }
         }
@@ -157,7 +157,7 @@ public class Pipeline {
 
           if (!thread.isAlive()) {
             log.log(
-                Level.FINE,
+                Level.FINER,
                 "Stage "
                     + stage.name()
                     + " has exited at priority "

--- a/src/main/java/build/buildfarm/worker/PipelineStage.java
+++ b/src/main/java/build/buildfarm/worker/PipelineStage.java
@@ -145,7 +145,7 @@ public abstract class PipelineStage implements Runnable {
   }
 
   protected void logStart(String operationName, String message) {
-    getLogger().log(Level.FINE, String.format("%s: %s", logIterateId(operationName), message));
+    getLogger().log(Level.FINER, String.format("%s: %s", logIterateId(operationName), message));
   }
 
   protected void logComplete(String operationName, long usecs, long stallUSecs, boolean success) {
@@ -155,7 +155,7 @@ public abstract class PipelineStage implements Runnable {
   protected void logComplete(String operationName, long usecs, long stallUSecs, String status) {
     getLogger()
         .log(
-            Level.FINE,
+            Level.FINER,
             String.format(
                 "%s: %g ms (%g ms stalled) %s",
                 logIterateId(operationName), usecs / 1000.0f, stallUSecs / 1000.0f, status));

--- a/src/main/java/build/buildfarm/worker/shard/CFCExecFileSystem.java
+++ b/src/main/java/build/buildfarm/worker/shard/CFCExecFileSystem.java
@@ -373,7 +373,8 @@ class CFCExecFileSystem implements ExecFileSystem {
     ImmutableList.Builder<String> inputFiles = new ImmutableList.Builder<>();
     ImmutableList.Builder<Digest> inputDirectories = new ImmutableList.Builder<>();
 
-    log.log(Level.FINE, "ExecFileSystem::createExecDir(" + operationName + ") calling fetchInputs");
+    log.log(
+        Level.FINER, "ExecFileSystem::createExecDir(" + operationName + ") calling fetchInputs");
     Iterable<ListenableFuture<Void>> fetchedFutures =
         fetchInputs(
             execDir,
@@ -431,7 +432,7 @@ class CFCExecFileSystem implements ExecFileSystem {
     rootInputDirectories.put(execDir, inputDirectories.build());
 
     log.log(
-        Level.FINE,
+        Level.FINER,
         "ExecFileSystem::createExecDir(" + operationName + ") stamping output directories");
     boolean stamped = false;
     try {

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -239,12 +239,12 @@ class ShardWorkerContext implements WorkerContext {
           } else {
             operationPollerCounter.inc();
             log.log(
-                Level.INFO, format("%s: poller: Completed Poll for %s: OK", name, operationName));
+                Level.FINE, format("%s: poller: Completed Poll for %s: OK", name, operationName));
           }
           return success;
         },
         () -> {
-          log.log(Level.INFO, format("%s: poller: Deadline expired for %s", name, operationName));
+          log.log(Level.FINE, format("%s: poller: Deadline expired for %s", name, operationName));
           onFailure.run();
         },
         deadline);
@@ -483,7 +483,7 @@ class ShardWorkerContext implements WorkerContext {
       throws IOException, InterruptedException {
     String outputFile = actionRoot.relativize(outputPath).toString();
     if (!Files.exists(outputPath)) {
-      log.log(Level.FINE, "ReportResultStage: " + outputFile + " does not exist...");
+      log.log(Level.FINER, "ReportResultStage: " + outputFile + " does not exist...");
       return;
     }
 
@@ -491,7 +491,7 @@ class ShardWorkerContext implements WorkerContext {
       String message =
           String.format(
               "ReportResultStage: %s is a directory but it should have been a file", outputPath);
-      log.log(Level.FINE, message);
+      log.log(Level.FINER, message);
       preconditionFailure
           .addViolationsBuilder()
           .setType(VIOLATION_TYPE_INVALID)
@@ -572,12 +572,12 @@ class ShardWorkerContext implements WorkerContext {
       throws IOException, InterruptedException {
     String outputDir = actionRoot.relativize(outputDirPath).toString();
     if (!Files.exists(outputDirPath)) {
-      log.log(Level.FINE, "ReportResultStage: " + outputDir + " does not exist...");
+      log.log(Level.FINER, "ReportResultStage: " + outputDir + " does not exist...");
       return;
     }
 
     if (!Files.isDirectory(outputDirPath)) {
-      log.log(Level.FINE, "ReportResultStage: " + outputDir + " is not a directory...");
+      log.log(Level.FINER, "ReportResultStage: " + outputDir + " is not a directory...");
       preconditionFailure
           .addViolationsBuilder()
           .setType(VIOLATION_TYPE_INVALID)
@@ -700,7 +700,7 @@ class ShardWorkerContext implements WorkerContext {
     boolean success = createBackplaneRetrier().execute(() -> instance.putOperation(operation));
     if (success && operation.getDone()) {
       completedOperations.inc();
-      log.log(Level.FINE, "CompletedOperation: " + operation.getName());
+      log.log(Level.FINER, "CompletedOperation: " + operation.getName());
     }
     return success;
   }


### PR DESCRIPTION
Currently we log a lot of stuff as info, most of which is trivial. This logging is also mixed with meaningful entries which are necessary for troubleshooting. This PR downgrades most frequent log entries to make the more meaningful entries easier to track.

The expected outcome of this change is to set log level to FINE to produce the same output as prior to this change.