### PR TITLE
Check for context cancelled before responding to error

### DIFF
--- a/src/main/java/build/buildfarm/common/services/WriteStreamObserver.java
+++ b/src/main/java/build/buildfarm/common/services/WriteStreamObserver.java
@@ -271,7 +271,8 @@ public class WriteStreamObserver implements StreamObserver<WriteRequest> {
 
   private boolean errorResponse(Throwable t) {
     if (exception.compareAndSet(null, t)) {
-      if (Status.fromThrowable(t).getCode() == Status.Code.CANCELLED || Context.current().isCancelled()) {
+      if (Status.fromThrowable(t).getCode() == Status.Code.CANCELLED
+          || Context.current().isCancelled()) {
         return false;
       }
       boolean isEntryLimitException = t instanceof EntryLimitException;

--- a/src/main/java/build/buildfarm/common/services/WriteStreamObserver.java
+++ b/src/main/java/build/buildfarm/common/services/WriteStreamObserver.java
@@ -271,7 +271,7 @@ public class WriteStreamObserver implements StreamObserver<WriteRequest> {
 
   private boolean errorResponse(Throwable t) {
     if (exception.compareAndSet(null, t)) {
-      if (Status.fromThrowable(t).getCode() == Status.Code.CANCELLED) {
+      if (Status.fromThrowable(t).getCode() == Status.Code.CANCELLED || withCancellation.isCancelled()) {
         return false;
       }
       boolean isEntryLimitException = t instanceof EntryLimitException;

--- a/src/main/java/build/buildfarm/common/services/WriteStreamObserver.java
+++ b/src/main/java/build/buildfarm/common/services/WriteStreamObserver.java
@@ -271,7 +271,7 @@ public class WriteStreamObserver implements StreamObserver<WriteRequest> {
 
   private boolean errorResponse(Throwable t) {
     if (exception.compareAndSet(null, t)) {
-      if (Status.fromThrowable(t).getCode() == Status.Code.CANCELLED || withCancellation.isCancelled()) {
+      if (Status.fromThrowable(t).getCode() == Status.Code.CANCELLED || Context.current().isCancelled()) {
         return false;
       }
       boolean isEntryLimitException = t instanceof EntryLimitException;

--- a/src/test/java/build/buildfarm/common/services/WriteStreamObserverTest.java
+++ b/src/test/java/build/buildfarm/common/services/WriteStreamObserverTest.java
@@ -115,11 +115,11 @@ public class WriteStreamObserverTest {
     WriteStreamObserver observer =
             context.call(
                     () -> new WriteStreamObserver(instance, 1, SECONDS, () -> {}, responseObserver));
-    observer.onNext(
+    context.run(() -> observer.onNext(
             WriteRequest.newBuilder()
                     .setResourceName(uploadResourceName(uploadBlobRequest))
                     .setData(cancelled)
-                    .build());
+                    .build()));
     verify(instance, times(1))
             .getBlobWrite(
                     eq(Compressor.Value.IDENTITY),

--- a/src/test/java/build/buildfarm/common/services/WriteStreamObserverTest.java
+++ b/src/test/java/build/buildfarm/common/services/WriteStreamObserverTest.java
@@ -2,7 +2,14 @@ package build.buildfarm.common.services;
 
 import static build.buildfarm.common.resources.ResourceParser.uploadResourceName;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
 
 import build.bazel.remote.execution.v2.Compressor;
 import build.bazel.remote.execution.v2.Digest;

--- a/src/test/java/build/buildfarm/common/services/WriteStreamObserverTest.java
+++ b/src/test/java/build/buildfarm/common/services/WriteStreamObserverTest.java
@@ -16,7 +16,6 @@ import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.RequestMetadata;
 import build.buildfarm.common.DigestUtil;
 import build.buildfarm.common.DigestUtil.HashFunction;
-import build.buildfarm.common.EntryLimitException;
 import build.buildfarm.common.Write;
 import build.buildfarm.common.io.FeedbackOutputStream;
 import build.buildfarm.common.resources.BlobInformation;
@@ -24,7 +23,6 @@ import build.buildfarm.common.resources.UploadBlobRequest;
 import build.buildfarm.instance.Instance;
 import com.google.bytestream.ByteStreamProto.WriteRequest;
 import com.google.bytestream.ByteStreamProto.WriteResponse;
-import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.protobuf.ByteString;
 import io.grpc.Context;
@@ -37,7 +35,6 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 
 @RunWith(JUnit4.class)


### PR DESCRIPTION
When a write fails because the write was already cancelled before due to something like deadline exceeded, we get an unknown error. The exception comes from [here](https://github.com/bazelbuild/bazel-buildfarm/blob/main/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java#L227) and when it gets to `errorResponse()`, it only checks if status code is cancelled. In this case the status code is unknown, so we need to check if context is cancelled to prevent `responseObserver` from being invoked

The code change adds checking if context is cancelled and a unit test testing when the exception has context cancelled.