### PR TITLE
Partial Revert "Instance cleanups (#1555)"

### DIFF
--- a/src/main/java/build/buildfarm/common/services/WriteStreamObserver.java
+++ b/src/main/java/build/buildfarm/common/services/WriteStreamObserver.java
@@ -326,9 +326,6 @@ public class WriteStreamObserver implements StreamObserver<WriteRequest> {
       throws EntryLimitException {
     long committedSize;
     try {
-      if (offset == 0) {
-        write.reset();
-      }
       committedSize = getCommittedSizeForWrite();
     } catch (IOException e) {
       errorResponse(e);
@@ -355,6 +352,10 @@ public class WriteStreamObserver implements StreamObserver<WriteRequest> {
                       resourceName, name))
               .asException());
     } else {
+      if (offset == 0 && offset != committedSize) {
+        write.reset();
+        committedSize = 0;
+      }
       if (earliestOffset < 0 || offset < earliestOffset) {
         earliestOffset = offset;
       }

--- a/src/main/java/build/buildfarm/common/services/WriteStreamObserver.java
+++ b/src/main/java/build/buildfarm/common/services/WriteStreamObserver.java
@@ -205,6 +205,7 @@ public class WriteStreamObserver implements StreamObserver<WriteRequest> {
         log.log(
             Level.FINEST, format("delivering committed_size for %s of %d", name, committedSize));
         responseObserver.onNext(response);
+        responseObserver.onCompleted();
       } catch (Exception e) {
         log.log(Level.SEVERE, format("error delivering committed_size to %s", name), e);
       }
@@ -477,23 +478,5 @@ public class WriteStreamObserver implements StreamObserver<WriteRequest> {
   @Override
   public void onCompleted() {
     log.log(Level.FINER, format("write completed for %s", name));
-    if (write == null) {
-      responseObserver.onCompleted();
-    } else {
-      Futures.addCallback(
-          write.getFuture(),
-          new FutureCallback<Long>() {
-            @Override
-            public void onSuccess(Long committedSize) {
-              responseObserver.onCompleted();
-            }
-
-            @Override
-            public void onFailure(Throwable t) {
-              // ignore
-            }
-          },
-          directExecutor());
-    }
   }
 }

--- a/src/main/java/build/buildfarm/instance/shard/ServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ServerInstance.java
@@ -1655,7 +1655,6 @@ public class ServerInstance extends NodeInstance {
           }
         },
         directExecutor());
