### PR TITLE
Specify direct guava dependency usage

### DIFF
--- a/persistentworkers/src/test/java/persistent/bazel/BUILD
+++ b/persistentworkers/src/test/java/persistent/bazel/BUILD
@@ -3,6 +3,7 @@ COMMON_DEPS = [
     "//persistentworkers/src/main/java/persistent/bazel:bazel-persistent-workers",
     "//persistentworkers/src/test/java/persistent/testutil:testutil",
     "//persistentworkers/src/main/protobuf:worker_protocol_java_proto",
+    "@maven//:com_google_guava_guava",
     "@maven//:com_google_protobuf_protobuf_java",
     "@maven//:com_google_truth_truth",
     "@maven//:commons_io_commons_io",

--- a/src/test/java/build/buildfarm/common/grpc/BUILD
+++ b/src/test/java/build/buildfarm/common/grpc/BUILD
@@ -23,6 +23,7 @@ java_test(
         "//src/test/java/build/buildfarm:test_runner",
         "@googleapis//:google_bytestream_bytestream_java_grpc",
         "@googleapis//:google_bytestream_bytestream_java_proto",
+        "@maven//:com_google_guava_guava",
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:com_google_truth_truth",
         "@maven//:io_grpc_grpc_api",

--- a/src/test/java/build/buildfarm/common/io/BUILD
+++ b/src/test/java/build/buildfarm/common/io/BUILD
@@ -8,6 +8,7 @@ java_test(
         "//src/test/java/build/buildfarm:test_runner",
         "@googleapis//:google_bytestream_bytestream_java_grpc",
         "@googleapis//:google_bytestream_bytestream_java_proto",
+        "@maven//:com_google_guava_guava",
         "@maven//:com_google_jimfs_jimfs",
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:com_google_truth_truth",

--- a/src/test/java/build/buildfarm/common/redis/BUILD
+++ b/src/test/java/build/buildfarm/common/redis/BUILD
@@ -6,6 +6,7 @@ COMMON_DEPS = [
     "//src/main/protobuf:build_buildfarm_v1test_buildfarm_java_proto",
     "//src/test/java/build/buildfarm:test_runner",
     "//third_party/jedis",
+    "@maven//:com_google_guava_guava",
     "@maven//:com_google_truth_truth",
     "@maven//:io_grpc_grpc_api",
     "@maven//:org_mockito_mockito_core",

--- a/src/test/java/build/buildfarm/common/services/BUILD
+++ b/src/test/java/build/buildfarm/common/services/BUILD
@@ -16,6 +16,7 @@ java_test(
         "//src/test/java/build/buildfarm:test_runner",
         "@googleapis//:google_bytestream_bytestream_java_grpc",
         "@googleapis//:google_bytestream_bytestream_java_proto",
+        "@maven//:com_google_guava_guava",
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:com_google_truth_truth",
         "@maven//:io_grpc_grpc_api",

--- a/src/test/java/build/buildfarm/server/services/BUILD
+++ b/src/test/java/build/buildfarm/server/services/BUILD
@@ -11,6 +11,7 @@ java_test(
         "//src/main/java/build/buildfarm/server/services",
         "//src/main/protobuf:build_buildfarm_v1test_buildfarm_java_proto",
         "//src/test/java/build/buildfarm:test_runner",
+        "@maven//:com_google_guava_guava",
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:com_google_truth_truth",
         "@maven//:io_grpc_grpc_stub",


### PR DESCRIPTION
Testing with bazel HEAD using jdk21 compilation has revealed new direct dependencies on guava.