### PR TITLE
Present operationNames by stage

### DIFF
--- a/src/main/java/build/buildfarm/tools/Cat.java
+++ b/src/main/java/build/buildfarm/tools/Cat.java
@@ -650,6 +650,9 @@ class Cat {
   private static void printStageInformation(StageInformation stage) {
     System.out.printf("%s slots configured: %d%n", stage.getName(), stage.getSlotsConfigured());
     System.out.printf("%s slots used %d%n", stage.getName(), stage.getSlotsUsed());
+    for (String operationName : stage.getOperationNamesList()) {
+      System.out.printf("%s operation %s\n", stage.getName(), operationName);
+    }
   }
 
   private static void printOperationTime(OperationTimesBetweenStages time) {

--- a/src/main/java/build/buildfarm/worker/ExecuteActionStage.java
+++ b/src/main/java/build/buildfarm/worker/ExecuteActionStage.java
@@ -107,7 +107,7 @@ public class ExecuteActionStage extends SuperscalarPipelineStage {
     int slotUsage = removeAndRelease(operationName, claims);
     executionTime.observe(usecs / 1000.0);
     executionStallTime.observe(stallUSecs / 1000.0);
-    logComplete(
+    complete(
         operationName,
         usecs,
         stallUSecs,
@@ -141,7 +141,7 @@ public class ExecuteActionStage extends SuperscalarPipelineStage {
       executors.add(executorThread);
       int slotUsage = executorClaims.addAndGet(limits.cpu.claimed);
       executionSlotUsage.set(slotUsage);
-      logStart(operationContext.operation.getName(), getUsage(slotUsage));
+      start(operationContext.operation.getName(), getUsage(slotUsage));
       executorThread.start();
     }
   }

--- a/src/main/java/build/buildfarm/worker/InputFetchStage.java
+++ b/src/main/java/build/buildfarm/worker/InputFetchStage.java
@@ -72,13 +72,14 @@ public class InputFetchStage extends SuperscalarPipelineStage {
     int size = removeAndRelease(operationName);
     inputFetchTime.observe(usecs / 1000.0);
     inputFetchStallTime.observe(stallUSecs / 1000.0);
-    logComplete(
+    complete(
         operationName,
         usecs,
         stallUSecs,
         String.format("%s, %s", success ? "Success" : "Failure", getUsage(size)));
   }
 
+  @Override
   public int getSlotUsage() {
     return fetchers.size();
   }
@@ -106,8 +107,7 @@ public class InputFetchStage extends SuperscalarPipelineStage {
       fetchers.add(fetcher);
       int slotUsage = fetchers.size();
       inputFetchSlotUsage.set(slotUsage);
-      logStart(
-          operationContext.queueEntry.getExecuteEntry().getOperationName(), getUsage(slotUsage));
+      start(operationContext.queueEntry.getExecuteEntry().getOperationName(), getUsage(slotUsage));
       fetcher.start();
     }
   }

--- a/src/main/java/build/buildfarm/worker/MatchStage.java
+++ b/src/main/java/build/buildfarm/worker/MatchStage.java
@@ -103,12 +103,12 @@ public class MatchStage extends PipelineStage {
     @SuppressWarnings("SameReturnValue")
     private boolean onOperationPolled() throws InterruptedException {
       String operationName = operationContext.queueEntry.getExecuteEntry().getOperationName();
-      logStart(operationName);
+      start(operationName);
 
       long matchingAtUSecs = stopwatch.elapsed(MICROSECONDS);
       OperationContext matchedOperationContext = match(operationContext);
       long matchedInUSecs = stopwatch.elapsed(MICROSECONDS) - matchingAtUSecs;
-      logComplete(operationName, matchedInUSecs, waitDuration, true);
+      complete(operationName, matchedInUSecs, waitDuration, true);
       matchedOperationContext.poller.pause();
       try {
         output.put(matchedOperationContext);
@@ -139,7 +139,7 @@ public class MatchStage extends PipelineStage {
     }
     MatchOperationListener listener = new MatchOperationListener(operationContext, stopwatch);
     try {
-      logStart();
+      start();
       workerContext.match(listener);
     } finally {
       if (!listener.wasMatched()) {

--- a/src/main/java/build/buildfarm/worker/PipelineStage.java
+++ b/src/main/java/build/buildfarm/worker/PipelineStage.java
@@ -19,6 +19,7 @@ import static java.util.concurrent.TimeUnit.MICROSECONDS;
 import com.google.common.base.Stopwatch;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.Nullable;
 
 public abstract class PipelineStage implements Runnable {
   protected final String name;
@@ -30,6 +31,7 @@ public abstract class PipelineStage implements Runnable {
   private volatile boolean closed = false;
   private Thread tickThread = null;
   private boolean tickCancelledFlag = false;
+  private String operationName = null;
 
   PipelineStage(
       String name, WorkerContext workerContext, PipelineStage output, PipelineStage error) {
@@ -39,10 +41,18 @@ public abstract class PipelineStage implements Runnable {
     this.error = error;
   }
 
+  public String getName() {
+    return name;
+  }
+
   private void runInterruptible() throws InterruptedException {
     while (!output.isClosed() || isClaimed()) {
       iterate();
     }
+  }
+
+  public @Nullable String getOperationName() {
+    return operationName;
   }
 
   @Override
@@ -94,7 +104,7 @@ public abstract class PipelineStage implements Runnable {
     Stopwatch stopwatch = Stopwatch.createUnstarted();
     try {
       operationContext = take();
-      logStart(operationContext.operation.getName());
+      start(operationContext.operation.getName());
       stopwatch.start();
       boolean valid = false;
       tickThread = Thread.currentThread();
@@ -128,31 +138,34 @@ public abstract class PipelineStage implements Runnable {
     }
     after(operationContext);
     long usecs = stopwatch.elapsed(MICROSECONDS);
-    logComplete(
-        operationContext.operation.getName(), usecs, stallUSecs, nextOperationContext != null);
+    complete(operationName, usecs, stallUSecs, nextOperationContext != null);
+    operationName = null;
   }
 
   private String logIterateId(String operationName) {
     return String.format("%s::iterate(%s)", name, operationName);
   }
 
-  protected void logStart() {
-    logStart("");
+  protected void start() {
+    start("");
   }
 
-  protected void logStart(String operationName) {
-    logStart(operationName, "Starting");
+  protected void start(String operationName) {
+    start(operationName, "Starting");
   }
 
-  protected void logStart(String operationName, String message) {
+  protected void start(String operationName, String message) {
+    // TODO to unary stage
+    this.operationName = operationName;
     getLogger().log(Level.FINER, String.format("%s: %s", logIterateId(operationName), message));
   }
 
-  protected void logComplete(String operationName, long usecs, long stallUSecs, boolean success) {
-    logComplete(operationName, usecs, stallUSecs, success ? "Success" : "Failed");
+  protected void complete(String operationName, long usecs, long stallUSecs, boolean success) {
+    complete(operationName, usecs, stallUSecs, success ? "Success" : "Failed");
   }
 
-  protected void logComplete(String operationName, long usecs, long stallUSecs, String status) {
+  protected void complete(String operationName, long usecs, long stallUSecs, String status) {
+    this.operationName = operationName;
     getLogger()
         .log(
             Level.FINER,

--- a/src/main/java/build/buildfarm/worker/SuperscalarPipelineStage.java
+++ b/src/main/java/build/buildfarm/worker/SuperscalarPipelineStage.java
@@ -14,16 +14,20 @@
 
 package build.buildfarm.worker;
 
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
-abstract class SuperscalarPipelineStage extends PipelineStage {
+public abstract class SuperscalarPipelineStage extends PipelineStage {
   protected final int width;
 
   @SuppressWarnings("rawtypes")
   protected final BlockingQueue claims;
+
+  protected Set<String> operationNames = new HashSet<>();
 
   private volatile boolean catastrophic = false;
 
@@ -45,6 +49,39 @@ abstract class SuperscalarPipelineStage extends PipelineStage {
   protected abstract void interruptAll();
 
   protected abstract int claimsRequired(OperationContext operationContext);
+
+  @Override
+  public String getOperationName() {
+    throw new UnsupportedOperationException("use getOperationNames on superscalar stages");
+  }
+
+  public int getWidth() {
+    return width;
+  }
+
+  public abstract int getSlotUsage();
+
+  public Iterable<String> getOperationNames() {
+    synchronized (operationNames) {
+      return new HashSet<String>(operationNames);
+    }
+  }
+
+  @Override
+  protected void start(String operationName, String message) {
+    synchronized (operationNames) {
+      operationNames.add(operationName);
+    }
+    super.start(operationName, message);
+  }
+
+  @Override
+  protected void complete(String operationName, long usecs, long stallUSecs, String status) {
+    super.complete(operationName, usecs, stallUSecs, status);
+    synchronized (operationNames) {
+      operationNames.remove(operationName);
+    }
+  }
 
   synchronized void waitForReleaseOrCatastrophe(BlockingQueue<OperationContext> queue) {
     boolean interrupted = false;

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -602,6 +602,8 @@ message StageInformation {
 
   // number of slots used for this stage
   int32 slots_used = 3;
+
+  repeated string operation_names = 4;
 }
 
 message WorkerProfileMessage {

--- a/src/test/java/build/buildfarm/worker/SuperscalarPipelineStageTest.java
+++ b/src/test/java/build/buildfarm/worker/SuperscalarPipelineStageTest.java
@@ -72,6 +72,11 @@ public class SuperscalarPipelineStageTest {
     boolean isFull() {
       return claims.size() == width;
     }
+
+    @Override
+    public int getSlotUsage() {
+      return 0;
+    }
   }
 
   @Test


### PR DESCRIPTION
Include Match and Report Result stages in output
Record the active operationName occupying slots in each of the stages and present them with WorkerProfile
Avoid several unnecessary casts with interfaces for operation slot stages.