### PR TITLE
Reorganize DequeueMatchEvaluator

### DIFF
--- a/_site/docs/architecture/queues.md
+++ b/_site/docs/architecture/queues.md
@@ -41,19 +41,17 @@ Additionally, if the action contains any platform properties is not mentioned by
 setting `allowUnmatched: true` can be used to allow a superset of action properties as long as a subset matches the provision queue.
 If no provision queues can be matched, the operation queue will provide an analysis on why none of the queues were eligible.
 
-When taking elements off of the operation queue, the worker's matching algorithm behaves in a similar manner:
-The worker's `DequeueMatchSettings` also have an `allowUnmatched` property.
-Workers also have the ability to reject an operation after matching with a provision queue and dequeuing a value.
-To avoid any of these rejections by the worker, you can use `acceptEverything: true`.
-
-When configuring your worker, consider the following decisions:
-First, if the `allowEverything` setting is `true`, the job is accepted.
-Otherwise, if any execution property for the queue has a wildcard key, the job is accepted.
-Otherwise, if the `allowUnmatched` setting is `true`, each key present in the queue's properties must be a wildcard or exist in the execution request's properties with an equal value.
-Otherwise, the execution request's properties must have exactly the same set of keys as the queue's execution properties, and the request's value for each property must equal the queue's if the queue's value for this property is not a wildcard.
+A worker will dequeue operations from matching queues and determine whether to keep and execute it according to the following procedure:
+For each property key-value in the operation's platform, an operation is REJECTED if:
+  The key is `min-cores` and the integer value is greater than the number of cores on the worker.
+  Or The key is `min-mem` and the integer value is greater than the number of bytes of RAM on the worker.
+  Or if the key exists in the `DequeueMatchSettings` platform with neither the value nor a `*` in the corresponding DMS platform key's values, 
+  Or if the `allowUnmatched` setting is `false`.
+For each resource requested in the operation's platform with the resource: prefix, the action is rejected if:
+  The resource amount cannot currently be satisfied with the associated resource capacity count
 
 There are special predefined execution property names which resolve to dynamic configuration for the worker to match against:
-`Worker`: The worker's `publicName` with no wildcard resolution
+`Worker`: The worker's `publicName`
 `min-cores`: Less than or equal to the `executeStageWidth`
 `process-wrapper`: The set of named `process-wrappers` present in configuration
 

--- a/_site/docs/configuration/configuration.md
+++ b/_site/docs/configuration/configuration.md
@@ -319,7 +319,6 @@ Note: In order for these settings to take effect, you must also configure `limit
 
 | Configuration    | Accepted and _Default_ Values | Description |
 |------------------|-------------------------------|-------------|
-| acceptEverything | boolean, _true_               |             |
 | allowUnmatched   | boolean, _false_              |             |
 
 Example:
@@ -327,7 +326,6 @@ Example:
 ```yaml
 worker:
   dequeueMatchSettings:
