### PR TITLE
Try to enable FINEST logging

### DIFF
--- a/examples/config.minimal.yml
+++ b/examples/config.minimal.yml
@@ -1,3 +1,10 @@
+server:
+  metrics:
+    publisher: LOG
+    logLevel: FINEST
+    topic: test
+    topicMaxConnections: 1000
+    secretName: test
 backplane:
   redisUri: "redis://localhost:6379"
   queues:

--- a/examples/logging.properties
+++ b/examples/logging.properties
@@ -1,4 +1,0 @@
-handlers=java.util.logging.ConsoleHandler
-java.util.logging.ConsoleHandler.level=FINE
-java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
-java.util.logging.SimpleFormatter.format=[%4$-7s] %2$s - %5$s %6$s %n

--- a/examples/server-logging.properties
+++ b/examples/server-logging.properties
@@ -1,0 +1,13 @@
+.level = ALL
+io.grpc.netty.level = SEVERE
+
+handlers=java.util.logging.ConsoleHandler,java.util.logging.FileHandler
+
+java.util.logging.SimpleFormatter.format=[%4$-7s] %2$s - %5$s %6$s %n
+
+java.util.logging.ConsoleHandler.level = INFO
+java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
+
+java.util.logging.FileHandler.level = ALL
+java.util.logging.FileHandler.pattern = /tmp/server.log
+java.util.logging.FileHandler.formatter=java.util.logging.SimpleFormatter

--- a/examples/worker-logging.properties
+++ b/examples/worker-logging.properties
@@ -1,0 +1,12 @@
+.level = FINEST
+
+handlers=java.util.logging.ConsoleHandler,java.util.logging.FileHandler
+
+java.util.logging.SimpleFormatter.format=[%4$-7s] %2$s - %5$s %6$s %n
+
+java.util.logging.ConsoleHandler.level = FINEST
+java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
+
+java.util.logging.FileHandler.level = FINEST
+java.util.logging.FileHandler.pattern = /tmp/worker.log
+java.util.logging.FileHandler.formatter=java.util.logging.SimpleFormatter

--- a/src/main/java/build/buildfarm/common/config/BuildfarmConfigs.java
+++ b/src/main/java/build/buildfarm/common/config/BuildfarmConfigs.java
@@ -301,6 +301,11 @@ public final class BuildfarmConfigs {
                             "the execution wrapper %s is missing and therefore the following features will not be available: %s",
                             tool, String.join(", ", features));
                     log.warning(message);
+                    log.severe(message);
+                    log.severe("info");
+                    log.severe("fine");
+                    log.severe("finer");
+                    log.severe("finest");
                   }
                 }));
   }

--- a/src/main/java/build/buildfarm/logging.properties
+++ b/src/main/java/build/buildfarm/logging.properties
@@ -1,4 +1,4 @@
 handlers=java.util.logging.ConsoleHandler
-java.util.logging.ConsoleHandler.level=INFO
+java.util.logging.ConsoleHandler.level=ALL
 java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
 java.util.logging.SimpleFormatter.format=[%4$-7s] %2$s - %5$s %6$s %n

--- a/src/main/java/build/buildfarm/worker/ExecuteActionStage.java
+++ b/src/main/java/build/buildfarm/worker/ExecuteActionStage.java
@@ -14,6 +14,7 @@
 
 package build.buildfarm.worker;
 
+import java.util.Arrays;
 import build.buildfarm.worker.resources.ResourceLimits;
 import com.google.common.collect.Sets;
 import io.prometheus.client.Gauge;
