### PR TITLE
Permit Absolute Symlink Targets with configuration

### DIFF
--- a/_site/docs/configuration/configuration.md
+++ b/_site/docs/configuration/configuration.md
@@ -28,13 +28,14 @@ For an example configuration containing all of the configuration values, see `ex
 
 ### Common
 
-| Configuration        | Accepted and _Default_ Values | Command Line Argument | Description                                       |
-|----------------------|-------------------------------|-----------------------|---------------------------------------------------|
-| digestFunction       | _SHA256_, SHA1                |                       | Digest function for this implementation           |
-| defaultActionTimeout | Integer, _600_                |                       | Default timeout value for an action (seconds)     |
-| maximumActionTimeout | Integer, _3600_               |                       | Maximum allowed action timeout (seconds)          |
-| maxEntrySizeBytes    | Long, _2147483648_            |                       | Maximum size of a single blob accepted (bytes)    |
-| prometheusPort       | Integer, _9090_               | --prometheus_port     | Listening port of the Prometheus metrics endpoint |
+| Configuration                | Accepted and _Default_ Values | Command Line Argument | Description                                                  |
+|------------------------------|-------------------------------|-----------------------|--------------------------------------------------------------|
+| digestFunction               | _SHA256_, SHA1                |                       | Digest function for this implementation                      |
+| defaultActionTimeout         | Integer, _600_                |                       | Default timeout value for an action (seconds)                |
+| maximumActionTimeout         | Integer, _3600_               |                       | Maximum allowed action timeout (seconds)                     |
+| maxEntrySizeBytes            | Long, _2147483648_            |                       | Maximum size of a single blob accepted (bytes)               |
+| prometheusPort               | Integer, _9090_               | --prometheus_port     | Listening port of the Prometheus metrics endpoint            |
+| allowSymlinkTargetAbsolute   | boolean, _false_              |                       | Permit inputs to contain symlinks with absolute path targets |
 
 Example:
 

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -3,6 +3,7 @@ defaultActionTimeout: 600
 maximumActionTimeout: 3600
 maxEntrySizeBytes: 2147483648 # 2 * 1024 * 1024 * 1024
 prometheusPort: 9090
+allowSymlinkTargetAbsolute: false
 server:
   instanceType: SHARD
   name: shard

--- a/src/main/java/build/buildfarm/common/config/BuildfarmConfigs.java
+++ b/src/main/java/build/buildfarm/common/config/BuildfarmConfigs.java
@@ -36,6 +36,7 @@ public final class BuildfarmConfigs {
   private long maximumActionTimeout = 3600;
   private long maxEntrySizeBytes = 2147483648L; // 2 * 1024 * 1024 * 1024
   private int prometheusPort = 9090;
+  private boolean allowSymlinkTargetAbsolute = false;
   private Server server = new Server();
   private Backplane backplane = new Backplane();
   private Worker worker = new Worker();

--- a/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ShardInstance.java
@@ -47,6 +47,7 @@ import static net.javacrumbs.futureconverter.java8guava.FutureConverter.toListen
 import build.bazel.remote.execution.v2.Action;
 import build.bazel.remote.execution.v2.ActionResult;
 import build.bazel.remote.execution.v2.BatchReadBlobsResponse.Response;
+import build.bazel.remote.execution.v2.CacheCapabilities;
 import build.bazel.remote.execution.v2.Command;
 import build.bazel.remote.execution.v2.Compressor;
 import build.bazel.remote.execution.v2.Digest;
@@ -60,6 +61,7 @@ import build.bazel.remote.execution.v2.Platform;
 import build.bazel.remote.execution.v2.Platform.Property;
 import build.bazel.remote.execution.v2.RequestMetadata;
 import build.bazel.remote.execution.v2.ResultsCachePolicy;
+import build.bazel.remote.execution.v2.SymlinkAbsolutePathStrategy;
 import build.buildfarm.actioncache.ActionCache;
 import build.buildfarm.actioncache.ShardActionCache;
 import build.buildfarm.backplane.Backplane;
@@ -2725,5 +2727,17 @@ public class ShardInstance extends AbstractServerInstance {
       return false;
     }
     return backplane.isBlacklisted(requestMetadata);
+  }
+
+  @Override
+  protected CacheCapabilities getCacheCapabilities() {
+    SymlinkAbsolutePathStrategy.Value symlinkAbsolutePathStrategy =
+        configs.isAllowSymlinkTargetAbsolute()
+            ? SymlinkAbsolutePathStrategy.Value.ALLOWED
+            : SymlinkAbsolutePathStrategy.Value.DISALLOWED;
+    return super.getCacheCapabilities()
+        .toBuilder()
+        .setSymlinkAbsolutePathStrategy(symlinkAbsolutePathStrategy)
+        .build();
   }
 }

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -337,6 +337,7 @@ public final class Worker extends LoggingMain {
         owner,
         configs.getWorker().isLinkInputDirectories(),
         configs.getWorker().getLinkedInputDirectories(),
+        configs.isAllowSymlinkTargetAbsolute(),
         removeDirectoryService,
         accessRecorder
         /* deadlineAfter=*/


### PR DESCRIPTION
Partial specification of the absolute symlink response per REAPI.
Remaining work will be in output identification.