### PR TITLE
Log write errors with worker address

### DIFF
--- a/src/main/java/build/buildfarm/common/grpc/StubWriteOutputStream.java
+++ b/src/main/java/build/buildfarm/common/grpc/StubWriteOutputStream.java
@@ -227,6 +227,14 @@ public class StubWriteOutputStream extends FeedbackOutputStream implements Write
 
                     @Override
                     public void onError(Throwable t) {
+                      log.log(
+                          WARNING,
+                          format(
+                              "%s: write(%s) on worker %s after %d bytes of content",
+                              Status.fromThrowable(t).getCode().name(),
+                              resourceName,
+                              bsStub.get().getChannel().authority(),
+                              writtenBytes));
                       writeFuture.setException(exceptionTranslator.apply(t));
                     }
 


### PR DESCRIPTION
For metrics purpose it will be helpful to find number of write timeouts per worker. This will help us figure out which worker is causing issues.