### PR TITLE
Upgrade com_google_protobuf for jvm compatibility

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -56,7 +56,7 @@ tasks:
   macos:
     name: "Unit Tests"
     environment:
-      BAZEL_USE_XCODE_TOOLCHAIN: 0
+      USE_BAZEL_VERSION: 17be878292730359c9c90efdceabed26126df7ae
     build_flags:
     - "--cxxopt=-std=c++14"
     - "--build_tag_filters=-container"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -55,7 +55,10 @@ tasks:
     - "..."
   macos:
     name: "Unit Tests"
+    environment:
+      BAZEL_USE_XCODE_TOOLCHAIN: 0
     build_flags:
+    - "--cxxopt=-std=c++14"
     - "--build_tag_filters=-container"
     build_targets:
     - "..."

--- a/deps.bzl
+++ b/deps.bzl
@@ -36,9 +36,9 @@ def archive_dependencies(third_party):
         # Needed for "well-known protos" and @com_google_protobuf//:protoc.
         {
             "name": "com_google_protobuf",
-            "sha256": "25f1292d4ea6666f460a2a30038eef121e6c3937ae0f61d610611dfb14b0bd32",
-            "strip_prefix": "protobuf-3.19.1",
-            "urls": ["https://github.com/protocolbuffers/protobuf/archive/v3.19.1.zip"],
+            "sha256": "79082dc68d8bab2283568ce0be3982b73e19ddd647c2411d1977ca5282d2d6b3",
+            "strip_prefix": "protobuf-25.0",
+            "urls": ["https://github.com/protocolbuffers/protobuf/archive/v25.0.zip"],
         },
         {
             "name": "com_github_bazelbuild_buildtools",


### PR DESCRIPTION
Correct deprecated AccessController usage warning
Requires a newer bazel than 6.4.0 for macos to choose unix toolchain with C++ std=c++14 specification for protobuf->absl dependency.