### PR TITLE
Consider output_* as relative to WD

### DIFF
--- a/src/main/java/build/buildfarm/worker/shard/CFCExecFileSystem.java
+++ b/src/main/java/build/buildfarm/worker/shard/CFCExecFileSystem.java
@@ -46,6 +46,7 @@ import build.buildfarm.common.io.Dirent;
 import build.buildfarm.worker.ExecDirException;
 import build.buildfarm.worker.ExecDirException.ViolationException;
 import build.buildfarm.worker.OutputDirectory;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -402,7 +403,8 @@ class CFCExecFileSystem implements ExecFileSystem {
     return ImmutableSet.of();
   }
 
-  private OutputDirectory createOutputDirectory(Command command) {
+  @VisibleForTesting
+  static OutputDirectory createOutputDirectory(Command command) {
     Iterable<String> files;
     Iterable<String> dirs;
     if (command.getOutputPathsCount() != 0) {
@@ -411,6 +413,10 @@ class CFCExecFileSystem implements ExecFileSystem {
     } else {
       files = command.getOutputFilesList();
       dirs = command.getOutputDirectoriesList();
+    }
+    if (!command.getWorkingDirectory().isEmpty()) {
+      files = Iterables.transform(files, file -> command.getWorkingDirectory() + "/" + file);
+      dirs = Iterables.transform(dirs, dir -> command.getWorkingDirectory() + "/" + dir);
     }
     return OutputDirectory.parse(files, dirs, command.getEnvironmentVariablesList());
   }

--- a/src/test/java/build/buildfarm/worker/shard/CFCExecFileSystemTest.java
+++ b/src/test/java/build/buildfarm/worker/shard/CFCExecFileSystemTest.java
@@ -1,0 +1,43 @@
+// Copyright 2023 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.worker.shard;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import build.bazel.remote.execution.v2.Command;
+import build.buildfarm.worker.OutputDirectory;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class CFCExecFileSystemTest {
+  @Test
+  public void outputDirectoryWorkingDirectoryRelative() {
+    Command command =
+        Command.newBuilder()
+            .setWorkingDirectory("foo/bar")
+            .addOutputFiles("baz/quux")
+            .addOutputDirectories("nope")
+            .build();
+
+    // verification is actually here with checked contents below
+    // throws unless the directory is relative to the WorkingDirectory
+    OutputDirectory workingOutputDirectory =
+        CFCExecFileSystem.createOutputDirectory(command).getChild("foo").getChild("bar");
+    assertThat(workingOutputDirectory.getChild("baz").isLeaf()).isTrue();
+    assertThat(workingOutputDirectory.getChild("nope").isLeaf()).isFalse();
+  }
+}


### PR DESCRIPTION
Per the REAPI spec:

`The paths are relative to the working directory of the action execution.`

Prefix the WorkingDirectory to paths used as OutputDirectory parameters, and verify that these are present in the layout of the directory for use.