### PR TITLE
Incremental changes for read through

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -151,9 +151,11 @@ def archive_dependencies(third_party):
         },
         {
             "name": "rules_oss_audit",
-            "sha256": "02962810bcf82d0c66f929ccc163423f53773b8b154574ca956345523243e70d",
-            "strip_prefix": "rules_oss_audit-1b2690cefd5a960c181e0d89bf3c076294a0e6f4",
-            "url": "https://github.com/vmware/rules_oss_audit/archive/1b2690cefd5a960c181e0d89bf3c076294a0e6f4.zip",
+            "sha256": "8ee8376b05b5ddd2287b070e9a88ec85ef907d47f44e321ce5d4bc2b192eed4e",
+            "strip_prefix": "rules_oss_audit-167dab5b16abdb5996438f22364de544ff24693f",
+            "url": "https://github.com/vmware/rules_oss_audit/archive/167dab5b16abdb5996438f22364de544ff24693f.zip",
+            "patch_args": ["-p1"],
+            "patches": ["%s:rules_oss_audit_pyyaml.patch" % third_party],
         },
     ]
 

--- a/src/main/java/build/buildfarm/cas/BUILD
+++ b/src/main/java/build/buildfarm/cas/BUILD
@@ -27,6 +27,7 @@ java_library(
         "@maven//:io_grpc_grpc_core",
         "@maven//:io_grpc_grpc_protobuf",
         "@maven//:io_grpc_grpc_stub",
+        "@maven//:io_netty_netty_codec_http",
         "@maven//:io_prometheus_simpleclient",
         "@maven//:net_jcip_jcip_annotations",
         "@maven//:org_projectlombok_lombok",

--- a/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
+++ b/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
@@ -1917,7 +1917,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
       lock = keyLocks.get(key);
     } catch (ExecutionException e) {
       // impossible without exception instantiating lock
-      throw new RuntimeException(e);
+      throw new RuntimeException(e.getCause());
     }
 
     lock.lock();

--- a/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
+++ b/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
@@ -92,6 +92,7 @@ import io.grpc.Deadline;
 import io.grpc.StatusException;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.ServerCallStreamObserver;
+import io.netty.handler.codec.http.QueryStringDecoder;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Gauge;
 import io.prometheus.client.Histogram;
@@ -99,6 +100,8 @@ import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.channels.ClosedByInterruptException;
 import java.nio.channels.ClosedChannelException;
 import java.nio.file.FileAlreadyExistsException;
