### PR TITLE
Enable graceful shutdown for server

### DIFF
--- a/_site/docs/configuration/configuration.md
+++ b/_site/docs/configuration/configuration.md
@@ -51,29 +51,31 @@ worker:
 
 ### Server
 
-| Configuration                    | Accepted and _Default_ Values | Environment Var         | Description                                                                                                                 |
-|----------------------------------|-------------------------------|-------------------------|-----------------------------------------------------------------------------------------------------------------------------|
-| instanceType                     | _SHARD_                       |                         | Type of implementation (SHARD is the only one supported)                                                                    |
-| name                             | String, _shard_               |                         | Implementation name                                                                                                         |
-| publicName                       | String, _DERIVED:port_        |   INSTANCE_NAME         | Host:port of the GRPC server, required to be accessible by all servers                                                      |
-| actionCacheReadOnly              | boolean, _false_              |                         | Allow/Deny writing to action cache                                                                                          |
-| port                             | Integer, _8980_               |                         | Listening port of the GRPC server                                                                                           |
-| casWriteTimeout                  | Integer, _3600_               |                         | CAS write timeout (seconds)                                                                                                 |
-| bytestreamTimeout                | Integer, _3600_               |                         | Byte Stream write timeout (seconds)                                                                                         |
-| sslCertificatePath               | String, _null_                |                         | Absolute path of the SSL certificate (if TLS used)                                                                          |
-| sslPrivateKeyPath                | String, _null_                |                         | Absolute path of the SSL private key (if TLS used)                                                                          |
-| runDispatchedMonitor             | boolean, _true_               |                         | Enable an agent to monitor the operation store to ensure that dispatched operations with expired worker leases are requeued |
-| dispatchedMonitorIntervalSeconds | Integer, _1_                  |                         | Dispatched monitor's lease expiration check interval (seconds)                                                              |
-| runOperationQueuer               | boolean, _true_               |                         | Aquire execute request entries cooperatively from an arrival queue on the backplane                                         |
-| ensureOutputsPresent             | boolean, _false_              |                         | Decide if all outputs are also present in the CAS. If any outputs are missing a cache miss is returned                      |
-| maxCpu                           | Integer, _0_                  |                         | Maximum number of CPU cores that any min/max-cores property may request (0 = unlimited)                                     |
-| maxRequeueAttempts               | Integer, _5_                  |                         | Maximum number of requeue attempts for an operation                                                                         |
-| useDenyList                      | boolean, _true_               |                         | Allow usage of a deny list when looking up actions and invocations (for cache only it is recommended to disable this check) |
-| grpcTimeout                      | Integer, _3600_               |                         | GRPC request timeout (seconds)                                                                                              |
-| executeKeepaliveAfterSeconds     | Integer, _60_                 |                         | Execute keep alive (seconds)                                                                                                |
-| recordBesEvents                  | boolean, _false_              |                         | Allow recording of BES events                                                                                               |
-| clusterId                        | String, _local_               |                         | Buildfarm cluster ID                                                                                                        |
-| cloudRegion                      | String, _us-east_1_           |                         | Deployment region in the cloud                                                                                              |
+| Configuration                    | Accepted and _Default_ Values | Environment Var | Description                                                                                                                 |
+|----------------------------------|-------------------------------|-----------------|-----------------------------------------------------------------------------------------------------------------------------|
+| instanceType                     | _SHARD_                       |                 | Type of implementation (SHARD is the only one supported)                                                                    |
+| name                             | String, _shard_               |                 | Implementation name                                                                                                         |
+| publicName                       | String, _DERIVED:port_        | INSTANCE_NAME   | Host:port of the GRPC server, required to be accessible by all servers                                                      |
+| actionCacheReadOnly              | boolean, _false_              |                 | Allow/Deny writing to action cache                                                                                          |
+| port                             | Integer, _8980_               |                 | Listening port of the GRPC server                                                                                           |
+| casWriteTimeout                  | Integer, _3600_               |                 | CAS write timeout (seconds)                                                                                                 |
+| bytestreamTimeout                | Integer, _3600_               |                 | Byte Stream write timeout (seconds)                                                                                         |
+| sslCertificatePath               | String, _null_                |                 | Absolute path of the SSL certificate (if TLS used)                                                                          |
+| sslPrivateKeyPath                | String, _null_                |                 | Absolute path of the SSL private key (if TLS used)                                                                          |
+| runDispatchedMonitor             | boolean, _true_               |                 | Enable an agent to monitor the operation store to ensure that dispatched operations with expired worker leases are requeued |
+| dispatchedMonitorIntervalSeconds | Integer, _1_                  |                 | Dispatched monitor's lease expiration check interval (seconds)                                                              |
+| runOperationQueuer               | boolean, _true_               |                 | Aquire execute request entries cooperatively from an arrival queue on the backplane                                         |
+| ensureOutputsPresent             | boolean, _false_              |                 | Decide if all outputs are also present in the CAS. If any outputs are missing a cache miss is returned                      |
+| maxCpu                           | Integer, _0_                  |                 | Maximum number of CPU cores that any min/max-cores property may request (0 = unlimited)                                     |
+| maxRequeueAttempts               | Integer, _5_                  |                 | Maximum number of requeue attempts for an operation                                                                         |
+| useDenyList                      | boolean, _true_               |                 | Allow usage of a deny list when looking up actions and invocations (for cache only it is recommended to disable this check) |
+| grpcTimeout                      | Integer, _3600_               |                 | GRPC request timeout (seconds)                                                                                              |
+| executeKeepaliveAfterSeconds     | Integer, _60_                 |                 | Execute keep alive (seconds)                                                                                                |
+| recordBesEvents                  | boolean, _false_              |                 | Allow recording of BES events                                                                                               |
+| clusterId                        | String, _local_               |                 | Buildfarm cluster ID                                                                                                        |
+| cloudRegion                      | String, _us-east_1_           |                 | Deployment region in the cloud                                                                                              |
+| gracefulShutdownSeconds          | Integer, 0                    |                 | Time in seconds to allow for connections in flight to finish when shutdown signal is received                               |
+
 
 Example:
 

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -31,6 +31,7 @@ server:
   recordBesEvents: false
   clusterId: local
   cloudRegion: us-east-1
+  gracefulShutdownSeconds: 0
   caches:
     directoryCacheMaxEntries: 10000
     commandCacheMaxEntries: 10000

--- a/src/main/java/build/buildfarm/common/config/Server.java
+++ b/src/main/java/build/buildfarm/common/config/Server.java
@@ -42,6 +42,7 @@ public class Server {
   private int maxInboundMetadataSize = 0;
   private ServerCacheConfigs caches = new ServerCacheConfigs();
   private boolean findMissingBlobsViaBackplane = false;
+  private int gracefulShutdownSeconds = 0;
 
   public String getSession() {
     return String.format("buildfarm-server-%s-%s", getPublicName(), sessionGuid);


### PR DESCRIPTION
Initial simple implementation of graceful shutdown on the server side. The reason for this functionality is to address the lack of connection draining on services using k8s load balancers. When a scale down even occurs, the sigterm is sent to the pod at the same time as the request is sent to the load balancer to take the target out of rotation. Even if connection draining is specified, because the sigterm shuts down the pod, all connections immediately sever, causing the client to error.

This PR introduces the customizable sleep timer to allow for the server pod to stay up for a predetermined period of time while connections drain via the load balancer. Future improvements could track connections and shut down the server before the full sleep timer elapses like we currently do on the worker.