### PR TITLE
Manipulate worker set directly in RSB

### DIFF
--- a/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
@@ -634,7 +634,7 @@ public class RedisShardBackplane implements Backplane {
             .setRemove(WorkerChange.Remove.newBuilder().setSource(source).setReason(reason).build())
             .build();
     String workerChangeJson = JsonFormat.printer().print(workerChange);
-    return subscriber.removeWorker(name)
+    return storageWorkerSet.remove(name)
         && client.call(
             jedis -> removeWorkerAndPublish(jedis, name, workerChangeJson, /* storage=*/ true));
   }


### PR DESCRIPTION
Avoid dependency on subscriber to update state changes when removing workers. This prevents an NPE which will occur invariably when workers are allowably configured with subscribeToBackplane: false.