-    acceptEverything: true
     allowUnmatched: false
 ```
 

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -103,7 +103,6 @@ worker:
   inlineContentLimit: 1048567 # 1024 * 1024
   operationPollPeriod: 1
   dequeueMatchSettings:
-    acceptEverything: true
     allowUnmatched: false
   storages:
     - type: FILESYSTEM

--- a/src/main/java/build/buildfarm/common/config/DequeueMatchSettings.java
+++ b/src/main/java/build/buildfarm/common/config/DequeueMatchSettings.java
@@ -3,11 +3,16 @@ package build.buildfarm.common.config;
 import build.bazel.remote.execution.v2.Platform;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.AccessLevel;
 import lombok.Data;
+import lombok.Getter;
 
 @Data
 public class DequeueMatchSettings {
-  private boolean acceptEverything = true;
+
+  @Getter(AccessLevel.NONE)
+  private boolean acceptEverything; // deprecated
+
   private boolean allowUnmatched = false;
   private List<Property> properties = new ArrayList();
 

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -18,6 +18,7 @@ import static build.buildfarm.cas.ContentAddressableStorage.UNLIMITED_ENTRY_SIZE
 import static build.buildfarm.common.Actions.checkPreconditionFailure;
 import static build.buildfarm.common.Errors.VIOLATION_TYPE_INVALID;
 import static build.buildfarm.common.Errors.VIOLATION_TYPE_MISSING;
+import static build.buildfarm.worker.DequeueMatchEvaluator.shouldKeepOperation;
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.DAYS;
 
@@ -38,6 +39,7 @@ import build.buildfarm.common.CommandUtils;
 import build.buildfarm.common.DigestUtil;
 import build.buildfarm.common.DigestUtil.ActionKey;
 import build.buildfarm.common.EntryLimitException;
+import build.buildfarm.common.ExecutionProperties;
 import build.buildfarm.common.InputStreamFactory;
 import build.buildfarm.common.LinuxSandboxOptions;
 import build.buildfarm.common.Poller;
@@ -54,8 +56,6 @@ import build.buildfarm.instance.MatchListener;
 import build.buildfarm.v1test.CASInsertionPolicy;
 import build.buildfarm.v1test.QueueEntry;
 import build.buildfarm.v1test.QueuedOperation;
-import build.buildfarm.worker.DequeueMatchEvaluator;
-import build.buildfarm.worker.DequeueResults;
 import build.buildfarm.worker.ExecutionPolicies;
 import build.buildfarm.worker.RetryingMatchListener;
 import build.buildfarm.worker.WorkerContext;
@@ -137,7 +137,7 @@ class ShardWorkerContext implements WorkerContext {
   private final boolean errorOperationOutputSizeExceeded;
 
   static SetMultimap<String, String> getMatchProvisions(
-      Iterable<ExecutionPolicy> policies, int executeStageWidth) {
+      Iterable<ExecutionPolicy> policies, String name, int executeStageWidth) {
     ImmutableSetMultimap.Builder<String, String> provisions = ImmutableSetMultimap.builder();
     Platform matchPlatform =
         ExecutionPolicies.getMatchPlatform(
@@ -146,6 +146,7 @@ class ShardWorkerContext implements WorkerContext {
       provisions.put(property.getName(), property.getValue());
     }
     provisions.put(PROVISION_CORES_NAME, String.format("%d", executeStageWidth));
+    provisions.put(ExecutionProperties.WORKER, name);
     return provisions.build();
   }
 
@@ -172,7 +173,7 @@ class ShardWorkerContext implements WorkerContext {
       LocalResourceSet resourceSet,
       CasWriter writer) {
     this.name = name;
-    this.matchProvisions = getMatchProvisions(policies, executeStageWidth);
+    this.matchProvisions = getMatchProvisions(policies, name, executeStageWidth);
     this.operationPollPeriod = operationPollPeriod;
     this.operationPoller = operationPoller;
     this.inputFetchStageWidth = inputFetchStageWidth;
@@ -284,10 +285,10 @@ class ShardWorkerContext implements WorkerContext {
   @SuppressWarnings("ConstantConditions")
   private void matchInterruptible(MatchListener listener) throws IOException, InterruptedException {
     QueueEntry queueEntry = takeEntryOffOperationQueue(listener);
-    if (queueEntry == null) {
-      listener.onEntry(null);
+    if (queueEntry == null || shouldKeepOperation(matchProvisions, resourceSet, queueEntry)) {
+      listener.onEntry(queueEntry);
     } else {
-      decideWhetherToKeepOperation(queueEntry, listener);
+      backplane.rejectOperation(queueEntry);
     }
   }
 
@@ -315,23 +316,6 @@ class ShardWorkerContext implements WorkerContext {
     }
     listener.onWaitEnd();
     return queueEntry;
-  }
-
-  private void decideWhetherToKeepOperation(QueueEntry queueEntry, MatchListener listener)
-      throws IOException, InterruptedException {
-    DequeueResults results =
-        DequeueMatchEvaluator.shouldKeepOperation(matchProvisions, name, resourceSet, queueEntry);
-    if (results.keep) {
-      listener.onEntry(queueEntry);
-    } else {
-      if (results.resourcesClaimed) {
-        returnLocalResources(queueEntry);
-      }
-      backplane.rejectOperation(queueEntry);
-    }
-    if (Thread.interrupted()) {
-      throw new InterruptedException();
-    }
   }
 
   @Override


### PR DESCRIPTION
Remove acceptEverything DequeueMatchSetting
Place worker name in workerProvisions
Only enable allowUnmatched effects on key mismatch
Only acquire resources after asserting compatibility
Update documentation to match changes