### PR TITLE
Update rules_docker dependencies via injection

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -106,10 +106,29 @@ def archive_dependencies(third_party):
             "patch_args": ["-p1"],
             "patches": ["%s:clang_toolchain.patch" % third_party],
         },
+
+        # Used to build release container images
         {
             "name": "io_bazel_rules_docker",
             "sha256": "b1e80761a8a8243d03ebca8845e9cc1ba6c82ce7c5179ce2b295cd36f7e394bf",
             "urls": ["https://github.com/bazelbuild/rules_docker/releases/download/v0.25.0/rules_docker-v0.25.0.tar.gz"],
+            "patch_args": ["-p0"],
+            "patches": ["%s:docker_go_toolchain.patch" % third_party],
+        },
+
+        # Updated versions of io_bazel_rules_docker dependencies for bazel compatibility
+        {
+            "name": "io_bazel_rules_go",
+            "sha256": "278b7ff5a826f3dc10f04feaf0b70d48b68748ccd512d7f98bf442077f043fe3",
+            "urls": [
+                "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.41.0/rules_go-v0.41.0.zip",
+                "https://github.com/bazelbuild/rules_go/releases/download/v0.41.0/rules_go-v0.41.0.zip",
+            ],
+        },
+        {
+            "name": "bazel_gazelle",
+            "sha256": "d3fa66a39028e97d76f9e2db8f1b0c11c099e8e01bf363a923074784e451f809",
+            "urls": ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.33.0/bazel-gazelle-v0.33.0.tar.gz"],
         },
 
         # Bazel is referenced as a dependency so that buildfarm can access the linux-sandbox as a potential execution wrapper.

--- a/third_party/docker_go_toolchain.patch
+++ b/third_party/docker_go_toolchain.patch
@@ -1,0 +1,11 @@
+--- repositories/go_repositories.bzl.orig	2023-09-23 08:36:00.148468653 -0400
++++ repositories/go_repositories.bzl	2023-09-23 08:33:22.502127476 -0400
+@@ -37,7 +37,7 @@
+         go_repository_default_config (str, optional): A file used to determine the root of the workspace.
+     """
+     go_rules_dependencies()
+-    go_register_toolchains()
++    go_register_toolchains("1.21.0")
+     gazelle_dependencies(go_repository_default_config = go_repository_default_config)
+     excludes = native.existing_rules().keys()
+     if "com_github_google_go_containerregistry" not in excludes:


### PR DESCRIPTION
Specify and patch more recent rules_go and bazel_gazelle per upstream patch.
Docker images work with recent HEAD releases of bazel as a result.

Depends on #1453 resolution to actually build //...
Fixes #1440