### PR TITLE
Upgrade opentelemetry javaagent to 1.28

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -176,9 +176,9 @@ def buildfarm_dependencies(repository_name = "build_buildfarm"):
     maybe(
         http_jar,
         "opentelemetry",
-        sha256 = "0523287984978c091be0d22a5c61f0bce8267eeafbbae58c98abaf99c9396832",
+        sha256 = "eccd069da36031667e5698705a6838d173d527a5affce6cc514a14da9dbf57d7",
         urls = [
-            "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v1.11.0/opentelemetry-javaagent.jar",
+            "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v1.28.0/opentelemetry-javaagent.jar",
         ],
     )
 


### PR DESCRIPTION
We've faced some issues relating to the older version of the opentelemetry javaagent. Maybe you have a reason to run the old one. Just close this PR if that is the case.

I believe there is a bug that was fixed in 1.12 that causes a GRPC context to expire early and interrupt a thread that shouldn't be interrupted. More specifically I think it's related to this https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/4169