### PR TITLE
Fix io_bytes_read metrics for buildfarm:server

### DIFF
--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -895,7 +895,7 @@ public class ShardInstance extends AbstractServerInstance {
               public void onNext(ByteString nextChunk) {
                 blobObserver.onNext(nextChunk);
                 received += nextChunk.size();
-                ioMetric.observe(received);
+                ioMetric.observe(nextChunk.size());
               }
 
               @Override


### PR DESCRIPTION
Fix io_bytes_read metrics for buildfarm:server. Previously  1MB (16 * 64) blob logged as 8.5MB ( (16 * (16+1) / 2) * 64 ).

The first 64KB chunk of read message was correctly as logged 64KB, but subsequent nth 64KB messages were erroneously logged as n * 64KB. As a result, a 1MB blob sent to the client in 16 chunks was being logged as 8.5MB.

```
1*64 + 2*64 + 3* 64 + ... + 16*64 = 8.5MB
```