### PR TITLE
Worker name execution properties matching

### DIFF
--- a/src/main/java/build/buildfarm/common/ExecutionProperties.java
+++ b/src/main/java/build/buildfarm/common/ExecutionProperties.java
@@ -293,4 +293,11 @@ public class ExecutionProperties {
    *     operation queue).
    */
   public static final String POOL = "Pool";
+
+  /**
+   * @field WORKER
+   * @brief The exec_property to ensure that the action only runs on the worker name given.
+   * @details Useful for diagnosing woker issues by targeting builds to a specific worker.
+   */
+  public static final String WORKER = "Worker";
 }

--- a/src/main/java/build/buildfarm/worker/DequeueMatchEvaluator.java
+++ b/src/main/java/build/buildfarm/worker/DequeueMatchEvaluator.java
@@ -46,6 +46,7 @@ public class DequeueMatchEvaluator {
    * @brief Decide whether the worker should keep the operation or put it back on the queue.
    * @details Compares the platform properties of the worker to the operation's platform properties.
    * @param workerProvisions The provisions of the worker.
+   * @param name Worker name.
    * @param resourceSet The limited resources that the worker has available.
    * @param queueEntry An entry recently removed from the queue.
    * @return Whether or not the worker should accept or reject the queue entry.
@@ -56,9 +57,10 @@ public class DequeueMatchEvaluator {
   @NotNull
   public static boolean shouldKeepOperation(
       SetMultimap<String, String> workerProvisions,
+      String name,
       LocalResourceSet resourceSet,
       QueueEntry queueEntry) {
-    return shouldKeepViaPlatform(workerProvisions, resourceSet, queueEntry.getPlatform());
+    return shouldKeepViaPlatform(workerProvisions, name, resourceSet, queueEntry.getPlatform());
   }
 
   /**
@@ -67,6 +69,7 @@ public class DequeueMatchEvaluator {
    * @details Compares the platform properties of the worker to the platform properties of the
    *     operation.
    * @param workerProvisions The provisions of the worker.
+   * @param name Worker name.
    * @param resourceSet The limited resources that the worker has available.
    * @param platform The platforms of operation.
    * @return Whether or not the worker should accept or reject the operation.
@@ -76,6 +79,7 @@ public class DequeueMatchEvaluator {
   @NotNull
   private static boolean shouldKeepViaPlatform(
       SetMultimap<String, String> workerProvisions,
+      String name,
       LocalResourceSet resourceSet,
       Platform platform) {
     // attempt to execute everything the worker gets off the queue,
@@ -84,11 +88,28 @@ public class DequeueMatchEvaluator {
     if (!LocalResourceSetUtils.claimResources(platform, resourceSet)) {
       return false;
     }
+
+    // The action might be requesting to run on a particular action
+    if (!keepForThisWorker(platform, name)) {
+      return false;
+    }
+
     if (configs.getWorker().getDequeueMatchSettings().isAcceptEverything()) {
       return true;
     }
 
     return satisfiesProperties(workerProvisions, platform);
+  }
+
+  private static boolean keepForThisWorker(Platform platform, String name) {
+    for (Platform.Property property : platform.getPropertiesList()) {
+      if (property.getName().equals(ExecutionProperties.WORKER)
+          && !property.getValue().equals(name)) {
+        // requested worker does not match this worker, reject
+        return false;
+      }
+    }
+    return true;
   }
 
   /**

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -315,7 +315,8 @@ class ShardWorkerContext implements WorkerContext {
   private void decideWhetherToKeepOperation(QueueEntry queueEntry, MatchListener listener)
       throws IOException, InterruptedException {
     if (queueEntry == null
-        || DequeueMatchEvaluator.shouldKeepOperation(matchProvisions, resourceSet, queueEntry)) {
+        || DequeueMatchEvaluator.shouldKeepOperation(
+            matchProvisions, name, resourceSet, queueEntry)) {
       listener.onEntry(queueEntry);
     } else {
       backplane.rejectOperation(queueEntry);

--- a/src/test/java/build/buildfarm/worker/DequeueMatchEvaluatorTest.java
+++ b/src/test/java/build/buildfarm/worker/DequeueMatchEvaluatorTest.java
@@ -59,7 +59,8 @@ public class DequeueMatchEvaluatorTest {
 
     // ACT
     boolean shouldKeep =
-        DequeueMatchEvaluator.shouldKeepOperation(workerProvisions, resourceSet, entry);
+        DequeueMatchEvaluator.shouldKeepOperation(
+            workerProvisions, "worker-name", resourceSet, entry);
 
     // ASSERT
     assertThat(shouldKeep).isTrue();
@@ -87,7 +88,8 @@ public class DequeueMatchEvaluatorTest {
 
     // ACT
     boolean shouldKeep =
-        DequeueMatchEvaluator.shouldKeepOperation(workerProvisions, resourceSet, entry);
+        DequeueMatchEvaluator.shouldKeepOperation(
+            workerProvisions, "worker-name", resourceSet, entry);
 
     // ASSERT
     // the worker accepts because it has more cores than the min-cores requested
@@ -117,7 +119,8 @@ public class DequeueMatchEvaluatorTest {
 
     // ACT
     boolean shouldKeep =
-        DequeueMatchEvaluator.shouldKeepOperation(workerProvisions, resourceSet, entry);
+        DequeueMatchEvaluator.shouldKeepOperation(
+            workerProvisions, "worker-name", resourceSet, entry);
 
     // ASSERT
     // the worker rejects because it has less cores than the min-cores requested
@@ -146,7 +149,8 @@ public class DequeueMatchEvaluatorTest {
 
     // ACT
     boolean shouldKeep =
-        DequeueMatchEvaluator.shouldKeepOperation(workerProvisions, resourceSet, entry);
+        DequeueMatchEvaluator.shouldKeepOperation(
+            workerProvisions, "worker-name", resourceSet, entry);
 
     // ASSERT
     // the worker accepts because it has the same cores as the min-cores requested
@@ -175,7 +179,8 @@ public class DequeueMatchEvaluatorTest {
 
     // ACT
     boolean shouldKeep =
-        DequeueMatchEvaluator.shouldKeepOperation(workerProvisions, resourceSet, entry);
+        DequeueMatchEvaluator.shouldKeepOperation(
+            workerProvisions, "worker-name", resourceSet, entry);
 
     // ASSERT
     assertThat(shouldKeep).isFalse();
@@ -184,7 +189,9 @@ public class DequeueMatchEvaluatorTest {
     configs.getWorker().getDequeueMatchSettings().setAcceptEverything(true);
 
     // ACT
-    shouldKeep = DequeueMatchEvaluator.shouldKeepOperation(workerProvisions, resourceSet, entry);
+    shouldKeep =
+        DequeueMatchEvaluator.shouldKeepOperation(
+            workerProvisions, "worker-name", resourceSet, entry);
 
     // ASSERT
     assertThat(shouldKeep).isTrue();
@@ -193,7 +200,9 @@ public class DequeueMatchEvaluatorTest {
     configs.getWorker().getDequeueMatchSettings().setAllowUnmatched(true);
 
     // ACT
-    shouldKeep = DequeueMatchEvaluator.shouldKeepOperation(workerProvisions, resourceSet, entry);
+    shouldKeep =
+        DequeueMatchEvaluator.shouldKeepOperation(
+            workerProvisions, "worker-name", resourceSet, entry);
 
     // ASSERT
     assertThat(shouldKeep).isTrue();
@@ -224,7 +233,8 @@ public class DequeueMatchEvaluatorTest {
 
     // ACT
     boolean shouldKeep =
-        DequeueMatchEvaluator.shouldKeepOperation(workerProvisions, resourceSet, entry);
+        DequeueMatchEvaluator.shouldKeepOperation(
+            workerProvisions, "worker-name", resourceSet, entry);
 
     // ASSERT
     // the worker accepts because the resource is available.
@@ -232,7 +242,9 @@ public class DequeueMatchEvaluatorTest {
     assertThat(resourceSet.resources.get("FOO").availablePermits()).isEqualTo(0);
 
     // ACT
-    shouldKeep = DequeueMatchEvaluator.shouldKeepOperation(workerProvisions, resourceSet, entry);
+    shouldKeep =
+        DequeueMatchEvaluator.shouldKeepOperation(
+            workerProvisions, "worker-name", resourceSet, entry);
 
     // ASSERT
     // the worker rejects because there are no resources left.
@@ -269,7 +281,8 @@ public class DequeueMatchEvaluatorTest {
 
     // ACT
     boolean shouldKeep =
-        DequeueMatchEvaluator.shouldKeepOperation(workerProvisions, resourceSet, entry);
+        DequeueMatchEvaluator.shouldKeepOperation(
+            workerProvisions, "worker-name", resourceSet, entry);
 
     // ASSERT
     // the worker accepts because the resource is available.
@@ -278,7 +291,9 @@ public class DequeueMatchEvaluatorTest {
     assertThat(resourceSet.resources.get("BAR").availablePermits()).isEqualTo(2);
 
     // ACT
-    shouldKeep = DequeueMatchEvaluator.shouldKeepOperation(workerProvisions, resourceSet, entry);
+    shouldKeep =
+        DequeueMatchEvaluator.shouldKeepOperation(
+            workerProvisions, "worker-name", resourceSet, entry);
 
     // ASSERT
     // the worker accepts because the resource is available.
@@ -287,7 +302,9 @@ public class DequeueMatchEvaluatorTest {
     assertThat(resourceSet.resources.get("BAR").availablePermits()).isEqualTo(0);
 
     // ACT
-    shouldKeep = DequeueMatchEvaluator.shouldKeepOperation(workerProvisions, resourceSet, entry);
+    shouldKeep =
+        DequeueMatchEvaluator.shouldKeepOperation(
+            workerProvisions, "worker-name", resourceSet, entry);
 
     // ASSERT
     // the worker rejects because there are no resources left.
@@ -330,7 +347,8 @@ public class DequeueMatchEvaluatorTest {
 
     // ACT
     boolean shouldKeep =
-        DequeueMatchEvaluator.shouldKeepOperation(workerProvisions, resourceSet, entry);
+        DequeueMatchEvaluator.shouldKeepOperation(
+            workerProvisions, "worker-name", resourceSet, entry);
 
     // ASSERT
     // the worker rejects because there are no resources left.


### PR DESCRIPTION
Permit an execution to be limited to a single Worker via an execution property that identifies its public name.