@@ -606,6 +609,20 @@ public abstract class CASFileCache implements ContentAddressableStorage {
 
   private static final int CHUNK_SIZE = 128 * 1024;
 
+  private static boolean shouldReadThrough(RequestMetadata requestMetadata) {
+    try {
+      URI uri = new URI(requestMetadata.getCorrelatedInvocationsId());
+      QueryStringDecoder decoder = new QueryStringDecoder(uri);
+      return decoder
+          .parameters()
+          .getOrDefault("THROUGH", ImmutableList.of("false"))
+          .get(0)
+          .equals("true");
+    } catch (URISyntaxException e) {
+      return false;
+    }
+  }
+
   @Override
   public void get(
       Compressor.Value compressor,
@@ -614,9 +631,28 @@ public abstract class CASFileCache implements ContentAddressableStorage {
       long count,
       ServerCallStreamObserver<ByteString> blobObserver,
       RequestMetadata requestMetadata) {
+    boolean readThrough = shouldReadThrough(requestMetadata);
     InputStream in;
     try {
-      in = newInput(compressor, digest, offset);
+      if (readThrough && !contains(digest, /* result=*/ null)) {
+        // really need to be able to reuse/restart the same write over
+        // multiple requests - if we get successive read throughs for a single
+        // digest, we should pick up from where we were last time
+        // Also servers should affinitize
+        // And share data, so that they can pick the same worker to pull from
+        // if possible.
+        Write write = getWrite(compressor, digest, UUID.randomUUID(), requestMetadata);
+        blobObserver.setOnCancelHandler(write::reset);
+        in =
+            new ReadThroughInputStream(
+                newExternalInput(compressor, digest, 0),
+                localOffset -> newTransparentInput(compressor, digest, localOffset),
+                digest.getSizeBytes(),
+                offset,
+                write);
+      } else {
+        in = newInput(compressor, digest, offset);
+      }
     } catch (IOException e) {
       blobObserver.onError(e);
       return;

--- a/src/main/java/build/buildfarm/common/config/BuildfarmConfigs.java
+++ b/src/main/java/build/buildfarm/common/config/BuildfarmConfigs.java
@@ -109,6 +109,9 @@ public final class BuildfarmConfigs {
     if (!Strings.isNullOrEmpty(options.redisUri)) {
       buildfarmConfigs.getBackplane().setRedisUri(options.redisUri);
     }
+    if (!Strings.isNullOrEmpty(options.root)) {
+      buildfarmConfigs.getWorker().setRoot(options.root);
+    }
     adjustWorkerConfigs(buildfarmConfigs);
     return buildfarmConfigs;
   }

--- a/src/main/java/build/buildfarm/common/config/BuildfarmConfigs.java
+++ b/src/main/java/build/buildfarm/common/config/BuildfarmConfigs.java
@@ -72,7 +72,7 @@ public final class BuildfarmConfigs {
       log.severe("Could not parse yml configuration file." + e);
       throw new RuntimeException(e);
     }
-    if (!options.publicName.isEmpty()) {
+    if (!Strings.isNullOrEmpty(options.publicName)) {
       buildfarmConfigs.getServer().setPublicName(options.publicName);
     }
     if (options.port > 0) {

--- a/src/main/java/build/buildfarm/common/config/BuildfarmConfigs.java
+++ b/src/main/java/build/buildfarm/common/config/BuildfarmConfigs.java
@@ -100,6 +100,9 @@ public final class BuildfarmConfigs {
     if (!Strings.isNullOrEmpty(options.publicName)) {
       buildfarmConfigs.getWorker().setPublicName(options.publicName);
     }
+    if (options.port >= 0) {
+      buildfarmConfigs.getWorker().setPort(options.port);
+    }
     if (options.prometheusPort >= 0) {
       buildfarmConfigs.setPrometheusPort(options.prometheusPort);
     }

--- a/src/main/java/build/buildfarm/common/config/BuildfarmOptions.java
+++ b/src/main/java/build/buildfarm/common/config/BuildfarmOptions.java
@@ -33,4 +33,7 @@ public class BuildfarmOptions extends OptionsBase {
       help = "URI for Redis connection. Use 'redis://' or 'rediss://' for the scheme",
       defaultValue = "")
   public String redisUri;
+
+  @Option(name = "port", help = "Port for the buildfarm service.", defaultValue = "-1")
+  public int port;
 }

--- a/src/main/java/build/buildfarm/common/config/ServerOptions.java
+++ b/src/main/java/build/buildfarm/common/config/ServerOptions.java
@@ -18,9 +18,6 @@ import com.google.devtools.common.options.Option;
 
 /** Command-line options definition for example server. */
 public class ServerOptions extends BuildfarmOptions {
-  @Option(name = "port", abbrev = 'p', help = "Port to use.", defaultValue = "-1")
-  public int port;
-
   @Option(name = "public_name", abbrev = 'n', help = "Name of this server.", defaultValue = "")
   public String publicName;
 }

--- a/src/main/java/build/buildfarm/server/BuildFarmServer.java
+++ b/src/main/java/build/buildfarm/server/BuildFarmServer.java
@@ -195,8 +195,10 @@ public class BuildFarmServer extends LoggingMain {
   private void shutdown() throws InterruptedException {
     log.info("*** shutting down gRPC server since JVM is shutting down");
     prepareServerForGracefulShutdown();
-    healthStatusManager.setStatus(
-        HealthStatusManager.SERVICE_NAME_ALL_SERVICES, ServingStatus.NOT_SERVING);
+    if (healthStatusManager != null) {
+      healthStatusManager.setStatus(
+          HealthStatusManager.SERVICE_NAME_ALL_SERVICES, ServingStatus.NOT_SERVING);
+    }
     PrometheusPublisher.stopHttpServer();
     healthCheckMetric.labels("stop").inc();
     try {

--- a/src/main/java/build/buildfarm/tools/Executor.java
+++ b/src/main/java/build/buildfarm/tools/Executor.java
@@ -238,7 +238,7 @@ class Executor {
 
     ByteStreamStub bsStub = ByteStreamGrpc.newStub(channel);
     for (Digest missingDigest : missingDigests) {
-      Path path = blobsDir.resolve(missingDigest.getHash() + "_" + missingDigest.getSizeBytes());
+      Path path = blobsDir.resolve(missingDigest.getHash());
       if (missingDigest.getSizeBytes() < Size.mbToBytes(1)) {
         Request request =
             Request.newBuilder()

--- a/third_party/rules_oss_audit_pyyaml.patch
+++ b/third_party/rules_oss_audit_pyyaml.patch
@@ -1,0 +1,7 @@
+diff --git a/oss_audit/tools/requirements.txt b/oss_audit/tools/requirements.txt
+index 932bd69..be2b74d 100644
+--- a/oss_audit/tools/requirements.txt
++++ b/oss_audit/tools/requirements.txt
+@@ -1 +1 @@
+-PyYAML==5.4.1
++PyYAML==6.0.1


### PR DESCRIPTION
Intended for rebase:
Make bf-executor small blob names consistent
Restore worker --root cmdline specification
Add --port option to worker
Read through external with query THROUGH=true
Consistent check for publicName presence
Prevent healthStatusManager NPE on start failure
Bump rules_oss_audit and patch for py3.11
Technically correct to unwrap EE on lock failure