### PR TITLE
revert: chore: bump rules_jvm_external

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -111,7 +111,7 @@ def buildfarm_init(name = "buildfarm"):
                         "org.xerial:sqlite-jdbc:3.34.0",
                         "org.jetbrains:annotations:16.0.2",
                         "org.yaml:snakeyaml:2.0",
-                        "org.projectlombok:lombok:1.18.30",
+                        "org.projectlombok:lombok:1.18.24",
                     ],
         generate_compat_repositories = True,
         repositories = [

--- a/defs.bzl
+++ b/defs.bzl
@@ -111,7 +111,7 @@ def buildfarm_init(name = "buildfarm"):
                         "org.xerial:sqlite-jdbc:3.34.0",
                         "org.jetbrains:annotations:16.0.2",
                         "org.yaml:snakeyaml:2.0",
-                        "org.projectlombok:lombok:1.18.24",
+                        "org.projectlombok:lombok:1.18.30",
                     ],
         generate_compat_repositories = True,
         repositories = [

--- a/deps.bzl
+++ b/deps.bzl
@@ -5,8 +5,8 @@ buildfarm dependencies that can be imported into other WORKSPACE files
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file", "http_jar")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
-RULES_JVM_EXTERNAL_TAG = "5.3"
-RULES_JVM_EXTERNAL_SHA = "d31e369b854322ca5098ea12c69d7175ded971435e55c18dd9dd5f29cc5249ac"
+RULES_JVM_EXTERNAL_TAG = "4.2"
+RULES_JVM_EXTERNAL_SHA = "cd1a77b7b02e8e008439ca76fd34f5b07aecb8c752961f9640dea15e9e5ba1ca"
 
 def archive_dependencies(third_party):
     return [
@@ -22,7 +22,7 @@ def archive_dependencies(third_party):
             "name": "rules_jvm_external",
             "strip_prefix": "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
             "sha256": RULES_JVM_EXTERNAL_SHA,
-            "url": "https://github.com/bazelbuild/rules_jvm_external/releases/download/%s/rules_jvm_external-%s.tar.gz" % (RULES_JVM_EXTERNAL_TAG, RULES_JVM_EXTERNAL_TAG),
+            "url": "https://github.com/bazelbuild/rules_jvm_external/archive/%s.zip" % RULES_JVM_EXTERNAL_TAG,
         },
 
         # Kubernetes rules.  Useful for local development with tilt.


### PR DESCRIPTION
upstream CI does not seem to pass on Windows without reverting this:
https://github.com/bazelbuild/bazel-buildfarm/commit/9d4c86c8021804aeb5f8723b4faf914963a95386

I'm not sure if something is wrong with the windows VM, or its tied to this dependency upgrade.