### PR TITLE
[Server][6.3.2] Improve ALREADY_EXISTS status handling

### DIFF
--- a/src/main/java/build/buildfarm/common/services/WriteStreamObserver.java
+++ b/src/main/java/build/buildfarm/common/services/WriteStreamObserver.java
@@ -20,6 +20,7 @@ import static build.buildfarm.common.UrlPath.parseUploadBlobDigest;
 import static build.buildfarm.common.UrlPath.parseUploadBlobUUID;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+import static io.grpc.Status.Code.ALREADY_EXISTS;
 import static io.grpc.Status.ABORTED;
 import static io.grpc.Status.CANCELLED;
 import static io.grpc.Status.INVALID_ARGUMENT;
@@ -31,6 +32,7 @@ import build.bazel.remote.execution.v2.RequestMetadata;
 import build.buildfarm.cas.DigestMismatchException;
 import build.buildfarm.common.EntryLimitException;
 import build.buildfarm.common.UrlPath.InvalidResourceNameException;
+import build.buildfarm.common.Write.WriteCompleteException;
 import build.buildfarm.common.Write;
 import build.buildfarm.common.grpc.TracingMetadataUtils;
 import build.buildfarm.common.io.FeedbackOutputStream;
@@ -403,6 +405,11 @@ public class WriteStreamObserver implements StreamObserver<WriteRequest> {
       ioMetric.observe(data.size());
     } catch (EntryLimitException e) {
       throw e;
+    } catch (WriteCompleteException e) {
+      Status status = Status.fromCode(ALREADY_EXISTS)
+          .withCause(e);
+      log.log(Level.FINE, format("already wrote data for %s", name), e);
+      errorResponse(status.asException());
     } catch (IOException e) {
       if (errorResponse(Status.fromThrowable(e).asException())) {
         log.log(Level.SEVERE, format("error writing data for %s", name), e);


### PR DESCRIPTION
Sending an ALREADY_EXISTS for duplicated writes. Sometimes we may have this value after the client makes a find missing blobs request

This also fixes an issue with some serious log spam