### PR TITLE
Pin the Java toolchain to `remotejdk_17`

### DIFF
--- a/.bazelci/run_server_test.sh
+++ b/.bazelci/run_server_test.sh
@@ -8,11 +8,11 @@ bazel build //src/main/java/build/buildfarm:buildfarm-shard-worker
 bazel build //src/main/java/build/buildfarm:buildfarm-server
 
 # Start a single worker
-bazel run //src/main/java/build/buildfarm:buildfarm-shard-worker $(pwd)/examples/config.minimal.yml > server.log 2>&1 &
+bazel run //src/main/java/build/buildfarm:buildfarm-shard-worker $(pwd)/examples/config.minimal.yml > worker.log 2>&1 &
 echo "Started buildfarm-shard-worker..."
 
 # Start a single server
-bazel run //src/main/java/build/buildfarm:buildfarm-server $(pwd)/examples/config.minimal.yml > worker.log 2>&1 &
+bazel run //src/main/java/build/buildfarm:buildfarm-server $(pwd)/examples/config.minimal.yml > server.log 2>&1 &
 echo "Started buildfarm-server..."
 
 echo "Wait for startup to finish..."

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,9 @@
+build --java_language_version=17
+build --java_runtime_version=remotejdk_17
+
+build --tool_java_language_version=17
+build --tool_java_runtime_version=remotejdk_17
+
 common --enable_platform_specific_config
 
 build:fuse --define=fuse=true

--- a/BUILD
+++ b/BUILD
@@ -120,7 +120,7 @@ sh_binary(
 java_image(
     name = "buildfarm-server",
     args = ["/app/build_buildfarm/examples/config.minimal.yml"],
-    base = "@amazon_corretto_java_image_base//image",
+    base = "@ubuntu-mantic//image",
     classpath_resources = [
         "//src/main/java/build/buildfarm:configs",
     ],
@@ -148,14 +148,14 @@ oss_audit(
 # Download cgroup-tools so that the worker is able to restrict actions via control groups.
 download_pkgs(
     name = "worker_pkgs",
-    image_tar = "@ubuntu-jammy//image",
+    image_tar = "@ubuntu-mantic//image",
     packages = ["cgroup-tools"],
     tags = ["container"],
 )
 
 install_pkgs(
     name = "worker_pkgs_image",
-    image_tar = "@ubuntu-jammy//image",
+    image_tar = "@ubuntu-mantic//image",
     installables_tar = ":worker_pkgs.tar",
     installation_cleanup_commands = "rm -rf /var/lib/apt/lists/*",
     output_image_name = "worker_pkgs_image",

--- a/images.bzl
+++ b/images.bzl
@@ -27,25 +27,11 @@ def buildfarm_images():
     )
 
     container_pull(
-        name = "ubuntu-bionic",
-        digest = "sha256:4bc527c7a288da405f2041928c63d0a6479a120ad63461c2f124c944def54be2",
+        name = "ubuntu-mantic",
+        digest = "sha256:1419bba15470a95242e917b3abcd8981ae36707b99df5ac705e1eee4d920c51c",
         registry = "index.docker.io",
         repository = "bazelbuild/buildfarm-worker-base",
-        tag = "bionic-java11-gcc",
+        tag = "mantic-java17-gcc",
     )
 
-    container_pull(
-        name = "ubuntu-jammy",
-        digest = "sha256:da847ee259ebe7f00631a2f0146d9add60ff0f94b031a2e522ce94c78b1335c2",
-        registry = "index.docker.io",
-        repository = "bazelbuild/buildfarm-worker-base",
-        tag = "jammy-java11-gcc",
-    )
 
-    container_pull(
-        name = "amazon_corretto_java_image_base",
-        registry = "index.docker.io",
-        repository = "amazoncorretto",
-        tag = "19",
-        digest = "sha256:81d0df4412140416b27211c999e1f3c4565ae89a5cd92889475d20af422ba507",
-    )

--- a/images.bzl
+++ b/images.bzl
@@ -33,5 +33,3 @@ def buildfarm_images():
         repository = "bazelbuild/buildfarm-worker-base",
         tag = "mantic-java17-gcc",
     )
-
-

--- a/jvm_flags.bzl
+++ b/jvm_flags.bzl
@@ -54,6 +54,12 @@ def ensure_accurate_metadata():
         "//config:windows": ["-Dsun.nio.fs.ensureAccurateMetadata=true"],
     })
 
+def add_opens_sun_nio_fs():
+    return select({
+        "//conditions:default": [],
+        "//config:windows": ["--add-opens java.base/sun.nio.fs=ALL-UNNAMED"],
+    })
+
 def server_telemetry():
     return select({
         "//config:open_telemetry": SERVER_TELEMETRY_JVM_FLAGS,
@@ -67,7 +73,7 @@ def worker_telemetry():
     })
 
 def server_jvm_flags():
-    return RECOMMENDED_JVM_FLAGS + DEFAULT_LOGGING_CONFIG + ensure_accurate_metadata() + server_telemetry()
+    return RECOMMENDED_JVM_FLAGS + DEFAULT_LOGGING_CONFIG + ensure_accurate_metadata() + add_opens_sun_nio_fs() + server_telemetry()
 
 def worker_jvm_flags():
