### PR TITLE
Treat '.' working_directory segment as current

### DIFF
--- a/src/main/java/build/buildfarm/instance/server/AbstractServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/server/AbstractServerInstance.java
@@ -1168,6 +1168,9 @@ public abstract class AbstractServerInstance implements Instance {
       } else {
         Directory directory = directoriesIndex.get(inputRootDigest);
         for (String segment : workingDirectory.split("/")) {
+          if (segment.equals(".")) {
+            continue;
+          }
           Directory nextDirectory = directory;
           // linear for now
           for (DirectoryNode dirNode : directory.getDirectoriesList()) {


### PR DESCRIPTION
Any '.' appearance as a segment should be considered to be the current directory in the search sequence of a working_directory path.

Fixes #1406 