### PR TITLE
Remove SpringBoot usage

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -43,22 +43,8 @@ IO_GRPC_MODULES = [
 ]
 
 COM_AWS_MODULES = [
-    "secretsmanager",
     "s3",
-]
-
-ORG_SPRING_MODULES = [
-    "spring-beans",
-    "spring-core",
-    "spring-context",
-    "spring-web",
-]
-
-ORG_SPRING_BOOT_MODULES = [
-    "spring-boot-autoconfigure",
-    "spring-boot",
-    "spring-boot-starter-web",
-    "spring-boot-starter-thymeleaf",
+    "secretsmanager",
 ]
 
 def buildfarm_init(name = "buildfarm"):
@@ -99,7 +85,6 @@ def buildfarm_init(name = "buildfarm"):
                         "org.slf4j:slf4j-simple:1.7.35",
                         "com.googlecode.json-simple:json-simple:1.1.1",
                         "com.jayway.jsonpath:json-path:2.4.0",
-                        "io.github.lognet:grpc-spring-boot-starter:4.5.4",
                         "org.bouncycastle:bcprov-jdk15on:1.70",
                         "net.jcip:jcip-annotations:1.0",
                     ] + ["io.netty:netty-%s:4.1.94.Final" % module for module in IO_NETTY_MODULES] +
@@ -122,9 +107,6 @@ def buildfarm_init(name = "buildfarm"):
                         "org.openjdk.jmh:jmh-core:1.23",
                         "org.openjdk.jmh:jmh-generator-annprocess:1.23",
                         "org.redisson:redisson:3.13.1",