@@ -73,6 +74,9 @@ public class ExecuteActionStage extends SuperscalarPipelineStage {
 
   @Override
   protected Logger getLogger() {
+    log.severe("severe - In ExecuteActionStage.java ~~~~~~~~~");
+    System.out.println(Arrays.toString(Thread.currentThread().getStackTrace()));
+    log.severe("finest - In ExecuteActionStage.java ~~~~~~~~~");
     return log;
   }
 

--- a/src/main/java/build/buildfarm/worker/Executor.java
+++ b/src/main/java/build/buildfarm/worker/Executor.java
@@ -24,6 +24,9 @@ import static java.util.concurrent.TimeUnit.MICROSECONDS;
 
 import build.bazel.remote.execution.v2.Action;
 import build.bazel.remote.execution.v2.ActionResult;
+
+import java.util.Arrays;
+
 import build.bazel.remote.execution.v2.Command;
 import build.bazel.remote.execution.v2.Command.EnvironmentVariable;
 import build.bazel.remote.execution.v2.ExecuteOperationMetadata;
@@ -290,11 +293,21 @@ class Executor {
         .setExecutionCompletedTimestamp(Timestamps.fromMillis(System.currentTimeMillis()));
     long executeUSecs = stopwatch.elapsed(MICROSECONDS);
 
+    System.out.println("I am here");
+    System.out.println(Arrays.toString(Thread.currentThread().getStackTrace()));
+    log.severe("executor finest");
+    log.severe("executor log.severe");
+    log.severe("executor fine");
+    log.severe("executor info");
+    log.severe("executor warning");
+    log.severe("executor log.severe");
+    log.log(Level.SEVERE, "executor Level.SEVERE");
     log.log(
         Level.FINER,
         String.format(
             "Executor::executeCommand(%s): Completed command: exit code %d",
             operationName, resultBuilder.getExitCode()));
+    System.out.println("I am there");
 
     operationContext.executeResponse.getStatusBuilder().setCode(statusCode.getNumber());
     OperationContext reportOperationContext =

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -25,6 +25,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.logging.Level.INFO;
 import static java.util.logging.Level.SEVERE;
 
+import java.util.logging.Logger;  
 import build.bazel.remote.execution.v2.Compressor;
 import build.bazel.remote.execution.v2.Digest;
 import build.buildfarm.backplane.Backplane;
@@ -717,6 +718,21 @@ public class Worker {
   }
 
   public static void main(String[] args) throws ConfigurationException {
+    java.util.logging.Logger rootLoger = java.util.logging.Logger.getLogger("");
+    java.util.logging.Handler[] handlers = rootLoger.getHandlers(); 
+    for (java.util.logging.Handler h : handlers) {
+        h.setLevel(Level.ALL);
+    }
+    rootLoger.setLevel(Level.ALL);
+    // java.util.logging.Logger[] loggers = java.util.logging.Logger.getLogger("").getLoggerContext().getLoggerList();  
+
+    // // Set the logging level for all the loggers and their child loggers  
+    // for (java.util.logging.Logger logger : loggers) {  
+    //     logger.setLevel(Level.ALL);  
+    // }
+    log.severe("severe - In Worker.java");
+    log.severe("finest - In Worker.java");
+
     configs = BuildfarmConfigs.loadWorkerConfigs(args);
     SpringApplication.run(Worker.class, args);
   }

--- a/src/test/java/build/buildfarm/logging.properties
+++ b/src/test/java/build/buildfarm/logging.properties
@@ -1,3 +1,4 @@
+.level = ALL
 handlers=java.util.logging.ConsoleHandler
 java.util.logging.ConsoleHandler.level=ALL
 java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter


### PR DESCRIPTION
```
bazelisk run //src/main/java/build/buildfarm:buildfarm-server -- --jvm_flag=-Djava.util.logging.config.file=$PWD/examples/server-logging.properties $PWD/examples/config.minimal.yml
```


```
bazel run //src/main/java/build/buildfarm:buildfarm-shard-worker -- --jvm_flag=-Djava.util.logging.config.file=$PWD/examples/worker-logging.properties $PWD/examples/config.minimal.yml
```

then building something remotely, this is what comes out of the worker console logs: https://pastebin.com/7PdHKJBj

You can see that based on the changes in `src/main/java/build/buildfarm/worker/ExecuteActionStage.java`, you'd expect both
```
[SEVERE ] build.buildfarm.worker.ExecuteActionStage getLogger - severe - In ExecuteActionStage.java ~~~~~~~~~
```

and

```
[FINEST ] build.buildfarm.worker.ExecuteActionStage getLogger - finest - In ExecuteActionStage.java ~~~~~~~~~
```

to show up.

Only the "severe" log line shows up.