### PR TITLE
build: support compiling protobuf on macOS

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -24,3 +24,6 @@ common --incompatible_disallow_empty_glob
 # TODO: migrate all dependencies from WORKSPACE to MODULE.bazel
 # https://github.com/bazelbuild/bazel-buildfarm/issues/1479
 common --noenable_bzlmod
+
+# Support protobuf on macOS with Xcode 15.x
+common:macos --host_cxxopt=-std=c++14 --cxxopt=-std=c++14


### PR DESCRIPTION
MacOS needs extra args to convince it to support C++14.

See also: https://github.com/protocolbuffers/protobuf/issues/12393