### PR TITLE
chore(deps): bump Guava from 31.1-jre to 32.1.1-jre

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -95,7 +95,7 @@ def buildfarm_init(name = "buildfarm"):
                         "com.google.errorprone:error_prone_annotations:2.9.0",
                         "com.google.errorprone:error_prone_core:0.92",
                         "com.google.guava:failureaccess:1.0.1",
-                        "com.google.guava:guava:31.1-jre",
+                        "com.google.guava:guava:32.1.1-jre",
                         "com.google.j2objc:j2objc-annotations:1.1",
                         "com.google.jimfs:jimfs:1.1",
                         "com.google.protobuf:protobuf-java-util:3.10.0",


### PR DESCRIPTION
Remediating https://nvd.nist.gov/vuln/detail/CVE-2023-2976