### PR TITLE
Update lombok dependency for jdk21

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -112,7 +112,7 @@ def buildfarm_init(name = "buildfarm"):
                         "org.xerial:sqlite-jdbc:3.34.0",
                         "org.jetbrains:annotations:16.0.2",
                         "org.yaml:snakeyaml:2.0",
-                        "org.projectlombok:lombok:1.18.24",
+                        "org.projectlombok:lombok:1.18.30",
                     ],
         generate_compat_repositories = True,
         override_targets = IO_GRPC_GRPC_JAVA_OVERRIDE_TARGETS,


### PR DESCRIPTION
Annotations under lombok were fixed for jdk21 in 1.18.28, update to current.

Fixes #1536 