-    write.reset(); // prevents a queryWriteStatus at index 0
     try (OutputStream out = write.getOutput(timeout.getSeconds(), SECONDS, () -> {})) {
       content.writeTo(out);
     } catch (IOException e) {

--- a/src/test/java/build/buildfarm/common/services/ByteStreamServiceTest.java
+++ b/src/test/java/build/buildfarm/common/services/ByteStreamServiceTest.java
@@ -173,7 +173,6 @@ public class ByteStreamServiceTest {
             .setResourceName(resourceName)
             .setData(shortContent)
             .build());
-    verify(write, times(1)).reset();
     requestObserver.onNext(
         WriteRequest.newBuilder().setWriteOffset(0).setData(content).setFinishWrite(true).build());
     assertThat(futureResponder.get())
@@ -182,8 +181,8 @@ public class ByteStreamServiceTest {
     verify(write, atLeastOnce()).getCommittedSize();
     verify(write, atLeastOnce())
         .getOutput(any(Long.class), any(TimeUnit.class), any(Runnable.class));
-    verify(write, times(2)).reset();
-    verify(write, times(2)).getFuture();
+    verify(write, times(1)).reset();
+    verify(write, times(1)).getFuture();
   }
 
   @Test
@@ -264,7 +263,7 @@ public class ByteStreamServiceTest {
     verify(write, atLeastOnce()).getCommittedSize();
     verify(write, atLeastOnce())
         .getOutput(any(Long.class), any(TimeUnit.class), any(Runnable.class));
-    verify(write, times(3)).getFuture();
+    verify(write, times(2)).getFuture();
   }
 
   static class CountingReadObserver implements StreamObserver<ReadResponse> {


### PR DESCRIPTION
Revert "Correct WSO and StubWriteOutputStream completion"
    
This reverts commit 1c845363dfc02181476a7483d7e5e8a47bf13ad7.

Revert "Explicit reset on WriteOffset 0 and blob write"
    
This reverts commit d747b2ecd4801dc159fc2ef8703331b432a5f423.

The commit is preventing builds from progressing by failing to properly move executions to workers. Revert fixes the issue.

Symptom: Build initiates, with only a few actions making it onto workers, with rest of them getting re-queued multiple times.  Very few completed operations, with most failing with failed precondition or unavailable.

Ex:

```
[924 / 6,080] 256 actions, 255 running

  | @com_google_protobuf//:protoc_lib; 9834s remote
  | Compiling src/google/protobuf/compiler/cpp/cpp_field.cc; 9832s remote
  | Compiling src/google/protobuf/compiler/csharp/csharp_enum.cc; 9532s remote
  | Compiling src/google/protobuf/compiler/plugin.pb.cc; 9474s remote
  | @com_google_protobuf//:protoc_lib; 9474s remote
  | Compiling src/google/protobuf/compiler/cpp/cpp_enum.cc; 9474s remote
  | @com_google_protobuf//:protoc_lib; 9474s remote
```

Server logs:

```
Dec 04, 2023 4:19:21 AM build.buildfarm.common.grpc.StubWriteOutputStream$2 onError
WARNING: CANCELLED: write(uploads/268deae7-0b60-4a1c-a0cd-2816f173ca3e/blobs/d9b085b67d5cf2cc9a6fce4ecf762262b1e14ae9/172) on worker 10.60.208.52:8981 after 172 bytes of content
Dec 04, 2023 4:19:22 AM build.buildfarm.common.grpc.StubWriteOutputStream$2 onError
WARNING: CANCELLED: write(uploads/d7ea2f4e-30ed-4e82-af50-4a46dc2eb2b2/blobs/8a8748b5f27f9437d51441de391506c1db49de36/96) on worker 10.60.208.52:8981 after 96 bytes of content
Dec 04, 2023 4:19:22 AM build.buildfarm.common.grpc.StubWriteOutputStream$2 onError
WARNING: CANCELLED: write(uploads/188f6a5a-a91c-4f74-a9ec-6fa8bffbfea8/blobs/49c5eef10e4885f947e9eccb64579ec4d1f20627/1248) on worker 10.60.208.52:8981 after 1248 bytes of content
Dec 04, 2023 4:19:22 AM build.buildfarm.common.grpc.StubWriteOutputStream$2 onError

...

INFO: ad358c46b9674b66a800e3100106ab376cc2ed02/172: FAILED_PRECONDITION: Action ad358c46b9674b66a800e3100106ab376cc2ed02/172 is invalid: The directory `/bazel-out/k8-fastbuild/bin/...` was not found in the CAS.; The directory `/bazel-out/k8-fastbuild/bin/..._platform_valid.runfiles/__main__/config/compute-3` was not found in the CAS.; The directory `/bazel-out/k8-fastbuild/bin/..._valid.runfiles/__main__/config/lidar` was not found in the CAS. ...
  PreconditionFailure: ...

...

SEVERE: error queueing shard/operations/baf94f6e-7d8a-4542-97ba-5f3136f738c6
io.grpc.StatusException: FAILED_PRECONDITION: Action ad358c46b9674b66a800e3100106ab376cc2ed02/172 is invalid: The directory `/bazel-out/k8-fastbuild/bin/..._valid.runfiles/__main__/config/ars540` was not found in the CAS.; The directory `/bazel-out/k8-fastbuild/bin/..._valid.runfiles/__main__/config/compute-3` was not found in the CAS.; The directory `/bazel-out/k8-fastbuild/bin/..._platform_valid.runfiles/__main__/config/lidar` was not found in the CAS. ...
	at io.grpc.Status.asException(Status.java:554)
	at io.grpc.protobuf.StatusProto.toStatusException(StatusProto.java:85)
	at build.buildfarm.instance.shard.ServerInstance$13.run(ServerInstance.java:2153)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)

...

Dec 04, 2023 4:22:24 AM build.buildfarm.instance.shard.DispatchedMonitor logOverdueOperation
INFO: DispatchedMonitor: Testing shard/operations/8cfe14f3-6211-4ef9-9ce7-994bd95f2445 because 10398ms overdue (1701663744519 >= 1701663734121)
Dec 04, 2023 4:22:24 AM build.buildfarm.instance.shard.DispatchedMonitor logOverdueOperation
INFO: DispatchedMonitor: Testing shard/operations/6c77ad18-461f-4383-af3b-90a97e29ce29 because 4704ms overdue (1701663744519 >= 1701663739815)
Dec 04, 2023 4:22:24 AM build.buildfarm.instance.shard.RedisShardBackplane queue
WARNING: removed dispatched operation shard/operations/8cfe14f3-6211-4ef9-9ce7-994bd95f2445
Dec 04, 2023 4:22:24 AM build.buildfarm.instance.shard.DispatchedMonitor lambda$requeueDispatchedOperation$0
INFO: DispatchedMonitor::run: requeue(shard/operations/8cfe14f3-6211-4ef9-9ce7-994bd95f2445) 7.67519ms
Dec 04, 2023 4:22:24 AM build.buildfarm.instance.shard.RedisShardBackplane queue
WARNING: removed dispatched operation shard/operations/6c77ad18-461f-4383-af3b-90a97e29ce29
Dec 04, 2023 4:22:24 AM build.buildfarm.instance.shard.DispatchedMonitor lambda$requeueDispatchedOperation$0
INFO: DispatchedMonitor::run: requeue(shard/operations/6c77ad18-461f-4383-af3b-90a97e29ce29) 9.06702ms

...

Dec 04, 2023 4:27:53 AM build.buildfarm.common.grpc.StubWriteOutputStream$2 onError
WARNING: DEADLINE_EXCEEDED: write(uploads/c4bc5a5c-039c-4345-ab50-00c87a87f214/blobs/29e8fa0b4c71ea374f43ba27e20353b388089efb/175987) on worker 10.60.208.52:8981 after 175987 bytes of content
Dec 04, 2023 4:27:53 AM build.buildfarm.instance.shard.ServerInstance$14 onFailure
WARNING: an rpc status was thrown with DEADLINE_EXCEEDED for shard/operations/9d7ee34a-7b53-4e4b-9548-fce5ac732ac7, discarding it
io.grpc.StatusRuntimeException: DEADLINE_EXCEEDED: deadline exceeded after 59.999944182s. [closed=[], committed=[remote_addr=/10.60.208.52:8981]]
	at io.grpc.Status.asRuntimeException(Status.java:539)
	at io.grpc.stub.ClientCalls$StreamObserverToCallListenerAdapter.onClose(ClientCalls.java:491)
	at io.grpc.internal.ClientCallImpl.closeObserver(ClientCallImpl.java:567)
	at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInternal(ClientCallImpl.java:735)
	at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInContext(ClientCallImpl.java:716)
	at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
	at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)

Dec 04, 2023 4:27:53 AM build.buildfarm.instance.server.NodeInstance logFailedStatus
INFO: c4467dafc814bd65ee96141afdfcd21900047b43/172: UNAVAILABLE: SUPPRESSED DEADLINE_EXCEEDED: DEADLINE_EXCEEDED: deadline exceeded after 59.999944182s. [closed=[], committed=[remote_addr=/10.60.208.52:8981]]

Dec 04, 2023 4:27:53 AM build.buildfarm.instance.shard.ServerInstance$1$1 onFailure
SEVERE: error queueing shard/operations/9d7ee34a-7b53-4e4b-9548-fce5ac732ac7
io.grpc.StatusException: UNAVAILABLE: SUPPRESSED DEADLINE_EXCEEDED: DEADLINE_EXCEEDED: deadline exceeded after 59.999944182s. [closed=[], committed=[remote_addr=/10.60.208.52:8981]]
	at io.grpc.Status.asException(Status.java:554)
	at io.grpc.protobuf.StatusProto.toStatusException(StatusProto.java:85)
	at build.buildfarm.instance.shard.ServerInstance$13.run(ServerInstance.java:2153)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```