-    return RECOMMENDED_JVM_FLAGS + DEFAULT_LOGGING_CONFIG + ensure_accurate_metadata() + worker_telemetry()
+    return RECOMMENDED_JVM_FLAGS + DEFAULT_LOGGING_CONFIG + ensure_accurate_metadata() + add_opens_sun_nio_fs() + worker_telemetry()

--- a/persistentworkers/src/main/java/persistent/common/processes/JavaProcessWrapper.java
+++ b/persistentworkers/src/main/java/persistent/common/processes/JavaProcessWrapper.java
@@ -10,12 +10,16 @@ import com.google.common.collect.ImmutableList;
 
 public class JavaProcessWrapper extends ProcessWrapper {
 
+  // Get the path of the JVM from the current process to avoid breaking the Bazel sandbox
+  public static final String CURRENT_JVM_COMMAND =
+          ProcessHandle.current().info().command().orElseThrow(() -> new RuntimeException("Unable to retrieve the path of the running JVM"));
+
   public JavaProcessWrapper(
       Path workDir, String classPath, String fullClassName, String[] args
   ) throws IOException {
     super(workDir, cmdArgs(
         new String[]{
-            "java",
+            CURRENT_JVM_COMMAND,
             "-cp",
             classPath,
             fullClassName

--- a/persistentworkers/src/test/java/persistent/bazel/processes/PersistentWorkerTest.java
+++ b/persistentworkers/src/test/java/persistent/bazel/processes/PersistentWorkerTest.java
@@ -16,6 +16,7 @@ import org.junit.runners.JUnit4;
 
 import persistent.bazel.client.PersistentWorker;
 import persistent.bazel.client.WorkerKey;
+import persistent.common.processes.JavaProcessWrapper;
 import persistent.testutil.ProcessUtils;
 import persistent.testutil.WorkerUtils;
 
@@ -55,7 +56,7 @@ public class PersistentWorkerTest {
     );
 
     ImmutableList<String> initCmd = ImmutableList.of(
-        "java",
+        JavaProcessWrapper.CURRENT_JVM_COMMAND,
         "-cp",
         jarPath.toString(),
         "adder.Adder",

--- a/src/main/java/build/buildfarm/BUILD
+++ b/src/main/java/build/buildfarm/BUILD
@@ -1,4 +1,4 @@
-load("//:jvm_flags.bzl", "ensure_accurate_metadata")
+load("//:jvm_flags.bzl", "add_opens_sun_nio_fs", "ensure_accurate_metadata")
 
 package(
     default_visibility = ["//src:__subpackages__"],
@@ -15,7 +15,7 @@ java_binary(
     classpath_resources = [
         ":configs",
     ],
-    jvm_flags = ensure_accurate_metadata(),
+    jvm_flags = ensure_accurate_metadata() + add_opens_sun_nio_fs(),
     main_class = "build.buildfarm.server.BuildFarmServer",
     visibility = ["//visibility:public"],
     runtime_deps = [
@@ -29,7 +29,7 @@ java_binary(
     classpath_resources = [
         ":configs",
     ],
-    jvm_flags = ensure_accurate_metadata(),
+    jvm_flags = ensure_accurate_metadata() + add_opens_sun_nio_fs(),
     main_class = "build.buildfarm.worker.shard.Worker",
     visibility = ["//visibility:public"],
     runtime_deps = [

--- a/src/test/java/build/buildfarm/cas/BUILD
+++ b/src/test/java/build/buildfarm/cas/BUILD
@@ -1,10 +1,10 @@
-load("//:jvm_flags.bzl", "ensure_accurate_metadata")
+load("//:jvm_flags.bzl", "add_opens_sun_nio_fs", "ensure_accurate_metadata")
 
 java_test(
     name = "tests",
     size = "small",
     srcs = glob(["**/*.java"]),
-    jvm_flags = ensure_accurate_metadata(),
+    jvm_flags = ensure_accurate_metadata() + add_opens_sun_nio_fs(),
     test_class = "build.buildfarm.AllTests",
     deps = [
         "//src/main/java/build/buildfarm/cas",

--- a/src/test/java/build/buildfarm/common/BUILD
+++ b/src/test/java/build/buildfarm/common/BUILD
@@ -1,10 +1,10 @@
-load("//:jvm_flags.bzl", "ensure_accurate_metadata")
+load("//:jvm_flags.bzl", "add_opens_sun_nio_fs", "ensure_accurate_metadata")
 
 java_test(
     name = "tests",
     size = "small",
     srcs = glob(["*.java"]),
-    jvm_flags = ensure_accurate_metadata(),
+    jvm_flags = ensure_accurate_metadata() + add_opens_sun_nio_fs(),
     test_class = "build.buildfarm.AllTests",
     deps = [
         "//src/main/java/build/buildfarm/common",


### PR DESCRIPTION
Closes #1508

Cleanups:
- remove the unused `ubuntu-bionic` base image
- replace `ubuntu-jammy:jammy-java11-gcc` with `ubuntu-mantic:mantic-java17-gcc`
- replace `amazoncorretto:19` with `ubuntu-mantic:mantic-java17-gcc`
- swap inverted log file names in a file