### PR TITLE
Fix deadlock when handling Write request

### DIFF
--- a/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
+++ b/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
@@ -963,12 +963,10 @@ public abstract class CASFileCache implements ContentAddressableStorage {
                 while (!closedFuture.isDone()) {
                   wait();
                 }
-                closedFuture.get(deadlineAfter, deadlineAfterUnits);
+                closedFuture.get();
               } catch (ExecutionException e) {
                 throw new IOException(e.getCause());
               } catch (InterruptedException e) {
-                throw new IOException(e);
-              } catch (TimeoutException e) {
                 throw new IOException(e);
               }
             }

--- a/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
+++ b/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
@@ -123,7 +123,6 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
@@ -862,10 +861,13 @@ public abstract class CASFileCache implements ContentAddressableStorage {
     Write write =
         new Write() {
           CancellableOutputStream out = null;
+
           @GuardedBy("this")
           boolean isReset = false;
+
           @GuardedBy("this")
           SettableFuture<Void> closedFuture = null;
+
           @GuardedBy("this")
           long fileCommittedSize = -1;
 


### PR DESCRIPTION
Prevent `getOutput` from holding a lock on the write while waiting for cancel to get called.

Fixes #1441 