### PR TITLE
Permit --prometheus_port to override config

### DIFF
--- a/src/main/java/build/buildfarm/common/config/BuildfarmConfigs.java
+++ b/src/main/java/build/buildfarm/common/config/BuildfarmConfigs.java
@@ -78,6 +78,9 @@ public final class BuildfarmConfigs {
     if (options.port > 0) {
       buildfarmConfigs.getServer().setPort(options.port);
     }
+    if (options.prometheusPort >= 0) {
+      buildfarmConfigs.setPrometheusPort(options.prometheusPort);
+    }
     adjustServerConfigs(buildfarmConfigs);
     return buildfarmConfigs;
   }
@@ -93,6 +96,9 @@ public final class BuildfarmConfigs {
     }
     if (!Strings.isNullOrEmpty(options.publicName)) {
       buildfarmConfigs.getWorker().setPublicName(options.publicName);
+    }
+    if (options.prometheusPort >= 0) {
+      buildfarmConfigs.setPrometheusPort(options.prometheusPort);
     }
     adjustWorkerConfigs(buildfarmConfigs);
     return buildfarmConfigs;

--- a/src/main/java/build/buildfarm/common/config/BuildfarmOptions.java
+++ b/src/main/java/build/buildfarm/common/config/BuildfarmOptions.java
@@ -1,4 +1,4 @@
-// Copyright 2017 The Bazel Authors. All rights reserved.
+// Copyright 2023 The Bazel Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,12 +15,16 @@
 package build.buildfarm.common.config;
 
 import com.google.devtools.common.options.Option;
+import com.google.devtools.common.options.OptionsBase;
 
-/** Command-line options definition for example server. */
-public class ServerOptions extends BuildfarmOptions {
-  @Option(name = "port", abbrev = 'p', help = "Port to use.", defaultValue = "-1")
-  public int port;
+/** Command-line options definition for Worker. */
+public class BuildfarmOptions extends OptionsBase {
+  @Option(name = "help", abbrev = 'h', help = "Prints usage info.", defaultValue = "true")
+  public boolean help;
 
-  @Option(name = "public_name", abbrev = 'n', help = "Name of this server.", defaultValue = "")
-  public String publicName;
+  @Option(
+      name = "prometheus_port",
+      help = "Port for the prometheus service. '0' will disable prometheus hosting",
+      defaultValue = "-1")
+  public int prometheusPort;
 }

--- a/src/main/java/build/buildfarm/common/config/ShardWorkerOptions.java
+++ b/src/main/java/build/buildfarm/common/config/ShardWorkerOptions.java
@@ -15,13 +15,9 @@
 package build.buildfarm.common.config;
 
 import com.google.devtools.common.options.Option;
-import com.google.devtools.common.options.OptionsBase;
 
 /** Command-line options definition for Worker. */
-public class ShardWorkerOptions extends OptionsBase {
-  @Option(name = "help", abbrev = 'h', help = "Prints usage info.", defaultValue = "true")
-  public boolean help;
-
+public class ShardWorkerOptions extends BuildfarmOptions {
   @Option(
       name = "root",
       help = "Root base directory for all work being performed.",


### PR DESCRIPTION
Specifying --prometheus_port for either server or worker will:
  Override the config value if delivered as int > 0, otherwise leave the
  config value alone.
Since prometheusPort as configured <= 0 disables the server, this permits users to specify '0' to override the config with a disable switch.

Updated quick_start docs to reflect this extra parameter.

Fixes #1449 