### PR TITLE
Add a production-ready helm chart for deploying buildfarm on k8s

### DIFF
--- a/kubernetes/helm-charts/buildfarm/.gitignore
+++ b/kubernetes/helm-charts/buildfarm/.gitignore
@@ -1,0 +1,2 @@
+charts
+Chart.lock

--- a/kubernetes/helm-charts/buildfarm/.helmignore
+++ b/kubernetes/helm-charts/buildfarm/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/kubernetes/helm-charts/buildfarm/Chart.yaml
+++ b/kubernetes/helm-charts/buildfarm/Chart.yaml
@@ -1,0 +1,30 @@
+apiVersion: v2
+name: buildfarm
+description: A Helm chart for bazel buildfarm
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "v2.5.0"
+
+dependencies:
+  - condition: redis.enabled
+    name: redis
+    repository: https://charts.helm.sh/stable
+    version: 10.5.7

--- a/kubernetes/helm-charts/buildfarm/templates/NOTES.txt
+++ b/kubernetes/helm-charts/buildfarm/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.server.ingress.enabled }}
+{{- range $host := .Values.server.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.server.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.server.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "buildfarm.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.server.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "buildfarm.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "buildfarm.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.server.service.port }}
+{{- else if contains "ClusterIP" .Values.server.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "buildfarm.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/kubernetes/helm-charts/buildfarm/templates/_helpers.tpl
+++ b/kubernetes/helm-charts/buildfarm/templates/_helpers.tpl
@@ -1,0 +1,73 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "buildfarm.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "buildfarm.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "buildfarm.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "buildfarm.labels" -}}
+helm.sh/chart: {{ include "buildfarm.chart" . }}
+{{ include "buildfarm.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "buildfarm.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "buildfarm.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "buildfarm.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "buildfarm.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+
+{{/* Checks for `externalRedis` */}}
+{{- if .Values.externalRedis.host }}
+  {{/* check if they are using externalRedis (the default value for `externalRedis.host` is "localhost") */}}
+  {{- if not (eq .Values.externalRedis.host "localhost") }}
+    {{- if .Values.redis.enabled }}
+    {{ required "If `externalRedis.host` is set, then `redis.enabled` should be `false`!" nil }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/kubernetes/helm-charts/buildfarm/templates/configmap.yaml
+++ b/kubernetes/helm-charts/buildfarm/templates/configmap.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "buildfarm.fullname" . }}-config
+data:
+  config.yml: |-
+    {{- range $key, $value := .Values.config }}
+    {{- if kindIs "map" $value }}
+    {{- else }}
+    {{ $key }}: {{ $value }}{{- end }}
+    {{- end }}
+    backplane:
+      {{- if .Values.redis.enabled }}
+      redisUri: "{{ .Values.redis.scheme }}://{{ printf "%s-redis-master.%s" (include "redis.fullname" .) (.Release.Namespace) }}:{{ "6379" }}"
+      {{- else }}
+      redisUri: "{{ .Values.externalRedis.uri }}"
+      {{- end }}
+      {{- with .Values.config.backplane }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+    {{- with .Values.config.server }}
+    server:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.config.worker }}
+    worker:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}

--- a/kubernetes/helm-charts/buildfarm/templates/server/deployment.yaml
+++ b/kubernetes/helm-charts/buildfarm/templates/server/deployment.yaml
@@ -1,0 +1,78 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "buildfarm.fullname" . }}-server
+  labels:
+    name: {{ include "buildfarm.fullname" . }}-server
+    {{- include "buildfarm.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.server.replicaCount }}
+  selector:
+    matchLabels:
+      name: {{ include "buildfarm.fullname" . }}-server
+      {{- include "buildfarm.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/server-config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        name: {{ include "buildfarm.fullname" . }}-server
+        {{- include "buildfarm.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "buildfarm.serviceAccountName" . }}
+      containers:
+        - name: buildfarm-server
+          image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.server.image.pullPolicy }}
+          command:
+            - bash
+            - /app/build_buildfarm/buildfarm-server.binary
+          args:
+            - /config/config.yml
+          env:
+            {{- if .Values.server.extraEnv }}
+            {{- toYaml .Values.server.extraEnv | nindent 12 }}
+            {{- end }}
+          ports:
+            - containerPort: 8980
+              name: "server-comm"
+            - containerPort: 9090
+              name: "metrics"
+          livenessProbe:
+            httpGet:
+              path: /
+              port: metrics
+          readinessProbe:
+            httpGet:
+              path: /
+              port: metrics
+          resources:
+            {{- toYaml .Values.server.resources | nindent 12 }}
+          volumeMounts:
+            - mountPath: /config
+              name: config
+              readOnly: true
+      {{- with .Values.server.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.server.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.server.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - configMap:
+            defaultMode: 420
+            name: {{ include "buildfarm.fullname" . }}-config
+          name: config

--- a/kubernetes/helm-charts/buildfarm/templates/server/service.yaml
+++ b/kubernetes/helm-charts/buildfarm/templates/server/service.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "buildfarm.fullname" . }}-server
+  labels:
+    name: {{ include "buildfarm.fullname" . }}-server
+    {{- include "buildfarm.labels" . | nindent 4 }}
+  {{- with .Values.server.service.annotations }}
+  annotations:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.server.service.type }}
+  ports:
+    - port: {{ .Values.server.service.port }}
+      targetPort: server-comm
+      protocol: TCP
+      name: gprc
+    - port: 9090
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+  selector:
+    name: {{ include "buildfarm.fullname" . }}-server
+    {{- include "buildfarm.selectorLabels" . | nindent 4 }}

--- a/kubernetes/helm-charts/buildfarm/templates/server/servicemonitor.yaml
+++ b/kubernetes/helm-charts/buildfarm/templates/server/servicemonitor.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.server.serviceMonitor.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "buildfarm.fullname" . }}-server
+  labels:
+    {{- include "buildfarm.labels" . | nindent 4 }}
+spec:
+  endpoints:
+    - port: "metrics"
+      {{- with .Values.server.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.server.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      honorLabels: true
+      path: {{ .Values.server.serviceMonitor.path }}
+      scheme: {{ .Values.server.serviceMonitor.scheme }}
+      {{- with .Values.server.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
+  jobLabel: "{{ .Release.Name }}"
+  selector:
+    matchLabels:
+      name: {{ include "buildfarm.fullname" . }}-server
+      {{- include "buildfarm.labels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  {{- with .Values.server.serviceMonitor.targetLabels }}
+  targetLabels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/kubernetes/helm-charts/buildfarm/templates/serviceaccount.yaml
+++ b/kubernetes/helm-charts/buildfarm/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "buildfarm.serviceAccountName" . }}
+  labels:
+    {{- include "buildfarm.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/kubernetes/helm-charts/buildfarm/templates/shard-worker/autoscaler.yaml
+++ b/kubernetes/helm-charts/buildfarm/templates/shard-worker/autoscaler.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.shardWorker.autoscaling.enabled -}}
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "buildfarm.fullname" . }}-shard-worker
+  labels:
+    name: {{ include "buildfarm.fullname" . }}-shard-worker
+    {{- include "buildfarm.labels" . | nindent 4 }}
+  {{- with .Values.shardWorker.service.annotations }}
+  annotations:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  maxReplicas: {{ .Values.shardWorker.autoscaling.maxReplicas }}
+  minReplicas: {{ .Values.shardWorker.autoscaling.minReplicas }}
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name:  {{ include "buildfarm.fullname" . }}-shard-worker
+  targetCPUUtilizationPercentage: {{ .Values.shardWorker.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/kubernetes/helm-charts/buildfarm/templates/shard-worker/service.yaml
+++ b/kubernetes/helm-charts/buildfarm/templates/shard-worker/service.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "buildfarm.fullname" . }}-shard-worker
+  labels:
+    name: {{ include "buildfarm.fullname" . }}-shard-worker
+    {{- include "buildfarm.labels" . | nindent 4 }}
+  {{- with .Values.shardWorker.service.annotations }}
+  annotations:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.shardWorker.service.type }}
+  ports:
+    - port: {{ .Values.shardWorker.service.port }}
+      targetPort: worker-comm
+      protocol: TCP
+      name: gprc
+    - port: 9090
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+  selector:
+    name: {{ include "buildfarm.fullname" . }}-shard-worker
+    {{- include "buildfarm.selectorLabels" . | nindent 4 }}

--- a/kubernetes/helm-charts/buildfarm/templates/shard-worker/servicemonitor.yaml
+++ b/kubernetes/helm-charts/buildfarm/templates/shard-worker/servicemonitor.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.shardWorker.serviceMonitor.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "buildfarm.fullname" . }}-shard-worker
+  labels:
+    {{- include "buildfarm.labels" . | nindent 4 }}
+spec:
+  endpoints:
+    - port: "metrics"
+      {{- with .Values.shardWorker.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.shardWorker.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      honorLabels: true
+      path: {{ .Values.shardWorker.serviceMonitor.path }}
+      scheme: {{ .Values.shardWorker.serviceMonitor.scheme }}
+      {{- with .Values.shardWorker.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
+  jobLabel: "{{ .Release.Name }}"
+  selector:
+    matchLabels:
+      name: {{ include "buildfarm.fullname" . }}-shard-worker
+      {{- include "buildfarm.labels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  {{- with .Values.shardWorker.serviceMonitor.targetLabels }}
+  targetLabels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}

--- a/kubernetes/helm-charts/buildfarm/templates/shard-worker/statefulsets.yaml
+++ b/kubernetes/helm-charts/buildfarm/templates/shard-worker/statefulsets.yaml
@@ -1,0 +1,110 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "buildfarm.fullname" . }}-shard-worker
+  labels:
+    name: {{ include "buildfarm.fullname" . }}-shard-worker
+    {{- include "buildfarm.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "buildfarm.fullname" . }}-shard-worker
+  {{- if .Values.shardWorker.autoscaling.enabled }}
+  replicas: {{ .Values.shardWorker.autoscaling.minReplicas }}
+  {{- else }}
+  replicas: {{ .Values.shardWorker.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      name: {{ include "buildfarm.fullname" . }}-shard-worker
+      {{- include "buildfarm.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/worker-config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        name: {{ include "buildfarm.fullname" . }}-shard-worker
+        {{- include "buildfarm.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "buildfarm.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: buildfarm-worker
+          image: "{{ .Values.shardWorker.image.repository }}:{{ .Values.shardWorker.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.shardWorker.image.pullPolicy }}
+          args:
+            - /config/config.yml
+            - --public_name=$(POD_IP):8982
+          command:
+            - bash
+            - /app/build_buildfarm/buildfarm-shard-worker.binary
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            {{- if .Values.shardWorker.extraEnv }}
+            {{- toYaml .Values.shardWorker.extraEnv | nindent 12 }}
+            {{- end }}
+          ports:
+            - containerPort: 8981
+              name: "worker-comm"
+            - containerPort: 9090
+              name: "metrics"
+          livenessProbe:
+            httpGet:
+              path: /
+              port: metrics
+          readinessProbe:
+            httpGet:
+              path: /
+              port: metrics
+          resources:
+            {{- toYaml .Values.shardWorker.resources | nindent 12 }}
+          volumeMounts:
+            - mountPath: /config
+              name: config
+              readOnly: true
+            - mountPath: /tmp/worker
+              name: {{ include "buildfarm.fullname" . }}-shard-worker-data
+          {{- with .Values.extraVolumeMounts }}
+          {{- tpl (toYaml .) $ | nindent 12 -}}
+          {{- end }}
+      {{- with .Values.shardWorker.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.shardWorker.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.shardWorker.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - configMap:
+            defaultMode: 420
+            name: {{ include "buildfarm.fullname" . }}-config
+          name: config
+        {{- with .Values.shardWorker.extraVolumes }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
+        {{- end }}
+  volumeClaimTemplates:
+    - metadata:
+        name: {{ include "buildfarm.fullname" . }}-shard-worker-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        {{- with .Values.shardWorker.storage.class }}
+        storageClassName: "{{ . }}"
+        {{- end }}
+        resources:
+          requests:
+            storage: "{{ .Values.shardWorker.storage.size }}"

--- a/kubernetes/helm-charts/buildfarm/templates/tests/test-connection.yaml
+++ b/kubernetes/helm-charts/buildfarm/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "buildfarm.fullname" . }}-test-connection"
+  labels:
+    {{- include "buildfarm.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: curl
+      image: appropriate/curl:latest
+      command: ['curl']
+      args: ['--output', '/dev/null', '{{ include "buildfarm.fullname" . }}-server:{{ .Values.server.service.port }}']
+  restartPolicy: Never

--- a/kubernetes/helm-charts/buildfarm/values.yaml
+++ b/kubernetes/helm-charts/buildfarm/values.yaml
@@ -1,0 +1,206 @@
+# Default values for buildfarm.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+nameOverride: ""
+fullnameOverride: ""
+
+imagePullSecrets: []
+
+config:
+  # see: https://github.com/bazelbuild/bazel-buildfarm/blob/main/examples/config.yml
+  digestFunction: SHA256
+  defaultActionTimeout: 600
+  maximumActionTimeout: 3600
+  maxEntrySizeBytes: "2147483648" # 2 * 1024 * 1024 * 1024
+  prometheusPort: 9090
+  backplane:
+    queues:
+        - name: "cpu"
+          allowUnmatched: true
+          properties:
+            - name: "min-cores"
+              value: "*"
+            - name: "max-cores"
+              value: "*"
+  server:
+    name: "shard"
+    recordBesEvents: true
+  worker:
+    port: 8982
+    publicName: "localhost:8982"
+    executeStageWidth: 80
+    inputFetchStageWidth: 8
+    realInputDirectories:
+      - "external"
+    root: "/tmp/worker"
+    storages:
+      - type: FILESYSTEM
+        path: "cache"
+        maxSizeBytes: 536870912000 # 500 * 1024 * 1024 * 1024
+
+server:
+  image:
+    repository: bazelbuild/buildfarm-server
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
+  replicaCount: 1
+  resources: { }
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+  service:
+    type: ClusterIP
+    port: 8980
+
+  ingress:
+    enabled: false
+    className: ""
+    annotations: { }
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+    hosts:
+      - host: chart-example.local
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+    tls: [ ]
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
+
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  extraVolumes: []
+    # - name: additionalSecret
+    #   secret:
+    #   secretName: my-secret
+    #   defaultMode: 0600
+
+  extraVolumeMounts: []
+    # - name: customConfig
+    #   mountPath: /mnt/config
+    #   readOnly: true
+  extraEnv:
+  - name: JAVABIN
+    value: "/usr/bin/java"
+
+  serviceMonitor:
+    ## If true, a ServiceMonitor CRD is created for a prometheus operator
+    ## https://github.com/coreos/prometheus-operator
+    ##
+    enabled: false
+    path: /metrics
+    #  namespace: monitoring  (defaults to use the namespace this chart is deployed to)
+    labels: {}
+    interval: 1m
+    scheme: http
+    tlsConfig: {}
+    scrapeTimeout: 30s
+    relabelings: []
+    targetLabels: []
+
+shardWorker:
+  image:
+    repository: bazelbuild/buildfarm-worker
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
+  replicaCount: 2
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 4
+    targetCPUUtilizationPercentage: 50
+
+  resources: { }
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+  storage:
+    # the storage class for pv, leave empty will using default
+    class: ""
+    size: 50Gi
+
+  service:
+    type: ClusterIP
+    port: 8982
+
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  extraVolumes: []
+    # - name: additionalSecret
+    #   secret:
+    #   secretName: my-secret
+    #   defaultMode: 0600
+
+  extraVolumeMounts: []
+    # - name: customConfig
+    #   mountPath: /mnt/config
+    #   readOnly: true
+  extraEnv:
+  - name: JAVABIN
+    value: "/usr/bin/java"
+  serviceMonitor:
+    ## If true, a ServiceMonitor CRD is created for a prometheus operator
+    ## https://github.com/coreos/prometheus-operator
+    ##
+    enabled: false
+    path: /metrics
+    #  namespace: monitoring  (defaults to use the namespace this chart is deployed to)
+    labels: {}
+    interval: 1m
+    scheme: http
+    tlsConfig: {}
+    scrapeTimeout: 30s
+    relabelings: []
+    targetLabels: []
+
+###################################
+## DATABASE | Embedded Redis
+###################################
+redis:
+  ## - set to `false` if using `externalRedis.*`
+  ##
+  enabled: true
+  scheme: "redis"
+  ## See more redis configs: https://github.com/bitnami/charts/blob/main/bitnami/redis/README.md
+  usePassword: false
+  ## configs for redis cluster mode
+  ##
+  cluster:
+    ## if redis runs in cluster mode
+    ##
+    enabled: false
+
+    ## the number of redis slaves
+    ##
+    slaveCount: 1
+
+externalRedis:
+  uri: "redis://localhost:6379"
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""


### PR DESCRIPTION
It's very convenient to deploy an app on k8s using helm chart. 

So we add  a production-ready helm chart for bazel buildfarm and tested in our k8s cluster.

Suggestions are welcomed, thx~