### PR TITLE
Update zstd-jni for latest version

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -68,7 +68,7 @@ def buildfarm_init(name = "buildfarm"):
                         "com.github.jnr:jnr-posix:3.0.53",
                         "com.github.pcj:google-options:1.0.0",
                         "com.github.serceman:jnr-fuse:0.5.5",
-                        "com.github.luben:zstd-jni:1.5.2-1",
+                        "com.github.luben:zstd-jni:1.5.5-7",
                         "com.github.oshi:oshi-core:6.4.0",
                         "com.google.auth:google-auth-library-credentials:0.9.1",
                         "com.google.auth:google-auth-library-oauth2-http:0.9.1",


### PR DESCRIPTION
There's been a few releases of it by now and this pulls the latest. For buildfarm, notable changes included performance enhancments during decompression.

See:
https://github.com/facebook/zstd/releases/tag/v1.5.5