### PR TITLE
Separate channel for write api

### DIFF
--- a/src/main/java/build/buildfarm/instance/shard/WorkerStubs.java
+++ b/src/main/java/build/buildfarm/instance/shard/WorkerStubs.java
@@ -57,6 +57,7 @@ public final class WorkerStubs {
         worker,
         digestUtil,
         createChannel(worker),
+        createChannel(worker), // separate write channel
         timeout,
         newStubRetrier(),
         newStubRetryService());

--- a/src/main/java/build/buildfarm/instance/stub/StubInstance.java
+++ b/src/main/java/build/buildfarm/instance/stub/StubInstance.java
@@ -160,6 +160,7 @@ public class StubInstance implements Instance {
   private final String identifier;
   private final DigestUtil digestUtil;
   private final ManagedChannel channel;
+  private final ManagedChannel writeChannel;
   private final @Nullable Duration grpcTimeout;
   private final Retrier retrier;
   private final @Nullable ListeningScheduledExecutorService retryService;
@@ -186,7 +187,6 @@ public class StubInstance implements Instance {
     this(name, identifier, digestUtil, channel, grpcTimeout, NO_RETRIES, /* retryService=*/ null);
   }
 
-  @SuppressWarnings("NullableProblems")
   public StubInstance(
       String name,
       String identifier,
@@ -195,10 +195,24 @@ public class StubInstance implements Instance {
       Duration grpcTimeout,
       Retrier retrier,
       @Nullable ListeningScheduledExecutorService retryService) {
+    this(name, identifier, digestUtil, channel, channel, grpcTimeout, retrier, retryService);
+  }
+
+  @SuppressWarnings("NullableProblems")
+  public StubInstance(
+      String name,
+      String identifier,
+      DigestUtil digestUtil,
+      ManagedChannel channel,
+      ManagedChannel writeChannel,
+      Duration grpcTimeout,
+      Retrier retrier,
+      @Nullable ListeningScheduledExecutorService retryService) {
     this.name = name;
     this.identifier = identifier;
     this.digestUtil = digestUtil;
     this.channel = channel;
+    this.writeChannel = writeChannel;
     this.grpcTimeout = grpcTimeout;
     this.retrier = retrier;
     this.retryService = retryService;
@@ -661,7 +675,7 @@ public class StubInstance implements Instance {
             deadlined(bsBlockingStub).withInterceptors(attachMetadataInterceptor(requestMetadata)),
         Suppliers.memoize(
             () ->
-                ByteStreamGrpc.newStub(channel)
+                ByteStreamGrpc.newStub(writeChannel)
                     .withInterceptors(attachMetadataInterceptor(requestMetadata))),
         resourceName,
         exceptionTranslator,

--- a/src/main/java/build/buildfarm/instance/stub/StubInstance.java
+++ b/src/main/java/build/buildfarm/instance/stub/StubInstance.java
@@ -372,8 +372,14 @@ public class StubInstance implements Instance {
   @Override
   public void stop() throws InterruptedException {
     isStopped = true;
-    channel.shutdownNow();
-    channel.awaitTermination(0, TimeUnit.SECONDS);
+    if (!channel.isShutdown()) {
+      channel.shutdownNow();
+      channel.awaitTermination(0, TimeUnit.SECONDS);
+    }
+    if (!writeChannel.isShutdown()) {
+      writeChannel.shutdownNow();
+      writeChannel.awaitTermination(0, TimeUnit.SECONDS);
+    }
     if (retryService != null && !shutdownAndAwaitTermination(retryService, 10, TimeUnit.SECONDS)) {
       log.log(Level.SEVERE, format("Could not shut down retry service for %s", identifier));
     }


### PR DESCRIPTION
The grpc channel has limit on the number of concurrent streams and currently it is not configurable. As per the [Grpc performance best practice](https://grpc.io/docs/guides/performance/), it is recommended to create separate channel for each area of high load in the application.