### PR TITLE
docs: Configuration docs cleanup

### DIFF
--- a/_site/docs/configuration/configuration.md
+++ b/_site/docs/configuration/configuration.md
@@ -105,12 +105,12 @@ server:
 
 ### Server Caches
 
-| Configuration            | Accepted and _Default_ Values | Description                                            |
-|--------------------------|-------------------------------|--------------------------------------------------------|
-| directoryCacheMaxEntries                  | Long, _64 * 1024_              | The max number of entries that the directory cache will hold.    |
-| commandCacheMaxEntries                  | Long, _64 * 1024_              | The max number of entries that the command cache will hold.    |
-| digestToActionCacheMaxEntries                  | Long, _64 * 1024_              | The max number of entries that the digest-to-action cache will hold.    |
-| recentServedExecutionsCacheMaxEntries                  | Long, _64 * 1024_              | The max number of entries that the executions cache will hold.    |
+| Configuration                         | Accepted and _Default_ Values | Description                                                          |
+|---------------------------------------|-------------------------------|----------------------------------------------------------------------|
+| directoryCacheMaxEntries              | Long, _64 * 1024_             | The max number of entries that the directory cache will hold.        |
+| commandCacheMaxEntries                | Long, _64 * 1024_             | The max number of entries that the command cache will hold.          |
+| digestToActionCacheMaxEntries         | Long, _64 * 1024_             | The max number of entries that the digest-to-action cache will hold. |
+| recentServedExecutionsCacheMaxEntries | Long, _64 * 1024_             | The max number of entries that the executions cache will hold.       |
 
 Example:
 

--- a/_site/docs/configuration/configuration.md
+++ b/_site/docs/configuration/configuration.md
@@ -21,8 +21,8 @@ worker:
   publicName: "localhost:8981"
 ```
 
-The configuration can be provided to the server and worker as a CLI argument or through the env variable `CONFIG_PATH`
-For an example config containing all of the configuration values, see `examples/config.yml`.
+The configuration can be provided to the server and worker as a CLI argument or through the environment variable `CONFIG_PATH`
+For an example configuration containing all of the configuration values, see `examples/config.yml`.
 
 ## All Configurations
 
@@ -64,7 +64,7 @@ worker:
 | sslPrivateKeyPath                | String, _null_                |                 | Absolute path of the SSL private key (if TLS used)                                                                          |
 | runDispatchedMonitor             | boolean, _true_               |                 | Enable an agent to monitor the operation store to ensure that dispatched operations with expired worker leases are requeued |
 | dispatchedMonitorIntervalSeconds | Integer, _1_                  |                 | Dispatched monitor's lease expiration check interval (seconds)                                                              |
-| runOperationQueuer               | boolean, _true_               |                 | Aquire execute request entries cooperatively from an arrival queue on the backplane                                         |
+| runOperationQueuer               | boolean, _true_               |                 | Acquire execute request entries cooperatively from an arrival queue on the backplane                                         |
 | ensureOutputsPresent             | boolean, _false_              |                 | Decide if all outputs are also present in the CAS. If any outputs are missing a cache miss is returned                      |
 | maxCpu                           | Integer, _0_                  |                 | Maximum number of CPU cores that any min/max-cores property may request (0 = unlimited)                                     |
 | maxRequeueAttempts               | Integer, _5_                  |                 | Maximum number of requeue attempts for an operation                                                                         |

--- a/_site/docs/configuration/configuration.md
+++ b/_site/docs/configuration/configuration.md
@@ -28,13 +28,13 @@ For an example config containing all of the configuration values, see `examples/
 
 ### Common
 
-| Configuration        | Accepted and _Default_ Values | Description                                       |
-|----------------------|-------------------------------|---------------------------------------------------|
-| digestFunction       | _SHA256_, SHA1                | Digest function for this implementation           |
-| defaultActionTimeout | Integer, _600_                | Default timeout value for an action (seconds)     |
-| maximumActionTimeout | Integer, _3600_               | Maximum allowed action timeout (seconds)          |
-| maxEntrySizeBytes    | Long, _2147483648_            | Maximum size of a single blob accepted (bytes)    |
-| prometheusPort       | Integer, _9090_               | Listening port of the Prometheus metrics endpoint |
+| Configuration        | Accepted and _Default_ Values | Command Line Argument | Description                                       |
+|----------------------|-------------------------------|-----------------------|---------------------------------------------------|
+| digestFunction       | _SHA256_, SHA1                |                       | Digest function for this implementation           |
+| defaultActionTimeout | Integer, _600_                |                       | Default timeout value for an action (seconds)     |
+| maximumActionTimeout | Integer, _3600_               |                       | Maximum allowed action timeout (seconds)          |
+| maxEntrySizeBytes    | Long, _2147483648_            |                       | Maximum size of a single blob accepted (bytes)    |
+| prometheusPort       | Integer, _9090_               | --prometheus_port     | Listening port of the Prometheus metrics endpoint |
 
 Example:
 


### PR DESCRIPTION
- documented `--prometheus_port`
- clean up Markdown tables, typos.