### PR TITLE
Rename instance types

### DIFF
--- a/admin/main/src/main/resources/proto/buildfarm.proto
+++ b/admin/main/src/main/resources/proto/buildfarm.proto
@@ -520,7 +520,7 @@ message RedisShardBackplaneConfig {
   int32 max_attempts = 33;
 }
 
-message ShardInstanceConfig {
+message ServerInstanceConfig {
   bool run_dispatched_monitor = 1;
 
   int32 dispatched_monitor_interval_seconds = 2;
@@ -544,7 +544,7 @@ message ShardInstanceConfig {
   google.protobuf.Duration grpc_timeout = 8;
 }
 
-message ShardWorkerInstanceConfig {
+message WorkerInstanceConfig {
   // whether to stream stdout from processes
   bool stream_stdout = 6;
 
@@ -568,7 +568,7 @@ message ShardWorkerInstanceConfig {
 }
 
 message ShardWorkerConfig {
-  ShardWorkerInstanceConfig shard_worker_instance_config = 1;
+  WorkerInstanceConfig shard_worker_instance_config = 1;
 
   int32 port = 2;
 
@@ -836,7 +836,7 @@ message InstanceConfig {
 
   oneof type {
     MemoryInstanceConfig memory_instance_config = 3;
-    ShardInstanceConfig shard_instance_config = 4;
+    ServerInstanceConfig shard_instance_config = 4;
   }
 }
 

--- a/src/main/java/build/buildfarm/instance/server/BUILD
+++ b/src/main/java/build/buildfarm/instance/server/BUILD
@@ -1,7 +1,7 @@
 java_library(
     name = "server",
     srcs = [
-        "AbstractServerInstance.java",
+        "NodeInstance.java",
         "GetDirectoryFunction.java",
         "OperationsMap.java",
         "WatchFuture.java",

--- a/src/main/java/build/buildfarm/instance/server/BUILD
+++ b/src/main/java/build/buildfarm/instance/server/BUILD
@@ -1,8 +1,8 @@
 java_library(
     name = "server",
     srcs = [
-        "NodeInstance.java",
         "GetDirectoryFunction.java",
+        "NodeInstance.java",
         "OperationsMap.java",
         "WatchFuture.java",
     ],

--- a/src/main/java/build/buildfarm/instance/server/NodeInstance.java
+++ b/src/main/java/build/buildfarm/instance/server/NodeInstance.java
@@ -144,7 +144,7 @@ import javax.annotation.Nullable;
 import lombok.extern.java.Log;
 
 @Log
-public abstract class AbstractServerInstance implements Instance {
+public abstract class NodeInstance implements Instance {
   private final String name;
   protected final ContentAddressableStorage contentAddressableStorage;
   protected final ActionCache actionCache;
@@ -229,7 +229,7 @@ public abstract class AbstractServerInstance implements Instance {
   public static final String NO_REQUEUE_COMPLETE_MESSAGE =
       "Operation %s not requeued.  Operation has already completed.";
 
-  public AbstractServerInstance(
+  public NodeInstance(
       String name,
       DigestUtil digestUtil,
       ContentAddressableStorage contentAddressableStorage,
@@ -1967,19 +1967,19 @@ public abstract class AbstractServerInstance implements Instance {
   @Override
   public WorkerProfileMessage getWorkerProfile() {
     throw new UnsupportedOperationException(
-        "AbstractServerInstance doesn't support getWorkerProfile() method.");
+        "NodeInstance doesn't support getWorkerProfile() method.");
   }
 
   @Override
   public WorkerListMessage getWorkerList() {
     throw new UnsupportedOperationException(
-        "AbstractServerInstance doesn't support getWorkerList() method.");
+        "NodeInstance doesn't support getWorkerList() method.");
   }
 
   @Override
   public PrepareWorkerForGracefulShutDownRequestResults shutDownWorkerGracefully() {
     throw new UnsupportedOperationException(
-        "AbstractServerInstance doesn't support drainWorkerPipeline() method.");
+        "NodeInstance doesn't support drainWorkerPipeline() method.");
   }
 
   @Override

--- a/src/main/java/build/buildfarm/instance/server/NodeInstance.java
+++ b/src/main/java/build/buildfarm/instance/server/NodeInstance.java
@@ -1972,8 +1972,7 @@ public abstract class NodeInstance implements Instance {
 
   @Override
   public WorkerListMessage getWorkerList() {
-    throw new UnsupportedOperationException(
-        "NodeInstance doesn't support getWorkerList() method.");
+    throw new UnsupportedOperationException("NodeInstance doesn't support getWorkerList() method.");
   }
 
   @Override

--- a/src/main/java/build/buildfarm/instance/shard/RemoteInputStreamFactory.java
+++ b/src/main/java/build/buildfarm/instance/shard/RemoteInputStreamFactory.java
@@ -30,7 +30,7 @@ import build.buildfarm.backplane.Backplane;
 import build.buildfarm.common.DigestUtil;
 import build.buildfarm.common.InputStreamFactory;
 import build.buildfarm.instance.Instance;
-import build.buildfarm.instance.shard.ShardInstance.WorkersCallback;
+import build.buildfarm.instance.shard.ServerInstance.WorkersCallback;
 import com.google.common.base.Throwables;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.Iterables;

--- a/src/main/java/build/buildfarm/instance/shard/ServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ServerInstance.java
@@ -81,7 +81,7 @@ import build.buildfarm.common.config.BuildfarmConfigs;
 import build.buildfarm.common.grpc.UniformDelegateServerCallStreamObserver;
 import build.buildfarm.instance.Instance;
 import build.buildfarm.instance.MatchListener;
-import build.buildfarm.instance.server.AbstractServerInstance;
+import build.buildfarm.instance.server.NodeInstance;
 import build.buildfarm.operations.EnrichedOperation;
 import build.buildfarm.operations.FindOperationsResults;
 import build.buildfarm.v1test.BackplaneStatus;
@@ -167,7 +167,7 @@ import javax.naming.ConfigurationException;
 import lombok.extern.java.Log;
 
 @Log
-public class ShardInstance extends AbstractServerInstance {
+public class ServerInstance extends NodeInstance {
   private static final ListenableFuture<Void> IMMEDIATE_VOID_FUTURE = Futures.immediateFuture(null);
 
   private static final String TIMEOUT_OUT_OF_BOUNDS =
@@ -259,14 +259,14 @@ public class ShardInstance extends AbstractServerInstance {
           identifier,
           /* subscribeToBackplane=*/ true,
           configs.getServer().isRunFailsafeOperation(),
-          ShardInstance::stripOperation,
-          ShardInstance::stripQueuedOperation);
+          ServerInstance::stripOperation,
+          ServerInstance::stripQueuedOperation);
     } else {
       throw new IllegalArgumentException("Shard Backplane not set in config");
     }
   }
 
-  public ShardInstance(String name, String identifier, DigestUtil digestUtil, Runnable onStop)
+  public ServerInstance(String name, String identifier, DigestUtil digestUtil, Runnable onStop)
       throws InterruptedException, ConfigurationException {
     this(
         name,
@@ -276,7 +276,7 @@ public class ShardInstance extends AbstractServerInstance {
         /* actionCacheFetchService=*/ BuildfarmExecutors.getActionCacheFetchServicePool());
   }
 
-  private ShardInstance(
+  private ServerInstance(
       String name,
       DigestUtil digestUtil,
       Backplane backplane,
@@ -328,7 +328,7 @@ public class ShardInstance extends AbstractServerInstance {
             .build();
   }
 
-  public ShardInstance(
+  public ServerInstance(
       String name,
       DigestUtil digestUtil,
       Backplane backplane,
@@ -1086,7 +1086,7 @@ public class ShardInstance extends AbstractServerInstance {
                           backplane,
                           workerSet,
                           locationSet,
-                          ShardInstance.this::workerStub,
+                          ServerInstance.this::workerStub,
                           blobDigest,
                           directExecutor(),
                           RequestMetadata.getDefaultInstance()),
@@ -2251,7 +2251,7 @@ public class ShardInstance extends AbstractServerInstance {
             log.log(
                 Level.FINER,
                 format(
-                    "ShardInstance(%s): checkCache(%s): %sus elapsed",
+                    "ServerInstance(%s): checkCache(%s): %sus elapsed",
                     getName(), operation.getName(), checkCacheUSecs));
             return IMMEDIATE_VOID_FUTURE;
           }
@@ -2278,7 +2278,7 @@ public class ShardInstance extends AbstractServerInstance {
     log.log(
         Level.FINER,
         format(
-            "ShardInstance(%s): queue(%s): fetching action %s",
+            "ServerInstance(%s): queue(%s): fetching action %s",
             getName(), operation.getName(), actionDigest.getHash()));
     RequestMetadata requestMetadata = executeEntry.getRequestMetadata();
     ListenableFuture<Action> actionFuture =
@@ -2321,7 +2321,7 @@ public class ShardInstance extends AbstractServerInstance {
               log.log(
                   Level.FINER,
                   format(
-                      "ShardInstance(%s): queue(%s): fetched action %s transforming queuedOperation",
+                      "ServerInstance(%s): queue(%s): fetched action %s transforming queuedOperation",
                       getName(), operation.getName(), actionDigest.getHash()));
               Stopwatch transformStopwatch = Stopwatch.createStarted();
               return transform(
@@ -2351,7 +2351,7 @@ public class ShardInstance extends AbstractServerInstance {
               log.log(
                   Level.FINER,
                   format(
-                      "ShardInstance(%s): queue(%s): queuedOperation %s transformed, validating",
+                      "ServerInstance(%s): queue(%s): queuedOperation %s transformed, validating",
                       getName(),
                       operation.getName(),
                       DigestUtil.toString(
@@ -2373,7 +2373,7 @@ public class ShardInstance extends AbstractServerInstance {
               log.log(
                   Level.FINER,
                   format(
-                      "ShardInstance(%s): queue(%s): queuedOperation %s validated, uploading",
+                      "ServerInstance(%s): queue(%s): queuedOperation %s validated, uploading",
                       getName(),
                       operation.getName(),
                       DigestUtil.toString(
@@ -2425,7 +2425,7 @@ public class ShardInstance extends AbstractServerInstance {
               log.log(
                   Level.FINER,
                   format(
-                      "ShardInstance(%s): queue(%s): %dus checkCache, %dus transform, %dus validate, %dus upload, %dus queue, %dus elapsed",
+                      "ServerInstance(%s): queue(%s): %dus checkCache, %dus transform, %dus validate, %dus upload, %dus queue, %dus elapsed",
                       getName(),
                       queueOperation.getName(),
                       checkCacheUSecs,

--- a/src/main/java/build/buildfarm/server/BuildFarmServer.java
+++ b/src/main/java/build/buildfarm/server/BuildFarmServer.java
@@ -29,7 +29,7 @@ import build.buildfarm.common.grpc.TracingMetadataUtils.ServerHeadersInterceptor
 import build.buildfarm.common.services.ByteStreamService;
 import build.buildfarm.common.services.ContentAddressableStorageService;
 import build.buildfarm.instance.Instance;
-import build.buildfarm.instance.shard.ShardInstance;
+import build.buildfarm.instance.shard.ServerInstance;
 import build.buildfarm.metrics.prometheus.PrometheusPublisher;
 import build.buildfarm.server.services.ActionCacheService;
 import build.buildfarm.server.services.CapabilitiesService;
@@ -109,9 +109,9 @@ public class BuildFarmServer extends LoggingMain {
     }
   }
 
-  private ShardInstance createInstance()
+  private ServerInstance createInstance()
       throws IOException, ConfigurationException, InterruptedException {
-    return new ShardInstance(
+    return new ServerInstance(
         configs.getServer().getName(),
         configs.getServer().getSession() + "-" + configs.getServer().getName(),
         new DigestUtil(configs.getDigestFunction()),

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -532,8 +532,7 @@ public final class Worker extends LoggingMain {
             remoteInputStreamFactory, removeDirectoryService, accessRecorder, storage);
 
     instance =
-        new WorkerInstance(
-            configs.getWorker().getPublicName(), digestUtil, backplane, storage);
+        new WorkerInstance(configs.getWorker().getPublicName(), digestUtil, backplane, storage);
 
     // Create the appropriate writer for the context
     CasWriter writer;

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -123,7 +123,7 @@ public final class Worker extends LoggingMain {
   private boolean inGracefulShutdown = false;
   private boolean isPaused = false;
 
-  private ShardWorkerInstance instance;
+  private WorkerInstance instance;
 
   @SuppressWarnings("deprecation")
   private final HealthStatusManager healthStatusManager = new HealthStatusManager();
@@ -532,7 +532,7 @@ public final class Worker extends LoggingMain {
             remoteInputStreamFactory, removeDirectoryService, accessRecorder, storage);
 
     instance =
-        new ShardWorkerInstance(
+        new WorkerInstance(
             configs.getWorker().getPublicName(), digestUtil, backplane, storage);
 
     // Create the appropriate writer for the context

--- a/src/main/java/build/buildfarm/worker/shard/WorkerInstance.java
+++ b/src/main/java/build/buildfarm/worker/shard/WorkerInstance.java
@@ -36,7 +36,7 @@ import build.buildfarm.common.Watcher;
 import build.buildfarm.common.Write;
 import build.buildfarm.common.grpc.UniformDelegateServerCallStreamObserver;
 import build.buildfarm.instance.MatchListener;
-import build.buildfarm.instance.server.AbstractServerInstance;
+import build.buildfarm.instance.server.NodeInstance;
 import build.buildfarm.operations.EnrichedOperation;
 import build.buildfarm.operations.FindOperationsResults;
 import build.buildfarm.v1test.BackplaneStatus;
@@ -68,13 +68,13 @@ import java.util.logging.Logger;
 import lombok.extern.java.Log;
 
 @Log
-public class ShardWorkerInstance extends AbstractServerInstance {
+public class WorkerInstance extends NodeInstance {
   private static final Counter IO_METRIC =
       Counter.build().name("io_bytes_read").help("Read I/O (bytes)").register();
 
   private final Backplane backplane;
 
-  public ShardWorkerInstance(
+  public WorkerInstance(
       String name,
       DigestUtil digestUtil,
       Backplane backplane,
@@ -346,7 +346,7 @@ public class ShardWorkerInstance extends AbstractServerInstance {
         return null;
       }
     } else {
-      return AbstractServerInstance.expectExecuteOperationMetadata(operation);
+      return NodeInstance.expectExecuteOperationMetadata(operation);
     }
   }
 

--- a/src/test/java/build/buildfarm/instance/server/NodeInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/server/NodeInstanceTest.java
@@ -721,8 +721,7 @@ public class NodeInstanceTest {
             .build();
     ContentAddressableStorage contentAddressableStorage = mock(ContentAddressableStorage.class);
     ActionCache actionCache = mock(ActionCache.class);
-    NodeInstance instance =
-        new DummyServerInstance(contentAddressableStorage, actionCache);
+    NodeInstance instance = new DummyServerInstance(contentAddressableStorage, actionCache);
 
     Tree tree =
         Tree.newBuilder()

--- a/src/test/java/build/buildfarm/instance/server/NodeInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/server/NodeInstanceTest.java
@@ -17,13 +17,13 @@ package build.buildfarm.instance.server;
 import static build.buildfarm.common.Actions.checkPreconditionFailure;
 import static build.buildfarm.common.Errors.VIOLATION_TYPE_INVALID;
 import static build.buildfarm.common.Errors.VIOLATION_TYPE_MISSING;
-import static build.buildfarm.instance.server.AbstractServerInstance.ACTION_INPUT_ROOT_DIRECTORY_PATH;
-import static build.buildfarm.instance.server.AbstractServerInstance.DIRECTORY_NOT_SORTED;
-import static build.buildfarm.instance.server.AbstractServerInstance.DUPLICATE_DIRENT;
-import static build.buildfarm.instance.server.AbstractServerInstance.INVALID_COMMAND;
-import static build.buildfarm.instance.server.AbstractServerInstance.OUTPUT_DIRECTORY_IS_OUTPUT_ANCESTOR;
-import static build.buildfarm.instance.server.AbstractServerInstance.OUTPUT_FILE_IS_OUTPUT_ANCESTOR;
-import static build.buildfarm.instance.server.AbstractServerInstance.SYMLINK_TARGET_ABSOLUTE;
+import static build.buildfarm.instance.server.NodeInstance.ACTION_INPUT_ROOT_DIRECTORY_PATH;
+import static build.buildfarm.instance.server.NodeInstance.DIRECTORY_NOT_SORTED;
+import static build.buildfarm.instance.server.NodeInstance.DUPLICATE_DIRENT;
+import static build.buildfarm.instance.server.NodeInstance.INVALID_COMMAND;
+import static build.buildfarm.instance.server.NodeInstance.OUTPUT_DIRECTORY_IS_OUTPUT_ANCESTOR;
+import static build.buildfarm.instance.server.NodeInstance.OUTPUT_FILE_IS_OUTPUT_ANCESTOR;
+import static build.buildfarm.instance.server.NodeInstance.SYMLINK_TARGET_ABSOLUTE;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static org.mockito.Mockito.any;
@@ -99,10 +99,10 @@ import org.mockito.stubbing.Answer;
 
 @RunWith(JUnit4.class)
 @Log
-public class AbstractServerInstanceTest {
+public class NodeInstanceTest {
   private static final DigestUtil DIGEST_UTIL = new DigestUtil(HashFunction.SHA256);
 
-  static class DummyServerInstance extends AbstractServerInstance {
+  static class DummyServerInstance extends NodeInstance {
     DummyServerInstance(
         ContentAddressableStorage contentAddressableStorage, ActionCache actionCache) {
       super(
@@ -261,7 +261,7 @@ public class AbstractServerInstanceTest {
   @Test
   public void duplicateFileInputIsInvalid() {
     PreconditionFailure.Builder preconditionFailure = PreconditionFailure.newBuilder();
-    AbstractServerInstance.validateActionInputDirectory(
+    NodeInstance.validateActionInputDirectory(
         ACTION_INPUT_ROOT_DIRECTORY_PATH,
         Directory.newBuilder()
             .addAllFiles(
@@ -290,7 +290,7 @@ public class AbstractServerInstanceTest {
     Directory emptyDirectory = Directory.getDefaultInstance();
     Digest emptyDirectoryDigest = DIGEST_UTIL.compute(emptyDirectory);
     PreconditionFailure.Builder preconditionFailure = PreconditionFailure.newBuilder();
-    AbstractServerInstance.validateActionInputDirectory(
+    NodeInstance.validateActionInputDirectory(
         ACTION_INPUT_ROOT_DIRECTORY_PATH,
         Directory.newBuilder()
             .addAllDirectories(
@@ -320,7 +320,7 @@ public class AbstractServerInstanceTest {
   @Test
   public void unsortedFileInputIsInvalid() {
     PreconditionFailure.Builder preconditionFailure = PreconditionFailure.newBuilder();
-    AbstractServerInstance.validateActionInputDirectory(
+    NodeInstance.validateActionInputDirectory(
         ACTION_INPUT_ROOT_DIRECTORY_PATH,
         Directory.newBuilder()
             .addAllFiles(
@@ -349,7 +349,7 @@ public class AbstractServerInstanceTest {
     Directory emptyDirectory = Directory.getDefaultInstance();
     Digest emptyDirectoryDigest = DIGEST_UTIL.compute(emptyDirectory);
     PreconditionFailure.Builder preconditionFailure = PreconditionFailure.newBuilder();
-    AbstractServerInstance.validateActionInputDirectory(
+    NodeInstance.validateActionInputDirectory(
         ACTION_INPUT_ROOT_DIRECTORY_PATH,
         Directory.newBuilder()
             .addAllDirectories(
@@ -384,7 +384,7 @@ public class AbstractServerInstanceTest {
     Directory emptyDirectory = Directory.getDefaultInstance();
     Digest emptyDirectoryDigest = DIGEST_UTIL.compute(emptyDirectory);
     PreconditionFailure.Builder preconditionFailure = PreconditionFailure.newBuilder();
-    AbstractServerInstance.validateActionInputDirectory(
+    NodeInstance.validateActionInputDirectory(
         ACTION_INPUT_ROOT_DIRECTORY_PATH,
         Directory.newBuilder()
             .addAllDirectories(
@@ -422,7 +422,7 @@ public class AbstractServerInstanceTest {
         Directory.newBuilder()
             .addSymlinks(SymlinkNode.newBuilder().setName("foo").setTarget("/root/secret").build())
             .build();
-    AbstractServerInstance.validateActionInputDirectory(
+    NodeInstance.validateActionInputDirectory(
         ACTION_INPUT_ROOT_DIRECTORY_PATH,
         absoluteSymlinkDirectory,
         /* pathDigests=*/ new Stack<>(),
@@ -442,7 +442,7 @@ public class AbstractServerInstanceTest {
 
     // valid for allowed
     preconditionFailure = PreconditionFailure.newBuilder();
-    AbstractServerInstance.validateActionInputDirectory(
+    NodeInstance.validateActionInputDirectory(
         ACTION_INPUT_ROOT_DIRECTORY_PATH,
         absoluteSymlinkDirectory,
         /* pathDigests=*/ new Stack<>(),
@@ -459,7 +459,7 @@ public class AbstractServerInstanceTest {
   @Test
   public void nestedOutputDirectoriesAreInvalid() {
     PreconditionFailure.Builder preconditionFailureBuilder = PreconditionFailure.newBuilder();
-    AbstractServerInstance.validateOutputs(
+    NodeInstance.validateOutputs(
         ImmutableSet.of(),
         ImmutableSet.of(),
         ImmutableSet.of(),
@@ -476,7 +476,7 @@ public class AbstractServerInstanceTest {
   @Test
   public void outputDirectoriesContainingOutputFilesAreInvalid() {
     PreconditionFailure.Builder preconditionFailureBuilder = PreconditionFailure.newBuilder();
-    AbstractServerInstance.validateOutputs(
+    NodeInstance.validateOutputs(
         ImmutableSet.of(),
         ImmutableSet.of(),
         ImmutableSet.of("foo/bar"),
@@ -493,7 +493,7 @@ public class AbstractServerInstanceTest {
   @Test
   public void outputFilesAsOutputDirectoryAncestorsAreInvalid() {
     PreconditionFailure.Builder preconditionFailureBuilder = PreconditionFailure.newBuilder();
-    AbstractServerInstance.validateOutputs(
+    NodeInstance.validateOutputs(
         ImmutableSet.of(),
         ImmutableSet.of(),
         ImmutableSet.of("foo"),
@@ -509,7 +509,7 @@ public class AbstractServerInstanceTest {
 
   @Test
   public void emptyArgumentListIsInvalid() {
-    AbstractServerInstance instance = new DummyServerInstance();
+    NodeInstance instance = new DummyServerInstance();
 
     PreconditionFailure.Builder preconditionFailureBuilder = PreconditionFailure.newBuilder();
     instance.validateCommand(
@@ -529,7 +529,7 @@ public class AbstractServerInstanceTest {
 
   @Test
   public void absoluteWorkingDirectoryIsInvalid() {
-    AbstractServerInstance instance = new DummyServerInstance();
+    NodeInstance instance = new DummyServerInstance();
 
     PreconditionFailure.Builder preconditionFailureBuilder = PreconditionFailure.newBuilder();
     instance.validateCommand(
@@ -549,7 +549,7 @@ public class AbstractServerInstanceTest {
 
   @Test
   public void undeclaredWorkingDirectoryIsInvalid() {
-    AbstractServerInstance instance = new DummyServerInstance();
+    NodeInstance instance = new DummyServerInstance();
 
     Digest inputRootDigest = DIGEST_UTIL.compute(Directory.getDefaultInstance());
     PreconditionFailure.Builder preconditionFailureBuilder = PreconditionFailure.newBuilder();
@@ -590,7 +590,7 @@ public class AbstractServerInstanceTest {
                         .setDigest(missingDirectoryDigest)
                         .build()))
             .build();
-    AbstractServerInstance.validateActionInputDirectory(
+    NodeInstance.validateActionInputDirectory(
         ACTION_INPUT_ROOT_DIRECTORY_PATH,
         root,
         /* pathDigests=*/ new Stack<>(),
@@ -652,7 +652,7 @@ public class AbstractServerInstanceTest {
                     DirectoryNode.newBuilder().setName("bar").setDigest(fooDigest).build(),
                     DirectoryNode.newBuilder().setName("foo").setDigest(fooDigest).build()))
             .build();
-    AbstractServerInstance.validateActionInputDirectory(
+    NodeInstance.validateActionInputDirectory(
         ACTION_INPUT_ROOT_DIRECTORY_PATH,
         root,
         /* pathDigests=*/ new Stack<>(),
@@ -721,7 +721,7 @@ public class AbstractServerInstanceTest {
             .build();
     ContentAddressableStorage contentAddressableStorage = mock(ContentAddressableStorage.class);
     ActionCache actionCache = mock(ActionCache.class);
-    AbstractServerInstance instance =
+    NodeInstance instance =
         new DummyServerInstance(contentAddressableStorage, actionCache);
 
     Tree tree =
@@ -782,7 +782,7 @@ public class AbstractServerInstanceTest {
     Digest expectedDigest = contentDigest.toBuilder().setSizeBytes(-1).build();
 
     ContentAddressableStorage contentAddressableStorage = mock(ContentAddressableStorage.class);
-    AbstractServerInstance instance = new DummyServerInstance(contentAddressableStorage, null);
+    NodeInstance instance = new DummyServerInstance(contentAddressableStorage, null);
     RequestMetadata requestMetadata = RequestMetadata.getDefaultInstance();
     Write write = mock(Write.class);
 

--- a/src/test/java/build/buildfarm/instance/shard/BUILD
+++ b/src/test/java/build/buildfarm/instance/shard/BUILD
@@ -110,10 +110,10 @@ java_test(
 )
 
 java_test(
-    name = "ShardInstanceTest",
+    name = "ServerInstanceTest",
     size = "small",
     srcs = [
-        "ShardInstanceTest.java",
+        "ServerInstanceTest.java",
         "UnobservableWatcher.java",
     ],
     data = ["//examples:example_configs"],

--- a/src/test/java/build/buildfarm/instance/shard/ServerInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/shard/ServerInstanceTest.java
@@ -20,9 +20,9 @@ import static build.bazel.remote.execution.v2.ExecutionStage.Value.QUEUED;
 import static build.buildfarm.common.Actions.invalidActionVerboseMessage;
 import static build.buildfarm.common.Errors.VIOLATION_TYPE_INVALID;
 import static build.buildfarm.common.Errors.VIOLATION_TYPE_MISSING;
-import static build.buildfarm.instance.server.AbstractServerInstance.INVALID_PLATFORM;
-import static build.buildfarm.instance.server.AbstractServerInstance.MISSING_ACTION;
-import static build.buildfarm.instance.server.AbstractServerInstance.MISSING_COMMAND;
+import static build.buildfarm.instance.server.NodeInstance.INVALID_PLATFORM;
+import static build.buildfarm.instance.server.NodeInstance.MISSING_ACTION;
+import static build.buildfarm.instance.server.NodeInstance.MISSING_COMMAND;
 import static com.google.common.base.Predicates.notNull;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
@@ -121,14 +121,14 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.stubbing.Answer;
 
 @RunWith(JUnit4.class)
-public class ShardInstanceTest {
+public class ServerInstanceTest {
   private static final DigestUtil DIGEST_UTIL = new DigestUtil(HashFunction.SHA256);
   private static final long QUEUE_TEST_TIMEOUT_SECONDS = 3;
   private static final Duration DEFAULT_TIMEOUT = Durations.fromSeconds(60);
   private static final Command SIMPLE_COMMAND =
       Command.newBuilder().addAllArguments(ImmutableList.of("true")).build();
 
-  private ShardInstance instance;
+  private ServerInstance instance;
   private Map<String, Long> blobDigests;
 
   @Mock private Backplane mockBackplane;
@@ -145,7 +145,7 @@ public class ShardInstanceTest {
     blobDigests = Maps.newHashMap();
     ActionCache actionCache = new ShardActionCache(10, mockBackplane, newDirectExecutorService());
     instance =
-        new ShardInstance(
+        new ServerInstance(
             "shard",
             DIGEST_UTIL,
             mockBackplane,

--- a/src/test/java/build/buildfarm/worker/shard/WorkerInstanceTest.java
+++ b/src/test/java/build/buildfarm/worker/shard/WorkerInstanceTest.java
@@ -50,19 +50,19 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 @RunWith(JUnit4.class)
-public class ShardWorkerInstanceTest {
+public class WorkerInstanceTest {
   private final DigestUtil DIGEST_UTIL = new DigestUtil(HashFunction.SHA256);
 
   @Mock private Backplane backplane;
 
   @Mock private ContentAddressableStorage storage;
 
-  private ShardWorkerInstance instance;
+  private WorkerInstance instance;
 
   @Before
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
-    instance = new ShardWorkerInstance("test", DIGEST_UTIL, backplane, storage);
+    instance = new WorkerInstance("test", DIGEST_UTIL, backplane, storage);
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
This is the current hierarchy.  Some of the names make it confusing.
 - `ShardInstance` is only used by Server.  It should mention server so we don't confuse it with worker logic.
 - `AbstractServerInstance` is used by workers - not just servers
 
![Screenshot from 2023-10-29 23-23-35](https://github.com/bazelbuild/bazel-buildfarm/assets/1312081/c7fcf04f-8b42-4dd1-812b-0704fa53f80b)

After renames:
![Screenshot from 2023-10-29 23-25-30](https://github.com/bazelbuild/bazel-buildfarm/assets/1312081/9d1119be-ee47-4a5f-a286-5c33c19e68cf)
