### PR TITLE
Remove incorrect external resolve of WD on upload

### DIFF
--- a/src/main/java/build/buildfarm/worker/ReportResultStage.java
+++ b/src/main/java/build/buildfarm/worker/ReportResultStage.java
@@ -98,7 +98,7 @@ public class ReportResultStage extends PipelineStage {
       workerContext.uploadOutputs(
           operationContext.queueEntry.getExecuteEntry().getActionDigest(),
           resultBuilder,
-          operationContext.execDir.resolve(operationContext.command.getWorkingDirectory()),
+          operationContext.execDir,
           operationContext.command);
     } catch (StatusException | StatusRuntimeException e) {
       ExecuteResponse executeResponse = operationContext.executeResponse.build();


### PR DESCRIPTION
Previous patch included a change in actionRoot parameter, expecting it to prefer the working directory rooted path to discover outputs. Might want to reapply this later, but for now leave the resolution in uploadOutputs.