### PR TITLE
Enable prometheus logging for buildfarm:worker read on client cancel

### DIFF
--- a/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
+++ b/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
@@ -89,6 +89,7 @@ import com.google.common.util.concurrent.SettableFuture;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.google.protobuf.ByteString;
 import io.grpc.Deadline;
+import io.grpc.Status;
 import io.grpc.StatusException;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.ServerCallStreamObserver;
@@ -636,6 +637,9 @@ public abstract class CASFileCache implements ContentAddressableStorage {
             in.close();
           } catch (IOException e) {
             log.log(Level.SEVERE, "error closing input stream on cancel", e);
+          } finally {
+            blobObserver.onError(
+                Status.CANCELLED.withDescription("client cancelled").asRuntimeException());
           }
         });
     byte[] buffer = new byte[CHUNK_SIZE];

--- a/src/main/java/build/buildfarm/instance/stub/StubInstance.java
+++ b/src/main/java/build/buildfarm/instance/stub/StubInstance.java
@@ -595,8 +595,7 @@ public class StubInstance implements Instance {
       ServerCallStreamObserver<ByteString> blobObserver,
       RequestMetadata requestMetadata) {
     throwIfStopped();
-    bsStub
-        .get()
+    deadlined(bsStub)
         .withInterceptors(attachMetadataInterceptor(requestMetadata))
         .read(
             ReadRequest.newBuilder()

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerInstance.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerInstance.java
@@ -129,6 +129,8 @@ public class ShardWorkerInstance extends AbstractServerInstance {
         offset,
         count,
         new UniformDelegateServerCallStreamObserver<ByteString>(blobObserver) {
+          boolean callClosed = false;
+
           @Override
           public void onNext(ByteString data) {
             blobObserver.onNext(data);
@@ -146,18 +148,26 @@ public class ShardWorkerInstance extends AbstractServerInstance {
           }
 
           @Override
-          public void onError(Throwable t) {
+          public synchronized void onError(Throwable t) {
+            if (callClosed) {
+              return;
+            }
             if (t instanceof IOException) {
               blobObserver.onError(Status.NOT_FOUND.withCause(t).asException());
               removeBlobLocation();
             } else {
               blobObserver.onError(t);
             }
+            callClosed = true;
           }
 
           @Override
-          public void onCompleted() {
+          public synchronized void onCompleted() {
+            if (callClosed) {
+              return;
+            }
             blobObserver.onCompleted();
+            callClosed = true;
           }
         },
         requestMetadata);


### PR DESCRIPTION
### Problem
Currently we don't see any metrics with status `cancelled` for buildfarm:worker read. This issue arises because the [onCancelHandler](https://github.com/bazelbuild/bazel-buildfarm/blob/831572372df54c4a7e8539dfd27c75bd7a4d0dac/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java#L633) does not invoke the `responseObserver.onError` method. As a result, the [reportEndMetrics](https://github.com/grpc-ecosystem/java-grpc-prometheus/blob/master/src/main/java/me/dinowernli/grpc/prometheus/MonitoringServerCall.java)  function, responsible for logging prometheus metrics, is not triggered.

### Solution
Added code to ensure that the responseObserver.onError method is called when the client initiates a cancellation request. Additionally, added a check in the [ServerStreamCallObserver](https://github.com/bazelbuild/bazel-buildfarm/blob/831572372df54c4a7e8539dfd27c75bd7a4d0dac/src/main/java/build/buildfarm/worker/shard/ShardWorkerInstance.java#L131) implementation to avoid the [call already closed](https://github.com/grpc/grpc-java/blob/4049f89e13f3a4f2ee240511f2b23c10bf917cab/core/src/main/java/io/grpc/internal/ServerCallImpl.java#L212) error, which could occur if the buildfarm:worker has already called onComplete or onError (realistically onComplete) by the time the cancellation request from the client (buildfarm:server) arrives.

