### PR TITLE
Check for "cores" exec property as min-cores match

### DIFF
--- a/src/main/java/build/buildfarm/worker/DequeueMatchEvaluator.java
+++ b/src/main/java/build/buildfarm/worker/DequeueMatchEvaluator.java
@@ -119,7 +119,8 @@ public class DequeueMatchEvaluator {
   private static boolean satisfiesProperty(
       SetMultimap<String, String> workerProvisions, Platform.Property property) {
     // validate min cores
-    if (property.getName().equals(ExecutionProperties.MIN_CORES)) {
+    if (property.getName().equals(ExecutionProperties.CORES)
+        || property.getName().equals(ExecutionProperties.MIN_CORES)) {
       if (!workerProvisions.containsKey(ExecutionProperties.CORES)) {
         return false;
       }


### PR DESCRIPTION
The execution platform property "cores" is detailed in documentation as specifying "min-cores" and "max-cores". Match this definition and prevent "cores" from being evaluated as a strict match with the worker provision properties (with likely rejection).