-                    ] + ["org.springframework.boot:%s:2.7.4" % module for module in ORG_SPRING_BOOT_MODULES] +
-                    ["org.springframework:%s:5.3.23" % module for module in ORG_SPRING_MODULES] +
-                    [
                         "org.threeten:threetenbp:1.3.3",
                         "org.xerial:sqlite-jdbc:3.34.0",
                         "org.jetbrains:annotations:16.0.2",

--- a/src/main/java/build/buildfarm/common/LoggingMain.java
+++ b/src/main/java/build/buildfarm/common/LoggingMain.java
@@ -7,24 +7,22 @@ public abstract class LoggingMain {
 
   protected abstract void onShutdown() throws InterruptedException;
 
-  class ShutdownThread extends Thread {
-    ShutdownThread(String applicationName) {
-      super(null, null, applicationName + "-Shutdown", 0);
-    }
-
-    @Override
-    public void run() {
-      try {
-        LoggingMain.this.onShutdown();
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-      } finally {
-        WaitingLogManager.release();
-      }
+  private void shutdown() {
+    try {
+      onShutdown();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    } finally {
+      WaitingLogManager.release();
     }
   }
 
   protected LoggingMain(String applicationName) {
-    Runtime.getRuntime().addShutdownHook(new ShutdownThread(applicationName));
+    Runtime.getRuntime()
+        .addShutdownHook(
+            new Thread(
+                /* group=*/ null,
+                /* target=*/ this::shutdown,
+                /* name=*/ applicationName + "-Shutdown"));
   }
 }

--- a/src/main/java/build/buildfarm/server/BUILD
+++ b/src/main/java/build/buildfarm/server/BUILD
@@ -25,11 +25,5 @@ java_library(
         "@maven//:javax_annotation_javax_annotation_api",
         "@maven//:org_bouncycastle_bcprov_jdk15on",
         "@maven//:org_projectlombok_lombok",
-        "@maven//:org_springframework_boot_spring_boot",
-        "@maven//:org_springframework_boot_spring_boot_autoconfigure",
-        "@maven//:org_springframework_boot_spring_boot_starter_thymeleaf",
-        "@maven//:org_springframework_spring_beans",
-        "@maven//:org_springframework_spring_context",
-        "@maven//:org_springframework_spring_core",
     ],
 )

--- a/src/main/java/build/buildfarm/server/BuildFarmServer.java
+++ b/src/main/java/build/buildfarm/server/BuildFarmServer.java
@@ -15,12 +15,13 @@
 package build.buildfarm.server;
 
 import static build.buildfarm.common.io.Utils.formatIOError;
-import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.util.concurrent.MoreExecutors.shutdownAndAwaitTermination;
 import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
 import static java.util.logging.Level.SEVERE;
+import static java.util.logging.Level.WARNING;
 
 import build.buildfarm.common.DigestUtil;
+import build.buildfarm.common.LoggingMain;
 import build.buildfarm.common.config.BuildfarmConfigs;
 import build.buildfarm.common.config.GrpcMetrics;
 import build.buildfarm.common.grpc.TracingMetadataUtils.ServerHeadersInterceptor;
@@ -36,7 +37,6 @@ import build.buildfarm.server.services.FetchService;
 import build.buildfarm.server.services.OperationQueueService;
 import build.buildfarm.server.services.OperationsService;
 import build.buildfarm.server.services.PublishBuildEventService;
-import com.google.devtools.common.options.OptionsParsingException;
 import io.grpc.ServerBuilder;
 import io.grpc.ServerInterceptor;
 import io.grpc.health.v1.HealthCheckResponse.ServingStatus;
@@ -47,24 +47,16 @@ import io.prometheus.client.Counter;
 import java.io.File;
 import java.io.IOException;
 import java.security.Security;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
+import java.util.concurrent.atomic.AtomicBoolean;
 import javax.naming.ConfigurationException;
 import lombok.extern.java.Log;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.ComponentScan;
 
 @SuppressWarnings("deprecation")
 @Log
-@SpringBootApplication
-@ComponentScan("build.buildfarm")
-public class BuildFarmServer {
+public class BuildFarmServer extends LoggingMain {
   private static final java.util.logging.Logger nettyLogger =
       java.util.logging.Logger.getLogger("io.grpc.netty");
   private static final Counter healthCheckMetric =
@@ -78,8 +70,13 @@ public class BuildFarmServer {
   private Instance instance;
   private HealthStatusManager healthStatusManager;
   private io.grpc.Server server;
-  private boolean stopping = false;
   private static BuildfarmConfigs configs = BuildfarmConfigs.getInstance();
+  private AtomicBoolean shutdownInitiated = new AtomicBoolean(true);
+  private AtomicBoolean released = new AtomicBoolean(true);
+
+  BuildFarmServer() {
+    super("BuildFarmServer");
+  }
 
   private ShardInstance createInstance()
       throws IOException, ConfigurationException, InterruptedException {
@@ -87,11 +84,13 @@ public class BuildFarmServer {
         configs.getServer().getName(),
         configs.getServer().getSession() + "-" + configs.getServer().getName(),
         new DigestUtil(configs.getDigestFunction()),
-        this::stop);
+        this::initiateShutdown);
   }
 
   public synchronized void start(ServerBuilder<?> serverBuilder, String publicName)
       throws IOException, ConfigurationException, InterruptedException {
+    shutdownInitiated.set(false);
+    released.set(false);
     instance = createInstance();
 
     healthStatusManager = new HealthStatusManager();
@@ -138,7 +137,6 @@ public class BuildFarmServer {
 
     log.info(String.format("%s initialized", configs.getServer().getSession()));
 
-    checkState(!stopping, "must not call start after stop");
     instance.start(publicName);
     server.start();
 
@@ -148,38 +146,69 @@ public class BuildFarmServer {
     healthCheckMetric.labels("start").inc();
   }
 
-  @PreDestroy
-  public void stop() {
-    synchronized (this) {
-      if (stopping) {
-        return;
-      }
-      stopping = true;
+  private synchronized void awaitRelease() throws InterruptedException {
+    while (!released.get()) {
+      wait();
     }
-    System.err.println("*** shutting down gRPC server since JVM is shutting down");
+  }
+
+  synchronized void stop() throws InterruptedException {
+    try {
+      shutdown();
+    } finally {
+      released.set(true);
+      notify();
+    }
+  }
+
+  private void shutdown() throws InterruptedException {
+    log.info("*** shutting down gRPC server since JVM is shutting down");
     healthStatusManager.setStatus(
         HealthStatusManager.SERVICE_NAME_ALL_SERVICES, ServingStatus.NOT_SERVING);
     PrometheusPublisher.stopHttpServer();
     healthCheckMetric.labels("stop").inc();
     try {
-      if (server != null) {
-        server.shutdown();
-      }
+      initiateShutdown();
       instance.stop();
-      server.awaitTermination(10, TimeUnit.SECONDS);
+      if (server != null && server.awaitTermination(10, TimeUnit.SECONDS)) {
+        server = null;
+      }
     } catch (InterruptedException e) {
       if (server != null) {
         server.shutdownNow();
+        server = null;
       }
+      throw e;
     }
     if (!shutdownAndAwaitTermination(keepaliveScheduler, 10, TimeUnit.SECONDS)) {
       log.warning("could not shut down keepalive scheduler");
     }
-    System.err.println("*** server shut down");
+    log.info("*** server shut down");
   }
 
-  @PostConstruct
-  public void init() throws OptionsParsingException {
+  @Override
+  protected void onShutdown() throws InterruptedException {
+    initiateShutdown();
+    awaitRelease();
+  }
+
+  private void initiateShutdown() {
+    shutdownInitiated.set(true);
+    if (server != null) {
+      server.shutdown();
+    }
+  }
+
+  private void awaitTermination() throws InterruptedException {
+    while (!shutdownInitiated.get()) {
+      if (server != null && server.awaitTermination(1, TimeUnit.SECONDS)) {
+        server = null;
+        shutdownInitiated.set(true);
+      }
+    }
+  }
+
+  public static void main(String[] args) throws Exception {
     // Only log severe log messages from Netty. Otherwise it logs warnings that look like this:
     //
     // 170714 08:16:28.552:WT 18 [io.grpc.netty.NettyServerHandler.onStreamError] Stream Error
@@ -187,35 +216,24 @@ public class BuildFarmServer {
     // unknown stream 11369
     nettyLogger.setLevel(SEVERE);
 
-    try {
-      start(
-          ServerBuilder.forPort(configs.getServer().getPort()),
-          configs.getServer().getPublicName());
-    } catch (IOException e) {
-      System.err.println("error: " + formatIOError(e));
-    } catch (InterruptedException e) {
-      System.err.println("error: interrupted");
-    } catch (ConfigurationException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  public static void main(String[] args) throws ConfigurationException {
     configs = BuildfarmConfigs.loadServerConfigs(args);
 
     // Configure Spring
-    SpringApplication app = new SpringApplication(BuildFarmServer.class);
-    Map<String, Object> springConfig = new HashMap<>();
-
-    // Disable Logback
-    System.setProperty("org.springframework.boot.logging.LoggingSystem", "none");
-
-    app.setDefaultProperties(springConfig);
+    BuildFarmServer server = new BuildFarmServer();
 
     try {
-      app.run(args);
-    } catch (Throwable t) {
-      log.log(SEVERE, "Error running application", t);
+      server.start(
+          ServerBuilder.forPort(configs.getServer().getPort()),
+          configs.getServer().getPublicName());
+      server.awaitTermination();
+    } catch (IOException e) {
+      log.severe("error: " + formatIOError(e));
+    } catch (InterruptedException e) {
+      log.log(WARNING, "interrupted", e);
+    } catch (Exception e) {
+      log.log(SEVERE, "Error running application", e);
+    } finally {
+      server.stop();
     }
   }
 }

--- a/src/main/java/build/buildfarm/worker/shard/BUILD
+++ b/src/main/java/build/buildfarm/worker/shard/BUILD
@@ -36,10 +36,5 @@ java_library(
         "@maven//:io_prometheus_simpleclient",
         "@maven//:javax_annotation_javax_annotation_api",
         "@maven//:org_projectlombok_lombok",
-        "@maven//:org_springframework_boot_spring_boot",
-        "@maven//:org_springframework_boot_spring_boot_autoconfigure",
-        "@maven//:org_springframework_spring_beans",
-        "@maven//:org_springframework_spring_context",
-        "@maven//:org_springframework_spring_core",
     ],
 )

--- a/src/main/java/build/buildfarm/worker/shard/ShutDownWorkerGracefully.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShutDownWorkerGracefully.java
@@ -18,7 +18,6 @@ import build.buildfarm.v1test.PrepareWorkerForGracefulShutDownRequest;
 import build.buildfarm.v1test.PrepareWorkerForGracefulShutDownRequestResults;
 import build.buildfarm.v1test.ShutDownWorkerGrpc;
 import io.grpc.stub.StreamObserver;
-import java.util.concurrent.CompletableFuture;
 import lombok.extern.java.Log;
 
 @Log
@@ -41,7 +40,7 @@ public class ShutDownWorkerGracefully extends ShutDownWorkerGrpc.ShutDownWorkerI
       PrepareWorkerForGracefulShutDownRequest request,
       StreamObserver<PrepareWorkerForGracefulShutDownRequestResults> responseObserver) {
     try {
-      CompletableFuture.runAsync(worker::prepareWorkerForGracefulShutdown);
+      worker.initiateShutdown();
       responseObserver.onNext(PrepareWorkerForGracefulShutDownRequestResults.newBuilder().build());
       responseObserver.onCompleted();
     } catch (Exception e) {


### PR DESCRIPTION
Reinstate prior usage of LoggingMain for safe shutdown, with added release mechanism for interrupted processes. All invoked shutdowns are graceful, with vastly improved shutdown speed for empty workers waiting for pipeline stages.