### PR TITLE
Locate Output Paths relative to WorkingDirectory

### DIFF
--- a/src/main/java/build/buildfarm/common/CommandUtils.java
+++ b/src/main/java/build/buildfarm/common/CommandUtils.java
@@ -46,7 +46,7 @@ public class CommandUtils {
    * @return The list of output paths.
    * @note Suggested return identifier: output_paths.
    */
-  public static List<Path> getResolvedOutputPaths(Command command, Path actionRoot) {
+  public static List<Path> getResolvedOutputPaths(Command command, Path workingDirectory) {
     // REAPI clients previously needed to specify whether the output path was a directory or file.
     // This turned out to be too restrictive-- some build tools don't know what an action produces
     // until it is done.
@@ -65,7 +65,7 @@ public class CommandUtils {
     // `output_directories` will be ignored!"
     if (command.getOutputPathsCount() != 0) {
       for (String outputPath : command.getOutputPathsList()) {
-        resolvedPaths.add(actionRoot.resolve(outputPath));
+        resolvedPaths.add(workingDirectory.resolve(outputPath));
       }
       return resolvedPaths;
     }
@@ -73,10 +73,10 @@ public class CommandUtils {
     // Assuming `output_paths` was not used,
     // fetch deprecated `output_files` and `output_directories` for backwards compatibility.
     for (String outputPath : command.getOutputFilesList()) {
-      resolvedPaths.add(actionRoot.resolve(outputPath));
+      resolvedPaths.add(workingDirectory.resolve(outputPath));
     }
     for (String outputPath : command.getOutputDirectoriesList()) {
-      resolvedPaths.add(actionRoot.resolve(outputPath));
+      resolvedPaths.add(workingDirectory.resolve(outputPath));
     }
 
     return resolvedPaths;

--- a/src/main/java/build/buildfarm/worker/ReportResultStage.java
+++ b/src/main/java/build/buildfarm/worker/ReportResultStage.java
@@ -98,7 +98,7 @@ public class ReportResultStage extends PipelineStage {
       workerContext.uploadOutputs(
           operationContext.queueEntry.getExecuteEntry().getActionDigest(),
           resultBuilder,
-          operationContext.execDir,
+          operationContext.execDir.resolve(operationContext.command.getWorkingDirectory()),
           operationContext.command);
     } catch (StatusException | StatusRuntimeException e) {
       ExecuteResponse executeResponse = operationContext.executeResponse.build();

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -499,11 +499,11 @@ class ShardWorkerContext implements WorkerContext {
   private void uploadOutputFile(
       ActionResult.Builder resultBuilder,
       Path outputPath,
-      Path actionRoot,
+      Path workingDirectory,
       String entrySizeViolationType,
       PreconditionFailure.Builder preconditionFailure)
       throws IOException, InterruptedException {
-    String outputFile = actionRoot.relativize(outputPath).toString();
+    String outputFile = workingDirectory.relativize(outputPath).toString();
     if (!Files.exists(outputPath)) {
       log.log(Level.FINER, "ReportResultStage: " + outputFile + " does not exist...");
       return;
@@ -733,14 +733,23 @@ class ShardWorkerContext implements WorkerContext {
 
     PreconditionFailure.Builder preconditionFailure = PreconditionFailure.newBuilder();
 
-    List<Path> outputPaths = CommandUtils.getResolvedOutputPaths(command, actionRoot);
+    Path workingDirectory = actionRoot.resolve(command.getWorkingDirectory());
+    List<Path> outputPaths = CommandUtils.getResolvedOutputPaths(command, workingDirectory);
     for (Path outputPath : outputPaths) {
       if (Files.isDirectory(outputPath)) {
         uploadOutputDirectory(
-            resultBuilder, outputPath, actionRoot, entrySizeViolationType, preconditionFailure);
+            resultBuilder,
+            outputPath,
+            workingDirectory,
+            entrySizeViolationType,
+            preconditionFailure);
       } else {
         uploadOutputFile(
-            resultBuilder, outputPath, actionRoot, entrySizeViolationType, preconditionFailure);
+            resultBuilder,
+            outputPath,
+            workingDirectory,
+            entrySizeViolationType,
+            preconditionFailure);
       }
     }
     checkPreconditionFailure(actionDigest, preconditionFailure.build());

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -82,6 +82,7 @@ import io.grpc.Deadline;
 import io.grpc.Status;
 import io.grpc.StatusException;
 import io.prometheus.client.Counter;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.FileVisitResult;
@@ -496,6 +497,15 @@ class ShardWorkerContext implements WorkerContext {
     }
   }
 
+  private static String toREOutputPath(String nativePath) {
+    // RE API OutputFile/Directory path
+    // The path separator is a forward slash `/`.
+    if (File.separatorChar != '/') {
+      return nativePath.replace(File.separatorChar, '/');
+    }
+    return nativePath;
+  }
+
   private void uploadOutputFile(
       ActionResult.Builder resultBuilder,
       Path outputPath,
@@ -503,7 +513,8 @@ class ShardWorkerContext implements WorkerContext {
       String entrySizeViolationType,
       PreconditionFailure.Builder preconditionFailure)
       throws IOException, InterruptedException {
-    String outputFile = workingDirectory.relativize(outputPath).toString();
+    String outputFile = toREOutputPath(workingDirectory.relativize(outputPath).toString());
+
     if (!Files.exists(outputPath)) {
       log.log(Level.FINER, "ReportResultStage: " + outputFile + " does not exist...");
       return;
@@ -599,11 +610,12 @@ class ShardWorkerContext implements WorkerContext {
   private void uploadOutputDirectory(
       ActionResult.Builder resultBuilder,
       Path outputDirPath,
-      Path actionRoot,
+      Path workingDirectory,
       String entrySizeViolationType,
       PreconditionFailure.Builder preconditionFailure)
       throws IOException, InterruptedException {
-    String outputDir = actionRoot.relativize(outputDirPath).toString();
+    String outputDir = toREOutputPath(workingDirectory.relativize(outputDirPath).toString());
+
     if (!Files.exists(outputDirPath)) {
       log.log(Level.FINER, "ReportResultStage: " + outputDir + " does not exist...");
       return;

--- a/src/test/java/build/buildfarm/worker/shard/ShardWorkerContextTest.java
+++ b/src/test/java/build/buildfarm/worker/shard/ShardWorkerContextTest.java
@@ -15,6 +15,7 @@
 package build.buildfarm.worker.shard;
 
 import static build.buildfarm.common.config.Server.INSTANCE_TYPE.SHARD;
+import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -22,9 +23,14 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import build.bazel.remote.execution.v2.ActionResult;
+import build.bazel.remote.execution.v2.Command;
+import build.bazel.remote.execution.v2.Digest;
+import build.bazel.remote.execution.v2.OutputFile;
 import build.bazel.remote.execution.v2.Platform;
 import build.bazel.remote.execution.v2.Platform.Property;
 import build.buildfarm.backplane.Backplane;
+import build.buildfarm.cas.ContentAddressableStorage;
 import build.buildfarm.common.DigestUtil;
 import build.buildfarm.common.DigestUtil.HashFunction;
 import build.buildfarm.common.InputStreamFactory;
@@ -37,7 +43,11 @@ import build.buildfarm.v1test.QueueEntry;
 import build.buildfarm.worker.WorkerContext;
 import build.buildfarm.worker.resources.LocalResourceSet;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.jimfs.Jimfs;
 import com.google.protobuf.Duration;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Before;
@@ -164,5 +174,23 @@ public class ShardWorkerContextTest {
     MatchListener listener = mock(MatchListener.class);
     context.match(listener);
     verify(listener, times(1)).onEntry(queueEntry);
+  }
+
+  @Test
+  public void uploadOutputsWorkingDirectoryRelative() throws Exception {
+    WorkerContext context = createTestContext();
+    Command command =
+        Command.newBuilder().setWorkingDirectory("foo/bar").addOutputFiles("baz/quux").build();
+    ContentAddressableStorage storage = mock(ContentAddressableStorage.class);
+    when(execFileSystem.getStorage()).thenReturn(storage);
+    Path actionRoot = Iterables.getFirst(Jimfs.newFileSystem().getRootDirectories(), null);
+    Files.createDirectories(actionRoot.resolve("foo/bar/baz"));
+    Files.createFile(actionRoot.resolve("foo/bar/baz/quux"));
+    ActionResult.Builder resultBuilder = ActionResult.newBuilder();
+    context.uploadOutputs(Digest.getDefaultInstance(), resultBuilder, actionRoot, command);
+
+    ActionResult result = resultBuilder.build();
+    OutputFile outputFile = Iterables.getOnlyElement(result.getOutputFilesList());
+    assertThat(outputFile.getPath()).isEqualTo("baz/quux");
   }
 }


### PR DESCRIPTION
Required as a corollary to OutputDirectory changes to consider outputs as relative to working directory.