### PR TITLE
Add request metadata interceptor to Worker

### DIFF
--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -41,6 +41,7 @@ import build.buildfarm.common.config.Cas;
 import build.buildfarm.common.config.GrpcMetrics;
 import build.buildfarm.common.grpc.Retrier;
 import build.buildfarm.common.grpc.Retrier.Backoff;
+import build.buildfarm.common.grpc.TracingMetadataUtils.ServerHeadersInterceptor;
 import build.buildfarm.common.services.ByteStreamService;
 import build.buildfarm.common.services.ContentAddressableStorageService;
 import build.buildfarm.instance.Instance;
@@ -233,6 +234,7 @@ public class Worker {
               storage, inputFetchStage, executeActionStage, context, completeStage, backplane));
     }
     GrpcMetrics.handleGrpcMetricIntercepts(serverBuilder, configs.getWorker().getGrpcMetrics());
+    serverBuilder.intercept(new ServerHeadersInterceptor());
 
     return serverBuilder.build();
   }


### PR DESCRIPTION
The RequestMetadata is transferred from BuildfarmServer to BuildfarmWorker;  however, it is not set within the Grpc context. Added interceptor `ServerHeadersInterceptor` which will set the requestMetadata in the GRPC context for BuildfarmWorker.
