### PR TITLE
Revert "Reorganize DequeueMatchEvaluator (#1537)"

### DIFF
--- a/_site/docs/architecture/queues.md
+++ b/_site/docs/architecture/queues.md
@@ -41,17 +41,19 @@ Additionally, if the action contains any platform properties is not mentioned by
 setting `allowUnmatched: true` can be used to allow a superset of action properties as long as a subset matches the provision queue.
 If no provision queues can be matched, the operation queue will provide an analysis on why none of the queues were eligible.
 
-A worker will dequeue operations from matching queues and determine whether to keep and execute it according to the following procedure:
-For each property key-value in the operation's platform, an operation is REJECTED if:
-  The key is `min-cores` and the integer value is greater than the number of cores on the worker.
-  Or The key is `min-mem` and the integer value is greater than the number of bytes of RAM on the worker.
-  Or if the key exists in the `DequeueMatchSettings` platform with neither the value nor a `*` in the corresponding DMS platform key's values, 
-  Or if the `allowUnmatched` setting is `false`.
-For each resource requested in the operation's platform with the resource: prefix, the action is rejected if:
-  The resource amount cannot currently be satisfied with the associated resource capacity count
+When taking elements off of the operation queue, the worker's matching algorithm behaves in a similar manner:
+The worker's `DequeueMatchSettings` also have an `allowUnmatched` property.
+Workers also have the ability to reject an operation after matching with a provision queue and dequeuing a value.
+To avoid any of these rejections by the worker, you can use `acceptEverything: true`.
+
+When configuring your worker, consider the following decisions:
+First, if the `allowEverything` setting is `true`, the job is accepted.
+Otherwise, if any execution property for the queue has a wildcard key, the job is accepted.
+Otherwise, if the `allowUnmatched` setting is `true`, each key present in the queue's properties must be a wildcard or exist in the execution request's properties with an equal value.
+Otherwise, the execution request's properties must have exactly the same set of keys as the queue's execution properties, and the request's value for each property must equal the queue's if the queue's value for this property is not a wildcard.
 
 There are special predefined execution property names which resolve to dynamic configuration for the worker to match against:
-`Worker`: The worker's `publicName`
+`Worker`: The worker's `publicName` with no wildcard resolution
 `min-cores`: Less than or equal to the `executeStageWidth`
 `process-wrapper`: The set of named `process-wrappers` present in configuration
 

--- a/_site/docs/configuration/configuration.md
+++ b/_site/docs/configuration/configuration.md
@@ -319,6 +319,7 @@ Note: In order for these settings to take effect, you must also configure `limit
 
 | Configuration    | Accepted and _Default_ Values | Description |
 |------------------|-------------------------------|-------------|
+| acceptEverything | boolean, _true_               |             |
 | allowUnmatched   | boolean, _false_              |             |
 
 Example:
@@ -326,6 +327,7 @@ Example:
 ```yaml
 worker:
   dequeueMatchSettings:
+    acceptEverything: true
     allowUnmatched: false
 ```
 

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -103,6 +103,7 @@ worker:
   inlineContentLimit: 1048567 # 1024 * 1024
   operationPollPeriod: 1
   dequeueMatchSettings:
+    acceptEverything: true
     allowUnmatched: false
   storages:
     - type: FILESYSTEM

--- a/src/main/java/build/buildfarm/common/config/DequeueMatchSettings.java
+++ b/src/main/java/build/buildfarm/common/config/DequeueMatchSettings.java
@@ -3,16 +3,11 @@ package build.buildfarm.common.config;
 import build.bazel.remote.execution.v2.Platform;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.AccessLevel;
 import lombok.Data;
-import lombok.Getter;
 
 @Data
 public class DequeueMatchSettings {
-
-  @Getter(AccessLevel.NONE)
-  private boolean acceptEverything; // deprecated
-
+  private boolean acceptEverything = true;
   private boolean allowUnmatched = false;
   private List<Property> properties = new ArrayList();
 

--- a/src/main/java/build/buildfarm/worker/DequeueMatchEvaluator.java
+++ b/src/main/java/build/buildfarm/worker/DequeueMatchEvaluator.java
@@ -55,11 +55,12 @@ public class DequeueMatchEvaluator {
    */
   @SuppressWarnings("NullableProblems")
   @NotNull
-  public static boolean shouldKeepOperation(
+  public static DequeueResults shouldKeepOperation(
       SetMultimap<String, String> workerProvisions,
+      String name,
       LocalResourceSet resourceSet,
       QueueEntry queueEntry) {
-    return shouldKeepViaPlatform(workerProvisions, resourceSet, queueEntry.getPlatform());
+    return shouldKeepViaPlatform(workerProvisions, name, resourceSet, queueEntry.getPlatform());
   }
 
   /**
@@ -76,12 +77,43 @@ public class DequeueMatchEvaluator {
    */
   @SuppressWarnings("NullableProblems")
   @NotNull
-  private static boolean shouldKeepViaPlatform(
+  private static DequeueResults shouldKeepViaPlatform(
       SetMultimap<String, String> workerProvisions,
+      String name,
       LocalResourceSet resourceSet,
       Platform platform) {
-    return satisfiesProperties(workerProvisions, platform)
-        && LocalResourceSetUtils.claimResources(platform, resourceSet);
+    // attempt to execute everything the worker gets off the queue,
+    // provided there is enough resources to do so.
+    DequeueResults results = new DequeueResults();
+
+    if (!LocalResourceSetUtils.claimResources(platform, resourceSet)) {
+      return results;
+    }
+    results.resourcesClaimed = true;
+
+    // The action might be requesting to run on a particular action
+    if (!keepForThisWorker(platform, name)) {
+      return results;
+    }
+
+    if (configs.getWorker().getDequeueMatchSettings().isAcceptEverything()) {
+      results.keep = true;
+      return results;
+    }
+
+    results.keep = satisfiesProperties(workerProvisions, platform);
+    return results;
+  }
+
+  private static boolean keepForThisWorker(Platform platform, String name) {
+    for (Platform.Property property : platform.getPropertiesList()) {
+      if (property.getName().equals(ExecutionProperties.WORKER)
+          && !property.getValue().equals(name)) {
+        // requested worker does not match this worker, reject
+        return false;
+      }
+    }
+    return true;
   }
 
   /**
@@ -151,13 +183,13 @@ public class DequeueMatchEvaluator {
       return possibleMemories >= memBytesRequested;
     }
 
-    // ensure exact matches
-    if (workerProvisions.containsKey(property.getName())) {
-      return workerProvisions.containsEntry(property.getName(), property.getValue())
-          || workerProvisions.containsEntry(property.getName(), "*");
+    // accept other properties not specified on the worker
+    if (configs.getWorker().getDequeueMatchSettings().isAllowUnmatched()) {
+      return true;
     }
 
-    // accept other properties not specified on the worker
-    return configs.getWorker().getDequeueMatchSettings().isAllowUnmatched();
+    // ensure exact matches
+    return workerProvisions.containsEntry(property.getName(), property.getValue())
+        || workerProvisions.containsEntry(property.getName(), "*");
   }
 }

--- a/src/test/java/build/buildfarm/worker/DequeueMatchEvaluatorTest.java
+++ b/src/test/java/build/buildfarm/worker/DequeueMatchEvaluatorTest.java
@@ -59,7 +59,9 @@ public class DequeueMatchEvaluatorTest {
 
     // ACT
     boolean shouldKeep =
-        DequeueMatchEvaluator.shouldKeepOperation(workerProvisions, resourceSet, entry);
+        DequeueMatchEvaluator.shouldKeepOperation(
+                workerProvisions, "worker-name", resourceSet, entry)
+            .keep;
 
     // ASSERT
     assertThat(shouldKeep).isTrue();
@@ -87,7 +89,9 @@ public class DequeueMatchEvaluatorTest {
 
     // ACT
     boolean shouldKeep =
-        DequeueMatchEvaluator.shouldKeepOperation(workerProvisions, resourceSet, entry);
+        DequeueMatchEvaluator.shouldKeepOperation(
+                workerProvisions, "worker-name", resourceSet, entry)
+            .keep;
 
     // ASSERT
     // the worker accepts because it has more cores than the min-cores requested
@@ -102,6 +106,7 @@ public class DequeueMatchEvaluatorTest {
   @Test
   public void shouldKeepOperationInvalidMinCoresQueueEntry() throws Exception {
     // ARRANGE
+    configs.getWorker().getDequeueMatchSettings().setAcceptEverything(false);
     SetMultimap<String, String> workerProvisions = HashMultimap.create();
     LocalResourceSet resourceSet = new LocalResourceSet();
     workerProvisions.put("cores", "10");
@@ -116,7 +121,9 @@ public class DequeueMatchEvaluatorTest {
 
     // ACT
     boolean shouldKeep =
-        DequeueMatchEvaluator.shouldKeepOperation(workerProvisions, resourceSet, entry);
+        DequeueMatchEvaluator.shouldKeepOperation(
+                workerProvisions, "worker-name", resourceSet, entry)
+            .keep;
 
     // ASSERT
     // the worker rejects because it has less cores than the min-cores requested
@@ -145,7 +152,9 @@ public class DequeueMatchEvaluatorTest {
 
     // ACT
     boolean shouldKeep =
-        DequeueMatchEvaluator.shouldKeepOperation(workerProvisions, resourceSet, entry);
+        DequeueMatchEvaluator.shouldKeepOperation(
+                workerProvisions, "worker-name", resourceSet, entry)
+            .keep;
 
     // ASSERT
     // the worker accepts because it has the same cores as the min-cores requested
@@ -159,6 +168,7 @@ public class DequeueMatchEvaluatorTest {
   @Test
   public void shouldKeepOperationUnmatchedPropertiesRejectionAcceptance() throws Exception {
     // ARRANGE
+    configs.getWorker().getDequeueMatchSettings().setAcceptEverything(false);
     configs.getWorker().getDequeueMatchSettings().setAllowUnmatched(false);
     SetMultimap<String, String> workerProvisions = HashMultimap.create();
     LocalResourceSet resourceSet = new LocalResourceSet();
@@ -173,16 +183,33 @@ public class DequeueMatchEvaluatorTest {
 
     // ACT
     boolean shouldKeep =
-        DequeueMatchEvaluator.shouldKeepOperation(workerProvisions, resourceSet, entry);
+        DequeueMatchEvaluator.shouldKeepOperation(
+                workerProvisions, "worker-name", resourceSet, entry)
+            .keep;
 
     // ASSERT
     assertThat(shouldKeep).isFalse();
 
     // ARRANGE
+    configs.getWorker().getDequeueMatchSettings().setAcceptEverything(true);
+
+    // ACT
+    shouldKeep =
+        DequeueMatchEvaluator.shouldKeepOperation(
+                workerProvisions, "worker-name", resourceSet, entry)
+            .keep;
+
+    // ASSERT
+    assertThat(shouldKeep).isTrue();
+
+    // ARRANGE
     configs.getWorker().getDequeueMatchSettings().setAllowUnmatched(true);
 
     // ACT
-    shouldKeep = DequeueMatchEvaluator.shouldKeepOperation(workerProvisions, resourceSet, entry);
+    shouldKeep =
+        DequeueMatchEvaluator.shouldKeepOperation(
+                workerProvisions, "worker-name", resourceSet, entry)
+            .keep;
 
     // ASSERT
     assertThat(shouldKeep).isTrue();
@@ -194,6 +221,7 @@ public class DequeueMatchEvaluatorTest {
   @Test
   public void shouldKeepOperationClaimsResource() throws Exception {
     // ARRANGE
+    configs.getWorker().getDequeueMatchSettings().setAcceptEverything(true);
     configs.getWorker().getDequeueMatchSettings().setAllowUnmatched(true);
     SetMultimap<String, String> workerProvisions = HashMultimap.create();
     LocalResourceSet resourceSet = new LocalResourceSet();
@@ -212,7 +240,9 @@ public class DequeueMatchEvaluatorTest {
 
     // ACT
     boolean shouldKeep =
-        DequeueMatchEvaluator.shouldKeepOperation(workerProvisions, resourceSet, entry);
+        DequeueMatchEvaluator.shouldKeepOperation(
+                workerProvisions, "worker-name", resourceSet, entry)
+            .keep;
 
     // ASSERT
     // the worker accepts because the resource is available.
@@ -220,7 +250,10 @@ public class DequeueMatchEvaluatorTest {
     assertThat(resourceSet.resources.get("FOO").availablePermits()).isEqualTo(0);
 
     // ACT
-    shouldKeep = DequeueMatchEvaluator.shouldKeepOperation(workerProvisions, resourceSet, entry);
+    shouldKeep =
+        DequeueMatchEvaluator.shouldKeepOperation(
+                workerProvisions, "worker-name", resourceSet, entry)
+            .keep;
 
     // ASSERT
     // the worker rejects because there are no resources left.
@@ -229,44 +262,12 @@ public class DequeueMatchEvaluatorTest {
   }
 
   // Function under test: shouldKeepOperation
-  // Reason for testing: the local resource should be claimed
-  // Failure explanation: semaphore claim did not work as expected.
-  @Test
-  public void rejectOperationIgnoresResource() throws Exception {
-    // ARRANGE
-    configs.getWorker().getDequeueMatchSettings().setAllowUnmatched(false);
-    SetMultimap<String, String> workerProvisions = HashMultimap.create();
-    LocalResourceSet resourceSet = new LocalResourceSet();
-    resourceSet.resources.put("FOO", new Semaphore(1));
-
-    QueueEntry entry =
-        QueueEntry.newBuilder()
-            .setPlatform(
-                Platform.newBuilder()
-                    .addProperties(
-                        Platform.Property.newBuilder().setName("resource:FOO").setValue("1"))
-                    .addProperties(Platform.Property.newBuilder().setName("os").setValue("randos")))
-            .build();
-
-    // PRE-ASSERT
-    assertThat(resourceSet.resources.get("FOO").availablePermits()).isEqualTo(1);
-
-    // ACT
-    boolean shouldKeep =
-        DequeueMatchEvaluator.shouldKeepOperation(workerProvisions, resourceSet, entry);
-
-    // ASSERT
-    // the worker rejects because the os is not satisfied
-    assertThat(shouldKeep).isFalse();
-    assertThat(resourceSet.resources.get("FOO").availablePermits()).isEqualTo(1);
-  }
-
-  // Function under test: shouldKeepOperation
   // Reason for testing: the local resources should be claimed
   // Failure explanation: semaphore claim did not work as expected.
   @Test
   public void shouldKeepOperationClaimsMultipleResource() throws Exception {
     // ARRANGE
+    configs.getWorker().getDequeueMatchSettings().setAcceptEverything(true);
     configs.getWorker().getDequeueMatchSettings().setAllowUnmatched(true);
     SetMultimap<String, String> workerProvisions = HashMultimap.create();
     LocalResourceSet resourceSet = new LocalResourceSet();
@@ -289,7 +290,9 @@ public class DequeueMatchEvaluatorTest {
 
     // ACT
     boolean shouldKeep =
-        DequeueMatchEvaluator.shouldKeepOperation(workerProvisions, resourceSet, entry);
+        DequeueMatchEvaluator.shouldKeepOperation(
+                workerProvisions, "worker-name", resourceSet, entry)
+            .keep;
 
     // ASSERT
     // the worker accepts because the resource is available.
@@ -298,7 +301,10 @@ public class DequeueMatchEvaluatorTest {
     assertThat(resourceSet.resources.get("BAR").availablePermits()).isEqualTo(2);
 
     // ACT
-    shouldKeep = DequeueMatchEvaluator.shouldKeepOperation(workerProvisions, resourceSet, entry);
+    shouldKeep =
+        DequeueMatchEvaluator.shouldKeepOperation(
+                workerProvisions, "worker-name", resourceSet, entry)
+            .keep;
 
     // ASSERT
     // the worker accepts because the resource is available.
@@ -307,7 +313,10 @@ public class DequeueMatchEvaluatorTest {
     assertThat(resourceSet.resources.get("BAR").availablePermits()).isEqualTo(0);
 
     // ACT
-    shouldKeep = DequeueMatchEvaluator.shouldKeepOperation(workerProvisions, resourceSet, entry);
+    shouldKeep =
+        DequeueMatchEvaluator.shouldKeepOperation(
+                workerProvisions, "worker-name", resourceSet, entry)
+            .keep;
 
     // ASSERT
     // the worker rejects because there are no resources left.
@@ -323,6 +332,7 @@ public class DequeueMatchEvaluatorTest {
   @Test
   public void shouldKeepOperationFailsToClaimSameAmountRemains() throws Exception {
     // ARRANGE
+    configs.getWorker().getDequeueMatchSettings().setAcceptEverything(true);
     configs.getWorker().getDequeueMatchSettings().setAllowUnmatched(true);
     SetMultimap<String, String> workerProvisions = HashMultimap.create();
     LocalResourceSet resourceSet = new LocalResourceSet();
@@ -349,7 +359,9 @@ public class DequeueMatchEvaluatorTest {
 
     // ACT
     boolean shouldKeep =
-        DequeueMatchEvaluator.shouldKeepOperation(workerProvisions, resourceSet, entry);
+        DequeueMatchEvaluator.shouldKeepOperation(
+                workerProvisions, "worker-name", resourceSet, entry)
+            .keep;
 
     // ASSERT
     // the worker rejects because there are no resources left.


### PR DESCRIPTION
This reverts commit 339aa131a971c1e541ede590ea8096cfbde97824.

This commit causes actions to not be picked up by workers and sit in the queue indefinitely, causing the entire cluster to be locked up.