### PR TITLE
Remove subscribeToBackplane, adjust failsafe op

### DIFF
--- a/examples/config.yml
+++ b/examples/config.yml
@@ -22,6 +22,7 @@ server:
   dispatchedMonitorIntervalSeconds: 1
   runOperationQueuer: true
   ensureOutputsPresent: false
+  runFailsafeOperation: true
   maxCpu: 0
   maxRequeueAttempts: 5
   useDenyList: true
@@ -70,8 +71,6 @@ backplane:
   operationChannelPrefix: "OperationChannel"
   casPrefix: "ContentAddressableStorage"
   casExpire: 604800 # 1 week
-  subscribeToBackplane: true
-  runFailsafeOperation: true
   maxQueueDepth: 100000
   maxPreQueueDepth: 1000000
   priorityQueue: false

--- a/src/main/java/build/buildfarm/common/config/Backplane.java
+++ b/src/main/java/build/buildfarm/common/config/Backplane.java
@@ -1,7 +1,9 @@
 package build.buildfarm.common.config;
 
 import com.google.common.base.Strings;
+import lombok.AccessLevel;
 import lombok.Data;
+import lombok.Getter;
 
 @Data
 public class Backplane {
@@ -32,8 +34,13 @@ public class Backplane {
   private String operationChannelPrefix = "OperationChannel";
   private String casPrefix = "ContentAddressableStorage";
   private int casExpire = 604800; // 1 Week
-  private boolean subscribeToBackplane = true;
-  private boolean runFailsafeOperation = true;
+
+  @Getter(AccessLevel.NONE)
+  private boolean subscribeToBackplane = true; // deprecated
+
+  @Getter(AccessLevel.NONE)
+  private boolean runFailsafeOperation = true; // deprecated
+
   private int maxQueueDepth = 100000;
   private int maxPreQueueDepth = 1000000;
   private boolean priorityQueue = false;

--- a/src/main/java/build/buildfarm/common/config/Server.java
+++ b/src/main/java/build/buildfarm/common/config/Server.java
@@ -24,6 +24,7 @@ public class Server {
   private String sslPrivateKeyPath = null;
   private boolean runDispatchedMonitor = true;
   private int dispatchedMonitorIntervalSeconds = 1;
+  private boolean runFailsafeOperation = true;
   private boolean runOperationQueuer = true;
   private boolean ensureOutputsPresent = false;
   private int maxRequeueAttempts = 5;

--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -254,7 +254,11 @@ public class ShardInstance extends AbstractServerInstance {
   private static Backplane createBackplane(String identifier) throws ConfigurationException {
     if (configs.getBackplane().getType().equals(SHARD)) {
       return new RedisShardBackplane(
-          identifier, ShardInstance::stripOperation, ShardInstance::stripQueuedOperation);
+          identifier,
+          /* subscribeToBackplane=*/ true,
+          configs.getServer().isRunFailsafeOperation(),
+          ShardInstance::stripOperation,
+          ShardInstance::stripQueuedOperation);
     } else {
       throw new IllegalArgumentException("Shard Backplane not set in config");
     }

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -546,7 +546,12 @@ public class Worker {
 
     if (SHARD.equals(configs.getBackplane().getType())) {
       backplane =
-          new RedisShardBackplane(identifier, this::stripOperation, this::stripQueuedOperation);
+          new RedisShardBackplane(
+              identifier,
+              /* subscribeToBackplane=*/ false,
+              /* runFailsafeOperation=*/ false,
+              this::stripOperation,
+              this::stripQueuedOperation);
       backplane.start(configs.getWorker().getPublicName());
     } else {
       throw new IllegalArgumentException("Shard Backplane not set in config");


### PR DESCRIPTION
A shard server is impractical without operation subscription, partition subscription confirmation between servers and workers. The failsafe execution is configuration that is likely not desired on workers. This change removes the failsafe behavior from workers via backplane config, and relegates the setting of failsafe boolean to server config. If the option is restored for workers, it can be added to worker configs so that configs may continue to be shared between workers and servers and retain independent addressability.