### PR TITLE
build: start adopting bzlmod

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -21,9 +21,7 @@ test --test_tag_filters=-redis,-integration
 # https://buildkite.com/bazel/bazelisk-plus-incompatible-flags
 common --incompatible_disallow_empty_glob
 
-# TODO: migrate all dependencies from WORKSPACE to MODULE.bazel
-# https://github.com/bazelbuild/bazel-buildfarm/issues/1479
-common --noenable_bzlmod
+common --enable_bzlmod
 
 # Support protobuf on macOS with Xcode 15.x
 common:macos --host_cxxopt=-std=c++14 --cxxopt=-std=c++14

--- a/BUILD
+++ b/BUILD
@@ -1,4 +1,4 @@
-load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
+load("@buildifier_prebuilt//:rules.bzl", "buildifier")
 load("@io_bazel_rules_docker//java:image.bzl", "java_image")
 load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,3 +9,9 @@ bazel_dep(name = "rules_cc", version = "0.0.9")
 bazel_dep(name = "rules_go", version = "0.43.0", repo_name = "io_bazel_rules_go")
 bazel_dep(name = "rules_jvm_external", version = "5.3")
 bazel_dep(name = "rules_license", version = "0.0.7")
+
+bazel_dep(
+    name = "buildifier_prebuilt",
+    version = "6.4.0",
+    dev_dependency = True,
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,6 +3,7 @@ module(
     repo_name = "build_buildfarm",
 )
 
+bazel_dep(name = "gazelle", version = "0.34.0", repo_name = "bazel_gazelle")
 bazel_dep(name = "platforms", version = "0.0.7")
 bazel_dep(name = "rules_cc", version = "0.0.9")
 bazel_dep(name = "rules_go", version = "0.43.0", repo_name = "io_bazel_rules_go")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,2 +1,9 @@
-# TODO: migrate all dependencies from WORKSPACE to MODULE.bazel
-# https://github.com/bazelbuild/bazel-buildfarm/issues/1479
+module(
+    name = "build_buildfarm",
+    repo_name = "build_buildfarm",
+)
+
+bazel_dep(name = "platforms", version = "0.0.7")
+bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "rules_jvm_external", version = "5.3")
+bazel_dep(name = "rules_license", version = "0.0.7")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,5 +5,6 @@ module(
 
 bazel_dep(name = "platforms", version = "0.0.7")
 bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "rules_go", version = "0.43.0", repo_name = "io_bazel_rules_go")
 bazel_dep(name = "rules_jvm_external", version = "5.3")
 bazel_dep(name = "rules_license", version = "0.0.7")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,0 +1,8484 @@
+{
+  "lockFileVersion": 3,
+  "moduleFileHash": "3f11511a2b9a5f6fb04a3324b46b42a4fa6bcae5f2aed6e1f6f6cf980cfd218e",
+  "flags": {
+    "cmdRegistries": [
+      "https://bcr.bazel.build/"
+    ],
+    "cmdModuleOverrides": {},
+    "allowedYankedVersions": [],
+    "envVarAllowedYankedVersions": "",
+    "ignoreDevDependency": false,
+    "directDependenciesMode": "WARNING",
+    "compatibilityMode": "ERROR"
+  },
+  "localOverrideHashes": {
+    "bazel_tools": "922ea6752dc9105de5af957f7a99a6933c0a6a712d23df6aad16a9c399f7e787"
+  },
+  "moduleDepGraph": {
+    "<root>": {
+      "name": "build_buildfarm",
+      "version": "",
+      "key": "<root>",
+      "repoName": "build_buildfarm",
+      "executionPlatformsToRegister": [],
+      "toolchainsToRegister": [],
+      "extensionUsages": [
+        {
+          "extensionBzlFile": "@rules_jvm_external//:extensions.bzl",
+          "extensionName": "maven",
+          "usingModule": "<root>",
+          "location": {
+            "file": "@@//:MODULE.bazel",
+            "line": 47,
+            "column": 22
+          },
+          "imports": {
+            "maven": "maven",
+            "unpinned_maven": "unpinned_maven"
+          },
+          "devImports": [],
+          "tags": [
+            {
+              "tagName": "install",
+              "attributeValues": {
+                "artifacts": [
+                  "com.amazonaws:aws-java-sdk-s3:1.12.544",
+                  "com.amazonaws:aws-java-sdk-secretsmanager:1.12.544",
+                  "com.fasterxml.jackson.core:jackson-databind:2.15.0",
+                  "com.github.ben-manes.caffeine:caffeine:2.9.0",
+                  "com.github.docker-java:docker-java:3.3.3",
+                  "com.github.fppt:jedis-mock:1.0.10",
+                  "com.github.jnr:jffi:1.3.11",
+                  "com.github.jnr:jffi:jar:native:1.3.11",
+                  "com.github.jnr:jnr-constants:0.10.4",
+                  "com.github.jnr:jnr-ffi:2.2.14",
+                  "com.github.jnr:jnr-posix:3.1.17",
+                  "com.github.pcj:google-options:1.0.0",
+                  "com.github.serceman:jnr-fuse:0.5.7",
+                  "com.github.luben:zstd-jni:1.5.5-7",
+                  "com.github.oshi:oshi-core:6.4.5",
+                  "com.google.auth:google-auth-library-credentials:1.19.0",
+                  "com.google.auth:google-auth-library-oauth2-http:1.19.0",
+                  "com.google.code.findbugs:jsr305:3.0.2",
+                  "com.google.code.gson:gson:2.10.1",
+                  "com.google.errorprone:error_prone_annotations:2.22.0",
+                  "com.google.errorprone:error_prone_core:2.22.0",
+                  "com.google.guava:failureaccess:1.0.1",
+                  "com.google.guava:guava:32.1.1-jre",
+                  "com.google.j2objc:j2objc-annotations:2.8",
+                  "com.google.jimfs:jimfs:1.3.0",
+                  "com.google.protobuf:protobuf-java-util:3.19.1",
+                  "com.google.protobuf:protobuf-java:3.19.1",
+                  "com.google.truth:truth:1.1.5",
+                  "org.slf4j:slf4j-simple:2.0.9",
+                  "com.googlecode.json-simple:json-simple:1.1.1",
+                  "com.jayway.jsonpath:json-path:2.8.0",
+                  "org.bouncycastle:bcprov-jdk15on:1.70",
+                  "net.jcip:jcip-annotations:1.0",
+                  "io.netty:netty-buffer:4.1.97.Final",
+                  "io.netty:netty-codec:4.1.97.Final",
+                  "io.netty:netty-codec-http:4.1.97.Final",
+                  "io.netty:netty-codec-http2:4.1.97.Final",
+                  "io.netty:netty-codec-socks:4.1.97.Final",
+                  "io.netty:netty-common:4.1.97.Final",
+                  "io.netty:netty-handler:4.1.97.Final",
+                  "io.netty:netty-handler-proxy:4.1.97.Final",
+                  "io.netty:netty-resolver:4.1.97.Final",
+                  "io.netty:netty-transport:4.1.97.Final",
+                  "io.netty:netty-transport-native-epoll:4.1.97.Final",
+                  "io.netty:netty-transport-native-kqueue:4.1.97.Final",
+                  "io.netty:netty-transport-native-unix-common:4.1.97.Final",
+                  "io.grpc:grpc-api:1.56.1",
+                  "io.grpc:grpc-auth:1.56.1",
+                  "io.grpc:grpc-core:1.56.1",
+                  "io.grpc:grpc-context:1.56.1",
+                  "io.grpc:grpc-netty:1.56.1",
+                  "io.grpc:grpc-stub:1.56.1",
+                  "io.grpc:grpc-protobuf:1.56.1",
+                  "io.grpc:grpc-testing:1.56.1",
+                  "io.grpc:grpc-services:1.56.1",
+                  "io.grpc:grpc-netty-shaded:1.56.1",
+                  "io.prometheus:simpleclient:0.15.0",
+                  "io.prometheus:simpleclient_hotspot:0.15.0",
+                  "io.prometheus:simpleclient_httpserver:0.15.0",
+                  "junit:junit:4.13.2",
+                  "javax.annotation:javax.annotation-api:1.3.2",
+                  "net.javacrumbs.future-converter:future-converter-java8-guava:1.2.0",
+                  "org.apache.commons:commons-compress:1.23.0",
+                  "org.apache.commons:commons-pool2:2.11.1",
+                  "org.apache.commons:commons-lang3:3.13.0",
+                  "commons-io:commons-io:2.13.0",
+                  "me.dinowernli:java-grpc-prometheus:0.6.0",
+                  "org.apache.tomcat:annotations-api:6.0.53",
+                  "org.checkerframework:checker-qual:3.38.0",
+                  "org.mockito:mockito-core:2.25.0",
+                  "org.openjdk.jmh:jmh-core:1.37",
+                  "org.openjdk.jmh:jmh-generator-annprocess:1.37",
+                  "org.redisson:redisson:3.23.4",
+                  "org.threeten:threetenbp:1.6.8",
+                  "org.xerial:sqlite-jdbc:3.34.0",
+                  "org.jetbrains:annotations:16.0.2",
+                  "org.yaml:snakeyaml:2.2",
+                  "org.projectlombok:lombok:1.18.30"
+                ],
+                "fail_if_repin_required": true,
+                "generate_compat_repositories": true,
+                "lock_file": "//:maven_install.json"
+              },
+              "devDependency": false,
+              "location": {
+                "file": "@@//:MODULE.bazel",
+                "line": 48,
+                "column": 14
+              }
+            }
+          ],
+          "hasDevUseExtension": false,
+          "hasNonDevUseExtension": true
+        }
+      ],
+      "deps": {
+        "bazel_gazelle": "gazelle@0.34.0",
+        "platforms": "platforms@0.0.7",
+        "rules_cc": "rules_cc@0.0.9",
+        "io_bazel_rules_go": "rules_go@0.43.0",
+        "rules_jvm_external": "rules_jvm_external@5.3",
+        "rules_license": "rules_license@0.0.7",
+        "bazel_tools": "bazel_tools@_",
+        "local_config_platform": "local_config_platform@_"
+      }
+    },
+    "gazelle@0.34.0": {
+      "name": "gazelle",
+      "version": "0.34.0",
+      "key": "gazelle@0.34.0",
+      "repoName": "bazel_gazelle",
+      "executionPlatformsToRegister": [],
+      "toolchainsToRegister": [],
+      "extensionUsages": [
+        {
+          "extensionBzlFile": "@io_bazel_rules_go//go:extensions.bzl",
+          "extensionName": "go_sdk",
+          "usingModule": "gazelle@0.34.0",
+          "location": {
+            "file": "https://bcr.bazel.build/modules/gazelle/0.34.0/MODULE.bazel",
+            "line": 12,
+            "column": 23
+          },
+          "imports": {
+            "go_host_compatible_sdk_label": "go_host_compatible_sdk_label"
+          },
+          "devImports": [],
+          "tags": [],
+          "hasDevUseExtension": false,
+          "hasNonDevUseExtension": true
+        },
+        {
+          "extensionBzlFile": "@bazel_gazelle//internal/bzlmod:non_module_deps.bzl",
+          "extensionName": "non_module_deps",
+          "usingModule": "gazelle@0.34.0",
+          "location": {
+            "file": "https://bcr.bazel.build/modules/gazelle/0.34.0/MODULE.bazel",
+            "line": 20,
+            "column": 32
+          },
+          "imports": {
+            "bazel_gazelle_go_repository_cache": "bazel_gazelle_go_repository_cache",
+            "bazel_gazelle_go_repository_tools": "bazel_gazelle_go_repository_tools",
+            "bazel_gazelle_is_bazel_module": "bazel_gazelle_is_bazel_module"
+          },
+          "devImports": [],
+          "tags": [],
+          "hasDevUseExtension": false,
+          "hasNonDevUseExtension": true
+        },
+        {
+          "extensionBzlFile": "@bazel_gazelle//:extensions.bzl",
+          "extensionName": "go_deps",
+          "usingModule": "gazelle@0.34.0",
+          "location": {
+            "file": "https://bcr.bazel.build/modules/gazelle/0.34.0/MODULE.bazel",
+            "line": 28,
+            "column": 24
+          },
+          "imports": {
+            "com_github_bazelbuild_buildtools": "com_github_bazelbuild_buildtools",
+            "com_github_bmatcuk_doublestar_v4": "com_github_bmatcuk_doublestar_v4",
+            "com_github_fsnotify_fsnotify": "com_github_fsnotify_fsnotify",
+            "com_github_google_go_cmp": "com_github_google_go_cmp",
+            "com_github_pmezard_go_difflib": "com_github_pmezard_go_difflib",
+            "org_golang_x_mod": "org_golang_x_mod",
+            "org_golang_x_sync": "org_golang_x_sync",
+            "org_golang_x_tools": "org_golang_x_tools",
+            "org_golang_x_tools_go_vcs": "org_golang_x_tools_go_vcs",
+            "bazel_gazelle_go_repository_config": "bazel_gazelle_go_repository_config"
+          },
+          "devImports": [],
+          "tags": [
+            {
+              "tagName": "from_file",
+              "attributeValues": {
+                "go_mod": "//:go.mod"
+              },
+              "devDependency": false,
+              "location": {
+                "file": "https://bcr.bazel.build/modules/gazelle/0.34.0/MODULE.bazel",
+                "line": 29,
+                "column": 18
+              }
+            },
+            {
+              "tagName": "module",
+              "attributeValues": {
+                "path": "golang.org/x/tools",
+                "sum": "h1:Iey4qkscZuv0VvIt8E0neZjtPVQFSc870HQ448QgEmQ=",
+                "version": "v0.13.0"
+              },
+              "devDependency": false,
+              "location": {
+                "file": "https://bcr.bazel.build/modules/gazelle/0.34.0/MODULE.bazel",
+                "line": 33,
+                "column": 15
+              }
+            }
+          ],
+          "hasDevUseExtension": false,
+          "hasNonDevUseExtension": true
+        }
+      ],
+      "deps": {
+        "bazel_skylib": "bazel_skylib@1.4.1",
+        "com_google_protobuf": "protobuf@3.19.6",
+        "io_bazel_rules_go": "rules_go@0.43.0",
+        "rules_proto": "rules_proto@4.0.0",
+        "bazel_tools": "bazel_tools@_",
+        "local_config_platform": "local_config_platform@_"
+      },
+      "repoSpec": {
+        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "ruleClassName": "http_archive",
+        "attributes": {
+          "name": "gazelle~0.34.0",
+          "urls": [
+            "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.34.0/bazel-gazelle-v0.34.0.tar.gz"
+          ],
+          "integrity": "sha256-tzh/cu+1n4duTarkLx05EtDUVWPqx8sj0d4LCUq1iM8=",
+          "strip_prefix": "",
+          "remote_patches": {},
+          "remote_patch_strip": 0
+        }
+      }
+    },
+    "platforms@0.0.7": {
+      "name": "platforms",
+      "version": "0.0.7",
+      "key": "platforms@0.0.7",
+      "repoName": "platforms",
+      "executionPlatformsToRegister": [],
+      "toolchainsToRegister": [],
+      "extensionUsages": [],
+      "deps": {
+        "rules_license": "rules_license@0.0.7",
+        "bazel_tools": "bazel_tools@_",
+        "local_config_platform": "local_config_platform@_"
+      },
+      "repoSpec": {
+        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "ruleClassName": "http_archive",
+        "attributes": {
+          "name": "platforms",
+          "urls": [
+            "https://github.com/bazelbuild/platforms/releases/download/0.0.7/platforms-0.0.7.tar.gz"
+          ],
+          "integrity": "sha256-OlYcmee9vpFzqmU/1Xn+hJ8djWc5V4CrR3Cx84FDHVE=",
+          "strip_prefix": "",
+          "remote_patches": {},
+          "remote_patch_strip": 0
+        }
+      }
+    },
+    "rules_cc@0.0.9": {
+      "name": "rules_cc",
+      "version": "0.0.9",
+      "key": "rules_cc@0.0.9",
+      "repoName": "rules_cc",
+      "executionPlatformsToRegister": [],
+      "toolchainsToRegister": [
+        "@local_config_cc_toolchains//:all"
+      ],
+      "extensionUsages": [
+        {
+          "extensionBzlFile": "@bazel_tools//tools/cpp:cc_configure.bzl",
+          "extensionName": "cc_configure_extension",
+          "usingModule": "rules_cc@0.0.9",
+          "location": {
+            "file": "https://bcr.bazel.build/modules/rules_cc/0.0.9/MODULE.bazel",
+            "line": 9,
+            "column": 29
+          },
+          "imports": {
+            "local_config_cc_toolchains": "local_config_cc_toolchains"
+          },
+          "devImports": [],
+          "tags": [],
+          "hasDevUseExtension": false,
+          "hasNonDevUseExtension": true
+        }
+      ],
+      "deps": {
+        "platforms": "platforms@0.0.7",
+        "bazel_tools": "bazel_tools@_",
+        "local_config_platform": "local_config_platform@_"
+      },
+      "repoSpec": {
+        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "ruleClassName": "http_archive",
+        "attributes": {
+          "name": "rules_cc~0.0.9",
+          "urls": [
+            "https://github.com/bazelbuild/rules_cc/releases/download/0.0.9/rules_cc-0.0.9.tar.gz"
+          ],
+          "integrity": "sha256-IDeHW5pEVtzkp50RKorohbvEqtlo5lh9ym5k86CQDN8=",
+          "strip_prefix": "rules_cc-0.0.9",
+          "remote_patches": {
+            "https://bcr.bazel.build/modules/rules_cc/0.0.9/patches/module_dot_bazel_version.patch": "sha256-mM+qzOI0SgAdaJBlWOSMwMPKpaA9b7R37Hj/tp5bb4g="
+          },
+          "remote_patch_strip": 0
+        }
+      }
+    },
+    "rules_go@0.43.0": {
+      "name": "rules_go",
+      "version": "0.43.0",
+      "key": "rules_go@0.43.0",
+      "repoName": "io_bazel_rules_go",
+      "executionPlatformsToRegister": [],
+      "toolchainsToRegister": [
+        "@go_toolchains//:all"
+      ],
+      "extensionUsages": [
+        {
+          "extensionBzlFile": "@io_bazel_rules_go//go/private:extensions.bzl",
+          "extensionName": "non_module_dependencies",
+          "usingModule": "rules_go@0.43.0",
+          "location": {
+            "file": "https://bcr.bazel.build/modules/rules_go/0.43.0/MODULE.bazel",
+            "line": 14,
+            "column": 40
+          },
+          "imports": {
+            "io_bazel_rules_nogo": "io_bazel_rules_nogo"
+          },
+          "devImports": [],
+          "tags": [],
+          "hasDevUseExtension": false,
+          "hasNonDevUseExtension": true
+        },
+        {
+          "extensionBzlFile": "@io_bazel_rules_go//go:extensions.bzl",
+          "extensionName": "go_sdk",
+          "usingModule": "rules_go@0.43.0",
+          "location": {
+            "file": "https://bcr.bazel.build/modules/rules_go/0.43.0/MODULE.bazel",
+            "line": 20,
+            "column": 23
+          },
+          "imports": {
+            "go_toolchains": "go_toolchains"
+          },
+          "devImports": [],
+          "tags": [
+            {
+              "tagName": "download",
+              "attributeValues": {
+                "name": "go_default_sdk",
+                "version": "1.21.1"
+              },
+              "devDependency": false,
+              "location": {
+                "file": "https://bcr.bazel.build/modules/rules_go/0.43.0/MODULE.bazel",
+                "line": 21,
+                "column": 16
+              }
+            }
+          ],
+          "hasDevUseExtension": false,
+          "hasNonDevUseExtension": true
+        },
+        {
+          "extensionBzlFile": "@gazelle//:extensions.bzl",
+          "extensionName": "go_deps",
+          "usingModule": "rules_go@0.43.0",
+          "location": {
+            "file": "https://bcr.bazel.build/modules/rules_go/0.43.0/MODULE.bazel",
+            "line": 31,
+            "column": 24
+          },
+          "imports": {
+            "com_github_gogo_protobuf": "com_github_gogo_protobuf",
+            "com_github_golang_mock": "com_github_golang_mock",
+            "com_github_golang_protobuf": "com_github_golang_protobuf",
+            "org_golang_google_genproto": "org_golang_google_genproto",
+            "org_golang_google_grpc": "org_golang_google_grpc",
+            "org_golang_google_protobuf": "org_golang_google_protobuf",
+            "org_golang_x_net": "org_golang_x_net"
+          },
+          "devImports": [],
+          "tags": [
+            {
+              "tagName": "from_file",
+              "attributeValues": {
+                "go_mod": "//:go.mod"
+              },
+              "devDependency": false,
+              "location": {
+                "file": "https://bcr.bazel.build/modules/rules_go/0.43.0/MODULE.bazel",
+                "line": 32,
+                "column": 18
+              }
+            },
+            {
+              "tagName": "module",
+              "attributeValues": {
+                "path": "github.com/gogo/protobuf",
+                "sum": "h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=",
+                "version": "v1.3.2"
+              },
+              "devDependency": false,
+              "location": {
+                "file": "https://bcr.bazel.build/modules/rules_go/0.43.0/MODULE.bazel",
+                "line": 33,
+                "column": 15
+              }
+            }
+          ],
+          "hasDevUseExtension": false,
+          "hasNonDevUseExtension": true
+        }
+      ],
+      "deps": {
+        "bazel_features": "bazel_features@1.1.1",
+        "bazel_skylib": "bazel_skylib@1.4.1",
+        "platforms": "platforms@0.0.7",
+        "rules_proto": "rules_proto@4.0.0",
+        "com_google_protobuf": "protobuf@3.19.6",
+        "gazelle": "gazelle@0.34.0",
+        "bazel_tools": "bazel_tools@_",
+        "local_config_platform": "local_config_platform@_"
+      },
+      "repoSpec": {
+        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "ruleClassName": "http_archive",
+        "attributes": {
+          "name": "rules_go~0.43.0",
+          "urls": [
+            "https://github.com/bazelbuild/rules_go/releases/download/v0.43.0/rules_go-v0.43.0.zip"
+          ],
+          "integrity": "sha256-1qtrV+SMCVI+kwUPE2mPcIQoz9XmGSUuNp03evZZdwc=",
+          "strip_prefix": "",
+          "remote_patches": {},
+          "remote_patch_strip": 0
+        }
+      }
+    },
+    "rules_jvm_external@5.3": {
+      "name": "rules_jvm_external",
+      "version": "5.3",
+      "key": "rules_jvm_external@5.3",
+      "repoName": "rules_jvm_external",
+      "executionPlatformsToRegister": [],
+      "toolchainsToRegister": [],
+      "extensionUsages": [
+        {
+          "extensionBzlFile": "@rules_jvm_external//:non-module-deps.bzl",
+          "extensionName": "non_module_deps",
+          "usingModule": "rules_jvm_external@5.3",
+          "location": {
+            "file": "https://bcr.bazel.build/modules/rules_jvm_external/5.3/MODULE.bazel",
+            "line": 9,
+            "column": 32
+          },
+          "imports": {
+            "io_bazel_rules_kotlin": "io_bazel_rules_kotlin"
+          },
+          "devImports": [],
+          "tags": [],
+          "hasDevUseExtension": false,
+          "hasNonDevUseExtension": true
+        },
+        {
+          "extensionBzlFile": ":extensions.bzl",
+          "extensionName": "maven",
+          "usingModule": "rules_jvm_external@5.3",
+          "location": {
+            "file": "https://bcr.bazel.build/modules/rules_jvm_external/5.3/MODULE.bazel",
+            "line": 16,
+            "column": 22
+          },
+          "imports": {
+            "rules_jvm_external_deps": "rules_jvm_external_deps"
+          },
+          "devImports": [],
+          "tags": [
+            {
+              "tagName": "install",
+              "attributeValues": {
+                "name": "rules_jvm_external_deps",
+                "artifacts": [
+                  "com.google.auth:google-auth-library-credentials:1.17.0",
+                  "com.google.auth:google-auth-library-oauth2-http:1.17.0",
+                  "com.google.cloud:google-cloud-core:2.18.1",
+                  "com.google.cloud:google-cloud-storage:2.22.3",
+                  "com.google.code.gson:gson:2.10.1",
+                  "com.google.googlejavaformat:google-java-format:1.17.0",
+                  "com.google.guava:guava:32.0.0-jre",
+                  "org.apache.maven:maven-artifact:3.9.2",
+                  "software.amazon.awssdk:s3:2.20.78"
+                ],
+                "lock_file": "@rules_jvm_external//:rules_jvm_external_deps_install.json"
+              },
+              "devDependency": false,
+              "location": {
+                "file": "https://bcr.bazel.build/modules/rules_jvm_external/5.3/MODULE.bazel",
+                "line": 18,
+                "column": 14
+              }
+            }
+          ],
+          "hasDevUseExtension": false,
+          "hasNonDevUseExtension": true
+        }
+      ],
+      "deps": {
+        "bazel_skylib": "bazel_skylib@1.4.1",
+        "io_bazel_stardoc": "stardoc@0.5.3",
+        "bazel_tools": "bazel_tools@_",
+        "local_config_platform": "local_config_platform@_"
+      },
+      "repoSpec": {
+        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "ruleClassName": "http_archive",
+        "attributes": {
+          "name": "rules_jvm_external~5.3",
+          "urls": [
+            "https://github.com/bazelbuild/rules_jvm_external/releases/download/5.3/rules_jvm_external-5.3.tar.gz"
+          ],
+          "integrity": "sha256-0x42m4VDIspQmOoSxp1xdd7ZcUNeVcGN2d1fKcxSSaw=",
+          "strip_prefix": "rules_jvm_external-5.3",
+          "remote_patches": {},
+          "remote_patch_strip": 0
+        }
+      }
+    },
+    "rules_license@0.0.7": {
+      "name": "rules_license",
+      "version": "0.0.7",
+      "key": "rules_license@0.0.7",
+      "repoName": "rules_license",
+      "executionPlatformsToRegister": [],
+      "toolchainsToRegister": [],
+      "extensionUsages": [],
+      "deps": {
+        "bazel_tools": "bazel_tools@_",
+        "local_config_platform": "local_config_platform@_"
+      },
+      "repoSpec": {
+        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "ruleClassName": "http_archive",
+        "attributes": {
+          "name": "rules_license~0.0.7",
+          "urls": [
+            "https://github.com/bazelbuild/rules_license/releases/download/0.0.7/rules_license-0.0.7.tar.gz"
+          ],
+          "integrity": "sha256-RTHezLkTY5ww5cdRKgVNXYdWmNrrddjPkPKEN1/nw2A=",
+          "strip_prefix": "",
+          "remote_patches": {},
+          "remote_patch_strip": 0
+        }
+      }
+    },
+    "bazel_tools@_": {
+      "name": "bazel_tools",
+      "version": "",
+      "key": "bazel_tools@_",
+      "repoName": "bazel_tools",
+      "executionPlatformsToRegister": [],
+      "toolchainsToRegister": [
+        "@local_config_cc_toolchains//:all",
+        "@local_config_sh//:local_sh_toolchain"
+      ],
+      "extensionUsages": [
+        {
+          "extensionBzlFile": "@bazel_tools//tools/cpp:cc_configure.bzl",
+          "extensionName": "cc_configure_extension",
+          "usingModule": "bazel_tools@_",
+          "location": {
+            "file": "@@bazel_tools//:MODULE.bazel",
+            "line": 17,
+            "column": 29
+          },
+          "imports": {
+            "local_config_cc": "local_config_cc",
+            "local_config_cc_toolchains": "local_config_cc_toolchains"
+          },
+          "devImports": [],
+          "tags": [],
+          "hasDevUseExtension": false,
+          "hasNonDevUseExtension": true
+        },
+        {
+          "extensionBzlFile": "@bazel_tools//tools/osx:xcode_configure.bzl",
+          "extensionName": "xcode_configure_extension",
+          "usingModule": "bazel_tools@_",
+          "location": {
+            "file": "@@bazel_tools//:MODULE.bazel",
+            "line": 21,
+            "column": 32
+          },
+          "imports": {
+            "local_config_xcode": "local_config_xcode"
+          },
+          "devImports": [],
+          "tags": [],
+          "hasDevUseExtension": false,
+          "hasNonDevUseExtension": true
+        },
+        {
+          "extensionBzlFile": "@rules_java//java:extensions.bzl",
+          "extensionName": "toolchains",
+          "usingModule": "bazel_tools@_",
+          "location": {
+            "file": "@@bazel_tools//:MODULE.bazel",
+            "line": 24,
+            "column": 32
+          },
+          "imports": {
+            "local_jdk": "local_jdk",
+            "remote_java_tools": "remote_java_tools",
+            "remote_java_tools_linux": "remote_java_tools_linux",
+            "remote_java_tools_windows": "remote_java_tools_windows",
+            "remote_java_tools_darwin_x86_64": "remote_java_tools_darwin_x86_64",
+            "remote_java_tools_darwin_arm64": "remote_java_tools_darwin_arm64"
+          },
+          "devImports": [],
+          "tags": [],
+          "hasDevUseExtension": false,
+          "hasNonDevUseExtension": true
+        },
+        {
+          "extensionBzlFile": "@bazel_tools//tools/sh:sh_configure.bzl",
+          "extensionName": "sh_configure_extension",
+          "usingModule": "bazel_tools@_",
+          "location": {
+            "file": "@@bazel_tools//:MODULE.bazel",
+            "line": 35,
+            "column": 39
+          },
+          "imports": {
+            "local_config_sh": "local_config_sh"
+          },
+          "devImports": [],
+          "tags": [],
+          "hasDevUseExtension": false,
+          "hasNonDevUseExtension": true
+        },
+        {
+          "extensionBzlFile": "@bazel_tools//tools/test:extensions.bzl",
+          "extensionName": "remote_coverage_tools_extension",
+          "usingModule": "bazel_tools@_",
+          "location": {
+            "file": "@@bazel_tools//:MODULE.bazel",
+            "line": 39,
+            "column": 48
+          },
+          "imports": {
+            "remote_coverage_tools": "remote_coverage_tools"
+          },
+          "devImports": [],
+          "tags": [],
+          "hasDevUseExtension": false,
+          "hasNonDevUseExtension": true
+        },
+        {
+          "extensionBzlFile": "@bazel_tools//tools/android:android_extensions.bzl",
+          "extensionName": "remote_android_tools_extensions",
+          "usingModule": "bazel_tools@_",
+          "location": {
+            "file": "@@bazel_tools//:MODULE.bazel",
+            "line": 42,
+            "column": 42
+          },
+          "imports": {
+            "android_gmaven_r8": "android_gmaven_r8",
+            "android_tools": "android_tools"
+          },
+          "devImports": [],
+          "tags": [],
+          "hasDevUseExtension": false,
+          "hasNonDevUseExtension": true
+        }
+      ],
+      "deps": {
+        "rules_cc": "rules_cc@0.0.9",
+        "rules_java": "rules_java@7.1.0",
+        "rules_license": "rules_license@0.0.7",
+        "rules_proto": "rules_proto@4.0.0",
+        "rules_python": "rules_python@0.4.0",
+        "platforms": "platforms@0.0.7",
+        "com_google_protobuf": "protobuf@3.19.6",
+        "zlib": "zlib@1.3",
+        "build_bazel_apple_support": "apple_support@1.5.0",
+        "local_config_platform": "local_config_platform@_"
+      }
+    },
+    "local_config_platform@_": {
+      "name": "local_config_platform",
+      "version": "",
+      "key": "local_config_platform@_",
+      "repoName": "local_config_platform",
+      "executionPlatformsToRegister": [],
+      "toolchainsToRegister": [],
+      "extensionUsages": [],
+      "deps": {
+        "platforms": "platforms@0.0.7",
+        "bazel_tools": "bazel_tools@_"
+      }
+    },
+    "bazel_skylib@1.4.1": {
+      "name": "bazel_skylib",
+      "version": "1.4.1",
+      "key": "bazel_skylib@1.4.1",
+      "repoName": "bazel_skylib",
+      "executionPlatformsToRegister": [],
+      "toolchainsToRegister": [
+        "//toolchains/unittest:cmd_toolchain",
+        "//toolchains/unittest:bash_toolchain"
+      ],
+      "extensionUsages": [],
+      "deps": {
+        "platforms": "platforms@0.0.7",
+        "bazel_tools": "bazel_tools@_",
+        "local_config_platform": "local_config_platform@_"
+      },
+      "repoSpec": {
+        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "ruleClassName": "http_archive",
+        "attributes": {
+          "name": "bazel_skylib~1.4.1",
+          "urls": [
+            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-1.4.1.tar.gz"
+          ],
+          "integrity": "sha256-uKFSeQF3QYCvx5iusoxGNL3M8ZxNmOe90c550f6aqtc=",
+          "strip_prefix": "",
+          "remote_patches": {},
+          "remote_patch_strip": 0
+        }
+      }
+    },
+    "protobuf@3.19.6": {
+      "name": "protobuf",
+      "version": "3.19.6",
+      "key": "protobuf@3.19.6",
+      "repoName": "protobuf",
+      "executionPlatformsToRegister": [],
+      "toolchainsToRegister": [],
+      "extensionUsages": [],
+      "deps": {
+        "bazel_skylib": "bazel_skylib@1.4.1",
+        "zlib": "zlib@1.3",
+        "rules_python": "rules_python@0.4.0",
+        "rules_cc": "rules_cc@0.0.9",
+        "rules_proto": "rules_proto@4.0.0",
+        "rules_java": "rules_java@7.1.0",
+        "bazel_tools": "bazel_tools@_",
+        "local_config_platform": "local_config_platform@_"
+      },
+      "repoSpec": {
+        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "ruleClassName": "http_archive",
+        "attributes": {
+          "name": "protobuf~3.19.6",
+          "urls": [
+            "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.19.6.zip"
+          ],
+          "integrity": "sha256-OH4sVZuyx8G8N5jE5s/wFTgaebJ1hpavy/johzC0c4k=",
+          "strip_prefix": "protobuf-3.19.6",
+          "remote_patches": {
+            "https://bcr.bazel.build/modules/protobuf/3.19.6/patches/relative_repo_names.patch": "sha256-w/5gw/zGv8NFId+669hcdw1Uus2lxgYpulATHIwIByI=",
+            "https://bcr.bazel.build/modules/protobuf/3.19.6/patches/remove_dependency_on_rules_jvm_external.patch": "sha256-THUTnVgEBmjA0W7fKzIyZOVG58DnW9HQTkr4D2zKUUc=",
+            "https://bcr.bazel.build/modules/protobuf/3.19.6/patches/add_module_dot_bazel_for_examples.patch": "sha256-s/b1gi3baK3LsXefI2rQilhmkb2R5jVJdnT6zEcdfHY=",
+            "https://bcr.bazel.build/modules/protobuf/3.19.6/patches/module_dot_bazel.patch": "sha256-S0DEni8zgx7rHscW3z/rCEubQnYec0XhNet640cw0h4="
+          },
+          "remote_patch_strip": 1
+        }
+      }
+    },
+    "rules_proto@4.0.0": {
+      "name": "rules_proto",
+      "version": "4.0.0",
+      "key": "rules_proto@4.0.0",
+      "repoName": "rules_proto",
+      "executionPlatformsToRegister": [],
+      "toolchainsToRegister": [],
+      "extensionUsages": [],
+      "deps": {
+        "bazel_skylib": "bazel_skylib@1.4.1",
+        "rules_cc": "rules_cc@0.0.9",
+        "bazel_tools": "bazel_tools@_",
+        "local_config_platform": "local_config_platform@_"
+      },
+      "repoSpec": {
+        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "ruleClassName": "http_archive",
+        "attributes": {
+          "name": "rules_proto~4.0.0",
+          "urls": [
+            "https://github.com/bazelbuild/rules_proto/archive/refs/tags/4.0.0.zip"
+          ],
+          "integrity": "sha256-Lr5z6xyuRA19pNtRYMGjKaynwQpck4H/lwYyVjyhoq4=",
+          "strip_prefix": "rules_proto-4.0.0",
+          "remote_patches": {
+            "https://bcr.bazel.build/modules/rules_proto/4.0.0/patches/module_dot_bazel.patch": "sha256-MclJO7tIAM2ElDAmscNId9pKTpOuDGHgVlW/9VBOIp0="
+          },
+          "remote_patch_strip": 0
+        }
+      }
+    },
+    "bazel_features@1.1.1": {
+      "name": "bazel_features",
+      "version": "1.1.1",
+      "key": "bazel_features@1.1.1",
+      "repoName": "bazel_features",
+      "executionPlatformsToRegister": [],
+      "toolchainsToRegister": [],
+      "extensionUsages": [
+        {
+          "extensionBzlFile": "@bazel_features//private:extensions.bzl",
+          "extensionName": "version_extension",
+          "usingModule": "bazel_features@1.1.1",
+          "location": {
+            "file": "https://bcr.bazel.build/modules/bazel_features/1.1.1/MODULE.bazel",
+            "line": 6,
+            "column": 24
+          },
+          "imports": {
+            "bazel_features_globals": "bazel_features_globals",
+            "bazel_features_version": "bazel_features_version"
+          },
+          "devImports": [],
+          "tags": [],
+          "hasDevUseExtension": false,
+          "hasNonDevUseExtension": true
+        }
+      ],
+      "deps": {
+        "bazel_tools": "bazel_tools@_",
+        "local_config_platform": "local_config_platform@_"
+      },
+      "repoSpec": {
+        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "ruleClassName": "http_archive",
+        "attributes": {
+          "name": "bazel_features~1.1.1",
+          "urls": [
+            "https://github.com/bazel-contrib/bazel_features/releases/download/v1.1.1/bazel_features-v1.1.1.tar.gz"
+          ],
+          "integrity": "sha256-YsJuQn5cvHUQJERpJ2IuOYqdzfMsZDJSOIFXCdEcEag=",
+          "strip_prefix": "bazel_features-1.1.1",
+          "remote_patches": {
+            "https://bcr.bazel.build/modules/bazel_features/1.1.1/patches/module_dot_bazel_version.patch": "sha256-+56MAEsc7bYN/Pzhn252ZQUxiRzZg9bynXj1qpsmCYs="
+          },
+          "remote_patch_strip": 1
+        }
+      }
+    },
+    "stardoc@0.5.3": {
+      "name": "stardoc",
+      "version": "0.5.3",
+      "key": "stardoc@0.5.3",
+      "repoName": "stardoc",
+      "executionPlatformsToRegister": [],
+      "toolchainsToRegister": [],
+      "extensionUsages": [],
+      "deps": {
+        "bazel_skylib": "bazel_skylib@1.4.1",
+        "rules_java": "rules_java@7.1.0",
+        "bazel_tools": "bazel_tools@_",
+        "local_config_platform": "local_config_platform@_"
+      },
+      "repoSpec": {
+        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "ruleClassName": "http_archive",
+        "attributes": {
+          "name": "stardoc~0.5.3",
+          "urls": [
+            "https://github.com/bazelbuild/stardoc/releases/download/0.5.3/stardoc-0.5.3.tar.gz"
+          ],
+          "integrity": "sha256-P9j+xN3sPGcL2BCQTi4zFwvt/hL5Ct+UNQgYS+RYyLs=",
+          "strip_prefix": "",
+          "remote_patches": {
+            "https://bcr.bazel.build/modules/stardoc/0.5.3/patches/module_dot_bazel.patch": "sha256-Lgpy9OCr0zBWYuHoyM1rJJrgxn23X/bwgICEF7XiEug="
+          },
+          "remote_patch_strip": 0
+        }
+      }
+    },
+    "rules_java@7.1.0": {
+      "name": "rules_java",
+      "version": "7.1.0",
+      "key": "rules_java@7.1.0",
+      "repoName": "rules_java",
+      "executionPlatformsToRegister": [],
+      "toolchainsToRegister": [
+        "//toolchains:all",
+        "@local_jdk//:runtime_toolchain_definition",
+        "@local_jdk//:bootstrap_runtime_toolchain_definition",
+        "@remotejdk11_linux_toolchain_config_repo//:all",
+        "@remotejdk11_linux_aarch64_toolchain_config_repo//:all",
+        "@remotejdk11_linux_ppc64le_toolchain_config_repo//:all",
+        "@remotejdk11_linux_s390x_toolchain_config_repo//:all",
+        "@remotejdk11_macos_toolchain_config_repo//:all",
+        "@remotejdk11_macos_aarch64_toolchain_config_repo//:all",
+        "@remotejdk11_win_toolchain_config_repo//:all",
+        "@remotejdk11_win_arm64_toolchain_config_repo//:all",
+        "@remotejdk17_linux_toolchain_config_repo//:all",
+        "@remotejdk17_linux_aarch64_toolchain_config_repo//:all",
+        "@remotejdk17_linux_ppc64le_toolchain_config_repo//:all",
+        "@remotejdk17_linux_s390x_toolchain_config_repo//:all",
+        "@remotejdk17_macos_toolchain_config_repo//:all",
+        "@remotejdk17_macos_aarch64_toolchain_config_repo//:all",
+        "@remotejdk17_win_toolchain_config_repo//:all",
+        "@remotejdk17_win_arm64_toolchain_config_repo//:all",
+        "@remotejdk21_linux_toolchain_config_repo//:all",
+        "@remotejdk21_linux_aarch64_toolchain_config_repo//:all",
+        "@remotejdk21_macos_toolchain_config_repo//:all",
+        "@remotejdk21_macos_aarch64_toolchain_config_repo//:all",
+        "@remotejdk21_win_toolchain_config_repo//:all"
+      ],
+      "extensionUsages": [
+        {
+          "extensionBzlFile": "@rules_java//java:extensions.bzl",
+          "extensionName": "toolchains",
+          "usingModule": "rules_java@7.1.0",
+          "location": {
+            "file": "https://bcr.bazel.build/modules/rules_java/7.1.0/MODULE.bazel",
+            "line": 19,
+            "column": 27
+          },
+          "imports": {
+            "remote_java_tools": "remote_java_tools",
+            "remote_java_tools_linux": "remote_java_tools_linux",
+            "remote_java_tools_windows": "remote_java_tools_windows",
+            "remote_java_tools_darwin_x86_64": "remote_java_tools_darwin_x86_64",
+            "remote_java_tools_darwin_arm64": "remote_java_tools_darwin_arm64",
+            "local_jdk": "local_jdk",
+            "remotejdk11_linux_toolchain_config_repo": "remotejdk11_linux_toolchain_config_repo",
+            "remotejdk11_linux_aarch64_toolchain_config_repo": "remotejdk11_linux_aarch64_toolchain_config_repo",
+            "remotejdk11_linux_ppc64le_toolchain_config_repo": "remotejdk11_linux_ppc64le_toolchain_config_repo",
+            "remotejdk11_linux_s390x_toolchain_config_repo": "remotejdk11_linux_s390x_toolchain_config_repo",
+            "remotejdk11_macos_toolchain_config_repo": "remotejdk11_macos_toolchain_config_repo",
+            "remotejdk11_macos_aarch64_toolchain_config_repo": "remotejdk11_macos_aarch64_toolchain_config_repo",
+            "remotejdk11_win_toolchain_config_repo": "remotejdk11_win_toolchain_config_repo",
+            "remotejdk11_win_arm64_toolchain_config_repo": "remotejdk11_win_arm64_toolchain_config_repo",
+            "remotejdk17_linux_toolchain_config_repo": "remotejdk17_linux_toolchain_config_repo",
+            "remotejdk17_linux_aarch64_toolchain_config_repo": "remotejdk17_linux_aarch64_toolchain_config_repo",
+            "remotejdk17_linux_ppc64le_toolchain_config_repo": "remotejdk17_linux_ppc64le_toolchain_config_repo",
+            "remotejdk17_linux_s390x_toolchain_config_repo": "remotejdk17_linux_s390x_toolchain_config_repo",
+            "remotejdk17_macos_toolchain_config_repo": "remotejdk17_macos_toolchain_config_repo",
+            "remotejdk17_macos_aarch64_toolchain_config_repo": "remotejdk17_macos_aarch64_toolchain_config_repo",
+            "remotejdk17_win_toolchain_config_repo": "remotejdk17_win_toolchain_config_repo",
+            "remotejdk17_win_arm64_toolchain_config_repo": "remotejdk17_win_arm64_toolchain_config_repo",
+            "remotejdk21_linux_toolchain_config_repo": "remotejdk21_linux_toolchain_config_repo",
+            "remotejdk21_linux_aarch64_toolchain_config_repo": "remotejdk21_linux_aarch64_toolchain_config_repo",
+            "remotejdk21_macos_toolchain_config_repo": "remotejdk21_macos_toolchain_config_repo",
+            "remotejdk21_macos_aarch64_toolchain_config_repo": "remotejdk21_macos_aarch64_toolchain_config_repo",
+            "remotejdk21_win_toolchain_config_repo": "remotejdk21_win_toolchain_config_repo"
+          },
+          "devImports": [],
+          "tags": [],
+          "hasDevUseExtension": false,
+          "hasNonDevUseExtension": true
+        }
+      ],
+      "deps": {
+        "platforms": "platforms@0.0.7",
+        "rules_cc": "rules_cc@0.0.9",
+        "bazel_skylib": "bazel_skylib@1.4.1",
+        "rules_proto": "rules_proto@4.0.0",
+        "rules_license": "rules_license@0.0.7",
+        "bazel_tools": "bazel_tools@_",
+        "local_config_platform": "local_config_platform@_"
+      },
+      "repoSpec": {
+        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "ruleClassName": "http_archive",
+        "attributes": {
+          "name": "rules_java~7.1.0",
+          "urls": [
+            "https://github.com/bazelbuild/rules_java/releases/download/7.1.0/rules_java-7.1.0.tar.gz"
+          ],
+          "integrity": "sha256-o3pOX2OrgnFuXdau75iO2EYcegC46TYnImKJn1h81OE=",
+          "strip_prefix": "",
+          "remote_patches": {},
+          "remote_patch_strip": 0
+        }
+      }
+    },
+    "rules_python@0.4.0": {
+      "name": "rules_python",
+      "version": "0.4.0",
+      "key": "rules_python@0.4.0",
+      "repoName": "rules_python",
+      "executionPlatformsToRegister": [],
+      "toolchainsToRegister": [
+        "@bazel_tools//tools/python:autodetecting_toolchain"
+      ],
+      "extensionUsages": [
+        {
+          "extensionBzlFile": "@rules_python//bzlmod:extensions.bzl",
+          "extensionName": "pip_install",
+          "usingModule": "rules_python@0.4.0",
+          "location": {
+            "file": "https://bcr.bazel.build/modules/rules_python/0.4.0/MODULE.bazel",
+            "line": 7,
+            "column": 28
+          },
+          "imports": {
+            "pypi__click": "pypi__click",
+            "pypi__pip": "pypi__pip",
+            "pypi__pip_tools": "pypi__pip_tools",
+            "pypi__pkginfo": "pypi__pkginfo",
+            "pypi__setuptools": "pypi__setuptools",
+            "pypi__wheel": "pypi__wheel"
+          },
+          "devImports": [],
+          "tags": [],
+          "hasDevUseExtension": false,
+          "hasNonDevUseExtension": true
+        }
+      ],
+      "deps": {
+        "bazel_tools": "bazel_tools@_",
+        "local_config_platform": "local_config_platform@_"
+      },
+      "repoSpec": {
+        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "ruleClassName": "http_archive",
+        "attributes": {
+          "name": "rules_python~0.4.0",
+          "urls": [
+            "https://github.com/bazelbuild/rules_python/releases/download/0.4.0/rules_python-0.4.0.tar.gz"
+          ],
+          "integrity": "sha256-lUqom0kb5KCDMEosuDgBnIuMNyCnq7nEy4GseiQjDOo=",
+          "strip_prefix": "",
+          "remote_patches": {
+            "https://bcr.bazel.build/modules/rules_python/0.4.0/patches/propagate_pip_install_dependencies.patch": "sha256-v7S/dem/mixg63MF4KoRGDA4KEol9ab/tIVp+6Xq0D0=",
+            "https://bcr.bazel.build/modules/rules_python/0.4.0/patches/module_dot_bazel.patch": "sha256-kG4VIfWxQazzTuh50mvsx6pmyoRVA4lfH5rkto/Oq+Y="
+          },
+          "remote_patch_strip": 1
+        }
+      }
+    },
+    "zlib@1.3": {
+      "name": "zlib",
+      "version": "1.3",
+      "key": "zlib@1.3",
+      "repoName": "zlib",
+      "executionPlatformsToRegister": [],
+      "toolchainsToRegister": [],
+      "extensionUsages": [],
+      "deps": {
+        "platforms": "platforms@0.0.7",
+        "rules_cc": "rules_cc@0.0.9",
+        "bazel_tools": "bazel_tools@_",
+        "local_config_platform": "local_config_platform@_"
+      },
+      "repoSpec": {
+        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "ruleClassName": "http_archive",
+        "attributes": {
+          "name": "zlib~1.3",
+          "urls": [
+            "https://github.com/madler/zlib/releases/download/v1.3/zlib-1.3.tar.gz"
+          ],
+          "integrity": "sha256-/wukwpIBPbwnUws6geH5qBPNOd4Byl4Pi/NVcC76WT4=",
+          "strip_prefix": "zlib-1.3",
+          "remote_patches": {
+            "https://bcr.bazel.build/modules/zlib/1.3/patches/add_build_file.patch": "sha256-Ei+FYaaOo7A3jTKunMEodTI0Uw5NXQyZEcboMC8JskY=",
+            "https://bcr.bazel.build/modules/zlib/1.3/patches/module_dot_bazel.patch": "sha256-fPWLM+2xaF/kuy+kZc1YTfW6hNjrkG400Ho7gckuyJk="
+          },
+          "remote_patch_strip": 0
+        }
+      }
+    },
+    "apple_support@1.5.0": {
+      "name": "apple_support",
+      "version": "1.5.0",
+      "key": "apple_support@1.5.0",
+      "repoName": "build_bazel_apple_support",
+      "executionPlatformsToRegister": [],
+      "toolchainsToRegister": [
+        "@local_config_apple_cc_toolchains//:all"
+      ],
+      "extensionUsages": [
+        {
+          "extensionBzlFile": "@build_bazel_apple_support//crosstool:setup.bzl",
+          "extensionName": "apple_cc_configure_extension",
+          "usingModule": "apple_support@1.5.0",
+          "location": {
+            "file": "https://bcr.bazel.build/modules/apple_support/1.5.0/MODULE.bazel",
+            "line": 17,
+            "column": 35
+          },
+          "imports": {
+            "local_config_apple_cc": "local_config_apple_cc",
+            "local_config_apple_cc_toolchains": "local_config_apple_cc_toolchains"
+          },
+          "devImports": [],
+          "tags": [],
+          "hasDevUseExtension": false,
+          "hasNonDevUseExtension": true
+        }
+      ],
+      "deps": {
+        "bazel_skylib": "bazel_skylib@1.4.1",
+        "platforms": "platforms@0.0.7",
+        "bazel_tools": "bazel_tools@_",
+        "local_config_platform": "local_config_platform@_"
+      },
+      "repoSpec": {
+        "bzlFile": "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "ruleClassName": "http_archive",
+        "attributes": {
+          "name": "apple_support~1.5.0",
+          "urls": [
+            "https://github.com/bazelbuild/apple_support/releases/download/1.5.0/apple_support.1.5.0.tar.gz"
+          ],
+          "integrity": "sha256-miM41vja0yRPgj8txghKA+TQ+7J8qJLclw5okNW0gYQ=",
+          "strip_prefix": "",
+          "remote_patches": {},
+          "remote_patch_strip": 0
+        }
+      }
+    }
+  },
+  "moduleExtensions": {
+    "@@apple_support~1.5.0//crosstool:setup.bzl%apple_cc_configure_extension": {
+      "general": {
+        "bzlTransitiveDigest": "pMLFCYaRPkgXPQ8vtuNkMfiHfPmRBy6QJfnid4sWfv0=",
+        "accumulatedFileDigests": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "local_config_apple_cc": {
+            "bzlFile": "@@apple_support~1.5.0//crosstool:setup.bzl",
+            "ruleClassName": "_apple_cc_autoconf",
+            "attributes": {
+              "name": "apple_support~1.5.0~apple_cc_configure_extension~local_config_apple_cc"
+            }
+          },
+          "local_config_apple_cc_toolchains": {
+            "bzlFile": "@@apple_support~1.5.0//crosstool:setup.bzl",
+            "ruleClassName": "_apple_cc_autoconf_toolchains",
+            "attributes": {
+              "name": "apple_support~1.5.0~apple_cc_configure_extension~local_config_apple_cc_toolchains"
+            }
+          }
+        }
+      }
+    },
+    "@@bazel_features~1.1.1//private:extensions.bzl%version_extension": {
+      "general": {
+        "bzlTransitiveDigest": "xm7Skm1Las5saxzFWt2hbS+e68BWi+MXyt6+lKIhjPA=",
+        "accumulatedFileDigests": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "bazel_features_version": {
+            "bzlFile": "@@bazel_features~1.1.1//private:version_repo.bzl",
+            "ruleClassName": "version_repo",
+            "attributes": {
+              "name": "bazel_features~1.1.1~version_extension~bazel_features_version"
+            }
+          },
+          "bazel_features_globals": {
+            "bzlFile": "@@bazel_features~1.1.1//private:globals_repo.bzl",
+            "ruleClassName": "globals_repo",
+            "attributes": {
+              "name": "bazel_features~1.1.1~version_extension~bazel_features_globals",
+              "globals": {
+                "RunEnvironmentInfo": "5.3.0",
+                "DefaultInfo": "0.0.1",
+                "__TestingOnly_NeverAvailable": "1000000000.0.0"
+              }
+            }
+          }
+        }
+      }
+    },
+    "@@bazel_tools//tools/cpp:cc_configure.bzl%cc_configure_extension": {
+      "general": {
+        "bzlTransitiveDigest": "O9sf6ilKWU9Veed02jG9o2HM/xgV/UAyciuFBuxrFRY=",
+        "accumulatedFileDigests": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "local_config_cc": {
+            "bzlFile": "@@bazel_tools//tools/cpp:cc_configure.bzl",
+            "ruleClassName": "cc_autoconf",
+            "attributes": {
+              "name": "bazel_tools~cc_configure_extension~local_config_cc"
+            }
+          },
+          "local_config_cc_toolchains": {
+            "bzlFile": "@@bazel_tools//tools/cpp:cc_configure.bzl",
+            "ruleClassName": "cc_autoconf_toolchains",
+            "attributes": {
+              "name": "bazel_tools~cc_configure_extension~local_config_cc_toolchains"
+            }
+          }
+        }
+      }
+    },
+    "@@bazel_tools//tools/osx:xcode_configure.bzl%xcode_configure_extension": {
+      "general": {
+        "bzlTransitiveDigest": "Qh2bWTU6QW6wkrd87qrU4YeY+SG37Nvw3A0PR4Y0L2Y=",
+        "accumulatedFileDigests": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "local_config_xcode": {
+            "bzlFile": "@@bazel_tools//tools/osx:xcode_configure.bzl",
+            "ruleClassName": "xcode_autoconf",
+            "attributes": {
+              "name": "bazel_tools~xcode_configure_extension~local_config_xcode",
+              "xcode_locator": "@bazel_tools//tools/osx:xcode_locator.m",
+              "remote_xcode": ""
+            }
+          }
+        }
+      }
+    },
+    "@@bazel_tools//tools/sh:sh_configure.bzl%sh_configure_extension": {
+      "general": {
+        "bzlTransitiveDigest": "hp4NgmNjEg5+xgvzfh6L83bt9/aiiWETuNpwNuF1MSU=",
+        "accumulatedFileDigests": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "local_config_sh": {
+            "bzlFile": "@@bazel_tools//tools/sh:sh_configure.bzl",
+            "ruleClassName": "sh_config",
+            "attributes": {
+              "name": "bazel_tools~sh_configure_extension~local_config_sh"
+            }
+          }
+        }
+      }
+    },
+    "@@rules_go~0.43.0//go:extensions.bzl%go_sdk": {
+      "os:osx,arch:aarch64": {
+        "bzlTransitiveDigest": "X7FY+0kUDFpsa3ulS9IPEJAqEW8vwFdmD7u4epims+M=",
+        "accumulatedFileDigests": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "go_default_sdk": {
+            "bzlFile": "@@rules_go~0.43.0//go/private:sdk.bzl",
+            "ruleClassName": "go_download_sdk_rule",
+            "attributes": {
+              "name": "rules_go~0.43.0~go_sdk~go_default_sdk",
+              "goos": "",
+              "goarch": "",
+              "sdks": {},
+              "experiments": [],
+              "patches": [],
+              "patch_strip": 0,
+              "urls": [
+                "https://dl.google.com/go/{}"
+              ],
+              "version": "1.21.1",
+              "strip_prefix": "go"
+            }
+          },
+          "go_host_compatible_sdk_label": {
+            "bzlFile": "@@rules_go~0.43.0//go/private:extensions.bzl",
+            "ruleClassName": "host_compatible_toolchain",
+            "attributes": {
+              "name": "rules_go~0.43.0~go_sdk~go_host_compatible_sdk_label",
+              "toolchain": "@go_default_sdk//:ROOT"
+            }
+          },
+          "go_toolchains": {
+            "bzlFile": "@@rules_go~0.43.0//go/private:sdk.bzl",
+            "ruleClassName": "go_multiple_toolchains",
+            "attributes": {
+              "name": "rules_go~0.43.0~go_sdk~go_toolchains",
+              "prefixes": [
+                "_0000_go_default_sdk_"
+              ],
+              "geese": [
+                ""
+              ],
+              "goarchs": [
+                ""
+              ],
+              "sdk_repos": [
+                "go_default_sdk"
+              ],
+              "sdk_types": [
+                "remote"
+              ],
+              "sdk_versions": [
+                "1.21.1"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "@@rules_java~7.1.0//java:extensions.bzl%toolchains": {
+      "general": {
+        "bzlTransitiveDigest": "iUIRqCK7tkhvcDJCAfPPqSd06IHG0a8HQD0xeQyVAqw=",
+        "accumulatedFileDigests": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "remotejdk21_linux_toolchain_config_repo": {
+            "bzlFile": "@@rules_java~7.1.0//toolchains:remote_java_repository.bzl",
+            "ruleClassName": "_toolchain_config",
+            "attributes": {
+              "name": "rules_java~7.1.0~toolchains~remotejdk21_linux_toolchain_config_repo",
+              "build_file": "\nconfig_setting(\n    name = \"prefix_version_setting\",\n    values = {\"java_runtime_version\": \"remotejdk_21\"},\n    visibility = [\"//visibility:private\"],\n)\nconfig_setting(\n    name = \"version_setting\",\n    values = {\"java_runtime_version\": \"21\"},\n    visibility = [\"//visibility:private\"],\n)\nalias(\n    name = \"version_or_prefix_version_setting\",\n    actual = select({\n        \":version_setting\": \":version_setting\",\n        \"//conditions:default\": \":prefix_version_setting\",\n    }),\n    visibility = [\"//visibility:private\"],\n)\ntoolchain(\n    name = \"toolchain\",\n    target_compatible_with = [\"@platforms//os:linux\", \"@platforms//cpu:x86_64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:runtime_toolchain_type\",\n    toolchain = \"@remotejdk21_linux//:jdk\",\n)\ntoolchain(\n    name = \"bootstrap_runtime_toolchain\",\n    # These constraints are not required for correctness, but prevent fetches of remote JDK for\n    # different architectures. As every Java compilation toolchain depends on a bootstrap runtime in\n    # the same configuration, this constraint will not result in toolchain resolution failures.\n    exec_compatible_with = [\"@platforms//os:linux\", \"@platforms//cpu:x86_64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type\",\n    toolchain = \"@remotejdk21_linux//:jdk\",\n)\n"
+            }
+          },
+          "remotejdk17_linux_s390x_toolchain_config_repo": {
+            "bzlFile": "@@rules_java~7.1.0//toolchains:remote_java_repository.bzl",
+            "ruleClassName": "_toolchain_config",
+            "attributes": {
+              "name": "rules_java~7.1.0~toolchains~remotejdk17_linux_s390x_toolchain_config_repo",
+              "build_file": "\nconfig_setting(\n    name = \"prefix_version_setting\",\n    values = {\"java_runtime_version\": \"remotejdk_17\"},\n    visibility = [\"//visibility:private\"],\n)\nconfig_setting(\n    name = \"version_setting\",\n    values = {\"java_runtime_version\": \"17\"},\n    visibility = [\"//visibility:private\"],\n)\nalias(\n    name = \"version_or_prefix_version_setting\",\n    actual = select({\n        \":version_setting\": \":version_setting\",\n        \"//conditions:default\": \":prefix_version_setting\",\n    }),\n    visibility = [\"//visibility:private\"],\n)\ntoolchain(\n    name = \"toolchain\",\n    target_compatible_with = [\"@platforms//os:linux\", \"@platforms//cpu:s390x\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:runtime_toolchain_type\",\n    toolchain = \"@remotejdk17_linux_s390x//:jdk\",\n)\ntoolchain(\n    name = \"bootstrap_runtime_toolchain\",\n    # These constraints are not required for correctness, but prevent fetches of remote JDK for\n    # different architectures. As every Java compilation toolchain depends on a bootstrap runtime in\n    # the same configuration, this constraint will not result in toolchain resolution failures.\n    exec_compatible_with = [\"@platforms//os:linux\", \"@platforms//cpu:s390x\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type\",\n    toolchain = \"@remotejdk17_linux_s390x//:jdk\",\n)\n"
+            }
+          },
+          "remotejdk17_macos_toolchain_config_repo": {
+            "bzlFile": "@@rules_java~7.1.0//toolchains:remote_java_repository.bzl",
+            "ruleClassName": "_toolchain_config",
+            "attributes": {
+              "name": "rules_java~7.1.0~toolchains~remotejdk17_macos_toolchain_config_repo",
+              "build_file": "\nconfig_setting(\n    name = \"prefix_version_setting\",\n    values = {\"java_runtime_version\": \"remotejdk_17\"},\n    visibility = [\"//visibility:private\"],\n)\nconfig_setting(\n    name = \"version_setting\",\n    values = {\"java_runtime_version\": \"17\"},\n    visibility = [\"//visibility:private\"],\n)\nalias(\n    name = \"version_or_prefix_version_setting\",\n    actual = select({\n        \":version_setting\": \":version_setting\",\n        \"//conditions:default\": \":prefix_version_setting\",\n    }),\n    visibility = [\"//visibility:private\"],\n)\ntoolchain(\n    name = \"toolchain\",\n    target_compatible_with = [\"@platforms//os:macos\", \"@platforms//cpu:x86_64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:runtime_toolchain_type\",\n    toolchain = \"@remotejdk17_macos//:jdk\",\n)\ntoolchain(\n    name = \"bootstrap_runtime_toolchain\",\n    # These constraints are not required for correctness, but prevent fetches of remote JDK for\n    # different architectures. As every Java compilation toolchain depends on a bootstrap runtime in\n    # the same configuration, this constraint will not result in toolchain resolution failures.\n    exec_compatible_with = [\"@platforms//os:macos\", \"@platforms//cpu:x86_64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type\",\n    toolchain = \"@remotejdk17_macos//:jdk\",\n)\n"
+            }
+          },
+          "remotejdk21_macos_aarch64_toolchain_config_repo": {
+            "bzlFile": "@@rules_java~7.1.0//toolchains:remote_java_repository.bzl",
+            "ruleClassName": "_toolchain_config",
+            "attributes": {
+              "name": "rules_java~7.1.0~toolchains~remotejdk21_macos_aarch64_toolchain_config_repo",
+              "build_file": "\nconfig_setting(\n    name = \"prefix_version_setting\",\n    values = {\"java_runtime_version\": \"remotejdk_21\"},\n    visibility = [\"//visibility:private\"],\n)\nconfig_setting(\n    name = \"version_setting\",\n    values = {\"java_runtime_version\": \"21\"},\n    visibility = [\"//visibility:private\"],\n)\nalias(\n    name = \"version_or_prefix_version_setting\",\n    actual = select({\n        \":version_setting\": \":version_setting\",\n        \"//conditions:default\": \":prefix_version_setting\",\n    }),\n    visibility = [\"//visibility:private\"],\n)\ntoolchain(\n    name = \"toolchain\",\n    target_compatible_with = [\"@platforms//os:macos\", \"@platforms//cpu:aarch64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:runtime_toolchain_type\",\n    toolchain = \"@remotejdk21_macos_aarch64//:jdk\",\n)\ntoolchain(\n    name = \"bootstrap_runtime_toolchain\",\n    # These constraints are not required for correctness, but prevent fetches of remote JDK for\n    # different architectures. As every Java compilation toolchain depends on a bootstrap runtime in\n    # the same configuration, this constraint will not result in toolchain resolution failures.\n    exec_compatible_with = [\"@platforms//os:macos\", \"@platforms//cpu:aarch64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type\",\n    toolchain = \"@remotejdk21_macos_aarch64//:jdk\",\n)\n"
+            }
+          },
+          "remotejdk17_linux_aarch64_toolchain_config_repo": {
+            "bzlFile": "@@rules_java~7.1.0//toolchains:remote_java_repository.bzl",
+            "ruleClassName": "_toolchain_config",
+            "attributes": {
+              "name": "rules_java~7.1.0~toolchains~remotejdk17_linux_aarch64_toolchain_config_repo",
+              "build_file": "\nconfig_setting(\n    name = \"prefix_version_setting\",\n    values = {\"java_runtime_version\": \"remotejdk_17\"},\n    visibility = [\"//visibility:private\"],\n)\nconfig_setting(\n    name = \"version_setting\",\n    values = {\"java_runtime_version\": \"17\"},\n    visibility = [\"//visibility:private\"],\n)\nalias(\n    name = \"version_or_prefix_version_setting\",\n    actual = select({\n        \":version_setting\": \":version_setting\",\n        \"//conditions:default\": \":prefix_version_setting\",\n    }),\n    visibility = [\"//visibility:private\"],\n)\ntoolchain(\n    name = \"toolchain\",\n    target_compatible_with = [\"@platforms//os:linux\", \"@platforms//cpu:aarch64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:runtime_toolchain_type\",\n    toolchain = \"@remotejdk17_linux_aarch64//:jdk\",\n)\ntoolchain(\n    name = \"bootstrap_runtime_toolchain\",\n    # These constraints are not required for correctness, but prevent fetches of remote JDK for\n    # different architectures. As every Java compilation toolchain depends on a bootstrap runtime in\n    # the same configuration, this constraint will not result in toolchain resolution failures.\n    exec_compatible_with = [\"@platforms//os:linux\", \"@platforms//cpu:aarch64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type\",\n    toolchain = \"@remotejdk17_linux_aarch64//:jdk\",\n)\n"
+            }
+          },
+          "remotejdk21_macos_aarch64": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_java~7.1.0~toolchains~remotejdk21_macos_aarch64",
+              "build_file_content": "load(\"@rules_java//java:defs.bzl\", \"java_runtime\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nexports_files([\"WORKSPACE\", \"BUILD.bazel\"])\n\nfilegroup(\n    name = \"jre\",\n    srcs = glob(\n        [\n            \"jre/bin/**\",\n            \"jre/lib/**\",\n        ],\n        allow_empty = True,\n        # In some configurations, Java browser plugin is considered harmful and\n        # common antivirus software blocks access to npjp2.dll interfering with Bazel,\n        # so do not include it in JRE on Windows.\n        exclude = [\"jre/bin/plugin2/**\"],\n    ),\n)\n\nfilegroup(\n    name = \"jdk-bin\",\n    srcs = glob(\n        [\"bin/**\"],\n        # The JDK on Windows sometimes contains a directory called\n        # \"%systemroot%\", which is not a valid label.\n        exclude = [\"**/*%*/**\"],\n    ),\n)\n\n# This folder holds security policies.\nfilegroup(\n    name = \"jdk-conf\",\n    srcs = glob(\n        [\"conf/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-include\",\n    srcs = glob(\n        [\"include/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-lib\",\n    srcs = glob(\n        [\"lib/**\", \"release\"],\n        allow_empty = True,\n        exclude = [\n            \"lib/missioncontrol/**\",\n            \"lib/visualvm/**\",\n        ],\n    ),\n)\n\njava_runtime(\n    name = \"jdk\",\n    srcs = [\n        \":jdk-bin\",\n        \":jdk-conf\",\n        \":jdk-include\",\n        \":jdk-lib\",\n        \":jre\",\n    ],\n    # Provide the 'java` binary explicitly so that the correct path is used by\n    # Bazel even when the host platform differs from the execution platform.\n    # Exactly one of the two globs will be empty depending on the host platform.\n    # When --incompatible_disallow_empty_glob is enabled, each individual empty\n    # glob will fail without allow_empty = True, even if the overall result is\n    # non-empty.\n    java = glob([\"bin/java.exe\", \"bin/java\"], allow_empty = True)[0],\n    version = 21,\n)\n",
+              "sha256": "2a7a99a3ea263dbd8d32a67d1e6e363ba8b25c645c826f5e167a02bbafaff1fa",
+              "strip_prefix": "zulu21.28.85-ca-jdk21.0.0-macosx_aarch64",
+              "urls": [
+                "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu21.28.85-ca-jdk21.0.0-macosx_aarch64.tar.gz",
+                "https://cdn.azul.com/zulu/bin/zulu21.28.85-ca-jdk21.0.0-macosx_aarch64.tar.gz"
+              ]
+            }
+          },
+          "remotejdk17_linux_toolchain_config_repo": {
+            "bzlFile": "@@rules_java~7.1.0//toolchains:remote_java_repository.bzl",
+            "ruleClassName": "_toolchain_config",
+            "attributes": {
+              "name": "rules_java~7.1.0~toolchains~remotejdk17_linux_toolchain_config_repo",
+              "build_file": "\nconfig_setting(\n    name = \"prefix_version_setting\",\n    values = {\"java_runtime_version\": \"remotejdk_17\"},\n    visibility = [\"//visibility:private\"],\n)\nconfig_setting(\n    name = \"version_setting\",\n    values = {\"java_runtime_version\": \"17\"},\n    visibility = [\"//visibility:private\"],\n)\nalias(\n    name = \"version_or_prefix_version_setting\",\n    actual = select({\n        \":version_setting\": \":version_setting\",\n        \"//conditions:default\": \":prefix_version_setting\",\n    }),\n    visibility = [\"//visibility:private\"],\n)\ntoolchain(\n    name = \"toolchain\",\n    target_compatible_with = [\"@platforms//os:linux\", \"@platforms//cpu:x86_64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:runtime_toolchain_type\",\n    toolchain = \"@remotejdk17_linux//:jdk\",\n)\ntoolchain(\n    name = \"bootstrap_runtime_toolchain\",\n    # These constraints are not required for correctness, but prevent fetches of remote JDK for\n    # different architectures. As every Java compilation toolchain depends on a bootstrap runtime in\n    # the same configuration, this constraint will not result in toolchain resolution failures.\n    exec_compatible_with = [\"@platforms//os:linux\", \"@platforms//cpu:x86_64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type\",\n    toolchain = \"@remotejdk17_linux//:jdk\",\n)\n"
+            }
+          },
+          "remotejdk17_macos_aarch64": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_java~7.1.0~toolchains~remotejdk17_macos_aarch64",
+              "build_file_content": "load(\"@rules_java//java:defs.bzl\", \"java_runtime\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nexports_files([\"WORKSPACE\", \"BUILD.bazel\"])\n\nfilegroup(\n    name = \"jre\",\n    srcs = glob(\n        [\n            \"jre/bin/**\",\n            \"jre/lib/**\",\n        ],\n        allow_empty = True,\n        # In some configurations, Java browser plugin is considered harmful and\n        # common antivirus software blocks access to npjp2.dll interfering with Bazel,\n        # so do not include it in JRE on Windows.\n        exclude = [\"jre/bin/plugin2/**\"],\n    ),\n)\n\nfilegroup(\n    name = \"jdk-bin\",\n    srcs = glob(\n        [\"bin/**\"],\n        # The JDK on Windows sometimes contains a directory called\n        # \"%systemroot%\", which is not a valid label.\n        exclude = [\"**/*%*/**\"],\n    ),\n)\n\n# This folder holds security policies.\nfilegroup(\n    name = \"jdk-conf\",\n    srcs = glob(\n        [\"conf/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-include\",\n    srcs = glob(\n        [\"include/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-lib\",\n    srcs = glob(\n        [\"lib/**\", \"release\"],\n        allow_empty = True,\n        exclude = [\n            \"lib/missioncontrol/**\",\n            \"lib/visualvm/**\",\n        ],\n    ),\n)\n\njava_runtime(\n    name = \"jdk\",\n    srcs = [\n        \":jdk-bin\",\n        \":jdk-conf\",\n        \":jdk-include\",\n        \":jdk-lib\",\n        \":jre\",\n    ],\n    # Provide the 'java` binary explicitly so that the correct path is used by\n    # Bazel even when the host platform differs from the execution platform.\n    # Exactly one of the two globs will be empty depending on the host platform.\n    # When --incompatible_disallow_empty_glob is enabled, each individual empty\n    # glob will fail without allow_empty = True, even if the overall result is\n    # non-empty.\n    java = glob([\"bin/java.exe\", \"bin/java\"], allow_empty = True)[0],\n    version = 17,\n)\n",
+              "sha256": "314b04568ec0ae9b36ba03c9cbd42adc9e1265f74678923b19297d66eb84dcca",
+              "strip_prefix": "zulu17.44.53-ca-jdk17.0.8.1-macosx_aarch64",
+              "urls": [
+                "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu17.44.53-ca-jdk17.0.8.1-macosx_aarch64.tar.gz",
+                "https://cdn.azul.com/zulu/bin/zulu17.44.53-ca-jdk17.0.8.1-macosx_aarch64.tar.gz"
+              ]
+            }
+          },
+          "remote_java_tools_windows": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_java~7.1.0~toolchains~remote_java_tools_windows",
+              "sha256": "c5c70c214a350f12cbf52da8270fa43ba629b795f3dd328028a38f8f0d39c2a1",
+              "urls": [
+                "https://mirror.bazel.build/bazel_java_tools/releases/java/v13.1/java_tools_windows-v13.1.zip",
+                "https://github.com/bazelbuild/java_tools/releases/download/java_v13.1/java_tools_windows-v13.1.zip"
+              ]
+            }
+          },
+          "remotejdk11_win": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_java~7.1.0~toolchains~remotejdk11_win",
+              "build_file_content": "load(\"@rules_java//java:defs.bzl\", \"java_runtime\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nexports_files([\"WORKSPACE\", \"BUILD.bazel\"])\n\nfilegroup(\n    name = \"jre\",\n    srcs = glob(\n        [\n            \"jre/bin/**\",\n            \"jre/lib/**\",\n        ],\n        allow_empty = True,\n        # In some configurations, Java browser plugin is considered harmful and\n        # common antivirus software blocks access to npjp2.dll interfering with Bazel,\n        # so do not include it in JRE on Windows.\n        exclude = [\"jre/bin/plugin2/**\"],\n    ),\n)\n\nfilegroup(\n    name = \"jdk-bin\",\n    srcs = glob(\n        [\"bin/**\"],\n        # The JDK on Windows sometimes contains a directory called\n        # \"%systemroot%\", which is not a valid label.\n        exclude = [\"**/*%*/**\"],\n    ),\n)\n\n# This folder holds security policies.\nfilegroup(\n    name = \"jdk-conf\",\n    srcs = glob(\n        [\"conf/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-include\",\n    srcs = glob(\n        [\"include/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-lib\",\n    srcs = glob(\n        [\"lib/**\", \"release\"],\n        allow_empty = True,\n        exclude = [\n            \"lib/missioncontrol/**\",\n            \"lib/visualvm/**\",\n        ],\n    ),\n)\n\njava_runtime(\n    name = \"jdk\",\n    srcs = [\n        \":jdk-bin\",\n        \":jdk-conf\",\n        \":jdk-include\",\n        \":jdk-lib\",\n        \":jre\",\n    ],\n    # Provide the 'java` binary explicitly so that the correct path is used by\n    # Bazel even when the host platform differs from the execution platform.\n    # Exactly one of the two globs will be empty depending on the host platform.\n    # When --incompatible_disallow_empty_glob is enabled, each individual empty\n    # glob will fail without allow_empty = True, even if the overall result is\n    # non-empty.\n    java = glob([\"bin/java.exe\", \"bin/java\"], allow_empty = True)[0],\n    version = 11,\n)\n",
+              "sha256": "43408193ce2fa0862819495b5ae8541085b95660153f2adcf91a52d3a1710e83",
+              "strip_prefix": "zulu11.66.15-ca-jdk11.0.20-win_x64",
+              "urls": [
+                "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu11.66.15-ca-jdk11.0.20-win_x64.zip",
+                "https://cdn.azul.com/zulu/bin/zulu11.66.15-ca-jdk11.0.20-win_x64.zip"
+              ]
+            }
+          },
+          "remotejdk11_win_toolchain_config_repo": {
+            "bzlFile": "@@rules_java~7.1.0//toolchains:remote_java_repository.bzl",
+            "ruleClassName": "_toolchain_config",
+            "attributes": {
+              "name": "rules_java~7.1.0~toolchains~remotejdk11_win_toolchain_config_repo",
+              "build_file": "\nconfig_setting(\n    name = \"prefix_version_setting\",\n    values = {\"java_runtime_version\": \"remotejdk_11\"},\n    visibility = [\"//visibility:private\"],\n)\nconfig_setting(\n    name = \"version_setting\",\n    values = {\"java_runtime_version\": \"11\"},\n    visibility = [\"//visibility:private\"],\n)\nalias(\n    name = \"version_or_prefix_version_setting\",\n    actual = select({\n        \":version_setting\": \":version_setting\",\n        \"//conditions:default\": \":prefix_version_setting\",\n    }),\n    visibility = [\"//visibility:private\"],\n)\ntoolchain(\n    name = \"toolchain\",\n    target_compatible_with = [\"@platforms//os:windows\", \"@platforms//cpu:x86_64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:runtime_toolchain_type\",\n    toolchain = \"@remotejdk11_win//:jdk\",\n)\ntoolchain(\n    name = \"bootstrap_runtime_toolchain\",\n    # These constraints are not required for correctness, but prevent fetches of remote JDK for\n    # different architectures. As every Java compilation toolchain depends on a bootstrap runtime in\n    # the same configuration, this constraint will not result in toolchain resolution failures.\n    exec_compatible_with = [\"@platforms//os:windows\", \"@platforms//cpu:x86_64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type\",\n    toolchain = \"@remotejdk11_win//:jdk\",\n)\n"
+            }
+          },
+          "remotejdk11_linux_aarch64": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_java~7.1.0~toolchains~remotejdk11_linux_aarch64",
+              "build_file_content": "load(\"@rules_java//java:defs.bzl\", \"java_runtime\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nexports_files([\"WORKSPACE\", \"BUILD.bazel\"])\n\nfilegroup(\n    name = \"jre\",\n    srcs = glob(\n        [\n            \"jre/bin/**\",\n            \"jre/lib/**\",\n        ],\n        allow_empty = True,\n        # In some configurations, Java browser plugin is considered harmful and\n        # common antivirus software blocks access to npjp2.dll interfering with Bazel,\n        # so do not include it in JRE on Windows.\n        exclude = [\"jre/bin/plugin2/**\"],\n    ),\n)\n\nfilegroup(\n    name = \"jdk-bin\",\n    srcs = glob(\n        [\"bin/**\"],\n        # The JDK on Windows sometimes contains a directory called\n        # \"%systemroot%\", which is not a valid label.\n        exclude = [\"**/*%*/**\"],\n    ),\n)\n\n# This folder holds security policies.\nfilegroup(\n    name = \"jdk-conf\",\n    srcs = glob(\n        [\"conf/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-include\",\n    srcs = glob(\n        [\"include/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-lib\",\n    srcs = glob(\n        [\"lib/**\", \"release\"],\n        allow_empty = True,\n        exclude = [\n            \"lib/missioncontrol/**\",\n            \"lib/visualvm/**\",\n        ],\n    ),\n)\n\njava_runtime(\n    name = \"jdk\",\n    srcs = [\n        \":jdk-bin\",\n        \":jdk-conf\",\n        \":jdk-include\",\n        \":jdk-lib\",\n        \":jre\",\n    ],\n    # Provide the 'java` binary explicitly so that the correct path is used by\n    # Bazel even when the host platform differs from the execution platform.\n    # Exactly one of the two globs will be empty depending on the host platform.\n    # When --incompatible_disallow_empty_glob is enabled, each individual empty\n    # glob will fail without allow_empty = True, even if the overall result is\n    # non-empty.\n    java = glob([\"bin/java.exe\", \"bin/java\"], allow_empty = True)[0],\n    version = 11,\n)\n",
+              "sha256": "54174439f2b3fddd11f1048c397fe7bb45d4c9d66d452d6889b013d04d21c4de",
+              "strip_prefix": "zulu11.66.15-ca-jdk11.0.20-linux_aarch64",
+              "urls": [
+                "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu11.66.15-ca-jdk11.0.20-linux_aarch64.tar.gz",
+                "https://cdn.azul.com/zulu/bin/zulu11.66.15-ca-jdk11.0.20-linux_aarch64.tar.gz"
+              ]
+            }
+          },
+          "remotejdk17_linux": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_java~7.1.0~toolchains~remotejdk17_linux",
+              "build_file_content": "load(\"@rules_java//java:defs.bzl\", \"java_runtime\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nexports_files([\"WORKSPACE\", \"BUILD.bazel\"])\n\nfilegroup(\n    name = \"jre\",\n    srcs = glob(\n        [\n            \"jre/bin/**\",\n            \"jre/lib/**\",\n        ],\n        allow_empty = True,\n        # In some configurations, Java browser plugin is considered harmful and\n        # common antivirus software blocks access to npjp2.dll interfering with Bazel,\n        # so do not include it in JRE on Windows.\n        exclude = [\"jre/bin/plugin2/**\"],\n    ),\n)\n\nfilegroup(\n    name = \"jdk-bin\",\n    srcs = glob(\n        [\"bin/**\"],\n        # The JDK on Windows sometimes contains a directory called\n        # \"%systemroot%\", which is not a valid label.\n        exclude = [\"**/*%*/**\"],\n    ),\n)\n\n# This folder holds security policies.\nfilegroup(\n    name = \"jdk-conf\",\n    srcs = glob(\n        [\"conf/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-include\",\n    srcs = glob(\n        [\"include/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-lib\",\n    srcs = glob(\n        [\"lib/**\", \"release\"],\n        allow_empty = True,\n        exclude = [\n            \"lib/missioncontrol/**\",\n            \"lib/visualvm/**\",\n        ],\n    ),\n)\n\njava_runtime(\n    name = \"jdk\",\n    srcs = [\n        \":jdk-bin\",\n        \":jdk-conf\",\n        \":jdk-include\",\n        \":jdk-lib\",\n        \":jre\",\n    ],\n    # Provide the 'java` binary explicitly so that the correct path is used by\n    # Bazel even when the host platform differs from the execution platform.\n    # Exactly one of the two globs will be empty depending on the host platform.\n    # When --incompatible_disallow_empty_glob is enabled, each individual empty\n    # glob will fail without allow_empty = True, even if the overall result is\n    # non-empty.\n    java = glob([\"bin/java.exe\", \"bin/java\"], allow_empty = True)[0],\n    version = 17,\n)\n",
+              "sha256": "b9482f2304a1a68a614dfacddcf29569a72f0fac32e6c74f83dc1b9a157b8340",
+              "strip_prefix": "zulu17.44.53-ca-jdk17.0.8.1-linux_x64",
+              "urls": [
+                "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu17.44.53-ca-jdk17.0.8.1-linux_x64.tar.gz",
+                "https://cdn.azul.com/zulu/bin/zulu17.44.53-ca-jdk17.0.8.1-linux_x64.tar.gz"
+              ]
+            }
+          },
+          "remotejdk11_linux_s390x_toolchain_config_repo": {
+            "bzlFile": "@@rules_java~7.1.0//toolchains:remote_java_repository.bzl",
+            "ruleClassName": "_toolchain_config",
+            "attributes": {
+              "name": "rules_java~7.1.0~toolchains~remotejdk11_linux_s390x_toolchain_config_repo",
+              "build_file": "\nconfig_setting(\n    name = \"prefix_version_setting\",\n    values = {\"java_runtime_version\": \"remotejdk_11\"},\n    visibility = [\"//visibility:private\"],\n)\nconfig_setting(\n    name = \"version_setting\",\n    values = {\"java_runtime_version\": \"11\"},\n    visibility = [\"//visibility:private\"],\n)\nalias(\n    name = \"version_or_prefix_version_setting\",\n    actual = select({\n        \":version_setting\": \":version_setting\",\n        \"//conditions:default\": \":prefix_version_setting\",\n    }),\n    visibility = [\"//visibility:private\"],\n)\ntoolchain(\n    name = \"toolchain\",\n    target_compatible_with = [\"@platforms//os:linux\", \"@platforms//cpu:s390x\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:runtime_toolchain_type\",\n    toolchain = \"@remotejdk11_linux_s390x//:jdk\",\n)\ntoolchain(\n    name = \"bootstrap_runtime_toolchain\",\n    # These constraints are not required for correctness, but prevent fetches of remote JDK for\n    # different architectures. As every Java compilation toolchain depends on a bootstrap runtime in\n    # the same configuration, this constraint will not result in toolchain resolution failures.\n    exec_compatible_with = [\"@platforms//os:linux\", \"@platforms//cpu:s390x\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type\",\n    toolchain = \"@remotejdk11_linux_s390x//:jdk\",\n)\n"
+            }
+          },
+          "remotejdk11_linux_toolchain_config_repo": {
+            "bzlFile": "@@rules_java~7.1.0//toolchains:remote_java_repository.bzl",
+            "ruleClassName": "_toolchain_config",
+            "attributes": {
+              "name": "rules_java~7.1.0~toolchains~remotejdk11_linux_toolchain_config_repo",
+              "build_file": "\nconfig_setting(\n    name = \"prefix_version_setting\",\n    values = {\"java_runtime_version\": \"remotejdk_11\"},\n    visibility = [\"//visibility:private\"],\n)\nconfig_setting(\n    name = \"version_setting\",\n    values = {\"java_runtime_version\": \"11\"},\n    visibility = [\"//visibility:private\"],\n)\nalias(\n    name = \"version_or_prefix_version_setting\",\n    actual = select({\n        \":version_setting\": \":version_setting\",\n        \"//conditions:default\": \":prefix_version_setting\",\n    }),\n    visibility = [\"//visibility:private\"],\n)\ntoolchain(\n    name = \"toolchain\",\n    target_compatible_with = [\"@platforms//os:linux\", \"@platforms//cpu:x86_64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:runtime_toolchain_type\",\n    toolchain = \"@remotejdk11_linux//:jdk\",\n)\ntoolchain(\n    name = \"bootstrap_runtime_toolchain\",\n    # These constraints are not required for correctness, but prevent fetches of remote JDK for\n    # different architectures. As every Java compilation toolchain depends on a bootstrap runtime in\n    # the same configuration, this constraint will not result in toolchain resolution failures.\n    exec_compatible_with = [\"@platforms//os:linux\", \"@platforms//cpu:x86_64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type\",\n    toolchain = \"@remotejdk11_linux//:jdk\",\n)\n"
+            }
+          },
+          "remotejdk11_macos": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_java~7.1.0~toolchains~remotejdk11_macos",
+              "build_file_content": "load(\"@rules_java//java:defs.bzl\", \"java_runtime\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nexports_files([\"WORKSPACE\", \"BUILD.bazel\"])\n\nfilegroup(\n    name = \"jre\",\n    srcs = glob(\n        [\n            \"jre/bin/**\",\n            \"jre/lib/**\",\n        ],\n        allow_empty = True,\n        # In some configurations, Java browser plugin is considered harmful and\n        # common antivirus software blocks access to npjp2.dll interfering with Bazel,\n        # so do not include it in JRE on Windows.\n        exclude = [\"jre/bin/plugin2/**\"],\n    ),\n)\n\nfilegroup(\n    name = \"jdk-bin\",\n    srcs = glob(\n        [\"bin/**\"],\n        # The JDK on Windows sometimes contains a directory called\n        # \"%systemroot%\", which is not a valid label.\n        exclude = [\"**/*%*/**\"],\n    ),\n)\n\n# This folder holds security policies.\nfilegroup(\n    name = \"jdk-conf\",\n    srcs = glob(\n        [\"conf/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-include\",\n    srcs = glob(\n        [\"include/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-lib\",\n    srcs = glob(\n        [\"lib/**\", \"release\"],\n        allow_empty = True,\n        exclude = [\n            \"lib/missioncontrol/**\",\n            \"lib/visualvm/**\",\n        ],\n    ),\n)\n\njava_runtime(\n    name = \"jdk\",\n    srcs = [\n        \":jdk-bin\",\n        \":jdk-conf\",\n        \":jdk-include\",\n        \":jdk-lib\",\n        \":jre\",\n    ],\n    # Provide the 'java` binary explicitly so that the correct path is used by\n    # Bazel even when the host platform differs from the execution platform.\n    # Exactly one of the two globs will be empty depending on the host platform.\n    # When --incompatible_disallow_empty_glob is enabled, each individual empty\n    # glob will fail without allow_empty = True, even if the overall result is\n    # non-empty.\n    java = glob([\"bin/java.exe\", \"bin/java\"], allow_empty = True)[0],\n    version = 11,\n)\n",
+              "sha256": "bcaab11cfe586fae7583c6d9d311c64384354fb2638eb9a012eca4c3f1a1d9fd",
+              "strip_prefix": "zulu11.66.15-ca-jdk11.0.20-macosx_x64",
+              "urls": [
+                "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu11.66.15-ca-jdk11.0.20-macosx_x64.tar.gz",
+                "https://cdn.azul.com/zulu/bin/zulu11.66.15-ca-jdk11.0.20-macosx_x64.tar.gz"
+              ]
+            }
+          },
+          "remotejdk11_win_arm64": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_java~7.1.0~toolchains~remotejdk11_win_arm64",
+              "build_file_content": "load(\"@rules_java//java:defs.bzl\", \"java_runtime\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nexports_files([\"WORKSPACE\", \"BUILD.bazel\"])\n\nfilegroup(\n    name = \"jre\",\n    srcs = glob(\n        [\n            \"jre/bin/**\",\n            \"jre/lib/**\",\n        ],\n        allow_empty = True,\n        # In some configurations, Java browser plugin is considered harmful and\n        # common antivirus software blocks access to npjp2.dll interfering with Bazel,\n        # so do not include it in JRE on Windows.\n        exclude = [\"jre/bin/plugin2/**\"],\n    ),\n)\n\nfilegroup(\n    name = \"jdk-bin\",\n    srcs = glob(\n        [\"bin/**\"],\n        # The JDK on Windows sometimes contains a directory called\n        # \"%systemroot%\", which is not a valid label.\n        exclude = [\"**/*%*/**\"],\n    ),\n)\n\n# This folder holds security policies.\nfilegroup(\n    name = \"jdk-conf\",\n    srcs = glob(\n        [\"conf/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-include\",\n    srcs = glob(\n        [\"include/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-lib\",\n    srcs = glob(\n        [\"lib/**\", \"release\"],\n        allow_empty = True,\n        exclude = [\n            \"lib/missioncontrol/**\",\n            \"lib/visualvm/**\",\n        ],\n    ),\n)\n\njava_runtime(\n    name = \"jdk\",\n    srcs = [\n        \":jdk-bin\",\n        \":jdk-conf\",\n        \":jdk-include\",\n        \":jdk-lib\",\n        \":jre\",\n    ],\n    # Provide the 'java` binary explicitly so that the correct path is used by\n    # Bazel even when the host platform differs from the execution platform.\n    # Exactly one of the two globs will be empty depending on the host platform.\n    # When --incompatible_disallow_empty_glob is enabled, each individual empty\n    # glob will fail without allow_empty = True, even if the overall result is\n    # non-empty.\n    java = glob([\"bin/java.exe\", \"bin/java\"], allow_empty = True)[0],\n    version = 11,\n)\n",
+              "sha256": "b8a28e6e767d90acf793ea6f5bed0bb595ba0ba5ebdf8b99f395266161e53ec2",
+              "strip_prefix": "jdk-11.0.13+8",
+              "urls": [
+                "https://mirror.bazel.build/aka.ms/download-jdk/microsoft-jdk-11.0.13.8.1-windows-aarch64.zip"
+              ]
+            }
+          },
+          "remotejdk17_macos": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_java~7.1.0~toolchains~remotejdk17_macos",
+              "build_file_content": "load(\"@rules_java//java:defs.bzl\", \"java_runtime\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nexports_files([\"WORKSPACE\", \"BUILD.bazel\"])\n\nfilegroup(\n    name = \"jre\",\n    srcs = glob(\n        [\n            \"jre/bin/**\",\n            \"jre/lib/**\",\n        ],\n        allow_empty = True,\n        # In some configurations, Java browser plugin is considered harmful and\n        # common antivirus software blocks access to npjp2.dll interfering with Bazel,\n        # so do not include it in JRE on Windows.\n        exclude = [\"jre/bin/plugin2/**\"],\n    ),\n)\n\nfilegroup(\n    name = \"jdk-bin\",\n    srcs = glob(\n        [\"bin/**\"],\n        # The JDK on Windows sometimes contains a directory called\n        # \"%systemroot%\", which is not a valid label.\n        exclude = [\"**/*%*/**\"],\n    ),\n)\n\n# This folder holds security policies.\nfilegroup(\n    name = \"jdk-conf\",\n    srcs = glob(\n        [\"conf/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-include\",\n    srcs = glob(\n        [\"include/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-lib\",\n    srcs = glob(\n        [\"lib/**\", \"release\"],\n        allow_empty = True,\n        exclude = [\n            \"lib/missioncontrol/**\",\n            \"lib/visualvm/**\",\n        ],\n    ),\n)\n\njava_runtime(\n    name = \"jdk\",\n    srcs = [\n        \":jdk-bin\",\n        \":jdk-conf\",\n        \":jdk-include\",\n        \":jdk-lib\",\n        \":jre\",\n    ],\n    # Provide the 'java` binary explicitly so that the correct path is used by\n    # Bazel even when the host platform differs from the execution platform.\n    # Exactly one of the two globs will be empty depending on the host platform.\n    # When --incompatible_disallow_empty_glob is enabled, each individual empty\n    # glob will fail without allow_empty = True, even if the overall result is\n    # non-empty.\n    java = glob([\"bin/java.exe\", \"bin/java\"], allow_empty = True)[0],\n    version = 17,\n)\n",
+              "sha256": "640453e8afe8ffe0fb4dceb4535fb50db9c283c64665eebb0ba68b19e65f4b1f",
+              "strip_prefix": "zulu17.44.53-ca-jdk17.0.8.1-macosx_x64",
+              "urls": [
+                "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu17.44.53-ca-jdk17.0.8.1-macosx_x64.tar.gz",
+                "https://cdn.azul.com/zulu/bin/zulu17.44.53-ca-jdk17.0.8.1-macosx_x64.tar.gz"
+              ]
+            }
+          },
+          "remotejdk21_macos": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_java~7.1.0~toolchains~remotejdk21_macos",
+              "build_file_content": "load(\"@rules_java//java:defs.bzl\", \"java_runtime\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nexports_files([\"WORKSPACE\", \"BUILD.bazel\"])\n\nfilegroup(\n    name = \"jre\",\n    srcs = glob(\n        [\n            \"jre/bin/**\",\n            \"jre/lib/**\",\n        ],\n        allow_empty = True,\n        # In some configurations, Java browser plugin is considered harmful and\n        # common antivirus software blocks access to npjp2.dll interfering with Bazel,\n        # so do not include it in JRE on Windows.\n        exclude = [\"jre/bin/plugin2/**\"],\n    ),\n)\n\nfilegroup(\n    name = \"jdk-bin\",\n    srcs = glob(\n        [\"bin/**\"],\n        # The JDK on Windows sometimes contains a directory called\n        # \"%systemroot%\", which is not a valid label.\n        exclude = [\"**/*%*/**\"],\n    ),\n)\n\n# This folder holds security policies.\nfilegroup(\n    name = \"jdk-conf\",\n    srcs = glob(\n        [\"conf/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-include\",\n    srcs = glob(\n        [\"include/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-lib\",\n    srcs = glob(\n        [\"lib/**\", \"release\"],\n        allow_empty = True,\n        exclude = [\n            \"lib/missioncontrol/**\",\n            \"lib/visualvm/**\",\n        ],\n    ),\n)\n\njava_runtime(\n    name = \"jdk\",\n    srcs = [\n        \":jdk-bin\",\n        \":jdk-conf\",\n        \":jdk-include\",\n        \":jdk-lib\",\n        \":jre\",\n    ],\n    # Provide the 'java` binary explicitly so that the correct path is used by\n    # Bazel even when the host platform differs from the execution platform.\n    # Exactly one of the two globs will be empty depending on the host platform.\n    # When --incompatible_disallow_empty_glob is enabled, each individual empty\n    # glob will fail without allow_empty = True, even if the overall result is\n    # non-empty.\n    java = glob([\"bin/java.exe\", \"bin/java\"], allow_empty = True)[0],\n    version = 21,\n)\n",
+              "sha256": "9639b87db586d0c89f7a9892ae47f421e442c64b97baebdff31788fbe23265bd",
+              "strip_prefix": "zulu21.28.85-ca-jdk21.0.0-macosx_x64",
+              "urls": [
+                "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu21.28.85-ca-jdk21.0.0-macosx_x64.tar.gz",
+                "https://cdn.azul.com/zulu/bin/zulu21.28.85-ca-jdk21.0.0-macosx_x64.tar.gz"
+              ]
+            }
+          },
+          "remotejdk21_macos_toolchain_config_repo": {
+            "bzlFile": "@@rules_java~7.1.0//toolchains:remote_java_repository.bzl",
+            "ruleClassName": "_toolchain_config",
+            "attributes": {
+              "name": "rules_java~7.1.0~toolchains~remotejdk21_macos_toolchain_config_repo",
+              "build_file": "\nconfig_setting(\n    name = \"prefix_version_setting\",\n    values = {\"java_runtime_version\": \"remotejdk_21\"},\n    visibility = [\"//visibility:private\"],\n)\nconfig_setting(\n    name = \"version_setting\",\n    values = {\"java_runtime_version\": \"21\"},\n    visibility = [\"//visibility:private\"],\n)\nalias(\n    name = \"version_or_prefix_version_setting\",\n    actual = select({\n        \":version_setting\": \":version_setting\",\n        \"//conditions:default\": \":prefix_version_setting\",\n    }),\n    visibility = [\"//visibility:private\"],\n)\ntoolchain(\n    name = \"toolchain\",\n    target_compatible_with = [\"@platforms//os:macos\", \"@platforms//cpu:x86_64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:runtime_toolchain_type\",\n    toolchain = \"@remotejdk21_macos//:jdk\",\n)\ntoolchain(\n    name = \"bootstrap_runtime_toolchain\",\n    # These constraints are not required for correctness, but prevent fetches of remote JDK for\n    # different architectures. As every Java compilation toolchain depends on a bootstrap runtime in\n    # the same configuration, this constraint will not result in toolchain resolution failures.\n    exec_compatible_with = [\"@platforms//os:macos\", \"@platforms//cpu:x86_64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type\",\n    toolchain = \"@remotejdk21_macos//:jdk\",\n)\n"
+            }
+          },
+          "remotejdk17_macos_aarch64_toolchain_config_repo": {
+            "bzlFile": "@@rules_java~7.1.0//toolchains:remote_java_repository.bzl",
+            "ruleClassName": "_toolchain_config",
+            "attributes": {
+              "name": "rules_java~7.1.0~toolchains~remotejdk17_macos_aarch64_toolchain_config_repo",
+              "build_file": "\nconfig_setting(\n    name = \"prefix_version_setting\",\n    values = {\"java_runtime_version\": \"remotejdk_17\"},\n    visibility = [\"//visibility:private\"],\n)\nconfig_setting(\n    name = \"version_setting\",\n    values = {\"java_runtime_version\": \"17\"},\n    visibility = [\"//visibility:private\"],\n)\nalias(\n    name = \"version_or_prefix_version_setting\",\n    actual = select({\n        \":version_setting\": \":version_setting\",\n        \"//conditions:default\": \":prefix_version_setting\",\n    }),\n    visibility = [\"//visibility:private\"],\n)\ntoolchain(\n    name = \"toolchain\",\n    target_compatible_with = [\"@platforms//os:macos\", \"@platforms//cpu:aarch64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:runtime_toolchain_type\",\n    toolchain = \"@remotejdk17_macos_aarch64//:jdk\",\n)\ntoolchain(\n    name = \"bootstrap_runtime_toolchain\",\n    # These constraints are not required for correctness, but prevent fetches of remote JDK for\n    # different architectures. As every Java compilation toolchain depends on a bootstrap runtime in\n    # the same configuration, this constraint will not result in toolchain resolution failures.\n    exec_compatible_with = [\"@platforms//os:macos\", \"@platforms//cpu:aarch64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type\",\n    toolchain = \"@remotejdk17_macos_aarch64//:jdk\",\n)\n"
+            }
+          },
+          "remotejdk17_win": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_java~7.1.0~toolchains~remotejdk17_win",
+              "build_file_content": "load(\"@rules_java//java:defs.bzl\", \"java_runtime\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nexports_files([\"WORKSPACE\", \"BUILD.bazel\"])\n\nfilegroup(\n    name = \"jre\",\n    srcs = glob(\n        [\n            \"jre/bin/**\",\n            \"jre/lib/**\",\n        ],\n        allow_empty = True,\n        # In some configurations, Java browser plugin is considered harmful and\n        # common antivirus software blocks access to npjp2.dll interfering with Bazel,\n        # so do not include it in JRE on Windows.\n        exclude = [\"jre/bin/plugin2/**\"],\n    ),\n)\n\nfilegroup(\n    name = \"jdk-bin\",\n    srcs = glob(\n        [\"bin/**\"],\n        # The JDK on Windows sometimes contains a directory called\n        # \"%systemroot%\", which is not a valid label.\n        exclude = [\"**/*%*/**\"],\n    ),\n)\n\n# This folder holds security policies.\nfilegroup(\n    name = \"jdk-conf\",\n    srcs = glob(\n        [\"conf/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-include\",\n    srcs = glob(\n        [\"include/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-lib\",\n    srcs = glob(\n        [\"lib/**\", \"release\"],\n        allow_empty = True,\n        exclude = [\n            \"lib/missioncontrol/**\",\n            \"lib/visualvm/**\",\n        ],\n    ),\n)\n\njava_runtime(\n    name = \"jdk\",\n    srcs = [\n        \":jdk-bin\",\n        \":jdk-conf\",\n        \":jdk-include\",\n        \":jdk-lib\",\n        \":jre\",\n    ],\n    # Provide the 'java` binary explicitly so that the correct path is used by\n    # Bazel even when the host platform differs from the execution platform.\n    # Exactly one of the two globs will be empty depending on the host platform.\n    # When --incompatible_disallow_empty_glob is enabled, each individual empty\n    # glob will fail without allow_empty = True, even if the overall result is\n    # non-empty.\n    java = glob([\"bin/java.exe\", \"bin/java\"], allow_empty = True)[0],\n    version = 17,\n)\n",
+              "sha256": "192f2afca57701de6ec496234f7e45d971bf623ff66b8ee4a5c81582054e5637",
+              "strip_prefix": "zulu17.44.53-ca-jdk17.0.8.1-win_x64",
+              "urls": [
+                "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu17.44.53-ca-jdk17.0.8.1-win_x64.zip",
+                "https://cdn.azul.com/zulu/bin/zulu17.44.53-ca-jdk17.0.8.1-win_x64.zip"
+              ]
+            }
+          },
+          "remotejdk11_macos_aarch64_toolchain_config_repo": {
+            "bzlFile": "@@rules_java~7.1.0//toolchains:remote_java_repository.bzl",
+            "ruleClassName": "_toolchain_config",
+            "attributes": {
+              "name": "rules_java~7.1.0~toolchains~remotejdk11_macos_aarch64_toolchain_config_repo",
+              "build_file": "\nconfig_setting(\n    name = \"prefix_version_setting\",\n    values = {\"java_runtime_version\": \"remotejdk_11\"},\n    visibility = [\"//visibility:private\"],\n)\nconfig_setting(\n    name = \"version_setting\",\n    values = {\"java_runtime_version\": \"11\"},\n    visibility = [\"//visibility:private\"],\n)\nalias(\n    name = \"version_or_prefix_version_setting\",\n    actual = select({\n        \":version_setting\": \":version_setting\",\n        \"//conditions:default\": \":prefix_version_setting\",\n    }),\n    visibility = [\"//visibility:private\"],\n)\ntoolchain(\n    name = \"toolchain\",\n    target_compatible_with = [\"@platforms//os:macos\", \"@platforms//cpu:aarch64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:runtime_toolchain_type\",\n    toolchain = \"@remotejdk11_macos_aarch64//:jdk\",\n)\ntoolchain(\n    name = \"bootstrap_runtime_toolchain\",\n    # These constraints are not required for correctness, but prevent fetches of remote JDK for\n    # different architectures. As every Java compilation toolchain depends on a bootstrap runtime in\n    # the same configuration, this constraint will not result in toolchain resolution failures.\n    exec_compatible_with = [\"@platforms//os:macos\", \"@platforms//cpu:aarch64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type\",\n    toolchain = \"@remotejdk11_macos_aarch64//:jdk\",\n)\n"
+            }
+          },
+          "remotejdk11_linux_ppc64le_toolchain_config_repo": {
+            "bzlFile": "@@rules_java~7.1.0//toolchains:remote_java_repository.bzl",
+            "ruleClassName": "_toolchain_config",
+            "attributes": {
+              "name": "rules_java~7.1.0~toolchains~remotejdk11_linux_ppc64le_toolchain_config_repo",
+              "build_file": "\nconfig_setting(\n    name = \"prefix_version_setting\",\n    values = {\"java_runtime_version\": \"remotejdk_11\"},\n    visibility = [\"//visibility:private\"],\n)\nconfig_setting(\n    name = \"version_setting\",\n    values = {\"java_runtime_version\": \"11\"},\n    visibility = [\"//visibility:private\"],\n)\nalias(\n    name = \"version_or_prefix_version_setting\",\n    actual = select({\n        \":version_setting\": \":version_setting\",\n        \"//conditions:default\": \":prefix_version_setting\",\n    }),\n    visibility = [\"//visibility:private\"],\n)\ntoolchain(\n    name = \"toolchain\",\n    target_compatible_with = [\"@platforms//os:linux\", \"@platforms//cpu:ppc\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:runtime_toolchain_type\",\n    toolchain = \"@remotejdk11_linux_ppc64le//:jdk\",\n)\ntoolchain(\n    name = \"bootstrap_runtime_toolchain\",\n    # These constraints are not required for correctness, but prevent fetches of remote JDK for\n    # different architectures. As every Java compilation toolchain depends on a bootstrap runtime in\n    # the same configuration, this constraint will not result in toolchain resolution failures.\n    exec_compatible_with = [\"@platforms//os:linux\", \"@platforms//cpu:ppc\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type\",\n    toolchain = \"@remotejdk11_linux_ppc64le//:jdk\",\n)\n"
+            }
+          },
+          "remotejdk21_linux": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_java~7.1.0~toolchains~remotejdk21_linux",
+              "build_file_content": "load(\"@rules_java//java:defs.bzl\", \"java_runtime\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nexports_files([\"WORKSPACE\", \"BUILD.bazel\"])\n\nfilegroup(\n    name = \"jre\",\n    srcs = glob(\n        [\n            \"jre/bin/**\",\n            \"jre/lib/**\",\n        ],\n        allow_empty = True,\n        # In some configurations, Java browser plugin is considered harmful and\n        # common antivirus software blocks access to npjp2.dll interfering with Bazel,\n        # so do not include it in JRE on Windows.\n        exclude = [\"jre/bin/plugin2/**\"],\n    ),\n)\n\nfilegroup(\n    name = \"jdk-bin\",\n    srcs = glob(\n        [\"bin/**\"],\n        # The JDK on Windows sometimes contains a directory called\n        # \"%systemroot%\", which is not a valid label.\n        exclude = [\"**/*%*/**\"],\n    ),\n)\n\n# This folder holds security policies.\nfilegroup(\n    name = \"jdk-conf\",\n    srcs = glob(\n        [\"conf/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-include\",\n    srcs = glob(\n        [\"include/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-lib\",\n    srcs = glob(\n        [\"lib/**\", \"release\"],\n        allow_empty = True,\n        exclude = [\n            \"lib/missioncontrol/**\",\n            \"lib/visualvm/**\",\n        ],\n    ),\n)\n\njava_runtime(\n    name = \"jdk\",\n    srcs = [\n        \":jdk-bin\",\n        \":jdk-conf\",\n        \":jdk-include\",\n        \":jdk-lib\",\n        \":jre\",\n    ],\n    # Provide the 'java` binary explicitly so that the correct path is used by\n    # Bazel even when the host platform differs from the execution platform.\n    # Exactly one of the two globs will be empty depending on the host platform.\n    # When --incompatible_disallow_empty_glob is enabled, each individual empty\n    # glob will fail without allow_empty = True, even if the overall result is\n    # non-empty.\n    java = glob([\"bin/java.exe\", \"bin/java\"], allow_empty = True)[0],\n    version = 21,\n)\n",
+              "sha256": "0c0eadfbdc47a7ca64aeab51b9c061f71b6e4d25d2d87674512e9b6387e9e3a6",
+              "strip_prefix": "zulu21.28.85-ca-jdk21.0.0-linux_x64",
+              "urls": [
+                "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu21.28.85-ca-jdk21.0.0-linux_x64.tar.gz",
+                "https://cdn.azul.com/zulu/bin/zulu21.28.85-ca-jdk21.0.0-linux_x64.tar.gz"
+              ]
+            }
+          },
+          "remote_java_tools_linux": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_java~7.1.0~toolchains~remote_java_tools_linux",
+              "sha256": "d134da9b04c9023fb6e56a5d4bffccee73f7bc9572ddc4e747778dacccd7a5a7",
+              "urls": [
+                "https://mirror.bazel.build/bazel_java_tools/releases/java/v13.1/java_tools_linux-v13.1.zip",
+                "https://github.com/bazelbuild/java_tools/releases/download/java_v13.1/java_tools_linux-v13.1.zip"
+              ]
+            }
+          },
+          "remotejdk21_win": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_java~7.1.0~toolchains~remotejdk21_win",
+              "build_file_content": "load(\"@rules_java//java:defs.bzl\", \"java_runtime\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nexports_files([\"WORKSPACE\", \"BUILD.bazel\"])\n\nfilegroup(\n    name = \"jre\",\n    srcs = glob(\n        [\n            \"jre/bin/**\",\n            \"jre/lib/**\",\n        ],\n        allow_empty = True,\n        # In some configurations, Java browser plugin is considered harmful and\n        # common antivirus software blocks access to npjp2.dll interfering with Bazel,\n        # so do not include it in JRE on Windows.\n        exclude = [\"jre/bin/plugin2/**\"],\n    ),\n)\n\nfilegroup(\n    name = \"jdk-bin\",\n    srcs = glob(\n        [\"bin/**\"],\n        # The JDK on Windows sometimes contains a directory called\n        # \"%systemroot%\", which is not a valid label.\n        exclude = [\"**/*%*/**\"],\n    ),\n)\n\n# This folder holds security policies.\nfilegroup(\n    name = \"jdk-conf\",\n    srcs = glob(\n        [\"conf/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-include\",\n    srcs = glob(\n        [\"include/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-lib\",\n    srcs = glob(\n        [\"lib/**\", \"release\"],\n        allow_empty = True,\n        exclude = [\n            \"lib/missioncontrol/**\",\n            \"lib/visualvm/**\",\n        ],\n    ),\n)\n\njava_runtime(\n    name = \"jdk\",\n    srcs = [\n        \":jdk-bin\",\n        \":jdk-conf\",\n        \":jdk-include\",\n        \":jdk-lib\",\n        \":jre\",\n    ],\n    # Provide the 'java` binary explicitly so that the correct path is used by\n    # Bazel even when the host platform differs from the execution platform.\n    # Exactly one of the two globs will be empty depending on the host platform.\n    # When --incompatible_disallow_empty_glob is enabled, each individual empty\n    # glob will fail without allow_empty = True, even if the overall result is\n    # non-empty.\n    java = glob([\"bin/java.exe\", \"bin/java\"], allow_empty = True)[0],\n    version = 21,\n)\n",
+              "sha256": "e9959d500a0d9a7694ac243baf657761479da132f0f94720cbffd092150bd802",
+              "strip_prefix": "zulu21.28.85-ca-jdk21.0.0-win_x64",
+              "urls": [
+                "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu21.28.85-ca-jdk21.0.0-win_x64.zip",
+                "https://cdn.azul.com/zulu/bin/zulu21.28.85-ca-jdk21.0.0-win_x64.zip"
+              ]
+            }
+          },
+          "remotejdk21_linux_aarch64": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_java~7.1.0~toolchains~remotejdk21_linux_aarch64",
+              "build_file_content": "load(\"@rules_java//java:defs.bzl\", \"java_runtime\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nexports_files([\"WORKSPACE\", \"BUILD.bazel\"])\n\nfilegroup(\n    name = \"jre\",\n    srcs = glob(\n        [\n            \"jre/bin/**\",\n            \"jre/lib/**\",\n        ],\n        allow_empty = True,\n        # In some configurations, Java browser plugin is considered harmful and\n        # common antivirus software blocks access to npjp2.dll interfering with Bazel,\n        # so do not include it in JRE on Windows.\n        exclude = [\"jre/bin/plugin2/**\"],\n    ),\n)\n\nfilegroup(\n    name = \"jdk-bin\",\n    srcs = glob(\n        [\"bin/**\"],\n        # The JDK on Windows sometimes contains a directory called\n        # \"%systemroot%\", which is not a valid label.\n        exclude = [\"**/*%*/**\"],\n    ),\n)\n\n# This folder holds security policies.\nfilegroup(\n    name = \"jdk-conf\",\n    srcs = glob(\n        [\"conf/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-include\",\n    srcs = glob(\n        [\"include/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-lib\",\n    srcs = glob(\n        [\"lib/**\", \"release\"],\n        allow_empty = True,\n        exclude = [\n            \"lib/missioncontrol/**\",\n            \"lib/visualvm/**\",\n        ],\n    ),\n)\n\njava_runtime(\n    name = \"jdk\",\n    srcs = [\n        \":jdk-bin\",\n        \":jdk-conf\",\n        \":jdk-include\",\n        \":jdk-lib\",\n        \":jre\",\n    ],\n    # Provide the 'java` binary explicitly so that the correct path is used by\n    # Bazel even when the host platform differs from the execution platform.\n    # Exactly one of the two globs will be empty depending on the host platform.\n    # When --incompatible_disallow_empty_glob is enabled, each individual empty\n    # glob will fail without allow_empty = True, even if the overall result is\n    # non-empty.\n    java = glob([\"bin/java.exe\", \"bin/java\"], allow_empty = True)[0],\n    version = 21,\n)\n",
+              "sha256": "1fb64b8036c5d463d8ab59af06bf5b6b006811e6012e3b0eb6bccf57f1c55835",
+              "strip_prefix": "zulu21.28.85-ca-jdk21.0.0-linux_aarch64",
+              "urls": [
+                "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu21.28.85-ca-jdk21.0.0-linux_aarch64.tar.gz",
+                "https://cdn.azul.com/zulu/bin/zulu21.28.85-ca-jdk21.0.0-linux_aarch64.tar.gz"
+              ]
+            }
+          },
+          "remotejdk11_linux_aarch64_toolchain_config_repo": {
+            "bzlFile": "@@rules_java~7.1.0//toolchains:remote_java_repository.bzl",
+            "ruleClassName": "_toolchain_config",
+            "attributes": {
+              "name": "rules_java~7.1.0~toolchains~remotejdk11_linux_aarch64_toolchain_config_repo",
+              "build_file": "\nconfig_setting(\n    name = \"prefix_version_setting\",\n    values = {\"java_runtime_version\": \"remotejdk_11\"},\n    visibility = [\"//visibility:private\"],\n)\nconfig_setting(\n    name = \"version_setting\",\n    values = {\"java_runtime_version\": \"11\"},\n    visibility = [\"//visibility:private\"],\n)\nalias(\n    name = \"version_or_prefix_version_setting\",\n    actual = select({\n        \":version_setting\": \":version_setting\",\n        \"//conditions:default\": \":prefix_version_setting\",\n    }),\n    visibility = [\"//visibility:private\"],\n)\ntoolchain(\n    name = \"toolchain\",\n    target_compatible_with = [\"@platforms//os:linux\", \"@platforms//cpu:aarch64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:runtime_toolchain_type\",\n    toolchain = \"@remotejdk11_linux_aarch64//:jdk\",\n)\ntoolchain(\n    name = \"bootstrap_runtime_toolchain\",\n    # These constraints are not required for correctness, but prevent fetches of remote JDK for\n    # different architectures. As every Java compilation toolchain depends on a bootstrap runtime in\n    # the same configuration, this constraint will not result in toolchain resolution failures.\n    exec_compatible_with = [\"@platforms//os:linux\", \"@platforms//cpu:aarch64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type\",\n    toolchain = \"@remotejdk11_linux_aarch64//:jdk\",\n)\n"
+            }
+          },
+          "remotejdk11_linux_s390x": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_java~7.1.0~toolchains~remotejdk11_linux_s390x",
+              "build_file_content": "load(\"@rules_java//java:defs.bzl\", \"java_runtime\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nexports_files([\"WORKSPACE\", \"BUILD.bazel\"])\n\nfilegroup(\n    name = \"jre\",\n    srcs = glob(\n        [\n            \"jre/bin/**\",\n            \"jre/lib/**\",\n        ],\n        allow_empty = True,\n        # In some configurations, Java browser plugin is considered harmful and\n        # common antivirus software blocks access to npjp2.dll interfering with Bazel,\n        # so do not include it in JRE on Windows.\n        exclude = [\"jre/bin/plugin2/**\"],\n    ),\n)\n\nfilegroup(\n    name = \"jdk-bin\",\n    srcs = glob(\n        [\"bin/**\"],\n        # The JDK on Windows sometimes contains a directory called\n        # \"%systemroot%\", which is not a valid label.\n        exclude = [\"**/*%*/**\"],\n    ),\n)\n\n# This folder holds security policies.\nfilegroup(\n    name = \"jdk-conf\",\n    srcs = glob(\n        [\"conf/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-include\",\n    srcs = glob(\n        [\"include/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-lib\",\n    srcs = glob(\n        [\"lib/**\", \"release\"],\n        allow_empty = True,\n        exclude = [\n            \"lib/missioncontrol/**\",\n            \"lib/visualvm/**\",\n        ],\n    ),\n)\n\njava_runtime(\n    name = \"jdk\",\n    srcs = [\n        \":jdk-bin\",\n        \":jdk-conf\",\n        \":jdk-include\",\n        \":jdk-lib\",\n        \":jre\",\n    ],\n    # Provide the 'java` binary explicitly so that the correct path is used by\n    # Bazel even when the host platform differs from the execution platform.\n    # Exactly one of the two globs will be empty depending on the host platform.\n    # When --incompatible_disallow_empty_glob is enabled, each individual empty\n    # glob will fail without allow_empty = True, even if the overall result is\n    # non-empty.\n    java = glob([\"bin/java.exe\", \"bin/java\"], allow_empty = True)[0],\n    version = 11,\n)\n",
+              "sha256": "a58fc0361966af0a5d5a31a2d8a208e3c9bb0f54f345596fd80b99ea9a39788b",
+              "strip_prefix": "jdk-11.0.15+10",
+              "urls": [
+                "https://mirror.bazel.build/github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.15+10/OpenJDK11U-jdk_s390x_linux_hotspot_11.0.15_10.tar.gz",
+                "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.15+10/OpenJDK11U-jdk_s390x_linux_hotspot_11.0.15_10.tar.gz"
+              ]
+            }
+          },
+          "remotejdk17_linux_aarch64": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_java~7.1.0~toolchains~remotejdk17_linux_aarch64",
+              "build_file_content": "load(\"@rules_java//java:defs.bzl\", \"java_runtime\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nexports_files([\"WORKSPACE\", \"BUILD.bazel\"])\n\nfilegroup(\n    name = \"jre\",\n    srcs = glob(\n        [\n            \"jre/bin/**\",\n            \"jre/lib/**\",\n        ],\n        allow_empty = True,\n        # In some configurations, Java browser plugin is considered harmful and\n        # common antivirus software blocks access to npjp2.dll interfering with Bazel,\n        # so do not include it in JRE on Windows.\n        exclude = [\"jre/bin/plugin2/**\"],\n    ),\n)\n\nfilegroup(\n    name = \"jdk-bin\",\n    srcs = glob(\n        [\"bin/**\"],\n        # The JDK on Windows sometimes contains a directory called\n        # \"%systemroot%\", which is not a valid label.\n        exclude = [\"**/*%*/**\"],\n    ),\n)\n\n# This folder holds security policies.\nfilegroup(\n    name = \"jdk-conf\",\n    srcs = glob(\n        [\"conf/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-include\",\n    srcs = glob(\n        [\"include/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-lib\",\n    srcs = glob(\n        [\"lib/**\", \"release\"],\n        allow_empty = True,\n        exclude = [\n            \"lib/missioncontrol/**\",\n            \"lib/visualvm/**\",\n        ],\n    ),\n)\n\njava_runtime(\n    name = \"jdk\",\n    srcs = [\n        \":jdk-bin\",\n        \":jdk-conf\",\n        \":jdk-include\",\n        \":jdk-lib\",\n        \":jre\",\n    ],\n    # Provide the 'java` binary explicitly so that the correct path is used by\n    # Bazel even when the host platform differs from the execution platform.\n    # Exactly one of the two globs will be empty depending on the host platform.\n    # When --incompatible_disallow_empty_glob is enabled, each individual empty\n    # glob will fail without allow_empty = True, even if the overall result is\n    # non-empty.\n    java = glob([\"bin/java.exe\", \"bin/java\"], allow_empty = True)[0],\n    version = 17,\n)\n",
+              "sha256": "6531cef61e416d5a7b691555c8cf2bdff689201b8a001ff45ab6740062b44313",
+              "strip_prefix": "zulu17.44.53-ca-jdk17.0.8.1-linux_aarch64",
+              "urls": [
+                "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu17.44.53-ca-jdk17.0.8.1-linux_aarch64.tar.gz",
+                "https://cdn.azul.com/zulu/bin/zulu17.44.53-ca-jdk17.0.8.1-linux_aarch64.tar.gz"
+              ]
+            }
+          },
+          "remotejdk17_win_arm64_toolchain_config_repo": {
+            "bzlFile": "@@rules_java~7.1.0//toolchains:remote_java_repository.bzl",
+            "ruleClassName": "_toolchain_config",
+            "attributes": {
+              "name": "rules_java~7.1.0~toolchains~remotejdk17_win_arm64_toolchain_config_repo",
+              "build_file": "\nconfig_setting(\n    name = \"prefix_version_setting\",\n    values = {\"java_runtime_version\": \"remotejdk_17\"},\n    visibility = [\"//visibility:private\"],\n)\nconfig_setting(\n    name = \"version_setting\",\n    values = {\"java_runtime_version\": \"17\"},\n    visibility = [\"//visibility:private\"],\n)\nalias(\n    name = \"version_or_prefix_version_setting\",\n    actual = select({\n        \":version_setting\": \":version_setting\",\n        \"//conditions:default\": \":prefix_version_setting\",\n    }),\n    visibility = [\"//visibility:private\"],\n)\ntoolchain(\n    name = \"toolchain\",\n    target_compatible_with = [\"@platforms//os:windows\", \"@platforms//cpu:arm64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:runtime_toolchain_type\",\n    toolchain = \"@remotejdk17_win_arm64//:jdk\",\n)\ntoolchain(\n    name = \"bootstrap_runtime_toolchain\",\n    # These constraints are not required for correctness, but prevent fetches of remote JDK for\n    # different architectures. As every Java compilation toolchain depends on a bootstrap runtime in\n    # the same configuration, this constraint will not result in toolchain resolution failures.\n    exec_compatible_with = [\"@platforms//os:windows\", \"@platforms//cpu:arm64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type\",\n    toolchain = \"@remotejdk17_win_arm64//:jdk\",\n)\n"
+            }
+          },
+          "remotejdk11_linux": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_java~7.1.0~toolchains~remotejdk11_linux",
+              "build_file_content": "load(\"@rules_java//java:defs.bzl\", \"java_runtime\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nexports_files([\"WORKSPACE\", \"BUILD.bazel\"])\n\nfilegroup(\n    name = \"jre\",\n    srcs = glob(\n        [\n            \"jre/bin/**\",\n            \"jre/lib/**\",\n        ],\n        allow_empty = True,\n        # In some configurations, Java browser plugin is considered harmful and\n        # common antivirus software blocks access to npjp2.dll interfering with Bazel,\n        # so do not include it in JRE on Windows.\n        exclude = [\"jre/bin/plugin2/**\"],\n    ),\n)\n\nfilegroup(\n    name = \"jdk-bin\",\n    srcs = glob(\n        [\"bin/**\"],\n        # The JDK on Windows sometimes contains a directory called\n        # \"%systemroot%\", which is not a valid label.\n        exclude = [\"**/*%*/**\"],\n    ),\n)\n\n# This folder holds security policies.\nfilegroup(\n    name = \"jdk-conf\",\n    srcs = glob(\n        [\"conf/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-include\",\n    srcs = glob(\n        [\"include/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-lib\",\n    srcs = glob(\n        [\"lib/**\", \"release\"],\n        allow_empty = True,\n        exclude = [\n            \"lib/missioncontrol/**\",\n            \"lib/visualvm/**\",\n        ],\n    ),\n)\n\njava_runtime(\n    name = \"jdk\",\n    srcs = [\n        \":jdk-bin\",\n        \":jdk-conf\",\n        \":jdk-include\",\n        \":jdk-lib\",\n        \":jre\",\n    ],\n    # Provide the 'java` binary explicitly so that the correct path is used by\n    # Bazel even when the host platform differs from the execution platform.\n    # Exactly one of the two globs will be empty depending on the host platform.\n    # When --incompatible_disallow_empty_glob is enabled, each individual empty\n    # glob will fail without allow_empty = True, even if the overall result is\n    # non-empty.\n    java = glob([\"bin/java.exe\", \"bin/java\"], allow_empty = True)[0],\n    version = 11,\n)\n",
+              "sha256": "a34b404f87a08a61148b38e1416d837189e1df7a040d949e743633daf4695a3c",
+              "strip_prefix": "zulu11.66.15-ca-jdk11.0.20-linux_x64",
+              "urls": [
+                "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu11.66.15-ca-jdk11.0.20-linux_x64.tar.gz",
+                "https://cdn.azul.com/zulu/bin/zulu11.66.15-ca-jdk11.0.20-linux_x64.tar.gz"
+              ]
+            }
+          },
+          "remotejdk11_macos_toolchain_config_repo": {
+            "bzlFile": "@@rules_java~7.1.0//toolchains:remote_java_repository.bzl",
+            "ruleClassName": "_toolchain_config",
+            "attributes": {
+              "name": "rules_java~7.1.0~toolchains~remotejdk11_macos_toolchain_config_repo",
+              "build_file": "\nconfig_setting(\n    name = \"prefix_version_setting\",\n    values = {\"java_runtime_version\": \"remotejdk_11\"},\n    visibility = [\"//visibility:private\"],\n)\nconfig_setting(\n    name = \"version_setting\",\n    values = {\"java_runtime_version\": \"11\"},\n    visibility = [\"//visibility:private\"],\n)\nalias(\n    name = \"version_or_prefix_version_setting\",\n    actual = select({\n        \":version_setting\": \":version_setting\",\n        \"//conditions:default\": \":prefix_version_setting\",\n    }),\n    visibility = [\"//visibility:private\"],\n)\ntoolchain(\n    name = \"toolchain\",\n    target_compatible_with = [\"@platforms//os:macos\", \"@platforms//cpu:x86_64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:runtime_toolchain_type\",\n    toolchain = \"@remotejdk11_macos//:jdk\",\n)\ntoolchain(\n    name = \"bootstrap_runtime_toolchain\",\n    # These constraints are not required for correctness, but prevent fetches of remote JDK for\n    # different architectures. As every Java compilation toolchain depends on a bootstrap runtime in\n    # the same configuration, this constraint will not result in toolchain resolution failures.\n    exec_compatible_with = [\"@platforms//os:macos\", \"@platforms//cpu:x86_64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type\",\n    toolchain = \"@remotejdk11_macos//:jdk\",\n)\n"
+            }
+          },
+          "remotejdk17_linux_ppc64le_toolchain_config_repo": {
+            "bzlFile": "@@rules_java~7.1.0//toolchains:remote_java_repository.bzl",
+            "ruleClassName": "_toolchain_config",
+            "attributes": {
+              "name": "rules_java~7.1.0~toolchains~remotejdk17_linux_ppc64le_toolchain_config_repo",
+              "build_file": "\nconfig_setting(\n    name = \"prefix_version_setting\",\n    values = {\"java_runtime_version\": \"remotejdk_17\"},\n    visibility = [\"//visibility:private\"],\n)\nconfig_setting(\n    name = \"version_setting\",\n    values = {\"java_runtime_version\": \"17\"},\n    visibility = [\"//visibility:private\"],\n)\nalias(\n    name = \"version_or_prefix_version_setting\",\n    actual = select({\n        \":version_setting\": \":version_setting\",\n        \"//conditions:default\": \":prefix_version_setting\",\n    }),\n    visibility = [\"//visibility:private\"],\n)\ntoolchain(\n    name = \"toolchain\",\n    target_compatible_with = [\"@platforms//os:linux\", \"@platforms//cpu:ppc\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:runtime_toolchain_type\",\n    toolchain = \"@remotejdk17_linux_ppc64le//:jdk\",\n)\ntoolchain(\n    name = \"bootstrap_runtime_toolchain\",\n    # These constraints are not required for correctness, but prevent fetches of remote JDK for\n    # different architectures. As every Java compilation toolchain depends on a bootstrap runtime in\n    # the same configuration, this constraint will not result in toolchain resolution failures.\n    exec_compatible_with = [\"@platforms//os:linux\", \"@platforms//cpu:ppc\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type\",\n    toolchain = \"@remotejdk17_linux_ppc64le//:jdk\",\n)\n"
+            }
+          },
+          "remotejdk17_win_arm64": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_java~7.1.0~toolchains~remotejdk17_win_arm64",
+              "build_file_content": "load(\"@rules_java//java:defs.bzl\", \"java_runtime\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nexports_files([\"WORKSPACE\", \"BUILD.bazel\"])\n\nfilegroup(\n    name = \"jre\",\n    srcs = glob(\n        [\n            \"jre/bin/**\",\n            \"jre/lib/**\",\n        ],\n        allow_empty = True,\n        # In some configurations, Java browser plugin is considered harmful and\n        # common antivirus software blocks access to npjp2.dll interfering with Bazel,\n        # so do not include it in JRE on Windows.\n        exclude = [\"jre/bin/plugin2/**\"],\n    ),\n)\n\nfilegroup(\n    name = \"jdk-bin\",\n    srcs = glob(\n        [\"bin/**\"],\n        # The JDK on Windows sometimes contains a directory called\n        # \"%systemroot%\", which is not a valid label.\n        exclude = [\"**/*%*/**\"],\n    ),\n)\n\n# This folder holds security policies.\nfilegroup(\n    name = \"jdk-conf\",\n    srcs = glob(\n        [\"conf/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-include\",\n    srcs = glob(\n        [\"include/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-lib\",\n    srcs = glob(\n        [\"lib/**\", \"release\"],\n        allow_empty = True,\n        exclude = [\n            \"lib/missioncontrol/**\",\n            \"lib/visualvm/**\",\n        ],\n    ),\n)\n\njava_runtime(\n    name = \"jdk\",\n    srcs = [\n        \":jdk-bin\",\n        \":jdk-conf\",\n        \":jdk-include\",\n        \":jdk-lib\",\n        \":jre\",\n    ],\n    # Provide the 'java` binary explicitly so that the correct path is used by\n    # Bazel even when the host platform differs from the execution platform.\n    # Exactly one of the two globs will be empty depending on the host platform.\n    # When --incompatible_disallow_empty_glob is enabled, each individual empty\n    # glob will fail without allow_empty = True, even if the overall result is\n    # non-empty.\n    java = glob([\"bin/java.exe\", \"bin/java\"], allow_empty = True)[0],\n    version = 17,\n)\n",
+              "sha256": "6802c99eae0d788e21f52d03cab2e2b3bf42bc334ca03cbf19f71eb70ee19f85",
+              "strip_prefix": "zulu17.44.53-ca-jdk17.0.8.1-win_aarch64",
+              "urls": [
+                "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu17.44.53-ca-jdk17.0.8.1-win_aarch64.zip",
+                "https://cdn.azul.com/zulu/bin/zulu17.44.53-ca-jdk17.0.8.1-win_aarch64.zip"
+              ]
+            }
+          },
+          "remote_java_tools_darwin_arm64": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_java~7.1.0~toolchains~remote_java_tools_darwin_arm64",
+              "sha256": "dab5bb87ec43e980faea6e1cec14bafb217b8e2f5346f53aa784fd715929a930",
+              "urls": [
+                "https://mirror.bazel.build/bazel_java_tools/releases/java/v13.1/java_tools_darwin_arm64-v13.1.zip",
+                "https://github.com/bazelbuild/java_tools/releases/download/java_v13.1/java_tools_darwin_arm64-v13.1.zip"
+              ]
+            }
+          },
+          "remotejdk17_linux_ppc64le": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_java~7.1.0~toolchains~remotejdk17_linux_ppc64le",
+              "build_file_content": "load(\"@rules_java//java:defs.bzl\", \"java_runtime\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nexports_files([\"WORKSPACE\", \"BUILD.bazel\"])\n\nfilegroup(\n    name = \"jre\",\n    srcs = glob(\n        [\n            \"jre/bin/**\",\n            \"jre/lib/**\",\n        ],\n        allow_empty = True,\n        # In some configurations, Java browser plugin is considered harmful and\n        # common antivirus software blocks access to npjp2.dll interfering with Bazel,\n        # so do not include it in JRE on Windows.\n        exclude = [\"jre/bin/plugin2/**\"],\n    ),\n)\n\nfilegroup(\n    name = \"jdk-bin\",\n    srcs = glob(\n        [\"bin/**\"],\n        # The JDK on Windows sometimes contains a directory called\n        # \"%systemroot%\", which is not a valid label.\n        exclude = [\"**/*%*/**\"],\n    ),\n)\n\n# This folder holds security policies.\nfilegroup(\n    name = \"jdk-conf\",\n    srcs = glob(\n        [\"conf/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-include\",\n    srcs = glob(\n        [\"include/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-lib\",\n    srcs = glob(\n        [\"lib/**\", \"release\"],\n        allow_empty = True,\n        exclude = [\n            \"lib/missioncontrol/**\",\n            \"lib/visualvm/**\",\n        ],\n    ),\n)\n\njava_runtime(\n    name = \"jdk\",\n    srcs = [\n        \":jdk-bin\",\n        \":jdk-conf\",\n        \":jdk-include\",\n        \":jdk-lib\",\n        \":jre\",\n    ],\n    # Provide the 'java` binary explicitly so that the correct path is used by\n    # Bazel even when the host platform differs from the execution platform.\n    # Exactly one of the two globs will be empty depending on the host platform.\n    # When --incompatible_disallow_empty_glob is enabled, each individual empty\n    # glob will fail without allow_empty = True, even if the overall result is\n    # non-empty.\n    java = glob([\"bin/java.exe\", \"bin/java\"], allow_empty = True)[0],\n    version = 17,\n)\n",
+              "sha256": "00a4c07603d0218cd678461b5b3b7e25b3253102da4022d31fc35907f21a2efd",
+              "strip_prefix": "jdk-17.0.8.1+1",
+              "urls": [
+                "https://mirror.bazel.build/github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1%2B1/OpenJDK17U-jdk_ppc64le_linux_hotspot_17.0.8.1_1.tar.gz",
+                "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1%2B1/OpenJDK17U-jdk_ppc64le_linux_hotspot_17.0.8.1_1.tar.gz"
+              ]
+            }
+          },
+          "remotejdk21_linux_aarch64_toolchain_config_repo": {
+            "bzlFile": "@@rules_java~7.1.0//toolchains:remote_java_repository.bzl",
+            "ruleClassName": "_toolchain_config",
+            "attributes": {
+              "name": "rules_java~7.1.0~toolchains~remotejdk21_linux_aarch64_toolchain_config_repo",
+              "build_file": "\nconfig_setting(\n    name = \"prefix_version_setting\",\n    values = {\"java_runtime_version\": \"remotejdk_21\"},\n    visibility = [\"//visibility:private\"],\n)\nconfig_setting(\n    name = \"version_setting\",\n    values = {\"java_runtime_version\": \"21\"},\n    visibility = [\"//visibility:private\"],\n)\nalias(\n    name = \"version_or_prefix_version_setting\",\n    actual = select({\n        \":version_setting\": \":version_setting\",\n        \"//conditions:default\": \":prefix_version_setting\",\n    }),\n    visibility = [\"//visibility:private\"],\n)\ntoolchain(\n    name = \"toolchain\",\n    target_compatible_with = [\"@platforms//os:linux\", \"@platforms//cpu:aarch64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:runtime_toolchain_type\",\n    toolchain = \"@remotejdk21_linux_aarch64//:jdk\",\n)\ntoolchain(\n    name = \"bootstrap_runtime_toolchain\",\n    # These constraints are not required for correctness, but prevent fetches of remote JDK for\n    # different architectures. As every Java compilation toolchain depends on a bootstrap runtime in\n    # the same configuration, this constraint will not result in toolchain resolution failures.\n    exec_compatible_with = [\"@platforms//os:linux\", \"@platforms//cpu:aarch64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type\",\n    toolchain = \"@remotejdk21_linux_aarch64//:jdk\",\n)\n"
+            }
+          },
+          "remotejdk11_win_arm64_toolchain_config_repo": {
+            "bzlFile": "@@rules_java~7.1.0//toolchains:remote_java_repository.bzl",
+            "ruleClassName": "_toolchain_config",
+            "attributes": {
+              "name": "rules_java~7.1.0~toolchains~remotejdk11_win_arm64_toolchain_config_repo",
+              "build_file": "\nconfig_setting(\n    name = \"prefix_version_setting\",\n    values = {\"java_runtime_version\": \"remotejdk_11\"},\n    visibility = [\"//visibility:private\"],\n)\nconfig_setting(\n    name = \"version_setting\",\n    values = {\"java_runtime_version\": \"11\"},\n    visibility = [\"//visibility:private\"],\n)\nalias(\n    name = \"version_or_prefix_version_setting\",\n    actual = select({\n        \":version_setting\": \":version_setting\",\n        \"//conditions:default\": \":prefix_version_setting\",\n    }),\n    visibility = [\"//visibility:private\"],\n)\ntoolchain(\n    name = \"toolchain\",\n    target_compatible_with = [\"@platforms//os:windows\", \"@platforms//cpu:arm64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:runtime_toolchain_type\",\n    toolchain = \"@remotejdk11_win_arm64//:jdk\",\n)\ntoolchain(\n    name = \"bootstrap_runtime_toolchain\",\n    # These constraints are not required for correctness, but prevent fetches of remote JDK for\n    # different architectures. As every Java compilation toolchain depends on a bootstrap runtime in\n    # the same configuration, this constraint will not result in toolchain resolution failures.\n    exec_compatible_with = [\"@platforms//os:windows\", \"@platforms//cpu:arm64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type\",\n    toolchain = \"@remotejdk11_win_arm64//:jdk\",\n)\n"
+            }
+          },
+          "local_jdk": {
+            "bzlFile": "@@rules_java~7.1.0//toolchains:local_java_repository.bzl",
+            "ruleClassName": "_local_java_repository_rule",
+            "attributes": {
+              "name": "rules_java~7.1.0~toolchains~local_jdk",
+              "java_home": "",
+              "version": "",
+              "build_file_content": "load(\"@rules_java//java:defs.bzl\", \"java_runtime\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nexports_files([\"WORKSPACE\", \"BUILD.bazel\"])\n\nfilegroup(\n    name = \"jre\",\n    srcs = glob(\n        [\n            \"jre/bin/**\",\n            \"jre/lib/**\",\n        ],\n        allow_empty = True,\n        # In some configurations, Java browser plugin is considered harmful and\n        # common antivirus software blocks access to npjp2.dll interfering with Bazel,\n        # so do not include it in JRE on Windows.\n        exclude = [\"jre/bin/plugin2/**\"],\n    ),\n)\n\nfilegroup(\n    name = \"jdk-bin\",\n    srcs = glob(\n        [\"bin/**\"],\n        # The JDK on Windows sometimes contains a directory called\n        # \"%systemroot%\", which is not a valid label.\n        exclude = [\"**/*%*/**\"],\n    ),\n)\n\n# This folder holds security policies.\nfilegroup(\n    name = \"jdk-conf\",\n    srcs = glob(\n        [\"conf/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-include\",\n    srcs = glob(\n        [\"include/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-lib\",\n    srcs = glob(\n        [\"lib/**\", \"release\"],\n        allow_empty = True,\n        exclude = [\n            \"lib/missioncontrol/**\",\n            \"lib/visualvm/**\",\n        ],\n    ),\n)\n\njava_runtime(\n    name = \"jdk\",\n    srcs = [\n        \":jdk-bin\",\n        \":jdk-conf\",\n        \":jdk-include\",\n        \":jdk-lib\",\n        \":jre\",\n    ],\n    # Provide the 'java` binary explicitly so that the correct path is used by\n    # Bazel even when the host platform differs from the execution platform.\n    # Exactly one of the two globs will be empty depending on the host platform.\n    # When --incompatible_disallow_empty_glob is enabled, each individual empty\n    # glob will fail without allow_empty = True, even if the overall result is\n    # non-empty.\n    java = glob([\"bin/java.exe\", \"bin/java\"], allow_empty = True)[0],\n    version = {RUNTIME_VERSION},\n)\n"
+            }
+          },
+          "remote_java_tools_darwin_x86_64": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_java~7.1.0~toolchains~remote_java_tools_darwin_x86_64",
+              "sha256": "0db40d8505a2b65ef0ed46e4256757807db8162f7acff16225be57c1d5726dbc",
+              "urls": [
+                "https://mirror.bazel.build/bazel_java_tools/releases/java/v13.1/java_tools_darwin_x86_64-v13.1.zip",
+                "https://github.com/bazelbuild/java_tools/releases/download/java_v13.1/java_tools_darwin_x86_64-v13.1.zip"
+              ]
+            }
+          },
+          "remote_java_tools": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_java~7.1.0~toolchains~remote_java_tools",
+              "sha256": "286bdbbd66e616fc4ed3f90101418729a73baa7e8c23a98ffbef558f74c0ad14",
+              "urls": [
+                "https://mirror.bazel.build/bazel_java_tools/releases/java/v13.1/java_tools-v13.1.zip",
+                "https://github.com/bazelbuild/java_tools/releases/download/java_v13.1/java_tools-v13.1.zip"
+              ]
+            }
+          },
+          "remotejdk17_linux_s390x": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_java~7.1.0~toolchains~remotejdk17_linux_s390x",
+              "build_file_content": "load(\"@rules_java//java:defs.bzl\", \"java_runtime\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nexports_files([\"WORKSPACE\", \"BUILD.bazel\"])\n\nfilegroup(\n    name = \"jre\",\n    srcs = glob(\n        [\n            \"jre/bin/**\",\n            \"jre/lib/**\",\n        ],\n        allow_empty = True,\n        # In some configurations, Java browser plugin is considered harmful and\n        # common antivirus software blocks access to npjp2.dll interfering with Bazel,\n        # so do not include it in JRE on Windows.\n        exclude = [\"jre/bin/plugin2/**\"],\n    ),\n)\n\nfilegroup(\n    name = \"jdk-bin\",\n    srcs = glob(\n        [\"bin/**\"],\n        # The JDK on Windows sometimes contains a directory called\n        # \"%systemroot%\", which is not a valid label.\n        exclude = [\"**/*%*/**\"],\n    ),\n)\n\n# This folder holds security policies.\nfilegroup(\n    name = \"jdk-conf\",\n    srcs = glob(\n        [\"conf/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-include\",\n    srcs = glob(\n        [\"include/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-lib\",\n    srcs = glob(\n        [\"lib/**\", \"release\"],\n        allow_empty = True,\n        exclude = [\n            \"lib/missioncontrol/**\",\n            \"lib/visualvm/**\",\n        ],\n    ),\n)\n\njava_runtime(\n    name = \"jdk\",\n    srcs = [\n        \":jdk-bin\",\n        \":jdk-conf\",\n        \":jdk-include\",\n        \":jdk-lib\",\n        \":jre\",\n    ],\n    # Provide the 'java` binary explicitly so that the correct path is used by\n    # Bazel even when the host platform differs from the execution platform.\n    # Exactly one of the two globs will be empty depending on the host platform.\n    # When --incompatible_disallow_empty_glob is enabled, each individual empty\n    # glob will fail without allow_empty = True, even if the overall result is\n    # non-empty.\n    java = glob([\"bin/java.exe\", \"bin/java\"], allow_empty = True)[0],\n    version = 17,\n)\n",
+              "sha256": "ffacba69c6843d7ca70d572489d6cc7ab7ae52c60f0852cedf4cf0d248b6fc37",
+              "strip_prefix": "jdk-17.0.8.1+1",
+              "urls": [
+                "https://mirror.bazel.build/github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1%2B1/OpenJDK17U-jdk_s390x_linux_hotspot_17.0.8.1_1.tar.gz",
+                "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1%2B1/OpenJDK17U-jdk_s390x_linux_hotspot_17.0.8.1_1.tar.gz"
+              ]
+            }
+          },
+          "remotejdk17_win_toolchain_config_repo": {
+            "bzlFile": "@@rules_java~7.1.0//toolchains:remote_java_repository.bzl",
+            "ruleClassName": "_toolchain_config",
+            "attributes": {
+              "name": "rules_java~7.1.0~toolchains~remotejdk17_win_toolchain_config_repo",
+              "build_file": "\nconfig_setting(\n    name = \"prefix_version_setting\",\n    values = {\"java_runtime_version\": \"remotejdk_17\"},\n    visibility = [\"//visibility:private\"],\n)\nconfig_setting(\n    name = \"version_setting\",\n    values = {\"java_runtime_version\": \"17\"},\n    visibility = [\"//visibility:private\"],\n)\nalias(\n    name = \"version_or_prefix_version_setting\",\n    actual = select({\n        \":version_setting\": \":version_setting\",\n        \"//conditions:default\": \":prefix_version_setting\",\n    }),\n    visibility = [\"//visibility:private\"],\n)\ntoolchain(\n    name = \"toolchain\",\n    target_compatible_with = [\"@platforms//os:windows\", \"@platforms//cpu:x86_64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:runtime_toolchain_type\",\n    toolchain = \"@remotejdk17_win//:jdk\",\n)\ntoolchain(\n    name = \"bootstrap_runtime_toolchain\",\n    # These constraints are not required for correctness, but prevent fetches of remote JDK for\n    # different architectures. As every Java compilation toolchain depends on a bootstrap runtime in\n    # the same configuration, this constraint will not result in toolchain resolution failures.\n    exec_compatible_with = [\"@platforms//os:windows\", \"@platforms//cpu:x86_64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type\",\n    toolchain = \"@remotejdk17_win//:jdk\",\n)\n"
+            }
+          },
+          "remotejdk11_linux_ppc64le": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_java~7.1.0~toolchains~remotejdk11_linux_ppc64le",
+              "build_file_content": "load(\"@rules_java//java:defs.bzl\", \"java_runtime\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nexports_files([\"WORKSPACE\", \"BUILD.bazel\"])\n\nfilegroup(\n    name = \"jre\",\n    srcs = glob(\n        [\n            \"jre/bin/**\",\n            \"jre/lib/**\",\n        ],\n        allow_empty = True,\n        # In some configurations, Java browser plugin is considered harmful and\n        # common antivirus software blocks access to npjp2.dll interfering with Bazel,\n        # so do not include it in JRE on Windows.\n        exclude = [\"jre/bin/plugin2/**\"],\n    ),\n)\n\nfilegroup(\n    name = \"jdk-bin\",\n    srcs = glob(\n        [\"bin/**\"],\n        # The JDK on Windows sometimes contains a directory called\n        # \"%systemroot%\", which is not a valid label.\n        exclude = [\"**/*%*/**\"],\n    ),\n)\n\n# This folder holds security policies.\nfilegroup(\n    name = \"jdk-conf\",\n    srcs = glob(\n        [\"conf/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-include\",\n    srcs = glob(\n        [\"include/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-lib\",\n    srcs = glob(\n        [\"lib/**\", \"release\"],\n        allow_empty = True,\n        exclude = [\n            \"lib/missioncontrol/**\",\n            \"lib/visualvm/**\",\n        ],\n    ),\n)\n\njava_runtime(\n    name = \"jdk\",\n    srcs = [\n        \":jdk-bin\",\n        \":jdk-conf\",\n        \":jdk-include\",\n        \":jdk-lib\",\n        \":jre\",\n    ],\n    # Provide the 'java` binary explicitly so that the correct path is used by\n    # Bazel even when the host platform differs from the execution platform.\n    # Exactly one of the two globs will be empty depending on the host platform.\n    # When --incompatible_disallow_empty_glob is enabled, each individual empty\n    # glob will fail without allow_empty = True, even if the overall result is\n    # non-empty.\n    java = glob([\"bin/java.exe\", \"bin/java\"], allow_empty = True)[0],\n    version = 11,\n)\n",
+              "sha256": "a8fba686f6eb8ae1d1a9566821dbd5a85a1108b96ad857fdbac5c1e4649fc56f",
+              "strip_prefix": "jdk-11.0.15+10",
+              "urls": [
+                "https://mirror.bazel.build/github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.15+10/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.15_10.tar.gz",
+                "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.15+10/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.15_10.tar.gz"
+              ]
+            }
+          },
+          "remotejdk11_macos_aarch64": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_java~7.1.0~toolchains~remotejdk11_macos_aarch64",
+              "build_file_content": "load(\"@rules_java//java:defs.bzl\", \"java_runtime\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nexports_files([\"WORKSPACE\", \"BUILD.bazel\"])\n\nfilegroup(\n    name = \"jre\",\n    srcs = glob(\n        [\n            \"jre/bin/**\",\n            \"jre/lib/**\",\n        ],\n        allow_empty = True,\n        # In some configurations, Java browser plugin is considered harmful and\n        # common antivirus software blocks access to npjp2.dll interfering with Bazel,\n        # so do not include it in JRE on Windows.\n        exclude = [\"jre/bin/plugin2/**\"],\n    ),\n)\n\nfilegroup(\n    name = \"jdk-bin\",\n    srcs = glob(\n        [\"bin/**\"],\n        # The JDK on Windows sometimes contains a directory called\n        # \"%systemroot%\", which is not a valid label.\n        exclude = [\"**/*%*/**\"],\n    ),\n)\n\n# This folder holds security policies.\nfilegroup(\n    name = \"jdk-conf\",\n    srcs = glob(\n        [\"conf/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-include\",\n    srcs = glob(\n        [\"include/**\"],\n        allow_empty = True,\n    ),\n)\n\nfilegroup(\n    name = \"jdk-lib\",\n    srcs = glob(\n        [\"lib/**\", \"release\"],\n        allow_empty = True,\n        exclude = [\n            \"lib/missioncontrol/**\",\n            \"lib/visualvm/**\",\n        ],\n    ),\n)\n\njava_runtime(\n    name = \"jdk\",\n    srcs = [\n        \":jdk-bin\",\n        \":jdk-conf\",\n        \":jdk-include\",\n        \":jdk-lib\",\n        \":jre\",\n    ],\n    # Provide the 'java` binary explicitly so that the correct path is used by\n    # Bazel even when the host platform differs from the execution platform.\n    # Exactly one of the two globs will be empty depending on the host platform.\n    # When --incompatible_disallow_empty_glob is enabled, each individual empty\n    # glob will fail without allow_empty = True, even if the overall result is\n    # non-empty.\n    java = glob([\"bin/java.exe\", \"bin/java\"], allow_empty = True)[0],\n    version = 11,\n)\n",
+              "sha256": "7632bc29f8a4b7d492b93f3bc75a7b61630894db85d136456035ab2a24d38885",
+              "strip_prefix": "zulu11.66.15-ca-jdk11.0.20-macosx_aarch64",
+              "urls": [
+                "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu11.66.15-ca-jdk11.0.20-macosx_aarch64.tar.gz",
+                "https://cdn.azul.com/zulu/bin/zulu11.66.15-ca-jdk11.0.20-macosx_aarch64.tar.gz"
+              ]
+            }
+          },
+          "remotejdk21_win_toolchain_config_repo": {
+            "bzlFile": "@@rules_java~7.1.0//toolchains:remote_java_repository.bzl",
+            "ruleClassName": "_toolchain_config",
+            "attributes": {
+              "name": "rules_java~7.1.0~toolchains~remotejdk21_win_toolchain_config_repo",
+              "build_file": "\nconfig_setting(\n    name = \"prefix_version_setting\",\n    values = {\"java_runtime_version\": \"remotejdk_21\"},\n    visibility = [\"//visibility:private\"],\n)\nconfig_setting(\n    name = \"version_setting\",\n    values = {\"java_runtime_version\": \"21\"},\n    visibility = [\"//visibility:private\"],\n)\nalias(\n    name = \"version_or_prefix_version_setting\",\n    actual = select({\n        \":version_setting\": \":version_setting\",\n        \"//conditions:default\": \":prefix_version_setting\",\n    }),\n    visibility = [\"//visibility:private\"],\n)\ntoolchain(\n    name = \"toolchain\",\n    target_compatible_with = [\"@platforms//os:windows\", \"@platforms//cpu:x86_64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:runtime_toolchain_type\",\n    toolchain = \"@remotejdk21_win//:jdk\",\n)\ntoolchain(\n    name = \"bootstrap_runtime_toolchain\",\n    # These constraints are not required for correctness, but prevent fetches of remote JDK for\n    # different architectures. As every Java compilation toolchain depends on a bootstrap runtime in\n    # the same configuration, this constraint will not result in toolchain resolution failures.\n    exec_compatible_with = [\"@platforms//os:windows\", \"@platforms//cpu:x86_64\"],\n    target_settings = [\":version_or_prefix_version_setting\"],\n    toolchain_type = \"@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type\",\n    toolchain = \"@remotejdk21_win//:jdk\",\n)\n"
+            }
+          }
+        }
+      }
+    },
+    "@@rules_jvm_external~5.3//:extensions.bzl%maven": {
+      "general": {
+        "bzlTransitiveDigest": "9VQBVBpk1BYX8MlZX/v6yoWpeoWbbeIDc8bZ2kiueLI=",
+        "accumulatedFileDigests": {
+          "@@//:maven_install.json": "a5ee74885480c4e38f70dd8ca3e8ef2b7d89c81a581bbc196965d22aabd9b2ab",
+          "@@rules_jvm_external~5.3//:rules_jvm_external_deps_install.json": "741ab2ef3843a43eaacb45d1448835c9deb99c95162279f513096eface8acd44"
+        },
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "io_grpc_grpc_netty_shaded_jar_sources_1_56_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_grpc_grpc_netty_shaded_jar_sources_1_56_1",
+              "sha256": "4a7dd3517fc4540e926cd958b3a48ffc561f42ad9dfe31e3f2ccc13ba1742939",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/grpc/grpc-netty-shaded/1.56.1/grpc-netty-shaded-1.56.1-sources.jar"
+              ],
+              "downloaded_file_path": "io/grpc/grpc-netty-shaded/1.56.1/grpc-netty-shaded-1.56.1-sources.jar"
+            }
+          },
+          "me_dinowernli_java_grpc_prometheus": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~me_dinowernli_java_grpc_prometheus",
+              "generating_repository": "maven",
+              "target_name": "me_dinowernli_java_grpc_prometheus"
+            }
+          },
+          "com_sun_activation_jakarta_activation_1_2_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_sun_activation_jakarta_activation_1_2_1",
+              "sha256": "d84d4ba8b55cdb7fdcbb885e6939386367433f56f5ab8cfdc302a7c3587fa92b",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/sun/activation/jakarta.activation/1.2.1/jakarta.activation-1.2.1.jar"
+              ],
+              "downloaded_file_path": "com/sun/activation/jakarta.activation/1.2.1/jakarta.activation-1.2.1.jar"
+            }
+          },
+          "io_netty_netty_resolver_dns_jar_sources_4_1_96_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_resolver_dns_jar_sources_4_1_96_Final",
+              "sha256": "77eeef5ac81bf4b1ad919dc0e7b44bd4f2a4f71418c57beb341685f299fdc963",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/netty/netty-resolver-dns/4.1.96.Final/netty-resolver-dns-4.1.96.Final-sources.jar"
+              ],
+              "downloaded_file_path": "io/netty/netty-resolver-dns/4.1.96.Final/netty-resolver-dns-4.1.96.Final-sources.jar"
+            }
+          },
+          "io_grpc_grpc_alts_1_55_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_grpc_grpc_alts_1_55_1",
+              "sha256": "9ab78b042d55cb501a2126c831896f3223e39c65085351b40a588b085ed6d431",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/grpc/grpc-alts/1.55.1/grpc-alts-1.55.1.jar",
+                "https://maven.google.com/io/grpc/grpc-alts/1.55.1/grpc-alts-1.55.1.jar"
+              ],
+              "downloaded_file_path": "io/grpc/grpc-alts/1.55.1/grpc-alts-1.55.1.jar"
+            }
+          },
+          "com_github_jnr_jffi_1_3_11": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_jnr_jffi_1_3_11",
+              "sha256": "74d3bce7397b4872ccb6a6fd84b8f260503f76509adc9548029f665852ad38d7",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/github/jnr/jffi/1.3.11/jffi-1.3.11.jar"
+              ],
+              "downloaded_file_path": "com/github/jnr/jffi/1.3.11/jffi-1.3.11.jar"
+            }
+          },
+          "io_prometheus_simpleclient_tracer_common_jar_sources_0_15_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_prometheus_simpleclient_tracer_common_jar_sources_0_15_0",
+              "sha256": "ad5a691dc6b1b5096de0a209530c07a8f98d31d51895730136699a74caa1145a",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/prometheus/simpleclient_tracer_common/0.15.0/simpleclient_tracer_common-0.15.0-sources.jar"
+              ],
+              "downloaded_file_path": "io/prometheus/simpleclient_tracer_common/0.15.0/simpleclient_tracer_common-0.15.0-sources.jar"
+            }
+          },
+          "com_google_truth_truth": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_truth_truth",
+              "generating_repository": "maven",
+              "target_name": "com_google_truth_truth"
+            }
+          },
+          "io_opencensus_opencensus_api_jar_sources_0_31_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_opencensus_opencensus_api_jar_sources_0_31_1",
+              "sha256": "6748d57aaae81995514ad3e2fb11a95aa88e158b3f93450288018eaccf31e86b",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/opencensus/opencensus-api/0.31.1/opencensus-api-0.31.1-sources.jar"
+              ],
+              "downloaded_file_path": "io/opencensus/opencensus-api/0.31.1/opencensus-api-0.31.1-sources.jar"
+            }
+          },
+          "com_github_kevinstern_software_and_algorithms_1_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_kevinstern_software_and_algorithms_1_0",
+              "sha256": "61ab82439cef37343b14f53154c461619375373a56b9338e895709fb54e0864c",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/github/kevinstern/software-and-algorithms/1.0/software-and-algorithms-1.0.jar"
+              ],
+              "downloaded_file_path": "com/github/kevinstern/software-and-algorithms/1.0/software-and-algorithms-1.0.jar"
+            }
+          },
+          "com_google_protobuf_protobuf_java_util": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_protobuf_protobuf_java_util",
+              "generating_repository": "maven",
+              "target_name": "com_google_protobuf_protobuf_java_util"
+            }
+          },
+          "io_grpc_grpc_api_1_56_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_grpc_grpc_api_1_56_1",
+              "sha256": "b090b1bb5a3b066f7f2ef14b9ba68e3304de80ba34f90414aed3b519c30999e8",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/grpc/grpc-api/1.56.1/grpc-api-1.56.1.jar"
+              ],
+              "downloaded_file_path": "io/grpc/grpc-api/1.56.1/grpc-api-1.56.1.jar"
+            }
+          },
+          "org_apache_commons_commons_compress_1_23_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_apache_commons_commons_compress_1_23_0",
+              "sha256": "c267f17160e9ef662b4d78b7f29dca7c82b15c5cff2cb6a9865ef4ab3dd5b787",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/apache/commons/commons-compress/1.23.0/commons-compress-1.23.0.jar"
+              ],
+              "downloaded_file_path": "org/apache/commons/commons-compress/1.23.0/commons-compress-1.23.0.jar"
+            }
+          },
+          "org_reactivestreams_reactive_streams_1_0_3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_reactivestreams_reactive_streams_1_0_3",
+              "sha256": "1dee0481072d19c929b623e155e14d2f6085dc011529a0a0dbefc84cf571d865",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/reactivestreams/reactive-streams/1.0.3/reactive-streams-1.0.3.jar",
+                "https://maven.google.com/org/reactivestreams/reactive-streams/1.0.3/reactive-streams-1.0.3.jar"
+              ],
+              "downloaded_file_path": "org/reactivestreams/reactive-streams/1.0.3/reactive-streams-1.0.3.jar"
+            }
+          },
+          "com_google_protobuf_protobuf_java_util_3_22_3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_protobuf_protobuf_java_util_3_22_3",
+              "sha256": "c615f76879dc5c303e4df5b94a6afa39534058c7545db2d483fd95d9f63c8bfe",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java-util/3.22.3/protobuf-java-util-3.22.3.jar"
+              ],
+              "downloaded_file_path": "com/google/protobuf/protobuf-java-util/3.22.3/protobuf-java-util-3.22.3.jar"
+            }
+          },
+          "org_reactivestreams_reactive_streams_1_0_4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_reactivestreams_reactive_streams_1_0_4",
+              "sha256": "f75ca597789b3dac58f61857b9ac2e1034a68fa672db35055a8fb4509e325f28",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/reactivestreams/reactive-streams/1.0.4/reactive-streams-1.0.4.jar"
+              ],
+              "downloaded_file_path": "org/reactivestreams/reactive-streams/1.0.4/reactive-streams-1.0.4.jar"
+            }
+          },
+          "com_amazonaws_aws_java_sdk_s3_1_12_544": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_amazonaws_aws_java_sdk_s3_1_12_544",
+              "sha256": "817b2fac490d3e02ecaf3253c2e2ab0bf6d2291a841574cec70464312d669230",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-s3/1.12.544/aws-java-sdk-s3-1.12.544.jar"
+              ],
+              "downloaded_file_path": "com/amazonaws/aws-java-sdk-s3/1.12.544/aws-java-sdk-s3-1.12.544.jar"
+            }
+          },
+          "joda_time_joda_time_2_8_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~joda_time_joda_time_2_8_1",
+              "sha256": "b4670b95f75957c974284c5f3ada966040be2578f643c5c6083d262162061fa2",
+              "urls": [
+                "https://repo1.maven.org/maven2/joda-time/joda-time/2.8.1/joda-time-2.8.1.jar"
+              ],
+              "downloaded_file_path": "joda-time/joda-time/2.8.1/joda-time-2.8.1.jar"
+            }
+          },
+          "com_amazonaws_aws_java_sdk_s3": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_amazonaws_aws_java_sdk_s3",
+              "generating_repository": "maven",
+              "target_name": "com_amazonaws_aws_java_sdk_s3"
+            }
+          },
+          "com_github_fppt_jedis_mock": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_fppt_jedis_mock",
+              "generating_repository": "maven",
+              "target_name": "com_github_fppt_jedis_mock"
+            }
+          },
+          "com_jayway_jsonpath_json_path_2_8_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_jayway_jsonpath_json_path_2_8_0",
+              "sha256": "9601707e95cd79fb98570a01ea8cfb857b5cde948744d6e0edf733c11002c95b",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/jayway/jsonpath/json-path/2.8.0/json-path-2.8.0.jar"
+              ],
+              "downloaded_file_path": "com/jayway/jsonpath/json-path/2.8.0/json-path-2.8.0.jar"
+            }
+          },
+          "com_google_errorprone_error_prone_annotations_jar_sources_2_22_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_errorprone_error_prone_annotations_jar_sources_2_22_0",
+              "sha256": "c989d7144e4b3313514972df85f8f9dfd53b300e1359e13ca5e6453965c8fcef",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/errorprone/error_prone_annotations/2.22.0/error_prone_annotations-2.22.0-sources.jar"
+              ],
+              "downloaded_file_path": "com/google/errorprone/error_prone_annotations/2.22.0/error_prone_annotations-2.22.0-sources.jar"
+            }
+          },
+          "io_prometheus_simpleclient_tracer_otel_agent_jar_sources_0_15_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_prometheus_simpleclient_tracer_otel_agent_jar_sources_0_15_0",
+              "sha256": "9071a9ecf1473fd9c71c27082c549dd4e5686039444efb662392b1f3391a5d36",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/prometheus/simpleclient_tracer_otel_agent/0.15.0/simpleclient_tracer_otel_agent-0.15.0-sources.jar"
+              ],
+              "downloaded_file_path": "io/prometheus/simpleclient_tracer_otel_agent/0.15.0/simpleclient_tracer_otel_agent-0.15.0-sources.jar"
+            }
+          },
+          "com_github_serceman_jnr_fuse": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_serceman_jnr_fuse",
+              "generating_repository": "maven",
+              "target_name": "com_github_serceman_jnr_fuse"
+            }
+          },
+          "org_checkerframework_checker_qual_jar_sources_3_38_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_checkerframework_checker_qual_jar_sources_3_38_0",
+              "sha256": "c1184779ca27c09efe55b54109bf8a2b654112c6e8b28105c0c2dcc5a84465b1",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/checkerframework/checker-qual/3.38.0/checker-qual-3.38.0-sources.jar"
+              ],
+              "downloaded_file_path": "org/checkerframework/checker-qual/3.38.0/checker-qual-3.38.0-sources.jar"
+            }
+          },
+          "org_bouncycastle_bcprov_jdk15on_1_70": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_bouncycastle_bcprov_jdk15on_1_70",
+              "sha256": "8f3c20e3e2d565d26f33e8d4857a37d0d7f8ac39b62a7026496fcab1bdac30d4",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/bouncycastle/bcprov-jdk15on/1.70/bcprov-jdk15on-1.70.jar"
+              ],
+              "downloaded_file_path": "org/bouncycastle/bcprov-jdk15on/1.70/bcprov-jdk15on-1.70.jar"
+            }
+          },
+          "com_google_code_gson_gson_2_10_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_code_gson_gson_2_10_1",
+              "sha256": "4241c14a7727c34feea6507ec801318a3d4a90f070e4525681079fb94ee4c593",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/code/gson/gson/2.10.1/gson-2.10.1.jar"
+              ],
+              "downloaded_file_path": "com/google/code/gson/gson/2.10.1/gson-2.10.1.jar"
+            }
+          },
+          "io_netty_netty_handler_jar_sources_4_1_97_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_handler_jar_sources_4_1_97_Final",
+              "sha256": "905739df92b7fe6468504e1e91b964654381eb3d162766f39552d06a0cbf4cd3",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/netty/netty-handler/4.1.97.Final/netty-handler-4.1.97.Final-sources.jar"
+              ],
+              "downloaded_file_path": "io/netty/netty-handler/4.1.97.Final/netty-handler-4.1.97.Final-sources.jar"
+            }
+          },
+          "io_netty_netty_codec_dns_4_1_96_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_codec_dns_4_1_96_Final",
+              "sha256": "857d0213bd4e504ad897a7c0f967ef3f728f120feea3e824729dad525b44bbce",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/netty/netty-codec-dns/4.1.96.Final/netty-codec-dns-4.1.96.Final.jar"
+              ],
+              "downloaded_file_path": "io/netty/netty-codec-dns/4.1.96.Final/netty-codec-dns-4.1.96.Final.jar"
+            }
+          },
+          "com_google_errorprone_error_prone_core_2_22_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_errorprone_error_prone_core_2_22_0",
+              "sha256": "32a3df226a9a47f48dd895a9a89678d50ac404282c33400781c38757e8143f2c",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/errorprone/error_prone_core/2.22.0/error_prone_core-2.22.0.jar"
+              ],
+              "downloaded_file_path": "com/google/errorprone/error_prone_core/2.22.0/error_prone_core-2.22.0.jar"
+            }
+          },
+          "com_fasterxml_jackson_core_jackson_databind": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_fasterxml_jackson_core_jackson_databind",
+              "generating_repository": "maven",
+              "target_name": "com_fasterxml_jackson_core_jackson_databind"
+            }
+          },
+          "io_prometheus_simpleclient_jar_sources_0_15_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_prometheus_simpleclient_jar_sources_0_15_0",
+              "sha256": "996c0ae2c1f6fe658865f8b3b3d073d136bd60de1a37fa78db2d52db328d1adb",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/prometheus/simpleclient/0.15.0/simpleclient-0.15.0-sources.jar"
+              ],
+              "downloaded_file_path": "io/prometheus/simpleclient/0.15.0/simpleclient-0.15.0-sources.jar"
+            }
+          },
+          "org_ow2_asm_asm_tree_jar_sources_9_2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_ow2_asm_asm_tree_jar_sources_9_2",
+              "sha256": "c35bc5b4b6c54bf15abec34ab821cf9d0801a64451f4f6070d93dcb87122aa08",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/ow2/asm/asm-tree/9.2/asm-tree-9.2-sources.jar"
+              ],
+              "downloaded_file_path": "org/ow2/asm/asm-tree/9.2/asm-tree-9.2-sources.jar"
+            }
+          },
+          "io_netty_netty_transport_jar_sources_4_1_97_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_transport_jar_sources_4_1_97_Final",
+              "sha256": "2ee8b4402c42f9bbbb3b4a14cce1f80d0b48f2115c718ea464f3050f58c70b2e",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/netty/netty-transport/4.1.97.Final/netty-transport-4.1.97.Final-sources.jar"
+              ],
+              "downloaded_file_path": "io/netty/netty-transport/4.1.97.Final/netty-transport-4.1.97.Final-sources.jar"
+            }
+          },
+          "org_apache_commons_commons_math3_3_6_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_apache_commons_commons_math3_3_6_1",
+              "sha256": "1e56d7b058d28b65abd256b8458e3885b674c1d588fa43cd7d1cbb9c7ef2b308",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/apache/commons/commons-math3/3.6.1/commons-math3-3.6.1.jar"
+              ],
+              "downloaded_file_path": "org/apache/commons/commons-math3/3.6.1/commons-math3-3.6.1.jar"
+            }
+          },
+          "org_jboss_marshalling_jboss_marshalling_river_jar_sources_2_0_11_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_jboss_marshalling_jboss_marshalling_river_jar_sources_2_0_11_Final",
+              "sha256": "c3cb3209f18c0d1fec289669426b105d5247ad53ae98326369c9b4db4b80ceac",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/jboss/marshalling/jboss-marshalling-river/2.0.11.Final/jboss-marshalling-river-2.0.11.Final-sources.jar"
+              ],
+              "downloaded_file_path": "org/jboss/marshalling/jboss-marshalling-river/2.0.11.Final/jboss-marshalling-river-2.0.11.Final-sources.jar"
+            }
+          },
+          "jakarta_annotation_jakarta_annotation_api_jar_sources_1_3_5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~jakarta_annotation_jakarta_annotation_api_jar_sources_1_3_5",
+              "sha256": "aa27e9291dce4ddbb0aea52a1cbef41c6330b96b0ae387a995ed412b68a3af7c",
+              "urls": [
+                "https://repo1.maven.org/maven2/jakarta/annotation/jakarta.annotation-api/1.3.5/jakarta.annotation-api-1.3.5-sources.jar"
+              ],
+              "downloaded_file_path": "jakarta/annotation/jakarta.annotation-api/1.3.5/jakarta.annotation-api-1.3.5-sources.jar"
+            }
+          },
+          "org_apache_commons_commons_compress_jar_sources_1_23_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_apache_commons_commons_compress_jar_sources_1_23_0",
+              "sha256": "2ba017aee1a90ebd2b27ba245c2338f37bf23948f035a2bd75becf623906b709",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/apache/commons/commons-compress/1.23.0/commons-compress-1.23.0-sources.jar"
+              ],
+              "downloaded_file_path": "org/apache/commons/commons-compress/1.23.0/commons-compress-1.23.0-sources.jar"
+            }
+          },
+          "com_github_docker_java_docker_java_transport_netty_3_3_3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_docker_java_docker_java_transport_netty_3_3_3",
+              "sha256": "30152706a19f46f97bea55e85182762d8b5d2d23bea5e465af403537677f879b",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/github/docker-java/docker-java-transport-netty/3.3.3/docker-java-transport-netty-3.3.3.jar"
+              ],
+              "downloaded_file_path": "com/github/docker-java/docker-java-transport-netty/3.3.3/docker-java-transport-netty-3.3.3.jar"
+            }
+          },
+          "io_netty_netty_transport_native_epoll_4_1_97_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_transport_native_epoll_4_1_97_Final",
+              "sha256": "418a0d0d66d2d52a63a0e2cd5377f8c3186db47c09e3b8af39a43fec39c077fe",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/netty/netty-transport-native-epoll/4.1.97.Final/netty-transport-native-epoll-4.1.97.Final.jar"
+              ],
+              "downloaded_file_path": "io/netty/netty-transport-native-epoll/4.1.97.Final/netty-transport-native-epoll-4.1.97.Final.jar"
+            }
+          },
+          "net_javacrumbs_future_converter_future_converter_common_jar_sources_1_2_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~net_javacrumbs_future_converter_future_converter_common_jar_sources_1_2_0",
+              "sha256": "24f849eb33ef57a4ea597052f8fa78cbe14076cb36160e7b37a6373d1f162a70",
+              "urls": [
+                "https://repo1.maven.org/maven2/net/javacrumbs/future-converter/future-converter-common/1.2.0/future-converter-common-1.2.0-sources.jar"
+              ],
+              "downloaded_file_path": "net/javacrumbs/future-converter/future-converter-common/1.2.0/future-converter-common-1.2.0-sources.jar"
+            }
+          },
+          "com_google_errorprone_error_prone_type_annotations_2_22_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_errorprone_error_prone_type_annotations_2_22_0",
+              "sha256": "6618b1d28df562622b77187b5c6dfc9c4c97851af73bd64dc0300efe9a439b20",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/errorprone/error_prone_type_annotations/2.22.0/error_prone_type_annotations-2.22.0.jar"
+              ],
+              "downloaded_file_path": "com/google/errorprone/error_prone_type_annotations/2.22.0/error_prone_type_annotations-2.22.0.jar"
+            }
+          },
+          "com_fasterxml_jackson_jaxrs_jackson_jaxrs_json_provider_jar_sources_2_10_3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_fasterxml_jackson_jaxrs_jackson_jaxrs_json_provider_jar_sources_2_10_3",
+              "sha256": "b15fd7237ceb93aa289e22bb21335249e3cd33cd6a0fd1be769e6fc63b1513b5",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/fasterxml/jackson/jaxrs/jackson-jaxrs-json-provider/2.10.3/jackson-jaxrs-json-provider-2.10.3-sources.jar"
+              ],
+              "downloaded_file_path": "com/fasterxml/jackson/jaxrs/jackson-jaxrs-json-provider/2.10.3/jackson-jaxrs-json-provider-2.10.3-sources.jar"
+            }
+          },
+          "net_java_dev_jna_jna_platform_jar_sources_5_13_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~net_java_dev_jna_jna_platform_jar_sources_5_13_0",
+              "sha256": "2f39937649df7e74f36f2b56ee2f15c15d4f9218fde43369c48a6b51e3cc087e",
+              "urls": [
+                "https://repo1.maven.org/maven2/net/java/dev/jna/jna-platform/5.13.0/jna-platform-5.13.0-sources.jar"
+              ],
+              "downloaded_file_path": "net/java/dev/jna/jna-platform/5.13.0/jna-platform-5.13.0-sources.jar"
+            }
+          },
+          "net_javacrumbs_future_converter_future_converter_java8_common_1_2_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~net_javacrumbs_future_converter_future_converter_java8_common_1_2_0",
+              "sha256": "bed25293fabbf59e048f67f88e55140ebc1cfa4fa899e397545d0193e866a65c",
+              "urls": [
+                "https://repo1.maven.org/maven2/net/javacrumbs/future-converter/future-converter-java8-common/1.2.0/future-converter-java8-common-1.2.0.jar"
+              ],
+              "downloaded_file_path": "net/javacrumbs/future-converter/future-converter-java8-common/1.2.0/future-converter-java8-common-1.2.0.jar"
+            }
+          },
+          "io_prometheus_simpleclient_hotspot": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_prometheus_simpleclient_hotspot",
+              "generating_repository": "maven",
+              "target_name": "io_prometheus_simpleclient_hotspot"
+            }
+          },
+          "io_netty_netty_codec": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_codec",
+              "generating_repository": "maven",
+              "target_name": "io_netty_netty_codec"
+            }
+          },
+          "net_javacrumbs_future_converter_future_converter_guava_common_jar_sources_1_2_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~net_javacrumbs_future_converter_future_converter_guava_common_jar_sources_1_2_0",
+              "sha256": "f5a6c226632ab0c4225962146c8b4dbbfd8db75f1b573c2da29268ac1beecc57",
+              "urls": [
+                "https://repo1.maven.org/maven2/net/javacrumbs/future-converter/future-converter-guava-common/1.2.0/future-converter-guava-common-1.2.0-sources.jar"
+              ],
+              "downloaded_file_path": "net/javacrumbs/future-converter/future-converter-guava-common/1.2.0/future-converter-guava-common-1.2.0-sources.jar"
+            }
+          },
+          "io_grpc_grpc_api_1_55_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_grpc_grpc_api_1_55_1",
+              "sha256": "9f21b1585b1c578cf905fb4c926ce895494207cb5bf456a64a24c458850f51d3",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/grpc/grpc-api/1.55.1/grpc-api-1.55.1.jar",
+                "https://maven.google.com/io/grpc/grpc-api/1.55.1/grpc-api-1.55.1.jar"
+              ],
+              "downloaded_file_path": "io/grpc/grpc-api/1.55.1/grpc-api-1.55.1.jar"
+            }
+          },
+          "com_fasterxml_jackson_module_jackson_module_jaxb_annotations_jar_sources_2_10_3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_fasterxml_jackson_module_jackson_module_jaxb_annotations_jar_sources_2_10_3",
+              "sha256": "81e7738e3a836c465e3170cab143e1c3182c3ca5dd3cfabfceb9a23fe0939a34",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/fasterxml/jackson/module/jackson-module-jaxb-annotations/2.10.3/jackson-module-jaxb-annotations-2.10.3-sources.jar"
+              ],
+              "downloaded_file_path": "com/fasterxml/jackson/module/jackson-module-jaxb-annotations/2.10.3/jackson-module-jaxb-annotations-2.10.3-sources.jar"
+            }
+          },
+          "com_google_errorprone_error_prone_core_jar_sources_2_22_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_errorprone_error_prone_core_jar_sources_2_22_0",
+              "sha256": "98c52d46fe499a61eea86234f5463bba6968c595dacddb38d89c161e354c62b4",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/errorprone/error_prone_core/2.22.0/error_prone_core-2.22.0-sources.jar"
+              ],
+              "downloaded_file_path": "com/google/errorprone/error_prone_core/2.22.0/error_prone_core-2.22.0-sources.jar"
+            }
+          },
+          "net_bytebuddy_byte_buddy_jar_sources_1_14_5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~net_bytebuddy_byte_buddy_jar_sources_1_14_5",
+              "sha256": "143dd9fe73f0566cc703934b7fd15abbb97bfab045064c2f176067e70456a136",
+              "urls": [
+                "https://repo1.maven.org/maven2/net/bytebuddy/byte-buddy/1.14.5/byte-buddy-1.14.5-sources.jar"
+              ],
+              "downloaded_file_path": "net/bytebuddy/byte-buddy/1.14.5/byte-buddy-1.14.5-sources.jar"
+            }
+          },
+          "com_google_protobuf_protobuf_java_util_3_23_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_protobuf_protobuf_java_util_3_23_1",
+              "sha256": "35d78f70fcba8ecaad6b2025a4879099a27997079158500a08fafebad8918c8c",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java-util/3.23.1/protobuf-java-util-3.23.1.jar",
+                "https://maven.google.com/com/google/protobuf/protobuf-java-util/3.23.1/protobuf-java-util-3.23.1.jar"
+              ],
+              "downloaded_file_path": "com/google/protobuf/protobuf-java-util/3.23.1/protobuf-java-util-3.23.1.jar"
+            }
+          },
+          "org_ow2_asm_asm_9_5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_ow2_asm_asm_9_5",
+              "sha256": "b62e84b5980729751b0458c534cf1366f727542bb8d158621335682a460f0353",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/ow2/asm/asm/9.5/asm-9.5.jar"
+              ],
+              "downloaded_file_path": "org/ow2/asm/asm/9.5/asm-9.5.jar"
+            }
+          },
+          "software_amazon_ion_ion_java_jar_sources_1_0_2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~software_amazon_ion_ion_java_jar_sources_1_0_2",
+              "sha256": "d827fc9775443697bbcdfeb8ea2d3d75bf5ad7f2ca540dabda1a5f83cd0a39de",
+              "urls": [
+                "https://repo1.maven.org/maven2/software/amazon/ion/ion-java/1.0.2/ion-java-1.0.2-sources.jar"
+              ],
+              "downloaded_file_path": "software/amazon/ion/ion-java/1.0.2/ion-java-1.0.2-sources.jar"
+            }
+          },
+          "io_netty_netty_resolver_jar_sources_4_1_97_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_resolver_jar_sources_4_1_97_Final",
+              "sha256": "dd687a7b2016d38d92d988172b787c713d786e5b8c37896796b156e6798cbd95",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/netty/netty-resolver/4.1.97.Final/netty-resolver-4.1.97.Final-sources.jar"
+              ],
+              "downloaded_file_path": "io/netty/netty-resolver/4.1.97.Final/netty-resolver-4.1.97.Final-sources.jar"
+            }
+          },
+          "org_pcollections_pcollections_jar_sources_3_1_4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_pcollections_pcollections_jar_sources_3_1_4",
+              "sha256": "38d91b91467dedcedfd36b6b5f577008fd51748ce74150ebe11ec1227acce218",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/pcollections/pcollections/3.1.4/pcollections-3.1.4-sources.jar"
+              ],
+              "downloaded_file_path": "org/pcollections/pcollections/3.1.4/pcollections-3.1.4-sources.jar"
+            }
+          },
+          "com_google_guava_listenablefuture_9999_0_empty_to_avoid_conflict_with_guava": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_guava_listenablefuture_9999_0_empty_to_avoid_conflict_with_guava",
+              "sha256": "b372a037d4230aa57fbeffdef30fd6123f9c0c2db85d0aced00c91b974f33f99",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar"
+              ],
+              "downloaded_file_path": "com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar"
+            }
+          },
+          "com_jayway_jsonpath_json_path_jar_sources_2_8_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_jayway_jsonpath_json_path_jar_sources_2_8_0",
+              "sha256": "ce1d02241b445abf7f4c067b94d77c917fa06fbcbb048519b932a2197a2cc3fd",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/jayway/jsonpath/json-path/2.8.0/json-path-2.8.0-sources.jar"
+              ],
+              "downloaded_file_path": "com/jayway/jsonpath/json-path/2.8.0/json-path-2.8.0-sources.jar"
+            }
+          },
+          "com_google_code_gson_gson": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_code_gson_gson",
+              "generating_repository": "maven",
+              "target_name": "com_google_code_gson_gson"
+            }
+          },
+          "org_json_json_20220320": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_json_json_20220320",
+              "sha256": "1edf7fcea79a16b8dfdd3bc988ddec7f8908b1f7762fdf00d39acb037542747a",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/json/json/20220320/json-20220320.jar"
+              ],
+              "downloaded_file_path": "org/json/json/20220320/json-20220320.jar"
+            }
+          },
+          "com_fasterxml_jackson_jaxrs_jackson_jaxrs_base_2_10_3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_fasterxml_jackson_jaxrs_jackson_jaxrs_base_2_10_3",
+              "sha256": "3b6b74311d094990e6d8de356363988050fb2bf5389138b198b01a0ceb9a9668",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/fasterxml/jackson/jaxrs/jackson-jaxrs-base/2.10.3/jackson-jaxrs-base-2.10.3.jar"
+              ],
+              "downloaded_file_path": "com/fasterxml/jackson/jaxrs/jackson-jaxrs-base/2.10.3/jackson-jaxrs-base-2.10.3.jar"
+            }
+          },
+          "com_google_api_grpc_gapic_google_cloud_storage_v2_2_22_3_alpha": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_api_grpc_gapic_google_cloud_storage_v2_2_22_3_alpha",
+              "sha256": "2843f647000e82fe1d3b89eff32a15aab7671d917c90b739f31c9aa895bf957a",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/api/grpc/gapic-google-cloud-storage-v2/2.22.3-alpha/gapic-google-cloud-storage-v2-2.22.3-alpha.jar",
+                "https://maven.google.com/com/google/api/grpc/gapic-google-cloud-storage-v2/2.22.3-alpha/gapic-google-cloud-storage-v2-2.22.3-alpha.jar"
+              ],
+              "downloaded_file_path": "com/google/api/grpc/gapic-google-cloud-storage-v2/2.22.3-alpha/gapic-google-cloud-storage-v2-2.22.3-alpha.jar"
+            }
+          },
+          "com_github_ben_manes_caffeine_caffeine_3_0_5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_ben_manes_caffeine_caffeine_3_0_5",
+              "sha256": "8a9b54d3506a3b92ee46b217bcee79196b21ca6d52dc2967c686a205fb2f9c15",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/github/ben-manes/caffeine/caffeine/3.0.5/caffeine-3.0.5.jar"
+              ],
+              "downloaded_file_path": "com/github/ben-manes/caffeine/caffeine/3.0.5/caffeine-3.0.5.jar"
+            }
+          },
+          "org_jodd_jodd_core_jar_sources_5_1_6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_jodd_jodd_core_jar_sources_5_1_6",
+              "sha256": "2eb5a3af95296bc941767870bf5cb242ba7ee59a5eb0524c73e734578f6c6c16",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/jodd/jodd-core/5.1.6/jodd-core-5.1.6-sources.jar"
+              ],
+              "downloaded_file_path": "org/jodd/jodd-core/5.1.6/jodd-core-5.1.6-sources.jar"
+            }
+          },
+          "org_jetbrains_annotations": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_jetbrains_annotations",
+              "generating_repository": "maven",
+              "target_name": "org_jetbrains_annotations"
+            }
+          },
+          "com_amazonaws_aws_java_sdk_core_1_12_544": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_amazonaws_aws_java_sdk_core_1_12_544",
+              "sha256": "79682855ea21bd65094ad97109f9b3e4361d3e02926f5ee14ade3411c7ca43da",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-core/1.12.544/aws-java-sdk-core-1.12.544.jar"
+              ],
+              "downloaded_file_path": "com/amazonaws/aws-java-sdk-core/1.12.544/aws-java-sdk-core-1.12.544.jar"
+            }
+          },
+          "org_checkerframework_checker_qual_3_38_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_checkerframework_checker_qual_3_38_0",
+              "sha256": "9bd02cbe679a58afa0fba44c9621fe70130653e8c4564eb8d65e14bbfe26b7f8",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/checkerframework/checker-qual/3.38.0/checker-qual-3.38.0.jar"
+              ],
+              "downloaded_file_path": "org/checkerframework/checker-qual/3.38.0/checker-qual-3.38.0.jar"
+            }
+          },
+          "org_glassfish_hk2_external_jakarta_inject_2_6_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_glassfish_hk2_external_jakarta_inject_2_6_1",
+              "sha256": "5e88c123b3e41bca788b2683118867d9b6dec714247ea91c588aed46a36ee24f",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/glassfish/hk2/external/jakarta.inject/2.6.1/jakarta.inject-2.6.1.jar"
+              ],
+              "downloaded_file_path": "org/glassfish/hk2/external/jakarta.inject/2.6.1/jakarta.inject-2.6.1.jar"
+            }
+          },
+          "io_netty_netty_codec_socks_jar_sources_4_1_97_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_codec_socks_jar_sources_4_1_97_Final",
+              "sha256": "2b48738f837dfc66833b811f6a4eab7fc3a75abd47fee3e7572de7653e5172de",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/netty/netty-codec-socks/4.1.97.Final/netty-codec-socks-4.1.97.Final-sources.jar"
+              ],
+              "downloaded_file_path": "io/netty/netty-codec-socks/4.1.97.Final/netty-codec-socks-4.1.97.Final-sources.jar"
+            }
+          },
+          "com_google_http_client_google_http_client_apache_v2_1_43_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_http_client_google_http_client_apache_v2_1_43_1",
+              "sha256": "18b25a8bed630a7b90204b7020f72219fdda643935fca6405e6e3937ae92b361",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/http-client/google-http-client-apache-v2/1.43.1/google-http-client-apache-v2-1.43.1.jar",
+                "https://maven.google.com/com/google/http-client/google-http-client-apache-v2/1.43.1/google-http-client-apache-v2-1.43.1.jar"
+              ],
+              "downloaded_file_path": "com/google/http-client/google-http-client-apache-v2/1.43.1/google-http-client-apache-v2-1.43.1.jar"
+            }
+          },
+          "io_netty_netty_transport_classes_epoll_4_1_86_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_transport_classes_epoll_4_1_86_Final",
+              "sha256": "3cc7eb87d85d6b4bf3d596a172a92df09f8d746c2b283c85543c95795b51edda",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/netty/netty-transport-classes-epoll/4.1.86.Final/netty-transport-classes-epoll-4.1.86.Final.jar",
+                "https://maven.google.com/io/netty/netty-transport-classes-epoll/4.1.86.Final/netty-transport-classes-epoll-4.1.86.Final.jar"
+              ],
+              "downloaded_file_path": "io/netty/netty-transport-classes-epoll/4.1.86.Final/netty-transport-classes-epoll-4.1.86.Final.jar"
+            }
+          },
+          "com_github_jnr_jnr_x86asm_jar_sources_1_0_2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_jnr_jnr_x86asm_jar_sources_1_0_2",
+              "sha256": "3c983efd496f95ea5382ca014f96613786826136e0ce13d5c1cbc3097ea92ca0",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/github/jnr/jnr-x86asm/1.0.2/jnr-x86asm-1.0.2-sources.jar"
+              ],
+              "downloaded_file_path": "com/github/jnr/jnr-x86asm/1.0.2/jnr-x86asm-1.0.2-sources.jar"
+            }
+          },
+          "io_netty_netty_codec_4_1_97_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_codec_4_1_97_Final",
+              "sha256": "bcc96737a0f912fcf031cf8c45ebda352a90a40437db0832caad3d5a63618b38",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/netty/netty-codec/4.1.97.Final/netty-codec-4.1.97.Final.jar"
+              ],
+              "downloaded_file_path": "io/netty/netty-codec/4.1.97.Final/netty-codec-4.1.97.Final.jar"
+            }
+          },
+          "com_google_code_gson_gson_jar_sources_2_10_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_code_gson_gson_jar_sources_2_10_1",
+              "sha256": "eee1cc5c1f4267ee194cc245777e68084738ef390acd763354ce0ff6bfb7bcc1",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/code/gson/gson/2.10.1/gson-2.10.1-sources.jar"
+              ],
+              "downloaded_file_path": "com/google/code/gson/gson/2.10.1/gson-2.10.1-sources.jar"
+            }
+          },
+          "org_threeten_threetenbp": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_threeten_threetenbp",
+              "generating_repository": "maven",
+              "target_name": "org_threeten_threetenbp"
+            }
+          },
+          "com_github_jnr_jnr_ffi_2_2_14": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_jnr_jnr_ffi_2_2_14",
+              "sha256": "01fafe177b1e3136b3789aeb0ff0884ae1e24b5ada711192f67084103697f2d4",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/github/jnr/jnr-ffi/2.2.14/jnr-ffi-2.2.14.jar"
+              ],
+              "downloaded_file_path": "com/github/jnr/jnr-ffi/2.2.14/jnr-ffi-2.2.14.jar"
+            }
+          },
+          "com_google_auto_value_auto_value_annotations_1_10_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_auto_value_auto_value_annotations_1_10_1",
+              "sha256": "a4fe0a211925e938a8510d741763ee1171a11bf931f5891ef4d4ee84fca72be2",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/auto/value/auto-value-annotations/1.10.1/auto-value-annotations-1.10.1.jar"
+              ],
+              "downloaded_file_path": "com/google/auto/value/auto-value-annotations/1.10.1/auto-value-annotations-1.10.1.jar"
+            }
+          },
+          "org_ow2_asm_asm_tree_9_2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_ow2_asm_asm_tree_9_2",
+              "sha256": "aabf9bd23091a4ebfc109c1f3ee7cf3e4b89f6ba2d3f51c5243f16b3cffae011",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/ow2/asm/asm-tree/9.2/asm-tree-9.2.jar"
+              ],
+              "downloaded_file_path": "org/ow2/asm/asm-tree/9.2/asm-tree-9.2.jar"
+            }
+          },
+          "com_google_inject_guice_jar_sources_5_1_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_inject_guice_jar_sources_5_1_0",
+              "sha256": "79484227656350f8ea315198ed2ebdc8583e7ba42ecd90d367d66a7e491de52e",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/inject/guice/5.1.0/guice-5.1.0-sources.jar"
+              ],
+              "downloaded_file_path": "com/google/inject/guice/5.1.0/guice-5.1.0-sources.jar"
+            }
+          },
+          "com_google_api_client_google_api_client_2_2_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_api_client_google_api_client_2_2_0",
+              "sha256": "58eca9fb0a869391689ffc828b3bd0b19ac76042ff9fab4881eddf7fde76903f",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/api-client/google-api-client/2.2.0/google-api-client-2.2.0.jar",
+                "https://maven.google.com/com/google/api-client/google-api-client/2.2.0/google-api-client-2.2.0.jar"
+              ],
+              "downloaded_file_path": "com/google/api-client/google-api-client/2.2.0/google-api-client-2.2.0.jar"
+            }
+          },
+          "rules_jvm_external_deps": {
+            "bzlFile": "@@rules_jvm_external~5.3//:coursier.bzl",
+            "ruleClassName": "pinned_coursier_fetch",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~rules_jvm_external_deps",
+              "repositories": [
+                "{ \"repo_url\": \"https://repo1.maven.org/maven2\" }"
+              ],
+              "artifacts": [
+                "{ \"group\": \"com.google.auth\", \"artifact\": \"google-auth-library-credentials\", \"version\": \"1.17.0\" }",
+                "{ \"group\": \"com.google.auth\", \"artifact\": \"google-auth-library-oauth2-http\", \"version\": \"1.17.0\" }",
+                "{ \"group\": \"com.google.cloud\", \"artifact\": \"google-cloud-core\", \"version\": \"2.18.1\" }",
+                "{ \"group\": \"com.google.cloud\", \"artifact\": \"google-cloud-storage\", \"version\": \"2.22.3\" }",
+                "{ \"group\": \"com.google.code.gson\", \"artifact\": \"gson\", \"version\": \"2.10.1\" }",
+                "{ \"group\": \"com.google.googlejavaformat\", \"artifact\": \"google-java-format\", \"version\": \"1.17.0\" }",
+                "{ \"group\": \"com.google.guava\", \"artifact\": \"guava\", \"version\": \"32.0.0-jre\" }",
+                "{ \"group\": \"org.apache.maven\", \"artifact\": \"maven-artifact\", \"version\": \"3.9.2\" }",
+                "{ \"group\": \"software.amazon.awssdk\", \"artifact\": \"s3\", \"version\": \"2.20.78\" }"
+              ],
+              "fetch_sources": true,
+              "fetch_javadoc": false,
+              "generate_compat_repositories": false,
+              "maven_install_json": "@@rules_jvm_external~5.3//:rules_jvm_external_deps_install.json",
+              "override_targets": {},
+              "strict_visibility": false,
+              "strict_visibility_value": [
+                "@@//visibility:private"
+              ],
+              "jetify": false,
+              "jetify_include_list": [
+                "*"
+              ],
+              "additional_netrc_lines": [],
+              "fail_if_repin_required": false,
+              "use_starlark_android_rules": false,
+              "aar_import_bzl_label": "@build_bazel_rules_android//android:rules.bzl",
+              "duplicate_version_warning": "warn"
+            }
+          },
+          "net_javacrumbs_future_converter_future_converter_java8_guava": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~net_javacrumbs_future_converter_future_converter_java8_guava",
+              "generating_repository": "maven",
+              "target_name": "net_javacrumbs_future_converter_future_converter_java8_guava"
+            }
+          },
+          "com_google_http_client_google_http_client_appengine_1_43_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_http_client_google_http_client_appengine_1_43_1",
+              "sha256": "93762484a9324f824455b24da0cb698a7e3467e2e4962ee541a14ff1922c3a88",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/http-client/google-http-client-appengine/1.43.1/google-http-client-appengine-1.43.1.jar",
+                "https://maven.google.com/com/google/http-client/google-http-client-appengine/1.43.1/google-http-client-appengine-1.43.1.jar"
+              ],
+              "downloaded_file_path": "com/google/http-client/google-http-client-appengine/1.43.1/google-http-client-appengine-1.43.1.jar"
+            }
+          },
+          "io_grpc_grpc_auth_1_56_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_grpc_grpc_auth_1_56_1",
+              "sha256": "ac365e11532a4b779a2ac80ecc64dcbd3bafbdd666e08e22ffdb5c855069e3f9",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/grpc/grpc-auth/1.56.1/grpc-auth-1.56.1.jar"
+              ],
+              "downloaded_file_path": "io/grpc/grpc-auth/1.56.1/grpc-auth-1.56.1.jar"
+            }
+          },
+          "com_google_auto_service_auto_service_annotations_1_0_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_auto_service_auto_service_annotations_1_0_1",
+              "sha256": "c7bec54b7b5588b5967e870341091c5691181d954cf2039f1bf0a6eeb837473b",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/auto/service/auto-service-annotations/1.0.1/auto-service-annotations-1.0.1.jar"
+              ],
+              "downloaded_file_path": "com/google/auto/service/auto-service-annotations/1.0.1/auto-service-annotations-1.0.1.jar"
+            }
+          },
+          "io_grpc_grpc_xds_1_55_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_grpc_grpc_xds_1_55_1",
+              "sha256": "08e618b3e166981f86d8bd1623f161d6432923183c55338db77df49a2fb23893",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/grpc/grpc-xds/1.55.1/grpc-xds-1.55.1.jar",
+                "https://maven.google.com/io/grpc/grpc-xds/1.55.1/grpc-xds-1.55.1.jar"
+              ],
+              "downloaded_file_path": "io/grpc/grpc-xds/1.55.1/grpc-xds-1.55.1.jar"
+            }
+          },
+          "com_fasterxml_jackson_core_jackson_annotations_jar_sources_2_15_2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_fasterxml_jackson_core_jackson_annotations_jar_sources_2_15_2",
+              "sha256": "ce8e910f66e0c60d0beec66ccfe308a2426d606c85e67c76a5377dafb52eb4da",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.15.2/jackson-annotations-2.15.2-sources.jar"
+              ],
+              "downloaded_file_path": "com/fasterxml/jackson/core/jackson-annotations/2.15.2/jackson-annotations-2.15.2-sources.jar"
+            }
+          },
+          "junit_junit_4_13_2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~junit_junit_4_13_2",
+              "sha256": "8e495b634469d64fb8acfa3495a065cbacc8a0fff55ce1e31007be4c16dc57d3",
+              "urls": [
+                "https://repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.jar"
+              ],
+              "downloaded_file_path": "junit/junit/4.13.2/junit-4.13.2.jar"
+            }
+          },
+          "com_google_guava_guava_32_1_1_jre": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_guava_guava_32_1_1_jre",
+              "sha256": "91fbba37f1c8b251cf9ea9e7d3a369eb79eb1e6a5df1d4bbf483dd0380740281",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/guava/guava/32.1.1-jre/guava-32.1.1-jre.jar"
+              ],
+              "downloaded_file_path": "com/google/guava/guava/32.1.1-jre/guava-32.1.1-jre.jar"
+            }
+          },
+          "com_googlecode_json_simple_json_simple": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_googlecode_json_simple_json_simple",
+              "generating_repository": "maven",
+              "target_name": "com_googlecode_json_simple_json_simple"
+            }
+          },
+          "io_netty_netty_codec_socks_4_1_97_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_codec_socks_4_1_97_Final",
+              "sha256": "24081cae8a9685ff3fcde141f5050f28589c22e2ae6c447854e044df6d308028",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/netty/netty-codec-socks/4.1.97.Final/netty-codec-socks-4.1.97.Final.jar"
+              ],
+              "downloaded_file_path": "io/netty/netty-codec-socks/4.1.97.Final/netty-codec-socks-4.1.97.Final.jar"
+            }
+          },
+          "com_esotericsoftware_minlog_1_3_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_esotericsoftware_minlog_1_3_1",
+              "sha256": "5d4d632cfbebfe0a7644501cc303570b691406181bee65e9916b921c767d7c72",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/esotericsoftware/minlog/1.3.1/minlog-1.3.1.jar"
+              ],
+              "downloaded_file_path": "com/esotericsoftware/minlog/1.3.1/minlog-1.3.1.jar"
+            }
+          },
+          "org_hamcrest_hamcrest_core_1_3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_hamcrest_hamcrest_core_1_3",
+              "sha256": "66fdef91e9739348df7a096aa384a5685f4e875584cce89386a7a47251c4d8e9",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar"
+              ],
+              "downloaded_file_path": "org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar"
+            }
+          },
+          "com_google_http_client_google_http_client_1_42_3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_http_client_google_http_client_1_42_3",
+              "sha256": "e395dd1765e3e6bceb0c610706bcf4128de84bd6e65cf1d4adbf998b4114161c",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/http-client/google-http-client/1.42.3/google-http-client-1.42.3.jar"
+              ],
+              "downloaded_file_path": "com/google/http-client/google-http-client/1.42.3/google-http-client-1.42.3.jar"
+            }
+          },
+          "org_jodd_jodd_bean_5_1_6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_jodd_jodd_bean_5_1_6",
+              "sha256": "d07d805fe0d59b5d2dbc85d0ebfcf30f52d7fd5a3ff89ff4fbea1e46b1319705",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/jodd/jodd-bean/5.1.6/jodd-bean-5.1.6.jar"
+              ],
+              "downloaded_file_path": "org/jodd/jodd-bean/5.1.6/jodd-bean-5.1.6.jar"
+            }
+          },
+          "me_dinowernli_java_grpc_prometheus_0_6_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~me_dinowernli_java_grpc_prometheus_0_6_0",
+              "sha256": "badf9c84d9ea4b598bfa3fc690c85a8f6d863265829b9cb79f33884d48729ed8",
+              "urls": [
+                "https://repo1.maven.org/maven2/me/dinowernli/java-grpc-prometheus/0.6.0/java-grpc-prometheus-0.6.0.jar"
+              ],
+              "downloaded_file_path": "me/dinowernli/java-grpc-prometheus/0.6.0/java-grpc-prometheus-0.6.0.jar"
+            }
+          },
+          "org_mockito_mockito_core_jar_sources_2_25_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_mockito_mockito_core_jar_sources_2_25_0",
+              "sha256": "2230169d4ffad6f6c1b07bba0e81e30fa734941faf073e847839c695907645ff",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/mockito/mockito-core/2.25.0/mockito-core-2.25.0-sources.jar"
+              ],
+              "downloaded_file_path": "org/mockito/mockito-core/2.25.0/mockito-core-2.25.0-sources.jar"
+            }
+          },
+          "org_slf4j_jcl_over_slf4j_1_7_30": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_slf4j_jcl_over_slf4j_1_7_30",
+              "sha256": "71e9ee37b9e4eb7802a2acc5f41728a4cf3915e7483d798db3b4ff2ec8847c50",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/slf4j/jcl-over-slf4j/1.7.30/jcl-over-slf4j-1.7.30.jar"
+              ],
+              "downloaded_file_path": "org/slf4j/jcl-over-slf4j/1.7.30/jcl-over-slf4j-1.7.30.jar"
+            }
+          },
+          "org_json_json_jar_sources_20220320": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_json_json_jar_sources_20220320",
+              "sha256": "741ba87153d52919259b085e9a066a603b7efe41ede242336f4e3232d230a899",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/json/json/20220320/json-20220320-sources.jar"
+              ],
+              "downloaded_file_path": "org/json/json/20220320/json-20220320-sources.jar"
+            }
+          },
+          "io_grpc_grpc_stub": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_grpc_grpc_stub",
+              "generating_repository": "maven",
+              "target_name": "io_grpc_grpc_stub"
+            }
+          },
+          "com_google_errorprone_error_prone_check_api_2_22_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_errorprone_error_prone_check_api_2_22_0",
+              "sha256": "1717bbf65757b8e1a83f3b0aa78c5ac25a6493008bc730091d404cf798fc0639",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/errorprone/error_prone_check_api/2.22.0/error_prone_check_api-2.22.0.jar"
+              ],
+              "downloaded_file_path": "com/google/errorprone/error_prone_check_api/2.22.0/error_prone_check_api-2.22.0.jar"
+            }
+          },
+          "com_github_pcj_google_options_1_0_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_pcj_google_options_1_0_0",
+              "sha256": "f1f84449b46390a7fa73aac0b5acdec4312d6174146af0db1c92425c7005fdce",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/github/pcj/google-options/1.0.0/google-options-1.0.0.jar"
+              ],
+              "downloaded_file_path": "com/github/pcj/google-options/1.0.0/google-options-1.0.0.jar"
+            }
+          },
+          "com_github_luben_zstd_jni": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_luben_zstd_jni",
+              "generating_repository": "maven",
+              "target_name": "com_github_luben_zstd_jni"
+            }
+          },
+          "com_github_jnr_jnr_posix_3_1_17": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_jnr_jnr_posix_3_1_17",
+              "sha256": "9e24abedd700a1d8f0a2787566f2d0c4f3e4fbdb8be543d4b434ce445923c757",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/github/jnr/jnr-posix/3.1.17/jnr-posix-3.1.17.jar"
+              ],
+              "downloaded_file_path": "com/github/jnr/jnr-posix/3.1.17/jnr-posix-3.1.17.jar"
+            }
+          },
+          "net_bytebuddy_byte_buddy_agent_1_9_7": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~net_bytebuddy_byte_buddy_agent_1_9_7",
+              "sha256": "145ce0fab5390374e69b2b4070d65fedaa2b07c3cfad06b330bea1b6dcfa826f",
+              "urls": [
+                "https://repo1.maven.org/maven2/net/bytebuddy/byte-buddy-agent/1.9.7/byte-buddy-agent-1.9.7.jar"
+              ],
+              "downloaded_file_path": "net/bytebuddy/byte-buddy-agent/1.9.7/byte-buddy-agent-1.9.7.jar"
+            }
+          },
+          "io_github_eisop_dataflow_errorprone_jar_sources_3_34_0_eisop1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_github_eisop_dataflow_errorprone_jar_sources_3_34_0_eisop1",
+              "sha256": "ec56c0f0a96c5e22a3608f2cf9f41c11b5698fee92dd665c21c2dc918e65ef9f",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/github/eisop/dataflow-errorprone/3.34.0-eisop1/dataflow-errorprone-3.34.0-eisop1-sources.jar"
+              ],
+              "downloaded_file_path": "io/github/eisop/dataflow-errorprone/3.34.0-eisop1/dataflow-errorprone-3.34.0-eisop1-sources.jar"
+            }
+          },
+          "io_netty_netty_transport_native_kqueue": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_transport_native_kqueue",
+              "generating_repository": "maven",
+              "target_name": "io_netty_netty_transport_native_kqueue"
+            }
+          },
+          "org_jboss_marshalling_jboss_marshalling_2_0_11_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_jboss_marshalling_jboss_marshalling_2_0_11_Final",
+              "sha256": "93d6257e1ac0f93ba6ff85827c9ef65b5efabf7bd2241fb3b4caf6c426f4f149",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/jboss/marshalling/jboss-marshalling/2.0.11.Final/jboss-marshalling-2.0.11.Final.jar"
+              ],
+              "downloaded_file_path": "org/jboss/marshalling/jboss-marshalling/2.0.11.Final/jboss-marshalling-2.0.11.Final.jar"
+            }
+          },
+          "com_google_truth_truth_1_1_5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_truth_truth_1_1_5",
+              "sha256": "7f6d50d6f43a102942ef2c5a05f37a84f77788bb448cf33cceebf86d34e575c0",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/truth/truth/1.1.5/truth-1.1.5.jar"
+              ],
+              "downloaded_file_path": "com/google/truth/truth/1.1.5/truth-1.1.5.jar"
+            }
+          },
+          "io_netty_netty_transport_4_1_97_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_transport_4_1_97_Final",
+              "sha256": "197fd2d6c6b4afe677d9e95bf2e36b49a0bcabdfce0583683fb73f29a3f5a407",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/netty/netty-transport/4.1.97.Final/netty-transport-4.1.97.Final.jar"
+              ],
+              "downloaded_file_path": "io/netty/netty-transport/4.1.97.Final/netty-transport-4.1.97.Final.jar"
+            }
+          },
+          "io_grpc_grpc_context_jar_sources_1_56_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_grpc_grpc_context_jar_sources_1_56_1",
+              "sha256": "315a2c4145c3362131d4af25c27ae9cd4924f8f84e661a31402c56b223bcb956",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/grpc/grpc-context/1.56.1/grpc-context-1.56.1-sources.jar"
+              ],
+              "downloaded_file_path": "io/grpc/grpc-context/1.56.1/grpc-context-1.56.1-sources.jar"
+            }
+          },
+          "org_slf4j_slf4j_api_2_0_9": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_slf4j_slf4j_api_2_0_9",
+              "sha256": "0818930dc8d7debb403204611691da58e49d42c50b6ffcfdce02dadb7c3c2b6c",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/slf4j/slf4j-api/2.0.9/slf4j-api-2.0.9.jar"
+              ],
+              "downloaded_file_path": "org/slf4j/slf4j-api/2.0.9/slf4j-api-2.0.9.jar"
+            }
+          },
+          "com_google_j2objc_j2objc_annotations_2_8": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_j2objc_j2objc_annotations_2_8",
+              "sha256": "f02a95fa1a5e95edb3ed859fd0fb7df709d121a35290eff8b74dce2ab7f4d6ed",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/j2objc/j2objc-annotations/2.8/j2objc-annotations-2.8.jar"
+              ],
+              "downloaded_file_path": "com/google/j2objc/j2objc-annotations/2.8/j2objc-annotations-2.8.jar"
+            }
+          },
+          "io_netty_netty_codec_http2_4_1_97_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_codec_http2_4_1_97_Final",
+              "sha256": "51fabf675563b59dc51dde22d29dbc5a20f836469cf48b8d53a07d3db0d775ad",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/netty/netty-codec-http2/4.1.97.Final/netty-codec-http2-4.1.97.Final.jar"
+              ],
+              "downloaded_file_path": "io/netty/netty-codec-http2/4.1.97.Final/netty-codec-http2-4.1.97.Final.jar"
+            }
+          },
+          "io_prometheus_simpleclient_common_0_15_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_prometheus_simpleclient_common_0_15_0",
+              "sha256": "8d2fa21b5c7959010818245788bd43131633dea989d3facb28cec45b2da37918",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/prometheus/simpleclient_common/0.15.0/simpleclient_common-0.15.0.jar"
+              ],
+              "downloaded_file_path": "io/prometheus/simpleclient_common/0.15.0/simpleclient_common-0.15.0.jar"
+            }
+          },
+          "net_java_dev_jna_jna_jar_sources_5_13_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~net_java_dev_jna_jna_jar_sources_5_13_0",
+              "sha256": "a4c45843e8f60df141c4f37602365a421bb278ca1ef30ba0a043d6a871dd29f4",
+              "urls": [
+                "https://repo1.maven.org/maven2/net/java/dev/jna/jna/5.13.0/jna-5.13.0-sources.jar"
+              ],
+              "downloaded_file_path": "net/java/dev/jna/jna/5.13.0/jna-5.13.0-sources.jar"
+            }
+          },
+          "io_prometheus_simpleclient_hotspot_0_15_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_prometheus_simpleclient_hotspot_0_15_0",
+              "sha256": "3c99768b090065bc0b25219061f94970aa569a2e363488d9120c79769d78c1a6",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/prometheus/simpleclient_hotspot/0.15.0/simpleclient_hotspot-0.15.0.jar"
+              ],
+              "downloaded_file_path": "io/prometheus/simpleclient_hotspot/0.15.0/simpleclient_hotspot-0.15.0.jar"
+            }
+          },
+          "org_jboss_marshalling_jboss_marshalling_river_2_0_11_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_jboss_marshalling_jboss_marshalling_river_2_0_11_Final",
+              "sha256": "f3fa6545d15163468e1639fe3087de22234a9fd027a52be6e532bfe7bde6c554",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/jboss/marshalling/jboss-marshalling-river/2.0.11.Final/jboss-marshalling-river-2.0.11.Final.jar"
+              ],
+              "downloaded_file_path": "org/jboss/marshalling/jboss-marshalling-river/2.0.11.Final/jboss-marshalling-river-2.0.11.Final.jar"
+            }
+          },
+          "org_luaj_luaj_jse_jar_sources_3_0_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_luaj_luaj_jse_jar_sources_3_0_1",
+              "sha256": "e9fc8eb5593ef489bafb79b5561b49114e8a233834f160c4657efe927a613f53",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/luaj/luaj-jse/3.0.1/luaj-jse-3.0.1-sources.jar"
+              ],
+              "downloaded_file_path": "org/luaj/luaj-jse/3.0.1/luaj-jse-3.0.1-sources.jar"
+            }
+          },
+          "io_netty_netty_resolver_4_1_86_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_resolver_4_1_86_Final",
+              "sha256": "7628a1309d7f2443dc41d8923a7f269e2981b9616f80a999eb7264ae6bcbfdba",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/netty/netty-resolver/4.1.86.Final/netty-resolver-4.1.86.Final.jar",
+                "https://maven.google.com/io/netty/netty-resolver/4.1.86.Final/netty-resolver-4.1.86.Final.jar"
+              ],
+              "downloaded_file_path": "io/netty/netty-resolver/4.1.86.Final/netty-resolver-4.1.86.Final.jar"
+            }
+          },
+          "net_javacrumbs_future_converter_future_converter_java8_guava_jar_sources_1_2_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~net_javacrumbs_future_converter_future_converter_java8_guava_jar_sources_1_2_0",
+              "sha256": "3e209e1d6e80d1cde253ac0e28d50588112d0128a9bf05dae7f4aea3a36bdc03",
+              "urls": [
+                "https://repo1.maven.org/maven2/net/javacrumbs/future-converter/future-converter-java8-guava/1.2.0/future-converter-java8-guava-1.2.0-sources.jar"
+              ],
+              "downloaded_file_path": "net/javacrumbs/future-converter/future-converter-java8-guava/1.2.0/future-converter-java8-guava-1.2.0-sources.jar"
+            }
+          },
+          "org_jetbrains_annotations_jar_sources_16_0_2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_jetbrains_annotations_jar_sources_16_0_2",
+              "sha256": "699c2e6786e86fa5df5c82ffd0490d829107daa6225c0cffa290860abe4c1a80",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/jetbrains/annotations/16.0.2/annotations-16.0.2-sources.jar"
+              ],
+              "downloaded_file_path": "org/jetbrains/annotations/16.0.2/annotations-16.0.2-sources.jar"
+            }
+          },
+          "software_amazon_awssdk_crt_core_2_20_78": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~software_amazon_awssdk_crt_core_2_20_78",
+              "sha256": "f83ba65ea519cfcc2306994527d6432a969ac8efb418abfcf38128d08467f7cf",
+              "urls": [
+                "https://repo1.maven.org/maven2/software/amazon/awssdk/crt-core/2.20.78/crt-core-2.20.78.jar",
+                "https://maven.google.com/software/amazon/awssdk/crt-core/2.20.78/crt-core-2.20.78.jar"
+              ],
+              "downloaded_file_path": "software/amazon/awssdk/crt-core/2.20.78/crt-core-2.20.78.jar"
+            }
+          },
+          "com_google_guava_failureaccess": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_guava_failureaccess",
+              "generating_repository": "maven",
+              "target_name": "com_google_guava_failureaccess"
+            }
+          },
+          "com_google_cloud_google_cloud_core_http_2_18_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_cloud_google_cloud_core_http_2_18_1",
+              "sha256": "52466ba755e309ae43977209897aac76f40103115cf37ca755a428dae5a190ae",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/cloud/google-cloud-core-http/2.18.1/google-cloud-core-http-2.18.1.jar",
+                "https://maven.google.com/com/google/cloud/google-cloud-core-http/2.18.1/google-cloud-core-http-2.18.1.jar"
+              ],
+              "downloaded_file_path": "com/google/cloud/google-cloud-core-http/2.18.1/google-cloud-core-http-2.18.1.jar"
+            }
+          },
+          "javax_annotation_javax_annotation_api": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~javax_annotation_javax_annotation_api",
+              "generating_repository": "maven",
+              "target_name": "javax_annotation_javax_annotation_api"
+            }
+          },
+          "io_opencensus_opencensus_api_0_31_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_opencensus_opencensus_api_0_31_1",
+              "sha256": "f1474d47f4b6b001558ad27b952e35eda5cc7146788877fc52938c6eba24b382",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/opencensus/opencensus-api/0.31.1/opencensus-api-0.31.1.jar"
+              ],
+              "downloaded_file_path": "io/opencensus/opencensus-api/0.31.1/opencensus-api-0.31.1.jar"
+            }
+          },
+          "io_netty_netty_transport_classes_epoll_jar_sources_4_1_97_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_transport_classes_epoll_jar_sources_4_1_97_Final",
+              "sha256": "96e2dbe0d3d8d4dae3ddc23443c174388373c1f6dd76401e23a26bd952bf4d08",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/netty/netty-transport-classes-epoll/4.1.97.Final/netty-transport-classes-epoll-4.1.97.Final-sources.jar"
+              ],
+              "downloaded_file_path": "io/netty/netty-transport-classes-epoll/4.1.97.Final/netty-transport-classes-epoll-4.1.97.Final-sources.jar"
+            }
+          },
+          "io_netty_netty_codec_http2_4_1_86_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_codec_http2_4_1_86_Final",
+              "sha256": "e8e8e28e6ab6bb989aed904778922045f388cfb420bc1eb37abf4df8801db167",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/netty/netty-codec-http2/4.1.86.Final/netty-codec-http2-4.1.86.Final.jar",
+                "https://maven.google.com/io/netty/netty-codec-http2/4.1.86.Final/netty-codec-http2-4.1.86.Final.jar"
+              ],
+              "downloaded_file_path": "io/netty/netty-codec-http2/4.1.86.Final/netty-codec-http2-4.1.86.Final.jar"
+            }
+          },
+          "commons_io_commons_io": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~commons_io_commons_io",
+              "generating_repository": "maven",
+              "target_name": "commons_io_commons_io"
+            }
+          },
+          "io_netty_netty_transport_native_unix_common": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_transport_native_unix_common",
+              "generating_repository": "maven",
+              "target_name": "io_netty_netty_transport_native_unix_common"
+            }
+          },
+          "org_javassist_javassist_jar_sources_3_28_0_GA": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_javassist_javassist_jar_sources_3_28_0_GA",
+              "sha256": "0b6cf0d138dc208263a2a0a39b1daae217707d58d79d7a4973a68ce62f8c2d1f",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/javassist/javassist/3.28.0-GA/javassist-3.28.0-GA-sources.jar"
+              ],
+              "downloaded_file_path": "org/javassist/javassist/3.28.0-GA/javassist-3.28.0-GA-sources.jar"
+            }
+          },
+          "me_dinowernli_java_grpc_prometheus_jar_sources_0_6_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~me_dinowernli_java_grpc_prometheus_jar_sources_0_6_0",
+              "sha256": "a9029bdc0712ee294862aaa0c65e1308705472bb9fe429095b346a964be7b731",
+              "urls": [
+                "https://repo1.maven.org/maven2/me/dinowernli/java-grpc-prometheus/0.6.0/java-grpc-prometheus-0.6.0-sources.jar"
+              ],
+              "downloaded_file_path": "me/dinowernli/java-grpc-prometheus/0.6.0/java-grpc-prometheus-0.6.0-sources.jar"
+            }
+          },
+          "org_apache_maven_maven_artifact_3_9_2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_apache_maven_maven_artifact_3_9_2",
+              "sha256": "f2174221d412a79572817b5aa77125348f43266670b6329a9881cdccf7bbc4b1",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/apache/maven/maven-artifact/3.9.2/maven-artifact-3.9.2.jar",
+                "https://maven.google.com/org/apache/maven/maven-artifact/3.9.2/maven-artifact-3.9.2.jar"
+              ],
+              "downloaded_file_path": "org/apache/maven/maven-artifact/3.9.2/maven-artifact-3.9.2.jar"
+            }
+          },
+          "io_netty_netty_common": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_common",
+              "generating_repository": "maven",
+              "target_name": "io_netty_netty_common"
+            }
+          },
+          "com_google_j2objc_j2objc_annotations_jar_sources_2_8": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_j2objc_j2objc_annotations_jar_sources_2_8",
+              "sha256": "7413eed41f111453a08837f5ac680edded7faed466cbd35745e402e13f4cc3f5",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/j2objc/j2objc-annotations/2.8/j2objc-annotations-2.8-sources.jar"
+              ],
+              "downloaded_file_path": "com/google/j2objc/j2objc-annotations/2.8/j2objc-annotations-2.8-sources.jar"
+            }
+          },
+          "com_github_jnr_jffi_jar_sources_1_3_11": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_jnr_jffi_jar_sources_1_3_11",
+              "sha256": "df7dcc8843d61e60c5fe606e860646f1a82d11d2dc41a3d230da87fc0bcf4291",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/github/jnr/jffi/1.3.11/jffi-1.3.11-sources.jar"
+              ],
+              "downloaded_file_path": "com/github/jnr/jffi/1.3.11/jffi-1.3.11-sources.jar"
+            }
+          },
+          "org_apache_commons_commons_lang3_jar_sources_3_13_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_apache_commons_commons_lang3_jar_sources_3_13_0",
+              "sha256": "6152e03a6c29e0d9dd1415aaa42cb13f6fab5fc5b2333077c29b498927535453",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.13.0/commons-lang3-3.13.0-sources.jar"
+              ],
+              "downloaded_file_path": "org/apache/commons/commons-lang3/3.13.0/commons-lang3-3.13.0-sources.jar"
+            }
+          },
+          "software_amazon_eventstream_eventstream_1_0_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~software_amazon_eventstream_eventstream_1_0_1",
+              "sha256": "0c37d8e696117f02c302191b8110b0d0eb20fa412fce34c3a269ec73c16ce822",
+              "urls": [
+                "https://repo1.maven.org/maven2/software/amazon/eventstream/eventstream/1.0.1/eventstream-1.0.1.jar",
+                "https://maven.google.com/software/amazon/eventstream/eventstream/1.0.1/eventstream-1.0.1.jar"
+              ],
+              "downloaded_file_path": "software/amazon/eventstream/eventstream/1.0.1/eventstream-1.0.1.jar"
+            }
+          },
+          "com_github_docker_java_docker_java_transport_jersey_3_3_3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_docker_java_docker_java_transport_jersey_3_3_3",
+              "sha256": "7574d831272a56268f4468b901059cafdca6e10176c87fec83f65d26d28c6fb0",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/github/docker-java/docker-java-transport-jersey/3.3.3/docker-java-transport-jersey-3.3.3.jar"
+              ],
+              "downloaded_file_path": "com/github/docker-java/docker-java-transport-jersey/3.3.3/docker-java-transport-jersey-3.3.3.jar"
+            }
+          },
+          "org_glassfish_hk2_hk2_utils_jar_sources_2_6_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_glassfish_hk2_hk2_utils_jar_sources_2_6_1",
+              "sha256": "36552a965412a1d5a9eb2ee0282fd224151e79ac5dc42ae794f0bac67e523dc5",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/glassfish/hk2/hk2-utils/2.6.1/hk2-utils-2.6.1-sources.jar"
+              ],
+              "downloaded_file_path": "org/glassfish/hk2/hk2-utils/2.6.1/hk2-utils-2.6.1-sources.jar"
+            }
+          },
+          "io_netty_netty_handler": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_handler",
+              "generating_repository": "maven",
+              "target_name": "io_netty_netty_handler"
+            }
+          },
+          "com_google_api_grpc_proto_google_common_protos_jar_sources_2_17_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_api_grpc_proto_google_common_protos_jar_sources_2_17_0",
+              "sha256": "cadaaa7232e1469abf515b99f2642b120fed9f68d6f36899ee493058b2159f18",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-common-protos/2.17.0/proto-google-common-protos-2.17.0-sources.jar"
+              ],
+              "downloaded_file_path": "com/google/api/grpc/proto-google-common-protos/2.17.0/proto-google-common-protos-2.17.0-sources.jar"
+            }
+          },
+          "net_minidev_accessors_smart_jar_sources_2_4_9": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~net_minidev_accessors_smart_jar_sources_2_4_9",
+              "sha256": "4b6022d773826980f124e7a2aed243cea6541238bc1bed785e2ce86076567f50",
+              "urls": [
+                "https://repo1.maven.org/maven2/net/minidev/accessors-smart/2.4.9/accessors-smart-2.4.9-sources.jar"
+              ],
+              "downloaded_file_path": "net/minidev/accessors-smart/2.4.9/accessors-smart-2.4.9-sources.jar"
+            }
+          },
+          "com_fasterxml_jackson_core_jackson_core_jar_sources_2_15_2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_fasterxml_jackson_core_jackson_core_jar_sources_2_15_2",
+              "sha256": "4b29fe878549425194521d5c3270fae13f9c82cfcad639ebffea0963431bef45",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.15.2/jackson-core-2.15.2-sources.jar"
+              ],
+              "downloaded_file_path": "com/fasterxml/jackson/core/jackson-core/2.15.2/jackson-core-2.15.2-sources.jar"
+            }
+          },
+          "net_java_dev_jna_jna_platform_5_13_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~net_java_dev_jna_jna_platform_5_13_0",
+              "sha256": "474d7b88f6e97009b6ec1d98c3024dd95c23187c65dabfbc35331bcac3d173dd",
+              "urls": [
+                "https://repo1.maven.org/maven2/net/java/dev/jna/jna-platform/5.13.0/jna-platform-5.13.0.jar"
+              ],
+              "downloaded_file_path": "net/java/dev/jna/jna-platform/5.13.0/jna-platform-5.13.0.jar"
+            }
+          },
+          "io_grpc_grpc_protobuf_1_56_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_grpc_grpc_protobuf_1_56_1",
+              "sha256": "46185731a718d723d853723610a77e9062da9a6fc8b4ff14f370ba10cf097893",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/grpc/grpc-protobuf/1.56.1/grpc-protobuf-1.56.1.jar"
+              ],
+              "downloaded_file_path": "io/grpc/grpc-protobuf/1.56.1/grpc-protobuf-1.56.1.jar"
+            }
+          },
+          "org_openjdk_jmh_jmh_core": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_openjdk_jmh_jmh_core",
+              "generating_repository": "maven",
+              "target_name": "org_openjdk_jmh_jmh_core"
+            }
+          },
+          "com_github_serceman_jnr_fuse_jar_sources_0_5_7": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_serceman_jnr_fuse_jar_sources_0_5_7",
+              "sha256": "68a7003b43945ec3083fe2b8a5b882ff515449075122fcd6fb85f0c30bb750ab",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/github/serceman/jnr-fuse/0.5.7/jnr-fuse-0.5.7-sources.jar"
+              ],
+              "downloaded_file_path": "com/github/serceman/jnr-fuse/0.5.7/jnr-fuse-0.5.7-sources.jar"
+            }
+          },
+          "com_google_truth_truth_jar_sources_1_1_5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_truth_truth_jar_sources_1_1_5",
+              "sha256": "f1a94449ed48392525626f4e5edeff5c6e66af21c4c009ebb49b5109ac5db6b2",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/truth/truth/1.1.5/truth-1.1.5-sources.jar"
+              ],
+              "downloaded_file_path": "com/google/truth/truth/1.1.5/truth-1.1.5-sources.jar"
+            }
+          },
+          "org_jodd_jodd_core_5_1_6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_jodd_jodd_core_5_1_6",
+              "sha256": "4b504519263a98202480d3cf73562dff8245edc582350cc5f37d5965a0298122",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/jodd/jodd-core/5.1.6/jodd-core-5.1.6.jar"
+              ],
+              "downloaded_file_path": "org/jodd/jodd-core/5.1.6/jodd-core-5.1.6.jar"
+            }
+          },
+          "org_objenesis_objenesis_jar_sources_3_3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_objenesis_objenesis_jar_sources_3_3",
+              "sha256": "d06164f8ca002c8ef193cef2d682822014dd330505616af93a3fb64226fc131d",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/objenesis/objenesis/3.3/objenesis-3.3-sources.jar"
+              ],
+              "downloaded_file_path": "org/objenesis/objenesis/3.3/objenesis-3.3-sources.jar"
+            }
+          },
+          "io_grpc_grpc_core": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_grpc_grpc_core",
+              "generating_repository": "maven",
+              "target_name": "io_grpc_grpc_core"
+            }
+          },
+          "com_google_guava_guava_32_0_0_jre": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_guava_guava_32_0_0_jre",
+              "sha256": "39f3550b0343d8d19dd4e83bd165b58ea3389d2ddb9f2148e63903f79ecdb114",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/guava/guava/32.0.0-jre/guava-32.0.0-jre.jar",
+                "https://maven.google.com/com/google/guava/guava/32.0.0-jre/guava-32.0.0-jre.jar"
+              ],
+              "downloaded_file_path": "com/google/guava/guava/32.0.0-jre/guava-32.0.0-jre.jar"
+            }
+          },
+          "io_netty_netty_codec_socks": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_codec_socks",
+              "generating_repository": "maven",
+              "target_name": "io_netty_netty_codec_socks"
+            }
+          },
+          "org_apache_httpcomponents_httpcore_jar_sources_4_4_15": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_apache_httpcomponents_httpcore_jar_sources_4_4_15",
+              "sha256": "1510fc72cf2858244bdeb0d7f5d266fe584ecbd2ffe0d91b10a6d80641cd1985",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/apache/httpcomponents/httpcore/4.4.15/httpcore-4.4.15-sources.jar"
+              ],
+              "downloaded_file_path": "org/apache/httpcomponents/httpcore/4.4.15/httpcore-4.4.15-sources.jar"
+            }
+          },
+          "com_github_jnr_jnr_x86asm_1_0_2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_jnr_jnr_x86asm_1_0_2",
+              "sha256": "39f3675b910e6e9b93825f8284bec9f4ad3044cd20a6f7c8ff9e2f8695ebf21e",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/github/jnr/jnr-x86asm/1.0.2/jnr-x86asm-1.0.2.jar"
+              ],
+              "downloaded_file_path": "com/github/jnr/jnr-x86asm/1.0.2/jnr-x86asm-1.0.2.jar"
+            }
+          },
+          "software_amazon_awssdk_annotations_2_20_78": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~software_amazon_awssdk_annotations_2_20_78",
+              "sha256": "90ce2bb257ffa63942831f7329e28cf22fa4caf0cc96ee4f2f4557b7554eae1e",
+              "urls": [
+                "https://repo1.maven.org/maven2/software/amazon/awssdk/annotations/2.20.78/annotations-2.20.78.jar",
+                "https://maven.google.com/software/amazon/awssdk/annotations/2.20.78/annotations-2.20.78.jar"
+              ],
+              "downloaded_file_path": "software/amazon/awssdk/annotations/2.20.78/annotations-2.20.78.jar"
+            }
+          },
+          "io_grpc_grpc_netty": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_grpc_grpc_netty",
+              "generating_repository": "maven",
+              "target_name": "io_grpc_grpc_netty"
+            }
+          },
+          "io_grpc_grpc_testing": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_grpc_grpc_testing",
+              "generating_repository": "maven",
+              "target_name": "io_grpc_grpc_testing"
+            }
+          },
+          "io_grpc_grpc_api_jar_sources_1_56_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_grpc_grpc_api_jar_sources_1_56_1",
+              "sha256": "e5e58482c95a332706d6c12a758d55ec195b01a3e54e2a38a6239ed7a3de26c0",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/grpc/grpc-api/1.56.1/grpc-api-1.56.1-sources.jar"
+              ],
+              "downloaded_file_path": "io/grpc/grpc-api/1.56.1/grpc-api-1.56.1-sources.jar"
+            }
+          },
+          "org_ow2_asm_asm_jar_sources_9_5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_ow2_asm_asm_jar_sources_9_5",
+              "sha256": "11214bbba797e0615402b8d57fd4be83c93a65244c5a88778015520d61078376",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/ow2/asm/asm/9.5/asm-9.5-sources.jar"
+              ],
+              "downloaded_file_path": "org/ow2/asm/asm/9.5/asm-9.5-sources.jar"
+            }
+          },
+          "io_prometheus_simpleclient": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_prometheus_simpleclient",
+              "generating_repository": "maven",
+              "target_name": "io_prometheus_simpleclient"
+            }
+          },
+          "com_google_jimfs_jimfs_jar_sources_1_3_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_jimfs_jimfs_jar_sources_1_3_0",
+              "sha256": "aa30e127e68ddba8e76395d14806f838f22c9ef904b07ff0266dfc5de7163059",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/jimfs/jimfs/1.3.0/jimfs-1.3.0-sources.jar"
+              ],
+              "downloaded_file_path": "com/google/jimfs/jimfs/1.3.0/jimfs-1.3.0-sources.jar"
+            }
+          },
+          "com_google_apis_google_api_services_storage_v1_rev20230301_2_0_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_apis_google_api_services_storage_v1_rev20230301_2_0_0",
+              "sha256": "857ac102129477c55487ed94fd7e021b6093bd88370f9ccac799456a0ff86af9",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/apis/google-api-services-storage/v1-rev20230301-2.0.0/google-api-services-storage-v1-rev20230301-2.0.0.jar",
+                "https://maven.google.com/com/google/apis/google-api-services-storage/v1-rev20230301-2.0.0/google-api-services-storage-v1-rev20230301-2.0.0.jar"
+              ],
+              "downloaded_file_path": "com/google/apis/google-api-services-storage/v1-rev20230301-2.0.0/google-api-services-storage-v1-rev20230301-2.0.0.jar"
+            }
+          },
+          "io_netty_netty_codec_http2": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_codec_http2",
+              "generating_repository": "maven",
+              "target_name": "io_netty_netty_codec_http2"
+            }
+          },
+          "io_grpc_grpc_auth_1_55_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_grpc_grpc_auth_1_55_1",
+              "sha256": "45d9bfaf837c41abf01e087773f535ea5afa6faad1faecbc6f32cb9ae423adef",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/grpc/grpc-auth/1.55.1/grpc-auth-1.55.1.jar",
+                "https://maven.google.com/io/grpc/grpc-auth/1.55.1/grpc-auth-1.55.1.jar"
+              ],
+              "downloaded_file_path": "io/grpc/grpc-auth/1.55.1/grpc-auth-1.55.1.jar"
+            }
+          },
+          "com_google_auth_google_auth_library_credentials_1_17_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_auth_google_auth_library_credentials_1_17_0",
+              "sha256": "5de364ee7a9ce95d8715bf124bdb0d949d37649914db846cc7005584fba7ce4d",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/auth/google-auth-library-credentials/1.17.0/google-auth-library-credentials-1.17.0.jar",
+                "https://maven.google.com/com/google/auth/google-auth-library-credentials/1.17.0/google-auth-library-credentials-1.17.0.jar"
+              ],
+              "downloaded_file_path": "com/google/auth/google-auth-library-credentials/1.17.0/google-auth-library-credentials-1.17.0.jar"
+            }
+          },
+          "com_github_jnr_jnr_constants_jar_sources_0_10_4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_jnr_jnr_constants_jar_sources_0_10_4",
+              "sha256": "696f737f76a29d900401e52277274c3c12a47cb70d00eb9e3619f3ff0b261a5f",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/github/jnr/jnr-constants/0.10.4/jnr-constants-0.10.4-sources.jar"
+              ],
+              "downloaded_file_path": "com/github/jnr/jnr-constants/0.10.4/jnr-constants-0.10.4-sources.jar"
+            }
+          },
+          "io_grpc_grpc_services_1_56_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_grpc_grpc_services_1_56_1",
+              "sha256": "0d14ece28e97b30aa9ef1b63782d48261dd63738ef1c5615afefb8b963c121c8",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/grpc/grpc-services/1.56.1/grpc-services-1.56.1.jar"
+              ],
+              "downloaded_file_path": "io/grpc/grpc-services/1.56.1/grpc-services-1.56.1.jar"
+            }
+          },
+          "net_javacrumbs_future_converter_future_converter_common_1_2_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~net_javacrumbs_future_converter_future_converter_common_1_2_0",
+              "sha256": "567aeb2907088298fe5e67fd0fb1843571c24b46ef5b369f495c3d52c654b67b",
+              "urls": [
+                "https://repo1.maven.org/maven2/net/javacrumbs/future-converter/future-converter-common/1.2.0/future-converter-common-1.2.0.jar"
+              ],
+              "downloaded_file_path": "net/javacrumbs/future-converter/future-converter-common/1.2.0/future-converter-common-1.2.0.jar"
+            }
+          },
+          "org_codehaus_plexus_plexus_utils_3_5_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_codehaus_plexus_plexus_utils_3_5_1",
+              "sha256": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/codehaus/plexus/plexus-utils/3.5.1/plexus-utils-3.5.1.jar",
+                "https://maven.google.com/org/codehaus/plexus/plexus-utils/3.5.1/plexus-utils-3.5.1.jar"
+              ],
+              "downloaded_file_path": "org/codehaus/plexus/plexus-utils/3.5.1/plexus-utils-3.5.1.jar"
+            }
+          },
+          "com_github_fppt_jedis_mock_jar_sources_1_0_10": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_fppt_jedis_mock_jar_sources_1_0_10",
+              "sha256": "315cd23d9c010ceee598fc594d4674b63f4bcd0375fe8c2b90d79ce50a12bb7e",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/github/fppt/jedis-mock/1.0.10/jedis-mock-1.0.10-sources.jar"
+              ],
+              "downloaded_file_path": "com/github/fppt/jedis-mock/1.0.10/jedis-mock-1.0.10-sources.jar"
+            }
+          },
+          "io_grpc_grpc_protobuf_1_55_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_grpc_grpc_protobuf_1_55_1",
+              "sha256": "a170ef578cd94bf81c57f46cca9328e2db5136f45e18da80af26bbebcca9618c",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/grpc/grpc-protobuf/1.55.1/grpc-protobuf-1.55.1.jar",
+                "https://maven.google.com/io/grpc/grpc-protobuf/1.55.1/grpc-protobuf-1.55.1.jar"
+              ],
+              "downloaded_file_path": "io/grpc/grpc-protobuf/1.55.1/grpc-protobuf-1.55.1.jar"
+            }
+          },
+          "org_glassfish_jersey_inject_jersey_hk2_2_30_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_glassfish_jersey_inject_jersey_hk2_2_30_1",
+              "sha256": "cd5f4c10cf4915d1c217c295fc8b4eadceda7a28f9488b1d01de6b8792b33496",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/glassfish/jersey/inject/jersey-hk2/2.30.1/jersey-hk2-2.30.1.jar"
+              ],
+              "downloaded_file_path": "org/glassfish/jersey/inject/jersey-hk2/2.30.1/jersey-hk2-2.30.1.jar"
+            }
+          },
+          "net_java_dev_jna_jna_5_13_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~net_java_dev_jna_jna_5_13_0",
+              "sha256": "66d4f819a062a51a1d5627bffc23fac55d1677f0e0a1feba144aabdd670a64bb",
+              "urls": [
+                "https://repo1.maven.org/maven2/net/java/dev/jna/jna/5.13.0/jna-5.13.0.jar"
+              ],
+              "downloaded_file_path": "net/java/dev/jna/jna/5.13.0/jna-5.13.0.jar"
+            }
+          },
+          "com_google_http_client_google_http_client_1_43_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_http_client_google_http_client_1_43_1",
+              "sha256": "834e37b0af2cfe80b297be4d6a5c8fd0ccab1d0b13e9b8d7ac921e8dd2f251ec",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/http-client/google-http-client/1.43.1/google-http-client-1.43.1.jar",
+                "https://maven.google.com/com/google/http-client/google-http-client/1.43.1/google-http-client-1.43.1.jar"
+              ],
+              "downloaded_file_path": "com/google/http-client/google-http-client/1.43.1/google-http-client-1.43.1.jar"
+            }
+          },
+          "io_opencensus_opencensus_proto_0_2_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_opencensus_opencensus_proto_0_2_0",
+              "sha256": "0c192d451e9dd74e98721b27d02f0e2b6bca44b51563b5dabf2e211f7a3ebf13",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/opencensus/opencensus-proto/0.2.0/opencensus-proto-0.2.0.jar",
+                "https://maven.google.com/io/opencensus/opencensus-proto/0.2.0/opencensus-proto-0.2.0.jar"
+              ],
+              "downloaded_file_path": "io/opencensus/opencensus-proto/0.2.0/opencensus-proto-0.2.0.jar"
+            }
+          },
+          "com_fasterxml_jackson_core_jackson_databind_2_15_2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_fasterxml_jackson_core_jackson_databind_2_15_2",
+              "sha256": "0eb2fdad6e40ab8832a78c9b22f58196dd970594e8d3d5a26ead87847c4f3a96",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.15.2/jackson-databind-2.15.2.jar"
+              ],
+              "downloaded_file_path": "com/fasterxml/jackson/core/jackson-databind/2.15.2/jackson-databind-2.15.2.jar"
+            }
+          },
+          "org_slf4j_slf4j_api_1_7_30": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_slf4j_slf4j_api_1_7_30",
+              "sha256": "cdba07964d1bb40a0761485c6b1e8c2f8fd9eb1d19c53928ac0d7f9510105c57",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.30/slf4j-api-1.7.30.jar",
+                "https://maven.google.com/org/slf4j/slf4j-api/1.7.30/slf4j-api-1.7.30.jar"
+              ],
+              "downloaded_file_path": "org/slf4j/slf4j-api/1.7.30/slf4j-api-1.7.30.jar"
+            }
+          },
+          "io_grpc_grpc_grpclb_1_55_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_grpc_grpc_grpclb_1_55_1",
+              "sha256": "9d0dcf87d99a1042a3a2343e96d394220c6be07cf1a5082d5df066e2077b3428",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/grpc/grpc-grpclb/1.55.1/grpc-grpclb-1.55.1.jar",
+                "https://maven.google.com/io/grpc/grpc-grpclb/1.55.1/grpc-grpclb-1.55.1.jar"
+              ],
+              "downloaded_file_path": "io/grpc/grpc-grpclb/1.55.1/grpc-grpclb-1.55.1.jar"
+            }
+          },
+          "com_esotericsoftware_minlog_jar_sources_1_3_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_esotericsoftware_minlog_jar_sources_1_3_1",
+              "sha256": "fdaf83a8c51295eff3a8109473ce7b213582738f71593e16b1efa012ff1f99b5",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/esotericsoftware/minlog/1.3.1/minlog-1.3.1-sources.jar"
+              ],
+              "downloaded_file_path": "com/esotericsoftware/minlog/1.3.1/minlog-1.3.1-sources.jar"
+            }
+          },
+          "net_javacrumbs_future_converter_future_converter_java8_guava_1_2_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~net_javacrumbs_future_converter_future_converter_java8_guava_1_2_0",
+              "sha256": "3b47ae8e2b2bfad810586c37537f002273c05237bd3adecafe9f9f57a2b18fde",
+              "urls": [
+                "https://repo1.maven.org/maven2/net/javacrumbs/future-converter/future-converter-java8-guava/1.2.0/future-converter-java8-guava-1.2.0.jar"
+              ],
+              "downloaded_file_path": "net/javacrumbs/future-converter/future-converter-java8-guava/1.2.0/future-converter-java8-guava-1.2.0.jar"
+            }
+          },
+          "com_google_errorprone_error_prone_annotations_2_18_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_errorprone_error_prone_annotations_2_18_0",
+              "sha256": "9e6814cb71816988a4fd1b07a993a8f21bb7058d522c162b1de849e19bea54ae",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/errorprone/error_prone_annotations/2.18.0/error_prone_annotations-2.18.0.jar",
+                "https://maven.google.com/com/google/errorprone/error_prone_annotations/2.18.0/error_prone_annotations-2.18.0.jar"
+              ],
+              "downloaded_file_path": "com/google/errorprone/error_prone_annotations/2.18.0/error_prone_annotations-2.18.0.jar"
+            }
+          },
+          "com_google_cloud_google_cloud_core_2_18_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_cloud_google_cloud_core_2_18_1",
+              "sha256": "8a8da77a17193fae86012722237736db7d08cb6fac8df50a311427c95b26d4a6",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/cloud/google-cloud-core/2.18.1/google-cloud-core-2.18.1.jar",
+                "https://maven.google.com/com/google/cloud/google-cloud-core/2.18.1/google-cloud-core-2.18.1.jar"
+              ],
+              "downloaded_file_path": "com/google/cloud/google-cloud-core/2.18.1/google-cloud-core-2.18.1.jar"
+            }
+          },
+          "com_github_jnr_jffi_jar_native_1_3_11": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_jnr_jffi_jar_native_1_3_11",
+              "sha256": "f4c26c0a4a3eddfdbaaf4dda77d4d9f7d148ba4208798f32ce475ce4d6778744",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/github/jnr/jffi/1.3.11/jffi-1.3.11-native.jar"
+              ],
+              "downloaded_file_path": "com/github/jnr/jffi/1.3.11/jffi-1.3.11-native.jar"
+            }
+          },
+          "com_google_errorprone_error_prone_annotations": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_errorprone_error_prone_annotations",
+              "generating_repository": "maven",
+              "target_name": "com_google_errorprone_error_prone_annotations"
+            }
+          },
+          "io_netty_netty_codec_dns_jar_sources_4_1_96_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_codec_dns_jar_sources_4_1_96_Final",
+              "sha256": "080f78aa2451386f7c0ac993ed4b3eae28ea3b337c606aee29b0c723e01f9588",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/netty/netty-codec-dns/4.1.96.Final/netty-codec-dns-4.1.96.Final-sources.jar"
+              ],
+              "downloaded_file_path": "io/netty/netty-codec-dns/4.1.96.Final/netty-codec-dns-4.1.96.Final-sources.jar"
+            }
+          },
+          "io_netty_netty_handler_proxy_4_1_97_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_handler_proxy_4_1_97_Final",
+              "sha256": "c789f30d0905a09b2a17c4cf397e1b57b0d63db714624eb0dec2282b9619e206",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/netty/netty-handler-proxy/4.1.97.Final/netty-handler-proxy-4.1.97.Final.jar"
+              ],
+              "downloaded_file_path": "io/netty/netty-handler-proxy/4.1.97.Final/netty-handler-proxy-4.1.97.Final.jar"
+            }
+          },
+          "io_projectreactor_reactor_core_jar_sources_3_5_3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_projectreactor_reactor_core_jar_sources_3_5_3",
+              "sha256": "c4193dbe135cc2a1db71c55771249158f611d3663e0f42b3ede5ab9e4302bce4",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/projectreactor/reactor-core/3.5.3/reactor-core-3.5.3-sources.jar"
+              ],
+              "downloaded_file_path": "io/projectreactor/reactor-core/3.5.3/reactor-core-3.5.3-sources.jar"
+            }
+          },
+          "com_google_errorprone_error_prone_type_annotations_jar_sources_2_22_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_errorprone_error_prone_type_annotations_jar_sources_2_22_0",
+              "sha256": "84bbb947f3de91d97eee9abb6c5648c5b61d0fb4d132f86c4d7c80e4357e5da6",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/errorprone/error_prone_type_annotations/2.22.0/error_prone_type_annotations-2.22.0-sources.jar"
+              ],
+              "downloaded_file_path": "com/google/errorprone/error_prone_type_annotations/2.22.0/error_prone_type_annotations-2.22.0-sources.jar"
+            }
+          },
+          "com_google_api_grpc_proto_google_common_protos_2_17_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_api_grpc_proto_google_common_protos_2_17_0",
+              "sha256": "4ef1fe0c327fc1521d1d753b0b1c4a875a54bd14ebded3afff0ca395320b6ea9",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-common-protos/2.17.0/proto-google-common-protos-2.17.0.jar"
+              ],
+              "downloaded_file_path": "com/google/api/grpc/proto-google-common-protos/2.17.0/proto-google-common-protos-2.17.0.jar"
+            }
+          },
+          "io_netty_netty_codec_http_jar_sources_4_1_97_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_codec_http_jar_sources_4_1_97_Final",
+              "sha256": "fd45d71121285bed020b3cc2515288d252b9c07cbc4934a63615d7d8c8855289",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/netty/netty-codec-http/4.1.97.Final/netty-codec-http-4.1.97.Final-sources.jar"
+              ],
+              "downloaded_file_path": "io/netty/netty-codec-http/4.1.97.Final/netty-codec-http-4.1.97.Final-sources.jar"
+            }
+          },
+          "io_netty_netty_transport_native_epoll": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_transport_native_epoll",
+              "generating_repository": "maven",
+              "target_name": "io_netty_netty_transport_native_epoll"
+            }
+          },
+          "software_amazon_awssdk_aws_xml_protocol_2_20_78": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~software_amazon_awssdk_aws_xml_protocol_2_20_78",
+              "sha256": "c7977c61aeb3f74e471bedde0ab6ca44447af4cbff309c63f5e7d2a26dbcba7a",
+              "urls": [
+                "https://repo1.maven.org/maven2/software/amazon/awssdk/aws-xml-protocol/2.20.78/aws-xml-protocol-2.20.78.jar",
+                "https://maven.google.com/software/amazon/awssdk/aws-xml-protocol/2.20.78/aws-xml-protocol-2.20.78.jar"
+              ],
+              "downloaded_file_path": "software/amazon/awssdk/aws-xml-protocol/2.20.78/aws-xml-protocol-2.20.78.jar"
+            }
+          },
+          "com_sun_activation_jakarta_activation_jar_sources_1_2_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_sun_activation_jakarta_activation_jar_sources_1_2_1",
+              "sha256": "d254da455b0e1e36c7a9db2f0910fea9e8a012cbc85160207328e16bd3aea753",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/sun/activation/jakarta.activation/1.2.1/jakarta.activation-1.2.1-sources.jar"
+              ],
+              "downloaded_file_path": "com/sun/activation/jakarta.activation/1.2.1/jakarta.activation-1.2.1-sources.jar"
+            }
+          },
+          "io_grpc_grpc_testing_1_56_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_grpc_grpc_testing_1_56_1",
+              "sha256": "b4cd4f2c410040fb097108eb6b7fa84826365b4d91844bd30b21f4e97eee906d",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/grpc/grpc-testing/1.56.1/grpc-testing-1.56.1.jar"
+              ],
+              "downloaded_file_path": "io/grpc/grpc-testing/1.56.1/grpc-testing-1.56.1.jar"
+            }
+          },
+          "org_glassfish_hk2_external_aopalliance_repackaged_2_6_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_glassfish_hk2_external_aopalliance_repackaged_2_6_1",
+              "sha256": "bad77f9278d753406360af9e4747bd9b3161554ea9cd3d62411a0ae1f2c141fd",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/glassfish/hk2/external/aopalliance-repackaged/2.6.1/aopalliance-repackaged-2.6.1.jar"
+              ],
+              "downloaded_file_path": "org/glassfish/hk2/external/aopalliance-repackaged/2.6.1/aopalliance-repackaged-2.6.1.jar"
+            }
+          },
+          "org_openjdk_jmh_jmh_core_1_37": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_openjdk_jmh_jmh_core_1_37",
+              "sha256": "dc0eaf2bbf0036a70b60798c785d6e03a9daf06b68b8edb0f1ba9eb3421baeb3",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/openjdk/jmh/jmh-core/1.37/jmh-core-1.37.jar"
+              ],
+              "downloaded_file_path": "org/openjdk/jmh/jmh-core/1.37/jmh-core-1.37.jar"
+            }
+          },
+          "io_netty_netty_codec_http_4_1_86_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_codec_http_4_1_86_Final",
+              "sha256": "3f6ceb3112cfcf7b70545eb5111220ce57db54d593f23f64c38333bb22c40b84",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/netty/netty-codec-http/4.1.86.Final/netty-codec-http-4.1.86.Final.jar",
+                "https://maven.google.com/io/netty/netty-codec-http/4.1.86.Final/netty-codec-http-4.1.86.Final.jar"
+              ],
+              "downloaded_file_path": "io/netty/netty-codec-http/4.1.86.Final/netty-codec-http-4.1.86.Final.jar"
+            }
+          },
+          "aopalliance_aopalliance_1_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~aopalliance_aopalliance_1_0",
+              "sha256": "0addec670fedcd3f113c5c8091d783280d23f75e3acb841b61a9cdb079376a08",
+              "urls": [
+                "https://repo1.maven.org/maven2/aopalliance/aopalliance/1.0/aopalliance-1.0.jar"
+              ],
+              "downloaded_file_path": "aopalliance/aopalliance/1.0/aopalliance-1.0.jar"
+            }
+          },
+          "org_reactivestreams_reactive_streams_jar_sources_1_0_4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_reactivestreams_reactive_streams_jar_sources_1_0_4",
+              "sha256": "5a7a36ae9536698c434ebe119feb374d721210fee68eb821a37ef3859b64b708",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/reactivestreams/reactive-streams/1.0.4/reactive-streams-1.0.4-sources.jar"
+              ],
+              "downloaded_file_path": "org/reactivestreams/reactive-streams/1.0.4/reactive-streams-1.0.4-sources.jar"
+            }
+          },
+          "com_google_http_client_google_http_client_jackson2_1_43_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_http_client_google_http_client_jackson2_1_43_1",
+              "sha256": "1d41fa103da432dc49b41a321effc3e2fda722a3dc896a89dcdc3a4d5fe82255",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/http-client/google-http-client-jackson2/1.43.1/google-http-client-jackson2-1.43.1.jar",
+                "https://maven.google.com/com/google/http-client/google-http-client-jackson2/1.43.1/google-http-client-jackson2-1.43.1.jar"
+              ],
+              "downloaded_file_path": "com/google/http-client/google-http-client-jackson2/1.43.1/google-http-client-jackson2-1.43.1.jar"
+            }
+          },
+          "io_netty_netty_transport_4_1_86_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_transport_4_1_86_Final",
+              "sha256": "f6726dcd54e4922b46b3b4f4467b443a70a30eb08a62620c8fe502d8cb802c9f",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/netty/netty-transport/4.1.86.Final/netty-transport-4.1.86.Final.jar",
+                "https://maven.google.com/io/netty/netty-transport/4.1.86.Final/netty-transport-4.1.86.Final.jar"
+              ],
+              "downloaded_file_path": "io/netty/netty-transport/4.1.86.Final/netty-transport-4.1.86.Final.jar"
+            }
+          },
+          "com_amazonaws_jmespath_java_jar_sources_1_12_544": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_amazonaws_jmespath_java_jar_sources_1_12_544",
+              "sha256": "496d7f1c237d107b3c4c766ff603ba6b3e773e59c590e3ed0156f56fdb3d0b4a",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/amazonaws/jmespath-java/1.12.544/jmespath-java-1.12.544-sources.jar"
+              ],
+              "downloaded_file_path": "com/amazonaws/jmespath-java/1.12.544/jmespath-java-1.12.544-sources.jar"
+            }
+          },
+          "com_github_kevinstern_software_and_algorithms_jar_sources_1_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_kevinstern_software_and_algorithms_jar_sources_1_0",
+              "sha256": "37a46c7f8f6c5064ceb398be472c17507b1e7e7bfc72399c57efb5fa5310a8ae",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/github/kevinstern/software-and-algorithms/1.0/software-and-algorithms-1.0-sources.jar"
+              ],
+              "downloaded_file_path": "com/github/kevinstern/software-and-algorithms/1.0/software-and-algorithms-1.0-sources.jar"
+            }
+          },
+          "com_github_pcj_google_options": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_pcj_google_options",
+              "generating_repository": "maven",
+              "target_name": "com_github_pcj_google_options"
+            }
+          },
+          "io_github_eisop_dataflow_errorprone_3_34_0_eisop1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_github_eisop_dataflow_errorprone_3_34_0_eisop1",
+              "sha256": "89b4f5d2bd5059f067c5982a0e5988b87dfc8a8234795d68c6f3178846de3319",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/github/eisop/dataflow-errorprone/3.34.0-eisop1/dataflow-errorprone-3.34.0-eisop1.jar"
+              ],
+              "downloaded_file_path": "io/github/eisop/dataflow-errorprone/3.34.0-eisop1/dataflow-errorprone-3.34.0-eisop1.jar"
+            }
+          },
+          "com_github_docker_java_docker_java_jar_sources_3_3_3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_docker_java_docker_java_jar_sources_3_3_3",
+              "sha256": "ddc2c925a8b58cc47e5d683c770c9f261f6a6b7db028b38dd289be0e51a7c3df",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/github/docker-java/docker-java/3.3.3/docker-java-3.3.3-sources.jar"
+              ],
+              "downloaded_file_path": "com/github/docker-java/docker-java/3.3.3/docker-java-3.3.3-sources.jar"
+            }
+          },
+          "io_prometheus_simpleclient_tracer_otel_jar_sources_0_15_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_prometheus_simpleclient_tracer_otel_jar_sources_0_15_0",
+              "sha256": "f83fcb43addcd77adeb34ff00ee27141060ac103597272eb44f2d73aea4addea",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/prometheus/simpleclient_tracer_otel/0.15.0/simpleclient_tracer_otel-0.15.0-sources.jar"
+              ],
+              "downloaded_file_path": "io/prometheus/simpleclient_tracer_otel/0.15.0/simpleclient_tracer_otel-0.15.0-sources.jar"
+            }
+          },
+          "io_reactivex_rxjava3_rxjava_3_1_6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_reactivex_rxjava3_rxjava_3_1_6",
+              "sha256": "34682bd3ec6f043c5defb589a2d18113ba3e2d2372dd401744f8e4815c1db638",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/reactivex/rxjava3/rxjava/3.1.6/rxjava-3.1.6.jar"
+              ],
+              "downloaded_file_path": "io/reactivex/rxjava3/rxjava/3.1.6/rxjava-3.1.6.jar"
+            }
+          },
+          "com_github_jnr_jnr_a64asm_jar_sources_1_0_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_jnr_jnr_a64asm_jar_sources_1_0_0",
+              "sha256": "2106b98c7d794fb01237e7243d975b9bc8450aa87bf34f93d7b5fcc651af7ff1",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/github/jnr/jnr-a64asm/1.0.0/jnr-a64asm-1.0.0-sources.jar"
+              ],
+              "downloaded_file_path": "com/github/jnr/jnr-a64asm/1.0.0/jnr-a64asm-1.0.0-sources.jar"
+            }
+          },
+          "io_netty_netty_transport_classes_kqueue_4_1_97_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_transport_classes_kqueue_4_1_97_Final",
+              "sha256": "964ef63eb24a5c979f0af473da13f9574497e11bd41543a66d10609d34013b9f",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/netty/netty-transport-classes-kqueue/4.1.97.Final/netty-transport-classes-kqueue-4.1.97.Final.jar"
+              ],
+              "downloaded_file_path": "io/netty/netty-transport-classes-kqueue/4.1.97.Final/netty-transport-classes-kqueue-4.1.97.Final.jar"
+            }
+          },
+          "commons_io_commons_io_jar_sources_2_13_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~commons_io_commons_io_jar_sources_2_13_0",
+              "sha256": "1c7bece2e87ac49b24f09ec3c5ceb51560edd7a259889fceef96dda9c046a1b3",
+              "urls": [
+                "https://repo1.maven.org/maven2/commons-io/commons-io/2.13.0/commons-io-2.13.0-sources.jar"
+              ],
+              "downloaded_file_path": "commons-io/commons-io/2.13.0/commons-io-2.13.0-sources.jar"
+            }
+          },
+          "org_codehaus_mojo_animal_sniffer_annotations_jar_sources_1_23": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_codehaus_mojo_animal_sniffer_annotations_jar_sources_1_23",
+              "sha256": "4878fcc6808dbc88085a4622db670e703867754bc4bc40312c52bf3a3510d019",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/codehaus/mojo/animal-sniffer-annotations/1.23/animal-sniffer-annotations-1.23-sources.jar"
+              ],
+              "downloaded_file_path": "org/codehaus/mojo/animal-sniffer-annotations/1.23/animal-sniffer-annotations-1.23-sources.jar"
+            }
+          },
+          "com_google_inject_guice_5_1_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_inject_guice_5_1_0",
+              "sha256": "4130e50bfac48099c860f0d903b91860c81a249c90f38245f8fed58fc817bc26",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/inject/guice/5.1.0/guice-5.1.0.jar"
+              ],
+              "downloaded_file_path": "com/google/inject/guice/5.1.0/guice-5.1.0.jar"
+            }
+          },
+          "org_slf4j_slf4j_simple_jar_sources_2_0_9": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_slf4j_slf4j_simple_jar_sources_2_0_9",
+              "sha256": "45423388e9fc51af94ac936842211353dbde78c29350d1ed97445ed3e37416cd",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/slf4j/slf4j-simple/2.0.9/slf4j-simple-2.0.9-sources.jar"
+              ],
+              "downloaded_file_path": "org/slf4j/slf4j-simple/2.0.9/slf4j-simple-2.0.9-sources.jar"
+            }
+          },
+          "org_apache_commons_commons_pool2_jar_sources_2_11_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_apache_commons_commons_pool2_jar_sources_2_11_1",
+              "sha256": "00f8a2910e6c36784384f382fb6edc61a0e856c550ee866e8d285cdd3c167111",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/apache/commons/commons-pool2/2.11.1/commons-pool2-2.11.1-sources.jar"
+              ],
+              "downloaded_file_path": "org/apache/commons/commons-pool2/2.11.1/commons-pool2-2.11.1-sources.jar"
+            }
+          },
+          "com_amazonaws_aws_java_sdk_core_jar_sources_1_12_544": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_amazonaws_aws_java_sdk_core_jar_sources_1_12_544",
+              "sha256": "e1cc8b011d35e4d71ba452fbf0c2777a6dc2a2a4668ea8c9e72a610f77f1a71d",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-core/1.12.544/aws-java-sdk-core-1.12.544-sources.jar"
+              ],
+              "downloaded_file_path": "com/amazonaws/aws-java-sdk-core/1.12.544/aws-java-sdk-core-1.12.544-sources.jar"
+            }
+          },
+          "com_github_jnr_jnr_constants": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_jnr_jnr_constants",
+              "generating_repository": "maven",
+              "target_name": "com_github_jnr_jnr_constants"
+            }
+          },
+          "com_google_auto_auto_common_1_2_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_auto_auto_common_1_2_1",
+              "sha256": "f43f29fe2a6ebaf04b2598cdeec32a4e346d49a9404e990f5fc19c19f3a28d0e",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/auto/auto-common/1.2.1/auto-common-1.2.1.jar"
+              ],
+              "downloaded_file_path": "com/google/auto/auto-common/1.2.1/auto-common-1.2.1.jar"
+            }
+          },
+          "io_grpc_grpc_protobuf": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_grpc_grpc_protobuf",
+              "generating_repository": "maven",
+              "target_name": "io_grpc_grpc_protobuf"
+            }
+          },
+          "io_prometheus_simpleclient_tracer_otel_agent_0_15_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_prometheus_simpleclient_tracer_otel_agent_0_15_0",
+              "sha256": "0cbb4c29d17e9fe71bb2cec013c2999ae8a9050f237ad33211761b40d2586e0b",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/prometheus/simpleclient_tracer_otel_agent/0.15.0/simpleclient_tracer_otel_agent-0.15.0.jar"
+              ],
+              "downloaded_file_path": "io/prometheus/simpleclient_tracer_otel_agent/0.15.0/simpleclient_tracer_otel_agent-0.15.0.jar"
+            }
+          },
+          "io_netty_netty_buffer_4_1_86_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_buffer_4_1_86_Final",
+              "sha256": "e42e15f47c865266b1faa6e038ebfd7ddadcf9f4ae9e6617edd4881dbd4abe88",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/netty/netty-buffer/4.1.86.Final/netty-buffer-4.1.86.Final.jar",
+                "https://maven.google.com/io/netty/netty-buffer/4.1.86.Final/netty-buffer-4.1.86.Final.jar"
+              ],
+              "downloaded_file_path": "io/netty/netty-buffer/4.1.86.Final/netty-buffer-4.1.86.Final.jar"
+            }
+          },
+          "io_netty_netty_codec_4_1_86_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_codec_4_1_86_Final",
+              "sha256": "0456840b5c851dad6cab881cd1a9ad5d916db65d81048145df1d9a6d03325bea",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/netty/netty-codec/4.1.86.Final/netty-codec-4.1.86.Final.jar",
+                "https://maven.google.com/io/netty/netty-codec/4.1.86.Final/netty-codec-4.1.86.Final.jar"
+              ],
+              "downloaded_file_path": "io/netty/netty-codec/4.1.86.Final/netty-codec-4.1.86.Final.jar"
+            }
+          },
+          "org_openjdk_jmh_jmh_generator_annprocess_1_37": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_openjdk_jmh_jmh_generator_annprocess_1_37",
+              "sha256": "6a5604b5b804e0daca1145df1077609321687734a8b49387e49f10557c186c77",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/openjdk/jmh/jmh-generator-annprocess/1.37/jmh-generator-annprocess-1.37.jar"
+              ],
+              "downloaded_file_path": "org/openjdk/jmh/jmh-generator-annprocess/1.37/jmh-generator-annprocess-1.37.jar"
+            }
+          },
+          "org_projectlombok_lombok_jar_sources_1_18_30": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_projectlombok_lombok_jar_sources_1_18_30",
+              "sha256": "d41c3ab349c0ec484449b545d2ac5c26ccc9c8b23f2dbbd6176382469f9eac71",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/projectlombok/lombok/1.18.30/lombok-1.18.30-sources.jar"
+              ],
+              "downloaded_file_path": "org/projectlombok/lombok/1.18.30/lombok-1.18.30-sources.jar"
+            }
+          },
+          "org_apache_tomcat_annotations_api_6_0_53": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_apache_tomcat_annotations_api_6_0_53",
+              "sha256": "253829d3c12b7381d1044fc22c6436cff025fe0d459e4a329413e560a7d0dd13",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/apache/tomcat/annotations-api/6.0.53/annotations-api-6.0.53.jar"
+              ],
+              "downloaded_file_path": "org/apache/tomcat/annotations-api/6.0.53/annotations-api-6.0.53.jar"
+            }
+          },
+          "io_perfmark_perfmark_api_jar_sources_0_26_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_perfmark_perfmark_api_jar_sources_0_26_0",
+              "sha256": "7379e0fef0c32d69f3ebae8f271f426fc808613f1cfbc29e680757f348ba8aa4",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/perfmark/perfmark-api/0.26.0/perfmark-api-0.26.0-sources.jar"
+              ],
+              "downloaded_file_path": "io/perfmark/perfmark-api/0.26.0/perfmark-api-0.26.0-sources.jar"
+            }
+          },
+          "software_amazon_awssdk_aws_query_protocol_2_20_78": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~software_amazon_awssdk_aws_query_protocol_2_20_78",
+              "sha256": "74c9b42046e3829836d2351a3a0bb06ae54f7e4f0c3d319c9b68166f245db549",
+              "urls": [
+                "https://repo1.maven.org/maven2/software/amazon/awssdk/aws-query-protocol/2.20.78/aws-query-protocol-2.20.78.jar",
+                "https://maven.google.com/software/amazon/awssdk/aws-query-protocol/2.20.78/aws-query-protocol-2.20.78.jar"
+              ],
+              "downloaded_file_path": "software/amazon/awssdk/aws-query-protocol/2.20.78/aws-query-protocol-2.20.78.jar"
+            }
+          },
+          "org_projectlombok_lombok_1_18_30": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_projectlombok_lombok_1_18_30",
+              "sha256": "14151b47582d570b4de16a147ece3bdbd19ace4aee5bde3a5578c87db9ecb998",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/projectlombok/lombok/1.18.30/lombok-1.18.30.jar"
+              ],
+              "downloaded_file_path": "org/projectlombok/lombok/1.18.30/lombok-1.18.30.jar"
+            }
+          },
+          "org_apache_tomcat_annotations_api": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_apache_tomcat_annotations_api",
+              "generating_repository": "maven",
+              "target_name": "org_apache_tomcat_annotations_api"
+            }
+          },
+          "io_netty_netty_resolver_dns_4_1_96_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_resolver_dns_4_1_96_Final",
+              "sha256": "09a4f0cc4fc7af083515cfb84d6e70af4223dfe129858274cf506cc626f5175e",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/netty/netty-resolver-dns/4.1.96.Final/netty-resolver-dns-4.1.96.Final.jar"
+              ],
+              "downloaded_file_path": "io/netty/netty-resolver-dns/4.1.96.Final/netty-resolver-dns-4.1.96.Final.jar"
+            }
+          },
+          "com_google_api_grpc_proto_google_common_protos_2_19_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_api_grpc_proto_google_common_protos_2_19_1",
+              "sha256": "5557ee1b7f44a80fa595cdcedcc52ed3be143ce25408181c3ad136006cdd749f",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-common-protos/2.19.1/proto-google-common-protos-2.19.1.jar",
+                "https://maven.google.com/com/google/api/grpc/proto-google-common-protos/2.19.1/proto-google-common-protos-2.19.1.jar"
+              ],
+              "downloaded_file_path": "com/google/api/grpc/proto-google-common-protos/2.19.1/proto-google-common-protos-2.19.1.jar"
+            }
+          },
+          "com_github_oshi_oshi_core_jar_sources_6_4_5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_oshi_oshi_core_jar_sources_6_4_5",
+              "sha256": "1ff5c3475458db16fce29e1aabce48242fe80221144de4b2a1dc62bd18f15062",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/github/oshi/oshi-core/6.4.5/oshi-core-6.4.5-sources.jar"
+              ],
+              "downloaded_file_path": "com/github/oshi/oshi-core/6.4.5/oshi-core-6.4.5-sources.jar"
+            }
+          },
+          "javax_inject_javax_inject_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~javax_inject_javax_inject_1",
+              "sha256": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
+              "urls": [
+                "https://repo1.maven.org/maven2/javax/inject/javax.inject/1/javax.inject-1.jar"
+              ],
+              "downloaded_file_path": "javax/inject/javax.inject/1/javax.inject-1.jar"
+            }
+          },
+          "org_jodd_jodd_bean_jar_sources_5_1_6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_jodd_jodd_bean_jar_sources_5_1_6",
+              "sha256": "961cff0114d349d3491293eea0c74a910b8676326c1af682f07e500782180160",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/jodd/jodd-bean/5.1.6/jodd-bean-5.1.6-sources.jar"
+              ],
+              "downloaded_file_path": "org/jodd/jodd-bean/5.1.6/jodd-bean-5.1.6-sources.jar"
+            }
+          },
+          "software_amazon_awssdk_s3_2_20_78": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~software_amazon_awssdk_s3_2_20_78",
+              "sha256": "0a21d9d740f20e8d65985b8e31154a6603f4f15a7c5acea5a70957745519327b",
+              "urls": [
+                "https://repo1.maven.org/maven2/software/amazon/awssdk/s3/2.20.78/s3-2.20.78.jar",
+                "https://maven.google.com/software/amazon/awssdk/s3/2.20.78/s3-2.20.78.jar"
+              ],
+              "downloaded_file_path": "software/amazon/awssdk/s3/2.20.78/s3-2.20.78.jar"
+            }
+          },
+          "com_google_android_annotations_jar_sources_4_1_1_4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_android_annotations_jar_sources_4_1_1_4",
+              "sha256": "e9b667aa958df78ea1ad115f7bbac18a5869c3128b1d5043feb360b0cfce9d40",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/android/annotations/4.1.1.4/annotations-4.1.1.4-sources.jar"
+              ],
+              "downloaded_file_path": "com/google/android/annotations/4.1.1.4/annotations-4.1.1.4-sources.jar"
+            }
+          },
+          "org_glassfish_hk2_hk2_utils_2_6_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_glassfish_hk2_hk2_utils_2_6_1",
+              "sha256": "30727f79086452fdefdab08451d982c2082aa239d9f75cdeb1ba271e3c887036",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/glassfish/hk2/hk2-utils/2.6.1/hk2-utils-2.6.1.jar"
+              ],
+              "downloaded_file_path": "org/glassfish/hk2/hk2-utils/2.6.1/hk2-utils-2.6.1.jar"
+            }
+          },
+          "com_google_android_annotations_4_1_1_4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_android_annotations_4_1_1_4",
+              "sha256": "ba734e1e84c09d615af6a09d33034b4f0442f8772dec120efb376d86a565ae15",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/android/annotations/4.1.1.4/annotations-4.1.1.4.jar"
+              ],
+              "downloaded_file_path": "com/google/android/annotations/4.1.1.4/annotations-4.1.1.4.jar"
+            }
+          },
+          "com_github_pcj_google_options_jar_sources_1_0_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_pcj_google_options_jar_sources_1_0_0",
+              "sha256": "3871275e5323aaa132ed043c3c3bf6620f5fe73c8aeb456ce992db9ce5d59768",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/github/pcj/google-options/1.0.0/google-options-1.0.0-sources.jar"
+              ],
+              "downloaded_file_path": "com/github/pcj/google-options/1.0.0/google-options-1.0.0-sources.jar"
+            }
+          },
+          "com_google_guava_failureaccess_jar_sources_1_0_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_guava_failureaccess_jar_sources_1_0_1",
+              "sha256": "092346eebbb1657b51aa7485a246bf602bb464cc0b0e2e1c7e7201fadce1e98f",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1-sources.jar"
+              ],
+              "downloaded_file_path": "com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1-sources.jar"
+            }
+          },
+          "redis_clients_jedis_jar_sources_4_3_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~redis_clients_jedis_jar_sources_4_3_1",
+              "sha256": "8590d6ad29f6760424e5d832ee2f738b9790393c9986e6754a03427bfb8d5d04",
+              "urls": [
+                "https://repo1.maven.org/maven2/redis/clients/jedis/4.3.1/jedis-4.3.1-sources.jar"
+              ],
+              "downloaded_file_path": "redis/clients/jedis/4.3.1/jedis-4.3.1-sources.jar"
+            }
+          },
+          "com_google_api_grpc_proto_google_cloud_storage_v2_2_22_3_alpha": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_api_grpc_proto_google_cloud_storage_v2_2_22_3_alpha",
+              "sha256": "346cc208553f4b286868bd05ccf4558e3798609559ec2b8fc8b2ea5e15819d8b",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-cloud-storage-v2/2.22.3-alpha/proto-google-cloud-storage-v2-2.22.3-alpha.jar",
+                "https://maven.google.com/com/google/api/grpc/proto-google-cloud-storage-v2/2.22.3-alpha/proto-google-cloud-storage-v2-2.22.3-alpha.jar"
+              ],
+              "downloaded_file_path": "com/google/api/grpc/proto-google-cloud-storage-v2/2.22.3-alpha/proto-google-cloud-storage-v2-2.22.3-alpha.jar"
+            }
+          },
+          "com_google_auth_google_auth_library_oauth2_http": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_auth_google_auth_library_oauth2_http",
+              "generating_repository": "maven",
+              "target_name": "com_google_auth_google_auth_library_oauth2_http"
+            }
+          },
+          "io_github_java_diff_utils_java_diff_utils_jar_sources_4_12": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_github_java_diff_utils_java_diff_utils_jar_sources_4_12",
+              "sha256": "fa24217b6eaa115a05d4a8f0003fe913c62716ca2184d2e4f17de4a7d42a8822",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/github/java-diff-utils/java-diff-utils/4.12/java-diff-utils-4.12-sources.jar"
+              ],
+              "downloaded_file_path": "io/github/java-diff-utils/java-diff-utils/4.12/java-diff-utils-4.12-sources.jar"
+            }
+          },
+          "commons_io_commons_io_2_13_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~commons_io_commons_io_2_13_0",
+              "sha256": "671eaa39688dac2ffaa4645b3c9980ae2d0ea2471e4ae6a5da199cd15ae23666",
+              "urls": [
+                "https://repo1.maven.org/maven2/commons-io/commons-io/2.13.0/commons-io-2.13.0.jar"
+              ],
+              "downloaded_file_path": "commons-io/commons-io/2.13.0/commons-io-2.13.0.jar"
+            }
+          },
+          "commons_logging_commons_logging_jar_sources_1_2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~commons_logging_commons_logging_jar_sources_1_2",
+              "sha256": "44347acfe5860461728e9cb33251e97345be36f8a0dfd5c5130c172559455f41",
+              "urls": [
+                "https://repo1.maven.org/maven2/commons-logging/commons-logging/1.2/commons-logging-1.2-sources.jar"
+              ],
+              "downloaded_file_path": "commons-logging/commons-logging/1.2/commons-logging-1.2-sources.jar"
+            }
+          },
+          "jakarta_activation_jakarta_activation_api_jar_sources_1_2_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~jakarta_activation_jakarta_activation_api_jar_sources_1_2_1",
+              "sha256": "e9638b764202c0def1b4d54bd37a984c681b2ed46a548ae94ef3f7e4a4b58a31",
+              "urls": [
+                "https://repo1.maven.org/maven2/jakarta/activation/jakarta.activation-api/1.2.1/jakarta.activation-api-1.2.1-sources.jar"
+              ],
+              "downloaded_file_path": "jakarta/activation/jakarta.activation-api/1.2.1/jakarta.activation-api-1.2.1-sources.jar"
+            }
+          },
+          "io_grpc_grpc_netty_shaded_1_55_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_grpc_grpc_netty_shaded_1_55_1",
+              "sha256": "3dc035ea13bf854d4218bc6370ba8d786077a9e0d76337e61df7597a78a03c61",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/grpc/grpc-netty-shaded/1.55.1/grpc-netty-shaded-1.55.1.jar",
+                "https://maven.google.com/io/grpc/grpc-netty-shaded/1.55.1/grpc-netty-shaded-1.55.1.jar"
+              ],
+              "downloaded_file_path": "io/grpc/grpc-netty-shaded/1.55.1/grpc-netty-shaded-1.55.1.jar"
+            }
+          },
+          "com_github_luben_zstd_jni_jar_sources_1_5_5_7": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_luben_zstd_jni_jar_sources_1_5_5_7",
+              "sha256": "6560c8d5e307feebb75630032c3e16c07e079907cf0238cc45647495af704599",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/github/luben/zstd-jni/1.5.5-7/zstd-jni-1.5.5-7-sources.jar"
+              ],
+              "downloaded_file_path": "com/github/luben/zstd-jni/1.5.5-7/zstd-jni-1.5.5-7-sources.jar"
+            }
+          },
+          "com_github_luben_zstd_jni_1_5_5_7": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_luben_zstd_jni_1_5_5_7",
+              "sha256": "edd7fc60c2aaa6b77d3436f667bf30b06202633761ec20d683638b40e8f11426",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/github/luben/zstd-jni/1.5.5-7/zstd-jni-1.5.5-7.jar"
+              ],
+              "downloaded_file_path": "com/github/luben/zstd-jni/1.5.5-7/zstd-jni-1.5.5-7.jar"
+            }
+          },
+          "io_netty_netty_resolver": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_resolver",
+              "generating_repository": "maven",
+              "target_name": "io_netty_netty_resolver"
+            }
+          },
+          "org_redisson_redisson_3_23_4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_redisson_redisson_3_23_4",
+              "sha256": "fe59768d63419b0073c0cbd6029d0be864ad5c9d233dd1337945f9edfe3df3ca",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/redisson/redisson/3.23.4/redisson-3.23.4.jar"
+              ],
+              "downloaded_file_path": "org/redisson/redisson/3.23.4/redisson-3.23.4.jar"
+            }
+          },
+          "net_javacrumbs_future_converter_future_converter_guava_common_1_2_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~net_javacrumbs_future_converter_future_converter_guava_common_1_2_0",
+              "sha256": "82bfab706005ea51c3e76958a62564367cf9cae207c0b1d55b9734876b9780c1",
+              "urls": [
+                "https://repo1.maven.org/maven2/net/javacrumbs/future-converter/future-converter-guava-common/1.2.0/future-converter-guava-common-1.2.0.jar"
+              ],
+              "downloaded_file_path": "net/javacrumbs/future-converter/future-converter-guava-common/1.2.0/future-converter-guava-common-1.2.0.jar"
+            }
+          },
+          "org_ow2_asm_asm_util_9_2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_ow2_asm_asm_util_9_2",
+              "sha256": "ff5b3cd331ae8a9a804768280da98f50f424fef23dd3c788bb320e08c94ee598",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/ow2/asm/asm-util/9.2/asm-util-9.2.jar"
+              ],
+              "downloaded_file_path": "org/ow2/asm/asm-util/9.2/asm-util-9.2.jar"
+            }
+          },
+          "io_grpc_grpc_stub_1_55_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_grpc_grpc_stub_1_55_1",
+              "sha256": "58c114817d42237ce50a5f7677cf142564df64200e59c956e49302b6c8af616a",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/grpc/grpc-stub/1.55.1/grpc-stub-1.55.1.jar",
+                "https://maven.google.com/io/grpc/grpc-stub/1.55.1/grpc-stub-1.55.1.jar"
+              ],
+              "downloaded_file_path": "io/grpc/grpc-stub/1.55.1/grpc-stub-1.55.1.jar"
+            }
+          },
+          "org_apache_commons_commons_lang3_3_12_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_apache_commons_commons_lang3_3_12_0",
+              "sha256": "d919d904486c037f8d193412da0c92e22a9fa24230b9d67a57855c5c31c7e94e",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar",
+                "https://maven.google.com/org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar"
+              ],
+              "downloaded_file_path": "org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar"
+            }
+          },
+          "com_github_docker_java_docker_java_transport_3_3_3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_docker_java_docker_java_transport_3_3_3",
+              "sha256": "103b94685f398b036cf9243cb8899680bcdb4e54c32340a32b2b5737a87a33ba",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/github/docker-java/docker-java-transport/3.3.3/docker-java-transport-3.3.3.jar"
+              ],
+              "downloaded_file_path": "com/github/docker-java/docker-java-transport/3.3.3/docker-java-transport-3.3.3.jar"
+            }
+          },
+          "software_amazon_awssdk_auth_2_20_78": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~software_amazon_awssdk_auth_2_20_78",
+              "sha256": "9eb0c3d97668b318ae5dcd127f434186a73d8e2552ad0fdd1fb71e3ffa5f0bec",
+              "urls": [
+                "https://repo1.maven.org/maven2/software/amazon/awssdk/auth/2.20.78/auth-2.20.78.jar",
+                "https://maven.google.com/software/amazon/awssdk/auth/2.20.78/auth-2.20.78.jar"
+              ],
+              "downloaded_file_path": "software/amazon/awssdk/auth/2.20.78/auth-2.20.78.jar"
+            }
+          },
+          "io_grpc_grpc_core_jar_sources_1_56_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_grpc_grpc_core_jar_sources_1_56_1",
+              "sha256": "9fd5eb82e115bcfc3babadb486d37d1096e86ce869ae0d1ccc4270aec60351ef",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/grpc/grpc-core/1.56.1/grpc-core-1.56.1-sources.jar"
+              ],
+              "downloaded_file_path": "io/grpc/grpc-core/1.56.1/grpc-core-1.56.1-sources.jar"
+            }
+          },
+          "com_github_docker_java_docker_java_3_3_3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_docker_java_docker_java_3_3_3",
+              "sha256": "3afb208216a17d8ce26a8f689303292701c87b974d43780cfba47bb2199a4467",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/github/docker-java/docker-java/3.3.3/docker-java-3.3.3.jar"
+              ],
+              "downloaded_file_path": "com/github/docker-java/docker-java/3.3.3/docker-java-3.3.3.jar"
+            }
+          },
+          "org_apache_commons_commons_math3_jar_sources_3_6_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_apache_commons_commons_math3_jar_sources_3_6_1",
+              "sha256": "e2ff85a3c360d56c51a7021614a194f3fbaf224054642ac535016f118322934d",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/apache/commons/commons-math3/3.6.1/commons-math3-3.6.1-sources.jar"
+              ],
+              "downloaded_file_path": "org/apache/commons/commons-math3/3.6.1/commons-math3-3.6.1-sources.jar"
+            }
+          },
+          "com_fasterxml_jackson_core_jackson_core_2_15_2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_fasterxml_jackson_core_jackson_core_2_15_2",
+              "sha256": "303c99e82b1faa91a0bae5d8fbeb56f7e2adf9b526a900dd723bf140d62bd4b4",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.15.2/jackson-core-2.15.2.jar"
+              ],
+              "downloaded_file_path": "com/fasterxml/jackson/core/jackson-core/2.15.2/jackson-core-2.15.2.jar"
+            }
+          },
+          "io_netty_netty_transport_native_epoll_jar_linux_x86_64_4_1_97_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_transport_native_epoll_jar_linux_x86_64_4_1_97_Final",
+              "sha256": "1e83fc9f82e5415cdbb688c6a5c6bbbd7d198e9fdd6fdf64b3dc5d54dd1acfd0",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/netty/netty-transport-native-epoll/4.1.97.Final/netty-transport-native-epoll-4.1.97.Final-linux-x86_64.jar"
+              ],
+              "downloaded_file_path": "io/netty/netty-transport-native-epoll/4.1.97.Final/netty-transport-native-epoll-4.1.97.Final-linux-x86_64.jar"
+            }
+          },
+          "org_bouncycastle_bcpkix_jdk18on_1_75": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_bouncycastle_bcpkix_jdk18on_1_75",
+              "sha256": "9e2c1db5a6ed29fbc36b438d39ca9feb901bb69bad0ce8d7bc735264bea79bd3",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/bouncycastle/bcpkix-jdk18on/1.75/bcpkix-jdk18on-1.75.jar"
+              ],
+              "downloaded_file_path": "org/bouncycastle/bcpkix-jdk18on/1.75/bcpkix-jdk18on-1.75.jar"
+            }
+          },
+          "org_reflections_reflections_0_10_2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_reflections_reflections_0_10_2",
+              "sha256": "938a2d08fe54050d7610b944d8ddc3a09355710d9e6be0aac838dbc04e9a2825",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/reflections/reflections/0.10.2/reflections-0.10.2.jar"
+              ],
+              "downloaded_file_path": "org/reflections/reflections/0.10.2/reflections-0.10.2.jar"
+            }
+          },
+          "com_github_fppt_jedis_mock_1_0_10": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_fppt_jedis_mock_1_0_10",
+              "sha256": "118684813167330681c6f1bebea2c1b67e3ed96bb862867437c0e4270d1fc88d",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/github/fppt/jedis-mock/1.0.10/jedis-mock-1.0.10.jar"
+              ],
+              "downloaded_file_path": "com/github/fppt/jedis-mock/1.0.10/jedis-mock-1.0.10.jar"
+            }
+          },
+          "org_javassist_javassist_3_28_0_GA": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_javassist_javassist_3_28_0_GA",
+              "sha256": "57d0a9e9286f82f4eaa851125186997f811befce0e2060ff0a15a77f5a9dd9a7",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/javassist/javassist/3.28.0-GA/javassist-3.28.0-GA.jar"
+              ],
+              "downloaded_file_path": "org/javassist/javassist/3.28.0-GA/javassist-3.28.0-GA.jar"
+            }
+          },
+          "com_google_http_client_google_http_client_gson_1_43_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_http_client_google_http_client_gson_1_43_1",
+              "sha256": "017406e5105a33147ab13baf7b491ff53d99e54a5e2b61b7ccd651e164229698",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/http-client/google-http-client-gson/1.43.1/google-http-client-gson-1.43.1.jar",
+                "https://maven.google.com/com/google/http-client/google-http-client-gson/1.43.1/google-http-client-gson-1.43.1.jar"
+              ],
+              "downloaded_file_path": "com/google/http-client/google-http-client-gson/1.43.1/google-http-client-gson-1.43.1.jar"
+            }
+          },
+          "net_minidev_json_smart_2_4_10": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~net_minidev_json_smart_2_4_10",
+              "sha256": "70cab5e9488630dc631b1fc6e7fa550d95cddd19ba14db39ceca7cabfbd4e5ae",
+              "urls": [
+                "https://repo1.maven.org/maven2/net/minidev/json-smart/2.4.10/json-smart-2.4.10.jar"
+              ],
+              "downloaded_file_path": "net/minidev/json-smart/2.4.10/json-smart-2.4.10.jar"
+            }
+          },
+          "org_apache_httpcomponents_httpcore_4_4_15": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_apache_httpcomponents_httpcore_4_4_15",
+              "sha256": "3cbaed088c499a10f96dde58f39dc0e7985171abd88138ca1655a872011bb142",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/apache/httpcomponents/httpcore/4.4.15/httpcore-4.4.15.jar"
+              ],
+              "downloaded_file_path": "org/apache/httpcomponents/httpcore/4.4.15/httpcore-4.4.15.jar"
+            }
+          },
+          "io_grpc_grpc_protobuf_lite_1_56_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_grpc_grpc_protobuf_lite_1_56_1",
+              "sha256": "5605030f1668edf93ade7f24b0bfe5ecf943774e02cf0ac5cac02387ac910185",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/grpc/grpc-protobuf-lite/1.56.1/grpc-protobuf-lite-1.56.1.jar"
+              ],
+              "downloaded_file_path": "io/grpc/grpc-protobuf-lite/1.56.1/grpc-protobuf-lite-1.56.1.jar"
+            }
+          },
+          "org_apache_httpcomponents_httpcore_4_4_16": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_apache_httpcomponents_httpcore_4_4_16",
+              "sha256": "6c9b3dd142a09dc468e23ad39aad6f75a0f2b85125104469f026e52a474e464f",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/apache/httpcomponents/httpcore/4.4.16/httpcore-4.4.16.jar",
+                "https://maven.google.com/org/apache/httpcomponents/httpcore/4.4.16/httpcore-4.4.16.jar"
+              ],
+              "downloaded_file_path": "org/apache/httpcomponents/httpcore/4.4.16/httpcore-4.4.16.jar"
+            }
+          },
+          "org_slf4j_slf4j_simple": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_slf4j_slf4j_simple",
+              "generating_repository": "maven",
+              "target_name": "org_slf4j_slf4j_simple"
+            }
+          },
+          "io_netty_netty_codec_jar_sources_4_1_97_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_codec_jar_sources_4_1_97_Final",
+              "sha256": "3f512c1a7ffa112ce3f8a8fec9545017063ae06583e80e841bdee76477f891f4",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/netty/netty-codec/4.1.97.Final/netty-codec-4.1.97.Final-sources.jar"
+              ],
+              "downloaded_file_path": "io/netty/netty-codec/4.1.97.Final/netty-codec-4.1.97.Final-sources.jar"
+            }
+          },
+          "org_xerial_sqlite_jdbc_3_34_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_xerial_sqlite_jdbc_3_34_0",
+              "sha256": "605979c94e7fe00437f1e10dcfa657a23f125c8eb4d2f0ec17e3f84613894cc3",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/xerial/sqlite-jdbc/3.34.0/sqlite-jdbc-3.34.0.jar"
+              ],
+              "downloaded_file_path": "org/xerial/sqlite-jdbc/3.34.0/sqlite-jdbc-3.34.0.jar"
+            }
+          },
+          "org_slf4j_jcl_over_slf4j_jar_sources_1_7_30": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_slf4j_jcl_over_slf4j_jar_sources_1_7_30",
+              "sha256": "e746bd5e537c8ceeb0c815a4edbaa4169444f74e658038e1966d8a3596eb8d05",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/slf4j/jcl-over-slf4j/1.7.30/jcl-over-slf4j-1.7.30-sources.jar"
+              ],
+              "downloaded_file_path": "org/slf4j/jcl-over-slf4j/1.7.30/jcl-over-slf4j-1.7.30-sources.jar"
+            }
+          },
+          "io_grpc_grpc_netty_shaded_1_56_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_grpc_grpc_netty_shaded_1_56_1",
+              "sha256": "b15257e1137d609a7e8eb9bf4f0cec06b78ee69c030282db0a66d17cc9c3eaf1",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/grpc/grpc-netty-shaded/1.56.1/grpc-netty-shaded-1.56.1.jar"
+              ],
+              "downloaded_file_path": "io/grpc/grpc-netty-shaded/1.56.1/grpc-netty-shaded-1.56.1.jar"
+            }
+          },
+          "com_google_protobuf_protobuf_java": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_protobuf_protobuf_java",
+              "generating_repository": "maven",
+              "target_name": "com_google_protobuf_protobuf_java"
+            }
+          },
+          "unpinned_maven": {
+            "bzlFile": "@@rules_jvm_external~5.3//:coursier.bzl",
+            "ruleClassName": "coursier_fetch",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~unpinned_maven",
+              "repositories": [
+                "{ \"repo_url\": \"https://repo1.maven.org/maven2\" }"
+              ],
+              "artifacts": [
+                "{ \"group\": \"com.amazonaws\", \"artifact\": \"aws-java-sdk-s3\", \"version\": \"1.12.544\" }",
+                "{ \"group\": \"com.amazonaws\", \"artifact\": \"aws-java-sdk-secretsmanager\", \"version\": \"1.12.544\" }",
+                "{ \"group\": \"com.fasterxml.jackson.core\", \"artifact\": \"jackson-databind\", \"version\": \"2.15.0\" }",
+                "{ \"group\": \"com.github.ben-manes.caffeine\", \"artifact\": \"caffeine\", \"version\": \"2.9.0\" }",
+                "{ \"group\": \"com.github.docker-java\", \"artifact\": \"docker-java\", \"version\": \"3.3.3\" }",
+                "{ \"group\": \"com.github.fppt\", \"artifact\": \"jedis-mock\", \"version\": \"1.0.10\" }",
+                "{ \"group\": \"com.github.jnr\", \"artifact\": \"jffi\", \"version\": \"1.3.11\" }",
+                "{ \"group\": \"com.github.jnr\", \"artifact\": \"jffi\", \"version\": \"1.3.11\", \"packaging\": \"jar\", \"classifier\": \"native\" }",
+                "{ \"group\": \"com.github.jnr\", \"artifact\": \"jnr-constants\", \"version\": \"0.10.4\" }",
+                "{ \"group\": \"com.github.jnr\", \"artifact\": \"jnr-ffi\", \"version\": \"2.2.14\" }",
+                "{ \"group\": \"com.github.jnr\", \"artifact\": \"jnr-posix\", \"version\": \"3.1.17\" }",
+                "{ \"group\": \"com.github.pcj\", \"artifact\": \"google-options\", \"version\": \"1.0.0\" }",
+                "{ \"group\": \"com.github.serceman\", \"artifact\": \"jnr-fuse\", \"version\": \"0.5.7\" }",
+                "{ \"group\": \"com.github.luben\", \"artifact\": \"zstd-jni\", \"version\": \"1.5.5-7\" }",
+                "{ \"group\": \"com.github.oshi\", \"artifact\": \"oshi-core\", \"version\": \"6.4.5\" }",
+                "{ \"group\": \"com.google.auth\", \"artifact\": \"google-auth-library-credentials\", \"version\": \"1.19.0\" }",
+                "{ \"group\": \"com.google.auth\", \"artifact\": \"google-auth-library-oauth2-http\", \"version\": \"1.19.0\" }",
+                "{ \"group\": \"com.google.code.findbugs\", \"artifact\": \"jsr305\", \"version\": \"3.0.2\" }",
+                "{ \"group\": \"com.google.code.gson\", \"artifact\": \"gson\", \"version\": \"2.10.1\" }",
+                "{ \"group\": \"com.google.errorprone\", \"artifact\": \"error_prone_annotations\", \"version\": \"2.22.0\" }",
+                "{ \"group\": \"com.google.errorprone\", \"artifact\": \"error_prone_core\", \"version\": \"2.22.0\" }",
+                "{ \"group\": \"com.google.guava\", \"artifact\": \"failureaccess\", \"version\": \"1.0.1\" }",
+                "{ \"group\": \"com.google.guava\", \"artifact\": \"guava\", \"version\": \"32.1.1-jre\" }",
+                "{ \"group\": \"com.google.j2objc\", \"artifact\": \"j2objc-annotations\", \"version\": \"2.8\" }",
+                "{ \"group\": \"com.google.jimfs\", \"artifact\": \"jimfs\", \"version\": \"1.3.0\" }",
+                "{ \"group\": \"com.google.protobuf\", \"artifact\": \"protobuf-java-util\", \"version\": \"3.19.1\" }",
+                "{ \"group\": \"com.google.protobuf\", \"artifact\": \"protobuf-java\", \"version\": \"3.19.1\" }",
+                "{ \"group\": \"com.google.truth\", \"artifact\": \"truth\", \"version\": \"1.1.5\" }",
+                "{ \"group\": \"org.slf4j\", \"artifact\": \"slf4j-simple\", \"version\": \"2.0.9\" }",
+                "{ \"group\": \"com.googlecode.json-simple\", \"artifact\": \"json-simple\", \"version\": \"1.1.1\" }",
+                "{ \"group\": \"com.jayway.jsonpath\", \"artifact\": \"json-path\", \"version\": \"2.8.0\" }",
+                "{ \"group\": \"org.bouncycastle\", \"artifact\": \"bcprov-jdk15on\", \"version\": \"1.70\" }",
+                "{ \"group\": \"net.jcip\", \"artifact\": \"jcip-annotations\", \"version\": \"1.0\" }",
+                "{ \"group\": \"io.netty\", \"artifact\": \"netty-buffer\", \"version\": \"4.1.97.Final\" }",
+                "{ \"group\": \"io.netty\", \"artifact\": \"netty-codec\", \"version\": \"4.1.97.Final\" }",
+                "{ \"group\": \"io.netty\", \"artifact\": \"netty-codec-http\", \"version\": \"4.1.97.Final\" }",
+                "{ \"group\": \"io.netty\", \"artifact\": \"netty-codec-http2\", \"version\": \"4.1.97.Final\" }",
+                "{ \"group\": \"io.netty\", \"artifact\": \"netty-codec-socks\", \"version\": \"4.1.97.Final\" }",
+                "{ \"group\": \"io.netty\", \"artifact\": \"netty-common\", \"version\": \"4.1.97.Final\" }",
+                "{ \"group\": \"io.netty\", \"artifact\": \"netty-handler\", \"version\": \"4.1.97.Final\" }",
+                "{ \"group\": \"io.netty\", \"artifact\": \"netty-handler-proxy\", \"version\": \"4.1.97.Final\" }",
+                "{ \"group\": \"io.netty\", \"artifact\": \"netty-resolver\", \"version\": \"4.1.97.Final\" }",
+                "{ \"group\": \"io.netty\", \"artifact\": \"netty-transport\", \"version\": \"4.1.97.Final\" }",
+                "{ \"group\": \"io.netty\", \"artifact\": \"netty-transport-native-epoll\", \"version\": \"4.1.97.Final\" }",
+                "{ \"group\": \"io.netty\", \"artifact\": \"netty-transport-native-kqueue\", \"version\": \"4.1.97.Final\" }",
+                "{ \"group\": \"io.netty\", \"artifact\": \"netty-transport-native-unix-common\", \"version\": \"4.1.97.Final\" }",
+                "{ \"group\": \"io.grpc\", \"artifact\": \"grpc-api\", \"version\": \"1.56.1\" }",
+                "{ \"group\": \"io.grpc\", \"artifact\": \"grpc-auth\", \"version\": \"1.56.1\" }",
+                "{ \"group\": \"io.grpc\", \"artifact\": \"grpc-core\", \"version\": \"1.56.1\" }",
+                "{ \"group\": \"io.grpc\", \"artifact\": \"grpc-context\", \"version\": \"1.56.1\" }",
+                "{ \"group\": \"io.grpc\", \"artifact\": \"grpc-netty\", \"version\": \"1.56.1\" }",
+                "{ \"group\": \"io.grpc\", \"artifact\": \"grpc-stub\", \"version\": \"1.56.1\" }",
+                "{ \"group\": \"io.grpc\", \"artifact\": \"grpc-protobuf\", \"version\": \"1.56.1\" }",
+                "{ \"group\": \"io.grpc\", \"artifact\": \"grpc-testing\", \"version\": \"1.56.1\" }",
+                "{ \"group\": \"io.grpc\", \"artifact\": \"grpc-services\", \"version\": \"1.56.1\" }",
+                "{ \"group\": \"io.grpc\", \"artifact\": \"grpc-netty-shaded\", \"version\": \"1.56.1\" }",
+                "{ \"group\": \"io.prometheus\", \"artifact\": \"simpleclient\", \"version\": \"0.15.0\" }",
+                "{ \"group\": \"io.prometheus\", \"artifact\": \"simpleclient_hotspot\", \"version\": \"0.15.0\" }",
+                "{ \"group\": \"io.prometheus\", \"artifact\": \"simpleclient_httpserver\", \"version\": \"0.15.0\" }",
+                "{ \"group\": \"junit\", \"artifact\": \"junit\", \"version\": \"4.13.2\" }",
+                "{ \"group\": \"javax.annotation\", \"artifact\": \"javax.annotation-api\", \"version\": \"1.3.2\" }",
+                "{ \"group\": \"net.javacrumbs.future-converter\", \"artifact\": \"future-converter-java8-guava\", \"version\": \"1.2.0\" }",
+                "{ \"group\": \"org.apache.commons\", \"artifact\": \"commons-compress\", \"version\": \"1.23.0\" }",
+                "{ \"group\": \"org.apache.commons\", \"artifact\": \"commons-pool2\", \"version\": \"2.11.1\" }",
+                "{ \"group\": \"org.apache.commons\", \"artifact\": \"commons-lang3\", \"version\": \"3.13.0\" }",
+                "{ \"group\": \"commons-io\", \"artifact\": \"commons-io\", \"version\": \"2.13.0\" }",
+                "{ \"group\": \"me.dinowernli\", \"artifact\": \"java-grpc-prometheus\", \"version\": \"0.6.0\" }",
+                "{ \"group\": \"org.apache.tomcat\", \"artifact\": \"annotations-api\", \"version\": \"6.0.53\" }",
+                "{ \"group\": \"org.checkerframework\", \"artifact\": \"checker-qual\", \"version\": \"3.38.0\" }",
+                "{ \"group\": \"org.mockito\", \"artifact\": \"mockito-core\", \"version\": \"2.25.0\" }",
+                "{ \"group\": \"org.openjdk.jmh\", \"artifact\": \"jmh-core\", \"version\": \"1.37\" }",
+                "{ \"group\": \"org.openjdk.jmh\", \"artifact\": \"jmh-generator-annprocess\", \"version\": \"1.37\" }",
+                "{ \"group\": \"org.redisson\", \"artifact\": \"redisson\", \"version\": \"3.23.4\" }",
+                "{ \"group\": \"org.threeten\", \"artifact\": \"threetenbp\", \"version\": \"1.6.8\" }",
+                "{ \"group\": \"org.xerial\", \"artifact\": \"sqlite-jdbc\", \"version\": \"3.34.0\" }",
+                "{ \"group\": \"org.jetbrains\", \"artifact\": \"annotations\", \"version\": \"16.0.2\" }",
+                "{ \"group\": \"org.yaml\", \"artifact\": \"snakeyaml\", \"version\": \"2.2\" }",
+                "{ \"group\": \"org.projectlombok\", \"artifact\": \"lombok\", \"version\": \"1.18.30\" }"
+              ],
+              "fail_on_missing_checksum": true,
+              "fetch_sources": true,
+              "fetch_javadoc": false,
+              "excluded_artifacts": [],
+              "generate_compat_repositories": false,
+              "version_conflict_policy": "default",
+              "override_targets": {},
+              "strict_visibility": false,
+              "strict_visibility_value": [
+                "@@//visibility:private"
+              ],
+              "maven_install_json": "@@//:maven_install.json",
+              "resolve_timeout": 600,
+              "jetify": false,
+              "jetify_include_list": [
+                "*"
+              ],
+              "use_starlark_android_rules": false,
+              "aar_import_bzl_label": "@build_bazel_rules_android//android:rules.bzl",
+              "duplicate_version_warning": "warn"
+            }
+          },
+          "io_netty_netty_transport_native_unix_common_4_1_86_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_transport_native_unix_common_4_1_86_Final",
+              "sha256": "ec26d03a06565791d57e997f793677ee4d3fc47b290b7951898c2ecd0232f115",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/netty/netty-transport-native-unix-common/4.1.86.Final/netty-transport-native-unix-common-4.1.86.Final.jar",
+                "https://maven.google.com/io/netty/netty-transport-native-unix-common/4.1.86.Final/netty-transport-native-unix-common-4.1.86.Final.jar"
+              ],
+              "downloaded_file_path": "io/netty/netty-transport-native-unix-common/4.1.86.Final/netty-transport-native-unix-common-4.1.86.Final.jar"
+            }
+          },
+          "com_github_oshi_oshi_core_6_4_5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_oshi_oshi_core_6_4_5",
+              "sha256": "7e634fb57b8763b7803d5f9caaed46d19c3bdbe81ddd8a93e61528c700cdc09e",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/github/oshi/oshi-core/6.4.5/oshi-core-6.4.5.jar"
+              ],
+              "downloaded_file_path": "com/github/oshi/oshi-core/6.4.5/oshi-core-6.4.5.jar"
+            }
+          },
+          "joda_time_joda_time_jar_sources_2_8_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~joda_time_joda_time_jar_sources_2_8_1",
+              "sha256": "59086b3e0608df2eac1b21063d6bae37851173e24efc4cacd6705326408723d9",
+              "urls": [
+                "https://repo1.maven.org/maven2/joda-time/joda-time/2.8.1/joda-time-2.8.1-sources.jar"
+              ],
+              "downloaded_file_path": "joda-time/joda-time/2.8.1/joda-time-2.8.1-sources.jar"
+            }
+          },
+          "com_google_protobuf_protobuf_java_3_22_3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_protobuf_protobuf_java_3_22_3",
+              "sha256": "59d388ea6a2d2d76ae8efff7fd4d0c60c6f0f464c3d3ab9be8e5add092975708",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.22.3/protobuf-java-3.22.3.jar"
+              ],
+              "downloaded_file_path": "com/google/protobuf/protobuf-java/3.22.3/protobuf-java-3.22.3.jar"
+            }
+          },
+          "org_apache_commons_commons_lang3_3_13_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_apache_commons_commons_lang3_3_13_0",
+              "sha256": "82f528cf718c7a3c2f30fc5bc784e3c6a0a10b17605dadb9e16c82ede11e6064",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.13.0/commons-lang3-3.13.0.jar"
+              ],
+              "downloaded_file_path": "org/apache/commons/commons-lang3/3.13.0/commons-lang3-3.13.0.jar"
+            }
+          },
+          "software_amazon_awssdk_profiles_2_20_78": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~software_amazon_awssdk_profiles_2_20_78",
+              "sha256": "c54925f8710a63b545f272ad651b40fc4310c4d3f49df50257645604d6021f32",
+              "urls": [
+                "https://repo1.maven.org/maven2/software/amazon/awssdk/profiles/2.20.78/profiles-2.20.78.jar",
+                "https://maven.google.com/software/amazon/awssdk/profiles/2.20.78/profiles-2.20.78.jar"
+              ],
+              "downloaded_file_path": "software/amazon/awssdk/profiles/2.20.78/profiles-2.20.78.jar"
+            }
+          },
+          "io_grpc_grpc_stub_1_56_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_grpc_grpc_stub_1_56_1",
+              "sha256": "64ffca5dde4565c4c0f876deea3d105341d45ce605b29053e79dc86a22f7953b",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/grpc/grpc-stub/1.56.1/grpc-stub-1.56.1.jar"
+              ],
+              "downloaded_file_path": "io/grpc/grpc-stub/1.56.1/grpc-stub-1.56.1.jar"
+            }
+          },
+          "io_grpc_grpc_protobuf_lite_jar_sources_1_56_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_grpc_grpc_protobuf_lite_jar_sources_1_56_1",
+              "sha256": "515018e2d65b852e0fa99c6dcb6c1e711070e02bdb926ca5b3e04ed35ae0a874",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/grpc/grpc-protobuf-lite/1.56.1/grpc-protobuf-lite-1.56.1-sources.jar"
+              ],
+              "downloaded_file_path": "io/grpc/grpc-protobuf-lite/1.56.1/grpc-protobuf-lite-1.56.1-sources.jar"
+            }
+          },
+          "com_googlecode_json_simple_json_simple_1_1_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_googlecode_json_simple_json_simple_1_1_1",
+              "sha256": "4e69696892b88b41c55d49ab2fdcc21eead92bf54acc588c0050596c3b75199c",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/googlecode/json-simple/json-simple/1.1.1/json-simple-1.1.1.jar"
+              ],
+              "downloaded_file_path": "com/googlecode/json-simple/json-simple/1.1.1/json-simple-1.1.1.jar"
+            }
+          },
+          "io_netty_netty_transport_native_kqueue_4_1_97_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_transport_native_kqueue_4_1_97_Final",
+              "sha256": "85916dd7569148bb3d4bc831d45846807b39d2b6f593dc8794a42ca71a4086c9",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/netty/netty-transport-native-kqueue/4.1.97.Final/netty-transport-native-kqueue-4.1.97.Final.jar"
+              ],
+              "downloaded_file_path": "io/netty/netty-transport-native-kqueue/4.1.97.Final/netty-transport-native-kqueue-4.1.97.Final.jar"
+            }
+          },
+          "io_grpc_grpc_auth_jar_sources_1_56_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_grpc_grpc_auth_jar_sources_1_56_1",
+              "sha256": "301967032288267e509448bdcd8ba42c726b5e58732b2d7d357f864e036f0e23",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/grpc/grpc-auth/1.56.1/grpc-auth-1.56.1-sources.jar"
+              ],
+              "downloaded_file_path": "io/grpc/grpc-auth/1.56.1/grpc-auth-1.56.1-sources.jar"
+            }
+          },
+          "com_google_api_api_common_2_11_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_api_api_common_2_11_1",
+              "sha256": "21f67354fa308826395d2ed171d25416a8001d50ea70f82b68f2bdd17bb8947f",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/api/api-common/2.11.1/api-common-2.11.1.jar",
+                "https://maven.google.com/com/google/api/api-common/2.11.1/api-common-2.11.1.jar"
+              ],
+              "downloaded_file_path": "com/google/api/api-common/2.11.1/api-common-2.11.1.jar"
+            }
+          },
+          "io_netty_netty_transport_native_unix_common_4_1_97_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_transport_native_unix_common_4_1_97_Final",
+              "sha256": "412fe140257c2dda5a5e15bee911298bd61928d03ee6be4db588e82c196c5dc6",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/netty/netty-transport-native-unix-common/4.1.97.Final/netty-transport-native-unix-common-4.1.97.Final.jar"
+              ],
+              "downloaded_file_path": "io/netty/netty-transport-native-unix-common/4.1.97.Final/netty-transport-native-unix-common-4.1.97.Final.jar"
+            }
+          },
+          "com_google_oauth_client_google_oauth_client_1_34_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_oauth_client_google_oauth_client_1_34_1",
+              "sha256": "193edf97aefa28b93c5892bdc598bac34fa4c396588030084f290b1440e8b98a",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/oauth-client/google-oauth-client/1.34.1/google-oauth-client-1.34.1.jar",
+                "https://maven.google.com/com/google/oauth-client/google-oauth-client/1.34.1/google-oauth-client-1.34.1.jar"
+              ],
+              "downloaded_file_path": "com/google/oauth-client/google-oauth-client/1.34.1/google-oauth-client-1.34.1.jar"
+            }
+          },
+          "com_amazonaws_aws_java_sdk_secretsmanager": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_amazonaws_aws_java_sdk_secretsmanager",
+              "generating_repository": "maven",
+              "target_name": "com_amazonaws_aws_java_sdk_secretsmanager"
+            }
+          },
+          "javax_cache_cache_api_jar_sources_1_1_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~javax_cache_cache_api_jar_sources_1_1_1",
+              "sha256": "2387f48682d3475fd214a6b9c2d1ef732ae8ce9313a3b8f69e72449ce33c6068",
+              "urls": [
+                "https://repo1.maven.org/maven2/javax/cache/cache-api/1.1.1/cache-api-1.1.1-sources.jar"
+              ],
+              "downloaded_file_path": "javax/cache/cache-api/1.1.1/cache-api-1.1.1-sources.jar"
+            }
+          },
+          "org_bouncycastle_bcutil_jdk18on_jar_sources_1_75": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_bouncycastle_bcutil_jdk18on_jar_sources_1_75",
+              "sha256": "bf827dd7283566804ba0583d02c80f43f0713896814e9dc56b1242ff5cc656a7",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/bouncycastle/bcutil-jdk18on/1.75/bcutil-jdk18on-1.75-sources.jar"
+              ],
+              "downloaded_file_path": "org/bouncycastle/bcutil-jdk18on/1.75/bcutil-jdk18on-1.75-sources.jar"
+            }
+          },
+          "io_grpc_grpc_stub_jar_sources_1_56_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_grpc_grpc_stub_jar_sources_1_56_1",
+              "sha256": "da927063466a063aaee49ca7c43b8cd487d3f24d3b8bb694216304060f386b8c",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/grpc/grpc-stub/1.56.1/grpc-stub-1.56.1-sources.jar"
+              ],
+              "downloaded_file_path": "io/grpc/grpc-stub/1.56.1/grpc-stub-1.56.1-sources.jar"
+            }
+          },
+          "net_sf_jopt_simple_jopt_simple_5_0_4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~net_sf_jopt_simple_jopt_simple_5_0_4",
+              "sha256": "df26cc58f235f477db07f753ba5a3ab243ebe5789d9f89ecf68dd62ea9a66c28",
+              "urls": [
+                "https://repo1.maven.org/maven2/net/sf/jopt-simple/jopt-simple/5.0.4/jopt-simple-5.0.4.jar"
+              ],
+              "downloaded_file_path": "net/sf/jopt-simple/jopt-simple/5.0.4/jopt-simple-5.0.4.jar"
+            }
+          },
+          "jakarta_activation_jakarta_activation_api_1_2_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~jakarta_activation_jakarta_activation_api_1_2_1",
+              "sha256": "8b0a0f52fa8b05c5431921a063ed866efaa41dadf2e3a7ee3e1961f2b0d9645b",
+              "urls": [
+                "https://repo1.maven.org/maven2/jakarta/activation/jakarta.activation-api/1.2.1/jakarta.activation-api-1.2.1.jar"
+              ],
+              "downloaded_file_path": "jakarta/activation/jakarta.activation-api/1.2.1/jakarta.activation-api-1.2.1.jar"
+            }
+          },
+          "io_netty_netty_handler_proxy_jar_sources_4_1_97_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_handler_proxy_jar_sources_4_1_97_Final",
+              "sha256": "19e0dac14e5028af4c7068a0a2872f50ad06588a5140a065648f1ab3c31cf5bc",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/netty/netty-handler-proxy/4.1.97.Final/netty-handler-proxy-4.1.97.Final-sources.jar"
+              ],
+              "downloaded_file_path": "io/netty/netty-handler-proxy/4.1.97.Final/netty-handler-proxy-4.1.97.Final-sources.jar"
+            }
+          },
+          "io_netty_netty_transport_classes_kqueue_jar_sources_4_1_97_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_transport_classes_kqueue_jar_sources_4_1_97_Final",
+              "sha256": "1db14659fab815b08ed06a60553bebabd402687d35b204f1af5add7396a549f4",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/netty/netty-transport-classes-kqueue/4.1.97.Final/netty-transport-classes-kqueue-4.1.97.Final-sources.jar"
+              ],
+              "downloaded_file_path": "io/netty/netty-transport-classes-kqueue/4.1.97.Final/netty-transport-classes-kqueue-4.1.97.Final-sources.jar"
+            }
+          },
+          "software_amazon_awssdk_regions_2_20_78": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~software_amazon_awssdk_regions_2_20_78",
+              "sha256": "af2dd9874404ef3bda177000134b7d9e04279a24a726388175b4dff2590740d7",
+              "urls": [
+                "https://repo1.maven.org/maven2/software/amazon/awssdk/regions/2.20.78/regions-2.20.78.jar",
+                "https://maven.google.com/software/amazon/awssdk/regions/2.20.78/regions-2.20.78.jar"
+              ],
+              "downloaded_file_path": "software/amazon/awssdk/regions/2.20.78/regions-2.20.78.jar"
+            }
+          },
+          "com_github_docker_java_docker_java_transport_netty_jar_sources_3_3_3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_docker_java_docker_java_transport_netty_jar_sources_3_3_3",
+              "sha256": "9c8e9b8e0bf0495470d19c22e27b832dc5f0025786106212b0de6a478b5abde3",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/github/docker-java/docker-java-transport-netty/3.3.3/docker-java-transport-netty-3.3.3-sources.jar"
+              ],
+              "downloaded_file_path": "com/github/docker-java/docker-java-transport-netty/3.3.3/docker-java-transport-netty-3.3.3-sources.jar"
+            }
+          },
+          "io_grpc_grpc_protobuf_lite_1_55_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_grpc_grpc_protobuf_lite_1_55_1",
+              "sha256": "d0253390609c72ec09c31ae46e79b01cd72a2ce2ccae11176de550ffd475c853",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/grpc/grpc-protobuf-lite/1.55.1/grpc-protobuf-lite-1.55.1.jar",
+                "https://maven.google.com/io/grpc/grpc-protobuf-lite/1.55.1/grpc-protobuf-lite-1.55.1.jar"
+              ],
+              "downloaded_file_path": "io/grpc/grpc-protobuf-lite/1.55.1/grpc-protobuf-lite-1.55.1.jar"
+            }
+          },
+          "io_grpc_grpc_services_jar_sources_1_56_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_grpc_grpc_services_jar_sources_1_56_1",
+              "sha256": "e9676fe1c41585babbe70c26a28b418b87a80e81ed49481a5dfaaace1a71162e",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/grpc/grpc-services/1.56.1/grpc-services-1.56.1-sources.jar"
+              ],
+              "downloaded_file_path": "io/grpc/grpc-services/1.56.1/grpc-services-1.56.1-sources.jar"
+            }
+          },
+          "net_minidev_accessors_smart_2_4_9": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~net_minidev_accessors_smart_2_4_9",
+              "sha256": "accdd5c7ac4c49b155890aaea1ffca2a9ccd5826b562dd95a99fc1887003e031",
+              "urls": [
+                "https://repo1.maven.org/maven2/net/minidev/accessors-smart/2.4.9/accessors-smart-2.4.9.jar"
+              ],
+              "downloaded_file_path": "net/minidev/accessors-smart/2.4.9/accessors-smart-2.4.9.jar"
+            }
+          },
+          "com_fasterxml_jackson_core_jackson_annotations_2_15_2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_fasterxml_jackson_core_jackson_annotations_2_15_2",
+              "sha256": "04e21f94dcfee4b078fa5a5f53047b785aaba69d19de392f616e7a7fe5d3882f",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.15.2/jackson-annotations-2.15.2.jar"
+              ],
+              "downloaded_file_path": "com/fasterxml/jackson/core/jackson-annotations/2.15.2/jackson-annotations-2.15.2.jar"
+            }
+          },
+          "aopalliance_aopalliance_jar_sources_1_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~aopalliance_aopalliance_jar_sources_1_0",
+              "sha256": "e6ef91d439ada9045f419c77543ebe0416c3cdfc5b063448343417a3e4a72123",
+              "urls": [
+                "https://repo1.maven.org/maven2/aopalliance/aopalliance/1.0/aopalliance-1.0-sources.jar"
+              ],
+              "downloaded_file_path": "aopalliance/aopalliance/1.0/aopalliance-1.0-sources.jar"
+            }
+          },
+          "org_threeten_threetenbp_1_6_8": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_threeten_threetenbp_1_6_8",
+              "sha256": "e4b1eb3d90c38a54c7f3384fda957e0b5bf0b41b40672a44ae8b03cb6c87ce06",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/threeten/threetenbp/1.6.8/threetenbp-1.6.8.jar"
+              ],
+              "downloaded_file_path": "org/threeten/threetenbp/1.6.8/threetenbp-1.6.8.jar"
+            }
+          },
+          "io_netty_netty_handler_4_1_97_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_handler_4_1_97_Final",
+              "sha256": "bd4771d19149cbc9c7464ed2d58035d79cdfed7adb59d38718b0d8e7a3dcc2de",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/netty/netty-handler/4.1.97.Final/netty-handler-4.1.97.Final.jar"
+              ],
+              "downloaded_file_path": "io/netty/netty-handler/4.1.97.Final/netty-handler-4.1.97.Final.jar"
+            }
+          },
+          "com_google_http_client_google_http_client_jar_sources_1_42_3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_http_client_google_http_client_jar_sources_1_42_3",
+              "sha256": "60d3d16ff67d6a395a81560227f51d282d3c65235154a696cafafe9032f43d5f",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/http-client/google-http-client/1.42.3/google-http-client-1.42.3-sources.jar"
+              ],
+              "downloaded_file_path": "com/google/http-client/google-http-client/1.42.3/google-http-client-1.42.3-sources.jar"
+            }
+          },
+          "javax_inject_javax_inject_jar_sources_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~javax_inject_javax_inject_jar_sources_1",
+              "sha256": "c4b87ee2911c139c3daf498a781967f1eb2e75bc1a8529a2e7b328a15d0e433e",
+              "urls": [
+                "https://repo1.maven.org/maven2/javax/inject/javax.inject/1/javax.inject-1-sources.jar"
+              ],
+              "downloaded_file_path": "javax/inject/javax.inject/1/javax.inject-1-sources.jar"
+            }
+          },
+          "io_netty_netty_handler_proxy": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_handler_proxy",
+              "generating_repository": "maven",
+              "target_name": "io_netty_netty_handler_proxy"
+            }
+          },
+          "com_esotericsoftware_reflectasm_1_11_9": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_esotericsoftware_reflectasm_1_11_9",
+              "sha256": "712b44da79a5b7f47a28cbfcb3d8ecfc872fae349c48aa4d3e38a5d69956afce",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/esotericsoftware/reflectasm/1.11.9/reflectasm-1.11.9.jar"
+              ],
+              "downloaded_file_path": "com/esotericsoftware/reflectasm/1.11.9/reflectasm-1.11.9.jar"
+            }
+          },
+          "com_google_re2j_re2j_1_6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_re2j_re2j_1_6",
+              "sha256": "c8b5c3472d4db594a865b2e47f835d07fb8b1415eeba559dccfb0a6945f033cd",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/re2j/re2j/1.6/re2j-1.6.jar",
+                "https://maven.google.com/com/google/re2j/re2j/1.6/re2j-1.6.jar"
+              ],
+              "downloaded_file_path": "com/google/re2j/re2j/1.6/re2j-1.6.jar"
+            }
+          },
+          "software_amazon_awssdk_apache_client_2_20_78": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~software_amazon_awssdk_apache_client_2_20_78",
+              "sha256": "771923580e38678b7f66c3a63f4b5f79eef9ffb81027e2a422aed2713ce4138b",
+              "urls": [
+                "https://repo1.maven.org/maven2/software/amazon/awssdk/apache-client/2.20.78/apache-client-2.20.78.jar",
+                "https://maven.google.com/software/amazon/awssdk/apache-client/2.20.78/apache-client-2.20.78.jar"
+              ],
+              "downloaded_file_path": "software/amazon/awssdk/apache-client/2.20.78/apache-client-2.20.78.jar"
+            }
+          },
+          "com_jayway_jsonpath_json_path": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_jayway_jsonpath_json_path",
+              "generating_repository": "maven",
+              "target_name": "com_jayway_jsonpath_json_path"
+            }
+          },
+          "com_fasterxml_jackson_dataformat_jackson_dataformat_cbor_jar_sources_2_12_6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_fasterxml_jackson_dataformat_jackson_dataformat_cbor_jar_sources_2_12_6",
+              "sha256": "1e70fe124ab0a0c3e9a909e75735799e987fb71b4f7649eb10199f4f3b873287",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/fasterxml/jackson/dataformat/jackson-dataformat-cbor/2.12.6/jackson-dataformat-cbor-2.12.6-sources.jar"
+              ],
+              "downloaded_file_path": "com/fasterxml/jackson/dataformat/jackson-dataformat-cbor/2.12.6/jackson-dataformat-cbor-2.12.6-sources.jar"
+            }
+          },
+          "org_bouncycastle_bcpkix_jdk18on_jar_sources_1_75": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_bouncycastle_bcpkix_jdk18on_jar_sources_1_75",
+              "sha256": "bd621657020f859beff0c8279aef31380c18438596964da2c77a0542126bf780",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/bouncycastle/bcpkix-jdk18on/1.75/bcpkix-jdk18on-1.75-sources.jar"
+              ],
+              "downloaded_file_path": "org/bouncycastle/bcpkix-jdk18on/1.75/bcpkix-jdk18on-1.75-sources.jar"
+            }
+          },
+          "org_redisson_redisson_jar_sources_3_23_4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_redisson_redisson_jar_sources_3_23_4",
+              "sha256": "7701f55b848adeb366af2461e1323f50f2d8701e983b133b34f5085803cbbab6",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/redisson/redisson/3.23.4/redisson-3.23.4-sources.jar"
+              ],
+              "downloaded_file_path": "org/redisson/redisson/3.23.4/redisson-3.23.4-sources.jar"
+            }
+          },
+          "org_threeten_threetenbp_jar_sources_1_6_8": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_threeten_threetenbp_jar_sources_1_6_8",
+              "sha256": "6b68e90399fd0d97ee7abbe3918c87a236d52a3fb3c434359a11942f9a1abc59",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/threeten/threetenbp/1.6.8/threetenbp-1.6.8-sources.jar"
+              ],
+              "downloaded_file_path": "org/threeten/threetenbp/1.6.8/threetenbp-1.6.8-sources.jar"
+            }
+          },
+          "io_netty_netty_common_jar_sources_4_1_97_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_common_jar_sources_4_1_97_Final",
+              "sha256": "54e96a125cb58b3ac067fa59b4a97fb6f1aadbac3f3092e6cc7fa88684de9964",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/netty/netty-common/4.1.97.Final/netty-common-4.1.97.Final-sources.jar"
+              ],
+              "downloaded_file_path": "io/netty/netty-common/4.1.97.Final/netty-common-4.1.97.Final-sources.jar"
+            }
+          },
+          "org_glassfish_hk2_external_jakarta_inject_jar_sources_2_6_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_glassfish_hk2_external_jakarta_inject_jar_sources_2_6_1",
+              "sha256": "fbbadf59b395bf326910de95682eaaa83dcc0f1d65cd4a077c6988deff6a527a",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/glassfish/hk2/external/jakarta.inject/2.6.1/jakarta.inject-2.6.1-sources.jar"
+              ],
+              "downloaded_file_path": "org/glassfish/hk2/external/jakarta.inject/2.6.1/jakarta.inject-2.6.1-sources.jar"
+            }
+          },
+          "org_bouncycastle_bcprov_jdk18on_jar_sources_1_75": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_bouncycastle_bcprov_jdk18on_jar_sources_1_75",
+              "sha256": "72abfe335986c5f8d9f61489d5699dca7688303a7da60697cef77018187ac8bc",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/bouncycastle/bcprov-jdk18on/1.75/bcprov-jdk18on-1.75-sources.jar"
+              ],
+              "downloaded_file_path": "org/bouncycastle/bcprov-jdk18on/1.75/bcprov-jdk18on-1.75-sources.jar"
+            }
+          },
+          "javax_annotation_javax_annotation_api_1_3_2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~javax_annotation_javax_annotation_api_1_3_2",
+              "sha256": "e04ba5195bcd555dc95650f7cc614d151e4bcd52d29a10b8aa2197f3ab89ab9b",
+              "urls": [
+                "https://repo1.maven.org/maven2/javax/annotation/javax.annotation-api/1.3.2/javax.annotation-api-1.3.2.jar"
+              ],
+              "downloaded_file_path": "javax/annotation/javax.annotation-api/1.3.2/javax.annotation-api-1.3.2.jar"
+            }
+          },
+          "io_prometheus_simpleclient_httpserver_0_15_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_prometheus_simpleclient_httpserver_0_15_0",
+              "sha256": "a1a16e1f804e3382ed8b400220ecb2913c96412d937e618f54a7088e6eb432b6",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/prometheus/simpleclient_httpserver/0.15.0/simpleclient_httpserver-0.15.0.jar"
+              ],
+              "downloaded_file_path": "io/prometheus/simpleclient_httpserver/0.15.0/simpleclient_httpserver-0.15.0.jar"
+            }
+          },
+          "com_google_auth_google_auth_library_credentials": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_auth_google_auth_library_credentials",
+              "generating_repository": "maven",
+              "target_name": "com_google_auth_google_auth_library_credentials"
+            }
+          },
+          "com_google_jimfs_jimfs": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_jimfs_jimfs",
+              "generating_repository": "maven",
+              "target_name": "com_google_jimfs_jimfs"
+            }
+          },
+          "org_slf4j_slf4j_simple_2_0_9": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_slf4j_slf4j_simple_2_0_9",
+              "sha256": "71f9c6de6dbaec2d10caa303faf08c5e749be53b242896c64c96b7c6bb6d62dc",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/slf4j/slf4j-simple/2.0.9/slf4j-simple-2.0.9.jar"
+              ],
+              "downloaded_file_path": "org/slf4j/slf4j-simple/2.0.9/slf4j-simple-2.0.9.jar"
+            }
+          },
+          "org_glassfish_jersey_core_jersey_client_jar_sources_2_30_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_glassfish_jersey_core_jersey_client_jar_sources_2_30_1",
+              "sha256": "44618799a585b0529c7b1fc63bdf4e0c5faa11c9cc8fb27621f3b24106be9ab7",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/glassfish/jersey/core/jersey-client/2.30.1/jersey-client-2.30.1-sources.jar"
+              ],
+              "downloaded_file_path": "org/glassfish/jersey/core/jersey-client/2.30.1/jersey-client-2.30.1-sources.jar"
+            }
+          },
+          "com_github_docker_java_docker_java_core_jar_sources_3_3_3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_docker_java_docker_java_core_jar_sources_3_3_3",
+              "sha256": "4858f9c8671cd792067fdaa4e99f04f6a660f546d08e03041664b754b79235f8",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/github/docker-java/docker-java-core/3.3.3/docker-java-core-3.3.3-sources.jar"
+              ],
+              "downloaded_file_path": "com/github/docker-java/docker-java-core/3.3.3/docker-java-core-3.3.3-sources.jar"
+            }
+          },
+          "io_grpc_grpc_netty_shaded": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_grpc_grpc_netty_shaded",
+              "generating_repository": "maven",
+              "target_name": "io_grpc_grpc_netty_shaded"
+            }
+          },
+          "io_netty_netty_common_4_1_86_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_common_4_1_86_Final",
+              "sha256": "a35a3f16e7cd45c5d8529aa3e7702d4ef3b36213ea332db59744ea348fc2ae99",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/netty/netty-common/4.1.86.Final/netty-common-4.1.86.Final.jar",
+                "https://maven.google.com/io/netty/netty-common/4.1.86.Final/netty-common-4.1.86.Final.jar"
+              ],
+              "downloaded_file_path": "io/netty/netty-common/4.1.86.Final/netty-common-4.1.86.Final.jar"
+            }
+          },
+          "io_netty_netty_transport_native_kqueue_jar_sources_4_1_97_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_transport_native_kqueue_jar_sources_4_1_97_Final",
+              "sha256": "2ea352ecbfc3cf601f98b0ffb06d30169ba40ed912fd68d66c0cd6f0bcf4d4b6",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/netty/netty-transport-native-kqueue/4.1.97.Final/netty-transport-native-kqueue-4.1.97.Final-sources.jar"
+              ],
+              "downloaded_file_path": "io/netty/netty-transport-native-kqueue/4.1.97.Final/netty-transport-native-kqueue-4.1.97.Final-sources.jar"
+            }
+          },
+          "com_google_protobuf_protobuf_java_jar_sources_3_22_3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_protobuf_protobuf_java_jar_sources_3_22_3",
+              "sha256": "49a699e1a696b4c6f681f4f0f9af5247fc97e0e665c5fbbbf797be7e7cd9c091",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.22.3/protobuf-java-3.22.3-sources.jar"
+              ],
+              "downloaded_file_path": "com/google/protobuf/protobuf-java/3.22.3/protobuf-java-3.22.3-sources.jar"
+            }
+          },
+          "io_netty_netty_buffer_4_1_97_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_buffer_4_1_97_Final",
+              "sha256": "a4393f5b395486cc74d0325c9b41311abb9513ba0fd7ef8cf46e9345c3bffbea",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/netty/netty-buffer/4.1.97.Final/netty-buffer-4.1.97.Final.jar"
+              ],
+              "downloaded_file_path": "io/netty/netty-buffer/4.1.97.Final/netty-buffer-4.1.97.Final.jar"
+            }
+          },
+          "software_amazon_awssdk_arns_2_20_78": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~software_amazon_awssdk_arns_2_20_78",
+              "sha256": "83c9c5743f83375e1d4b5bedce3593107b4989beec96f809554f545feeae4f34",
+              "urls": [
+                "https://repo1.maven.org/maven2/software/amazon/awssdk/arns/2.20.78/arns-2.20.78.jar",
+                "https://maven.google.com/software/amazon/awssdk/arns/2.20.78/arns-2.20.78.jar"
+              ],
+              "downloaded_file_path": "software/amazon/awssdk/arns/2.20.78/arns-2.20.78.jar"
+            }
+          },
+          "io_netty_netty_buffer_jar_sources_4_1_97_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_buffer_jar_sources_4_1_97_Final",
+              "sha256": "0b691a25682115d65da9e565589e39ee272227a972ecf0de936b475d42a4be48",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/netty/netty-buffer/4.1.97.Final/netty-buffer-4.1.97.Final-sources.jar"
+              ],
+              "downloaded_file_path": "io/netty/netty-buffer/4.1.97.Final/netty-buffer-4.1.97.Final-sources.jar"
+            }
+          },
+          "io_grpc_grpc_services_1_55_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_grpc_grpc_services_1_55_1",
+              "sha256": "324d773ca903ce13b67686c98f28f56a201ee75cbb859de071d05683d06d337b",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/grpc/grpc-services/1.55.1/grpc-services-1.55.1.jar",
+                "https://maven.google.com/io/grpc/grpc-services/1.55.1/grpc-services-1.55.1.jar"
+              ],
+              "downloaded_file_path": "io/grpc/grpc-services/1.55.1/grpc-services-1.55.1.jar"
+            }
+          },
+          "com_kohlschutter_junixsocket_junixsocket_common_jar_sources_2_6_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_kohlschutter_junixsocket_junixsocket_common_jar_sources_2_6_1",
+              "sha256": "066422249c845d9a0439a91fd1035e2bdf13b7552f03e94d1caef795afe53612",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/kohlschutter/junixsocket/junixsocket-common/2.6.1/junixsocket-common-2.6.1-sources.jar"
+              ],
+              "downloaded_file_path": "com/kohlschutter/junixsocket/junixsocket-common/2.6.1/junixsocket-common-2.6.1-sources.jar"
+            }
+          },
+          "com_github_jnr_jnr_posix": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_jnr_jnr_posix",
+              "generating_repository": "maven",
+              "target_name": "com_github_jnr_jnr_posix"
+            }
+          },
+          "org_hamcrest_hamcrest_core_jar_sources_1_3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_hamcrest_hamcrest_core_jar_sources_1_3",
+              "sha256": "e223d2d8fbafd66057a8848cc94222d63c3cedd652cc48eddc0ab5c39c0f84df",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
+              ],
+              "downloaded_file_path": "org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
+            }
+          },
+          "io_netty_netty_transport_native_epoll_jar_sources_4_1_97_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_transport_native_epoll_jar_sources_4_1_97_Final",
+              "sha256": "a6e3591efc09729a68574bec1493bfc0d08019b6ed4a566b6cb4e8e45ab1e937",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/netty/netty-transport-native-epoll/4.1.97.Final/netty-transport-native-epoll-4.1.97.Final-sources.jar"
+              ],
+              "downloaded_file_path": "io/netty/netty-transport-native-epoll/4.1.97.Final/netty-transport-native-epoll-4.1.97.Final-sources.jar"
+            }
+          },
+          "com_google_auto_auto_common_jar_sources_1_2_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_auto_auto_common_jar_sources_1_2_1",
+              "sha256": "6802fc6e48f84cacadab9418bc8eba732f4c6a4189fc8569b1f619cb88112b25",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/auto/auto-common/1.2.1/auto-common-1.2.1-sources.jar"
+              ],
+              "downloaded_file_path": "com/google/auto/auto-common/1.2.1/auto-common-1.2.1-sources.jar"
+            }
+          },
+          "software_amazon_awssdk_aws_core_2_20_78": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~software_amazon_awssdk_aws_core_2_20_78",
+              "sha256": "83d02aa3fc781288b73b5392ef870282788cdd552fdf6ad31b9038e20a452395",
+              "urls": [
+                "https://repo1.maven.org/maven2/software/amazon/awssdk/aws-core/2.20.78/aws-core-2.20.78.jar",
+                "https://maven.google.com/software/amazon/awssdk/aws-core/2.20.78/aws-core-2.20.78.jar"
+              ],
+              "downloaded_file_path": "software/amazon/awssdk/aws-core/2.20.78/aws-core-2.20.78.jar"
+            }
+          },
+          "net_jcip_jcip_annotations_1_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~net_jcip_jcip_annotations_1_0",
+              "sha256": "be5805392060c71474bf6c9a67a099471274d30b83eef84bfc4e0889a4f1dcc0",
+              "urls": [
+                "https://repo1.maven.org/maven2/net/jcip/jcip-annotations/1.0/jcip-annotations-1.0.jar"
+              ],
+              "downloaded_file_path": "net/jcip/jcip-annotations/1.0/jcip-annotations-1.0.jar"
+            }
+          },
+          "org_checkerframework_checker_qual_3_33_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_checkerframework_checker_qual_3_33_0",
+              "sha256": "e316255bbfcd9fe50d165314b85abb2b33cb2a66a93c491db648e498a82c2de1",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/checkerframework/checker-qual/3.33.0/checker-qual-3.33.0.jar",
+                "https://maven.google.com/org/checkerframework/checker-qual/3.33.0/checker-qual-3.33.0.jar"
+              ],
+              "downloaded_file_path": "org/checkerframework/checker-qual/3.33.0/checker-qual-3.33.0.jar"
+            }
+          },
+          "software_amazon_awssdk_third_party_jackson_core_2_20_78": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~software_amazon_awssdk_third_party_jackson_core_2_20_78",
+              "sha256": "3bc11fd8888ab3b8026dec0894e51dd76a7460f4baac4c1adead7a03a87f8a44",
+              "urls": [
+                "https://repo1.maven.org/maven2/software/amazon/awssdk/third-party-jackson-core/2.20.78/third-party-jackson-core-2.20.78.jar",
+                "https://maven.google.com/software/amazon/awssdk/third-party-jackson-core/2.20.78/third-party-jackson-core-2.20.78.jar"
+              ],
+              "downloaded_file_path": "software/amazon/awssdk/third-party-jackson-core/2.20.78/third-party-jackson-core-2.20.78.jar"
+            }
+          },
+          "com_github_docker_java_docker_java_core_3_3_3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_docker_java_docker_java_core_3_3_3",
+              "sha256": "d1f60040b4666a6073d4a2e0b72fc86cfb1b77f36b093e46a4115ea255995267",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/github/docker-java/docker-java-core/3.3.3/docker-java-core-3.3.3.jar"
+              ],
+              "downloaded_file_path": "com/github/docker-java/docker-java-core/3.3.3/docker-java-core-3.3.3.jar"
+            }
+          },
+          "net_minidev_json_smart_jar_sources_2_4_10": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~net_minidev_json_smart_jar_sources_2_4_10",
+              "sha256": "e2ece85df4e5489cf5644fd826d2875527a405233b02496b7520d871755f395d",
+              "urls": [
+                "https://repo1.maven.org/maven2/net/minidev/json-smart/2.4.10/json-smart-2.4.10-sources.jar"
+              ],
+              "downloaded_file_path": "net/minidev/json-smart/2.4.10/json-smart-2.4.10-sources.jar"
+            }
+          },
+          "com_google_j2objc_j2objc_annotations": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_j2objc_j2objc_annotations",
+              "generating_repository": "maven",
+              "target_name": "com_google_j2objc_j2objc_annotations"
+            }
+          },
+          "org_projectlombok_lombok": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_projectlombok_lombok",
+              "generating_repository": "maven",
+              "target_name": "org_projectlombok_lombok"
+            }
+          },
+          "software_amazon_awssdk_http_client_spi_2_20_78": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~software_amazon_awssdk_http_client_spi_2_20_78",
+              "sha256": "a52f5fa04a3c7e5c15ae632e64c64c44d2d019a3ee609ddca38312039c7a5b24",
+              "urls": [
+                "https://repo1.maven.org/maven2/software/amazon/awssdk/http-client-spi/2.20.78/http-client-spi-2.20.78.jar",
+                "https://maven.google.com/software/amazon/awssdk/http-client-spi/2.20.78/http-client-spi-2.20.78.jar"
+              ],
+              "downloaded_file_path": "software/amazon/awssdk/http-client-spi/2.20.78/http-client-spi-2.20.78.jar"
+            }
+          },
+          "unpinned_rules_jvm_external_deps": {
+            "bzlFile": "@@rules_jvm_external~5.3//:coursier.bzl",
+            "ruleClassName": "coursier_fetch",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~unpinned_rules_jvm_external_deps",
+              "repositories": [
+                "{ \"repo_url\": \"https://repo1.maven.org/maven2\" }"
+              ],
+              "artifacts": [
+                "{ \"group\": \"com.google.auth\", \"artifact\": \"google-auth-library-credentials\", \"version\": \"1.17.0\" }",
+                "{ \"group\": \"com.google.auth\", \"artifact\": \"google-auth-library-oauth2-http\", \"version\": \"1.17.0\" }",
+                "{ \"group\": \"com.google.cloud\", \"artifact\": \"google-cloud-core\", \"version\": \"2.18.1\" }",
+                "{ \"group\": \"com.google.cloud\", \"artifact\": \"google-cloud-storage\", \"version\": \"2.22.3\" }",
+                "{ \"group\": \"com.google.code.gson\", \"artifact\": \"gson\", \"version\": \"2.10.1\" }",
+                "{ \"group\": \"com.google.googlejavaformat\", \"artifact\": \"google-java-format\", \"version\": \"1.17.0\" }",
+                "{ \"group\": \"com.google.guava\", \"artifact\": \"guava\", \"version\": \"32.0.0-jre\" }",
+                "{ \"group\": \"org.apache.maven\", \"artifact\": \"maven-artifact\", \"version\": \"3.9.2\" }",
+                "{ \"group\": \"software.amazon.awssdk\", \"artifact\": \"s3\", \"version\": \"2.20.78\" }"
+              ],
+              "fail_on_missing_checksum": true,
+              "fetch_sources": true,
+              "fetch_javadoc": false,
+              "excluded_artifacts": [],
+              "generate_compat_repositories": false,
+              "version_conflict_policy": "default",
+              "override_targets": {},
+              "strict_visibility": false,
+              "strict_visibility_value": [
+                "@@//visibility:private"
+              ],
+              "maven_install_json": "@@rules_jvm_external~5.3//:rules_jvm_external_deps_install.json",
+              "resolve_timeout": 600,
+              "jetify": false,
+              "jetify_include_list": [
+                "*"
+              ],
+              "use_starlark_android_rules": false,
+              "aar_import_bzl_label": "@build_bazel_rules_android//android:rules.bzl",
+              "duplicate_version_warning": "warn"
+            }
+          },
+          "org_bouncycastle_bcutil_jdk18on_1_75": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_bouncycastle_bcutil_jdk18on_1_75",
+              "sha256": "027f36578c1ffdf08878c1cc2aa1e191f4b9da119c1e8f113299c53f298fa664",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/bouncycastle/bcutil-jdk18on/1.75/bcutil-jdk18on-1.75.jar"
+              ],
+              "downloaded_file_path": "org/bouncycastle/bcutil-jdk18on/1.75/bcutil-jdk18on-1.75.jar"
+            }
+          },
+          "org_jetbrains_annotations_16_0_2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_jetbrains_annotations_16_0_2",
+              "sha256": "245abad9a39eab1266ac9a8796980f462577e708ef3f6d43be2e008e4b72b9b4",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/jetbrains/annotations/16.0.2/annotations-16.0.2.jar"
+              ],
+              "downloaded_file_path": "org/jetbrains/annotations/16.0.2/annotations-16.0.2.jar"
+            }
+          },
+          "com_google_http_client_google_http_client_gson_jar_sources_1_42_3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_http_client_google_http_client_gson_jar_sources_1_42_3",
+              "sha256": "9e476cdfe8cd02f6691a3549ccc2016a3d2de4ad1d3ef5234145e73b2e61f732",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/http-client/google-http-client-gson/1.42.3/google-http-client-gson-1.42.3-sources.jar"
+              ],
+              "downloaded_file_path": "com/google/http-client/google-http-client-gson/1.42.3/google-http-client-gson-1.42.3-sources.jar"
+            }
+          },
+          "software_amazon_awssdk_endpoints_spi_2_20_78": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~software_amazon_awssdk_endpoints_spi_2_20_78",
+              "sha256": "9e20aaeb3dda2305bc04fea71d284a5ab53c562a896cc9206bcff52281585bb2",
+              "urls": [
+                "https://repo1.maven.org/maven2/software/amazon/awssdk/endpoints-spi/2.20.78/endpoints-spi-2.20.78.jar",
+                "https://maven.google.com/software/amazon/awssdk/endpoints-spi/2.20.78/endpoints-spi-2.20.78.jar"
+              ],
+              "downloaded_file_path": "software/amazon/awssdk/endpoints-spi/2.20.78/endpoints-spi-2.20.78.jar"
+            }
+          },
+          "software_amazon_awssdk_json_utils_2_20_78": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~software_amazon_awssdk_json_utils_2_20_78",
+              "sha256": "a8f0752527d123de28ddea281ad5829bbe10bbb657fe96da32b454f976042f50",
+              "urls": [
+                "https://repo1.maven.org/maven2/software/amazon/awssdk/json-utils/2.20.78/json-utils-2.20.78.jar",
+                "https://maven.google.com/software/amazon/awssdk/json-utils/2.20.78/json-utils-2.20.78.jar"
+              ],
+              "downloaded_file_path": "software/amazon/awssdk/json-utils/2.20.78/json-utils-2.20.78.jar"
+            }
+          },
+          "io_grpc_grpc_netty_1_56_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_grpc_grpc_netty_1_56_1",
+              "sha256": "0f457ae74e16c8928c004c1f2086dfdd2905f05c75a8a02ca6750e7d7dc6c8cc",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/grpc/grpc-netty/1.56.1/grpc-netty-1.56.1.jar"
+              ],
+              "downloaded_file_path": "io/grpc/grpc-netty/1.56.1/grpc-netty-1.56.1.jar"
+            }
+          },
+          "io_prometheus_simpleclient_common_jar_sources_0_15_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_prometheus_simpleclient_common_jar_sources_0_15_0",
+              "sha256": "4b43be524ff3b9e00dc3859170700d0a74194625586a49eef03ea616365d1bf8",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/prometheus/simpleclient_common/0.15.0/simpleclient_common-0.15.0-sources.jar"
+              ],
+              "downloaded_file_path": "io/prometheus/simpleclient_common/0.15.0/simpleclient_common-0.15.0-sources.jar"
+            }
+          },
+          "org_bouncycastle_bcprov_jdk15on_jar_sources_1_70": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_bouncycastle_bcprov_jdk15on_jar_sources_1_70",
+              "sha256": "0252e39814e4403b5d91a7386c3a5ac3e1fe65d43c2d25fed8d45e8eebab2696",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/bouncycastle/bcprov-jdk15on/1.70/bcprov-jdk15on-1.70-sources.jar"
+              ],
+              "downloaded_file_path": "org/bouncycastle/bcprov-jdk15on/1.70/bcprov-jdk15on-1.70-sources.jar"
+            }
+          },
+          "io_opencensus_opencensus_contrib_http_util_0_31_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_opencensus_opencensus_contrib_http_util_0_31_1",
+              "sha256": "3ea995b55a4068be22989b70cc29a4d788c2d328d1d50613a7a9afd13fdd2d0a",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/opencensus/opencensus-contrib-http-util/0.31.1/opencensus-contrib-http-util-0.31.1.jar"
+              ],
+              "downloaded_file_path": "io/opencensus/opencensus-contrib-http-util/0.31.1/opencensus-contrib-http-util-0.31.1.jar"
+            }
+          },
+          "com_fasterxml_jackson_dataformat_jackson_dataformat_yaml_jar_sources_2_15_2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_fasterxml_jackson_dataformat_jackson_dataformat_yaml_jar_sources_2_15_2",
+              "sha256": "fcc3d81d341c72284a59639185558fb1035414b6f42724ae0dac013673cf62e9",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/fasterxml/jackson/dataformat/jackson-dataformat-yaml/2.15.2/jackson-dataformat-yaml-2.15.2-sources.jar"
+              ],
+              "downloaded_file_path": "com/fasterxml/jackson/dataformat/jackson-dataformat-yaml/2.15.2/jackson-dataformat-yaml-2.15.2-sources.jar"
+            }
+          },
+          "org_glassfish_jersey_inject_jersey_hk2_jar_sources_2_30_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_glassfish_jersey_inject_jersey_hk2_jar_sources_2_30_1",
+              "sha256": "e4a24b58b0a7fa5089ee3008356a2ee252766bb12516fc2eda27cc54e935bcd9",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/glassfish/jersey/inject/jersey-hk2/2.30.1/jersey-hk2-2.30.1-sources.jar"
+              ],
+              "downloaded_file_path": "org/glassfish/jersey/inject/jersey-hk2/2.30.1/jersey-hk2-2.30.1-sources.jar"
+            }
+          },
+          "com_google_auth_google_auth_library_oauth2_http_1_19_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_auth_google_auth_library_oauth2_http_1_19_0",
+              "sha256": "01bdf5c5cd85e10b794e401775d9909b56a38ffce313fbd39510a5d87ed56f58",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/auth/google-auth-library-oauth2-http/1.19.0/google-auth-library-oauth2-http-1.19.0.jar"
+              ],
+              "downloaded_file_path": "com/google/auth/google-auth-library-oauth2-http/1.19.0/google-auth-library-oauth2-http-1.19.0.jar"
+            }
+          },
+          "com_github_jnr_jnr_ffi": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_jnr_jnr_ffi",
+              "generating_repository": "maven",
+              "target_name": "com_github_jnr_jnr_ffi"
+            }
+          },
+          "software_amazon_awssdk_sdk_core_2_20_78": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~software_amazon_awssdk_sdk_core_2_20_78",
+              "sha256": "1d060bab19739fa3a2071b4693b6fc31608a8c968e9554a0a2d2481343132498",
+              "urls": [
+                "https://repo1.maven.org/maven2/software/amazon/awssdk/sdk-core/2.20.78/sdk-core-2.20.78.jar",
+                "https://maven.google.com/software/amazon/awssdk/sdk-core/2.20.78/sdk-core-2.20.78.jar"
+              ],
+              "downloaded_file_path": "software/amazon/awssdk/sdk-core/2.20.78/sdk-core-2.20.78.jar"
+            }
+          },
+          "software_amazon_awssdk_utils_2_20_78": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~software_amazon_awssdk_utils_2_20_78",
+              "sha256": "bf346be5ab0af9267a1c8101378f37e76fc977e9d8f5b8e5cfc98221e4179374",
+              "urls": [
+                "https://repo1.maven.org/maven2/software/amazon/awssdk/utils/2.20.78/utils-2.20.78.jar",
+                "https://maven.google.com/software/amazon/awssdk/utils/2.20.78/utils-2.20.78.jar"
+              ],
+              "downloaded_file_path": "software/amazon/awssdk/utils/2.20.78/utils-2.20.78.jar"
+            }
+          },
+          "com_google_auth_google_auth_library_credentials_1_19_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_auth_google_auth_library_credentials_1_19_0",
+              "sha256": "095984b0594888a47f311b3c9dcf6da9ed86feeea8f78140c55e14c27b0593e5",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/auth/google-auth-library-credentials/1.19.0/google-auth-library-credentials-1.19.0.jar"
+              ],
+              "downloaded_file_path": "com/google/auth/google-auth-library-credentials/1.19.0/google-auth-library-credentials-1.19.0.jar"
+            }
+          },
+          "org_glassfish_hk2_hk2_locator_2_6_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_glassfish_hk2_hk2_locator_2_6_1",
+              "sha256": "febc668deb9f2000c76bd4918d8086c0a4c74d07bd0c60486b72c6bd38b62874",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/glassfish/hk2/hk2-locator/2.6.1/hk2-locator-2.6.1.jar"
+              ],
+              "downloaded_file_path": "org/glassfish/hk2/hk2-locator/2.6.1/hk2-locator-2.6.1.jar"
+            }
+          },
+          "io_projectreactor_reactor_core_3_5_3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_projectreactor_reactor_core_3_5_3",
+              "sha256": "86017581188627ae6de5d3822882f3594f87f9289ec4479391790ccfd5631508",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/projectreactor/reactor-core/3.5.3/reactor-core-3.5.3.jar"
+              ],
+              "downloaded_file_path": "io/projectreactor/reactor-core/3.5.3/reactor-core-3.5.3.jar"
+            }
+          },
+          "com_github_jnr_jnr_constants_0_10_4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_jnr_jnr_constants_0_10_4",
+              "sha256": "9a5b8cf9798d9d0331b8d8966c5235a22c4307676e35803a24659e6d76096f78",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/github/jnr/jnr-constants/0.10.4/jnr-constants-0.10.4.jar"
+              ],
+              "downloaded_file_path": "com/github/jnr/jnr-constants/0.10.4/jnr-constants-0.10.4.jar"
+            }
+          },
+          "com_kohlschutter_junixsocket_junixsocket_common_2_6_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_kohlschutter_junixsocket_junixsocket_common_2_6_1",
+              "sha256": "93d120e2d49ddf5bfdee8258762fc874b26c657f027f8d6ccc1a055156bfcde1",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/kohlschutter/junixsocket/junixsocket-common/2.6.1/junixsocket-common-2.6.1.jar"
+              ],
+              "downloaded_file_path": "com/kohlschutter/junixsocket/junixsocket-common/2.6.1/junixsocket-common-2.6.1.jar"
+            }
+          },
+          "com_fasterxml_jackson_jaxrs_jackson_jaxrs_json_provider_2_10_3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_fasterxml_jackson_jaxrs_jackson_jaxrs_json_provider_2_10_3",
+              "sha256": "93026591dbb332030dbe865b9c811a016e470d8ff6daaa7031556d2185e62054",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/fasterxml/jackson/jaxrs/jackson-jaxrs-json-provider/2.10.3/jackson-jaxrs-json-provider-2.10.3.jar"
+              ],
+              "downloaded_file_path": "com/fasterxml/jackson/jaxrs/jackson-jaxrs-json-provider/2.10.3/jackson-jaxrs-json-provider-2.10.3.jar"
+            }
+          },
+          "io_prometheus_simpleclient_tracer_common_0_15_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_prometheus_simpleclient_tracer_common_0_15_0",
+              "sha256": "1baef082e619c06262e23de1b46ad35eb4df36ceb19be06ac7ef32a9833e12a4",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/prometheus/simpleclient_tracer_common/0.15.0/simpleclient_tracer_common-0.15.0.jar"
+              ],
+              "downloaded_file_path": "io/prometheus/simpleclient_tracer_common/0.15.0/simpleclient_tracer_common-0.15.0.jar"
+            }
+          },
+          "com_google_code_findbugs_jsr305_3_0_2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_code_findbugs_jsr305_3_0_2",
+              "sha256": "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar"
+              ],
+              "downloaded_file_path": "com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar"
+            }
+          },
+          "com_fasterxml_jackson_core_jackson_core_2_14_2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_fasterxml_jackson_core_jackson_core_2_14_2",
+              "sha256": "b5d37a77c88277b97e3593c8740925216c06df8e4172bbde058528df04ad3e7a",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.14.2/jackson-core-2.14.2.jar",
+                "https://maven.google.com/com/fasterxml/jackson/core/jackson-core/2.14.2/jackson-core-2.14.2.jar"
+              ],
+              "downloaded_file_path": "com/fasterxml/jackson/core/jackson-core/2.14.2/jackson-core-2.14.2.jar"
+            }
+          },
+          "com_github_jnr_jnr_ffi_jar_sources_2_2_14": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_jnr_jnr_ffi_jar_sources_2_2_14",
+              "sha256": "07f3eca123769c9aaeadd2f8d05a3ac3ed009a41b52f77efd12487112d7482f5",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/github/jnr/jnr-ffi/2.2.14/jnr-ffi-2.2.14-sources.jar"
+              ],
+              "downloaded_file_path": "com/github/jnr/jnr-ffi/2.2.14/jnr-ffi-2.2.14-sources.jar"
+            }
+          },
+          "com_github_ben_manes_caffeine_caffeine": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_ben_manes_caffeine_caffeine",
+              "generating_repository": "maven",
+              "target_name": "com_github_ben_manes_caffeine_caffeine"
+            }
+          },
+          "com_google_http_client_google_http_client_gson_1_42_3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_http_client_google_http_client_gson_1_42_3",
+              "sha256": "8196efaa89c5f73b00b2b48edad02fcd78524259407c37ab1860737988545cee",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/http-client/google-http-client-gson/1.42.3/google-http-client-gson-1.42.3.jar"
+              ],
+              "downloaded_file_path": "com/google/http-client/google-http-client-gson/1.42.3/google-http-client-gson-1.42.3.jar"
+            }
+          },
+          "io_grpc_grpc_api": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_grpc_grpc_api",
+              "generating_repository": "maven",
+              "target_name": "io_grpc_grpc_api"
+            }
+          },
+          "com_google_errorprone_error_prone_annotation_2_22_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_errorprone_error_prone_annotation_2_22_0",
+              "sha256": "554c42449c9920ea1f6baec1d1b8aaac404a88be653f7cb441ee059316f8a1d1",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/errorprone/error_prone_annotation/2.22.0/error_prone_annotation-2.22.0.jar"
+              ],
+              "downloaded_file_path": "com/google/errorprone/error_prone_annotation/2.22.0/error_prone_annotation-2.22.0.jar"
+            }
+          },
+          "org_glassfish_hk2_osgi_resource_locator_1_0_3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_glassfish_hk2_osgi_resource_locator_1_0_3",
+              "sha256": "aab5d7849f7cfcda2cc7c541ba1bd365151d42276f151c825387245dfde3dd74",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/glassfish/hk2/osgi-resource-locator/1.0.3/osgi-resource-locator-1.0.3.jar"
+              ],
+              "downloaded_file_path": "org/glassfish/hk2/osgi-resource-locator/1.0.3/osgi-resource-locator-1.0.3.jar"
+            }
+          },
+          "javax_annotation_javax_annotation_api_jar_sources_1_3_2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~javax_annotation_javax_annotation_api_jar_sources_1_3_2",
+              "sha256": "128971e52e0d84a66e3b6e049dab8ad7b2c58b7e1ad37fa2debd3d40c2947b95",
+              "urls": [
+                "https://repo1.maven.org/maven2/javax/annotation/javax.annotation-api/1.3.2/javax.annotation-api-1.3.2-sources.jar"
+              ],
+              "downloaded_file_path": "javax/annotation/javax.annotation-api/1.3.2/javax.annotation-api-1.3.2-sources.jar"
+            }
+          },
+          "org_openjdk_jmh_jmh_core_jar_sources_1_37": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_openjdk_jmh_jmh_core_jar_sources_1_37",
+              "sha256": "fd4beda07b3b94cd0e32199401bbb2d9ed3371a770c8c320761b9442ff3e8e05",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/openjdk/jmh/jmh-core/1.37/jmh-core-1.37-sources.jar"
+              ],
+              "downloaded_file_path": "org/openjdk/jmh/jmh-core/1.37/jmh-core-1.37-sources.jar"
+            }
+          },
+          "com_github_serceman_jnr_fuse_0_5_7": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_serceman_jnr_fuse_0_5_7",
+              "sha256": "ebe81ccbcbe1464996e5213ee24947cfba9eda7e9ffe154333f9bd8321217989",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/github/serceman/jnr-fuse/0.5.7/jnr-fuse-0.5.7.jar"
+              ],
+              "downloaded_file_path": "com/github/serceman/jnr-fuse/0.5.7/jnr-fuse-0.5.7.jar"
+            }
+          },
+          "org_openjdk_jmh_jmh_generator_annprocess_jar_sources_1_37": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_openjdk_jmh_jmh_generator_annprocess_jar_sources_1_37",
+              "sha256": "cc1b661fb209ae1a433e331e8e78bab680674153b0a6ac69d47d11c60fb5e47e",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/openjdk/jmh/jmh-generator-annprocess/1.37/jmh-generator-annprocess-1.37-sources.jar"
+              ],
+              "downloaded_file_path": "org/openjdk/jmh/jmh-generator-annprocess/1.37/jmh-generator-annprocess-1.37-sources.jar"
+            }
+          },
+          "org_yaml_snakeyaml": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_yaml_snakeyaml",
+              "generating_repository": "maven",
+              "target_name": "org_yaml_snakeyaml"
+            }
+          },
+          "com_google_auto_value_auto_value_annotations_jar_sources_1_10_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_auto_value_auto_value_annotations_jar_sources_1_10_1",
+              "sha256": "44e6ce2884c18869422765b238f7f173faccd24643fabb5e95597382e80d50a8",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/auto/value/auto-value-annotations/1.10.1/auto-value-annotations-1.10.1-sources.jar"
+              ],
+              "downloaded_file_path": "com/google/auto/value/auto-value-annotations/1.10.1/auto-value-annotations-1.10.1-sources.jar"
+            }
+          },
+          "io_grpc_grpc_rls_1_55_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_grpc_grpc_rls_1_55_1",
+              "sha256": "f828087440c2f6b274e196b21a6fb38db60648724c1be450f4d0ed991d819a6f",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/grpc/grpc-rls/1.55.1/grpc-rls-1.55.1.jar",
+                "https://maven.google.com/io/grpc/grpc-rls/1.55.1/grpc-rls-1.55.1.jar"
+              ],
+              "downloaded_file_path": "io/grpc/grpc-rls/1.55.1/grpc-rls-1.55.1.jar"
+            }
+          },
+          "jakarta_xml_bind_jakarta_xml_bind_api_jar_sources_2_3_2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~jakarta_xml_bind_jakarta_xml_bind_api_jar_sources_2_3_2",
+              "sha256": "61ceb3ed35ecf99f1803eac9c4b8f12103c7531952beae38ba53cc727f405532",
+              "urls": [
+                "https://repo1.maven.org/maven2/jakarta/xml/bind/jakarta.xml.bind-api/2.3.2/jakarta.xml.bind-api-2.3.2-sources.jar"
+              ],
+              "downloaded_file_path": "jakarta/xml/bind/jakarta.xml.bind-api/2.3.2/jakarta.xml.bind-api-2.3.2-sources.jar"
+            }
+          },
+          "com_google_googlejavaformat_google_java_format_1_17_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_googlejavaformat_google_java_format_1_17_0",
+              "sha256": "631ba54c39f6c20df027dc1420736df2e5e43c581880efdd1e46ddb4ce050e3e",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/googlejavaformat/google-java-format/1.17.0/google-java-format-1.17.0.jar",
+                "https://maven.google.com/com/google/googlejavaformat/google-java-format/1.17.0/google-java-format-1.17.0.jar"
+              ],
+              "downloaded_file_path": "com/google/googlejavaformat/google-java-format/1.17.0/google-java-format-1.17.0.jar"
+            }
+          },
+          "org_jboss_marshalling_jboss_marshalling_jar_sources_2_0_11_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_jboss_marshalling_jboss_marshalling_jar_sources_2_0_11_Final",
+              "sha256": "4e9b508e3423fb82a33e72c77fd4fe63f108f167fa648d50a933b1b71d9084f2",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/jboss/marshalling/jboss-marshalling/2.0.11.Final/jboss-marshalling-2.0.11.Final-sources.jar"
+              ],
+              "downloaded_file_path": "org/jboss/marshalling/jboss-marshalling/2.0.11.Final/jboss-marshalling-2.0.11.Final-sources.jar"
+            }
+          },
+          "com_google_guava_failureaccess_1_0_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_guava_failureaccess_1_0_1",
+              "sha256": "a171ee4c734dd2da837e4b16be9df4661afab72a41adaf31eb84dfdaf936ca26",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.jar"
+              ],
+              "downloaded_file_path": "com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.jar"
+            }
+          },
+          "io_perfmark_perfmark_api_0_26_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_perfmark_perfmark_api_0_26_0",
+              "sha256": "b7d23e93a34537ce332708269a0d1404788a5b5e1949e82f5535fce51b3ea95b",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/perfmark/perfmark-api/0.26.0/perfmark-api-0.26.0.jar"
+              ],
+              "downloaded_file_path": "io/perfmark/perfmark-api/0.26.0/perfmark-api-0.26.0.jar"
+            }
+          },
+          "commons_codec_commons_codec_jar_sources_1_15": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~commons_codec_commons_codec_jar_sources_1_15",
+              "sha256": "7019940b2298d333edb946e2db3d10f1caacbbd52bb64e85832cfd0017e049cc",
+              "urls": [
+                "https://repo1.maven.org/maven2/commons-codec/commons-codec/1.15/commons-codec-1.15-sources.jar"
+              ],
+              "downloaded_file_path": "commons-codec/commons-codec/1.15/commons-codec-1.15-sources.jar"
+            }
+          },
+          "io_netty_netty_codec_http_4_1_97_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_codec_http_4_1_97_Final",
+              "sha256": "7d6cad9cbd015e41f69787ce6a34beeba032b381e32e88207908431dc812778a",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/netty/netty-codec-http/4.1.97.Final/netty-codec-http-4.1.97.Final.jar"
+              ],
+              "downloaded_file_path": "io/netty/netty-codec-http/4.1.97.Final/netty-codec-http-4.1.97.Final.jar"
+            }
+          },
+          "io_netty_netty_codec_http2_jar_sources_4_1_97_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_codec_http2_jar_sources_4_1_97_Final",
+              "sha256": "7d8c2ec86545a19ccca24009809027f1745bc8339c8a97bcdc5833abd58e2ab3",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/netty/netty-codec-http2/4.1.97.Final/netty-codec-http2-4.1.97.Final-sources.jar"
+              ],
+              "downloaded_file_path": "io/netty/netty-codec-http2/4.1.97.Final/netty-codec-http2-4.1.97.Final-sources.jar"
+            }
+          },
+          "software_amazon_awssdk_protocol_core_2_20_78": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~software_amazon_awssdk_protocol_core_2_20_78",
+              "sha256": "9ae1459ad8bd5b6167997985ec7afebf9fc1105a3d727d8b485b276b5c2fbddb",
+              "urls": [
+                "https://repo1.maven.org/maven2/software/amazon/awssdk/protocol-core/2.20.78/protocol-core-2.20.78.jar",
+                "https://maven.google.com/software/amazon/awssdk/protocol-core/2.20.78/protocol-core-2.20.78.jar"
+              ],
+              "downloaded_file_path": "software/amazon/awssdk/protocol-core/2.20.78/protocol-core-2.20.78.jar"
+            }
+          },
+          "io_netty_netty_resolver_4_1_97_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_resolver_4_1_97_Final",
+              "sha256": "38a018c6d9fb2cb11b72881354782b45080bbd20b9a0ad6cde28b80d431ed0b1",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/netty/netty-resolver/4.1.97.Final/netty-resolver-4.1.97.Final.jar"
+              ],
+              "downloaded_file_path": "io/netty/netty-resolver/4.1.97.Final/netty-resolver-4.1.97.Final.jar"
+            }
+          },
+          "io_grpc_grpc_context_1_56_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_grpc_grpc_context_1_56_1",
+              "sha256": "3d442ce08bfb1b487edf76d12e2dfd991c3877af32cf772a83c73d06f89743bc",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/grpc/grpc-context/1.56.1/grpc-context-1.56.1.jar"
+              ],
+              "downloaded_file_path": "io/grpc/grpc-context/1.56.1/grpc-context-1.56.1.jar"
+            }
+          },
+          "io_prometheus_simpleclient_httpserver_jar_sources_0_15_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_prometheus_simpleclient_httpserver_jar_sources_0_15_0",
+              "sha256": "b06cfea384c1a0e7d233c9325eb62d9ea4d144a744ce7991a5a96ef8bb5a361e",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/prometheus/simpleclient_httpserver/0.15.0/simpleclient_httpserver-0.15.0-sources.jar"
+              ],
+              "downloaded_file_path": "io/prometheus/simpleclient_httpserver/0.15.0/simpleclient_httpserver-0.15.0-sources.jar"
+            }
+          },
+          "com_google_api_gax_httpjson_0_113_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_api_gax_httpjson_0_113_1",
+              "sha256": "f7e4e84caa6577466fc828858193667135b291da044f007eafde99c0f929b781",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/api/gax-httpjson/0.113.1/gax-httpjson-0.113.1.jar",
+                "https://maven.google.com/com/google/api/gax-httpjson/0.113.1/gax-httpjson-0.113.1.jar"
+              ],
+              "downloaded_file_path": "com/google/api/gax-httpjson/0.113.1/gax-httpjson-0.113.1.jar"
+            }
+          },
+          "jakarta_ws_rs_jakarta_ws_rs_api_jar_sources_2_1_6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~jakarta_ws_rs_jakarta_ws_rs_api_jar_sources_2_1_6",
+              "sha256": "5fb0591472e00439db7d1511caa40a39cda42e24b0bade6378f880384b7cc073",
+              "urls": [
+                "https://repo1.maven.org/maven2/jakarta/ws/rs/jakarta.ws.rs-api/2.1.6/jakarta.ws.rs-api-2.1.6-sources.jar"
+              ],
+              "downloaded_file_path": "jakarta/ws/rs/jakarta.ws.rs-api/2.1.6/jakarta.ws.rs-api-2.1.6-sources.jar"
+            }
+          },
+          "org_objenesis_objenesis_3_3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_objenesis_objenesis_3_3",
+              "sha256": "02dfd0b0439a5591e35b708ed2f5474eb0948f53abf74637e959b8e4ef69bfeb",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/objenesis/objenesis/3.3/objenesis-3.3.jar"
+              ],
+              "downloaded_file_path": "org/objenesis/objenesis/3.3/objenesis-3.3.jar"
+            }
+          },
+          "org_openjdk_jmh_jmh_generator_annprocess": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_openjdk_jmh_jmh_generator_annprocess",
+              "generating_repository": "maven",
+              "target_name": "org_openjdk_jmh_jmh_generator_annprocess"
+            }
+          },
+          "com_amazonaws_aws_java_sdk_s3_jar_sources_1_12_544": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_amazonaws_aws_java_sdk_s3_jar_sources_1_12_544",
+              "sha256": "b91ef0fec99308cb3216fac69f9bb1a84149f05ab9b59e705107f492c02b4f64",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-s3/1.12.544/aws-java-sdk-s3-1.12.544-sources.jar"
+              ],
+              "downloaded_file_path": "com/amazonaws/aws-java-sdk-s3/1.12.544/aws-java-sdk-s3-1.12.544-sources.jar"
+            }
+          },
+          "com_github_docker_java_docker_java_transport_jersey_jar_sources_3_3_3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_docker_java_docker_java_transport_jersey_jar_sources_3_3_3",
+              "sha256": "05a26581bdde6519c4d87aaae7569eebd713f5fda9f8fa28b51216d2d364a18b",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/github/docker-java/docker-java-transport-jersey/3.3.3/docker-java-transport-jersey-3.3.3-sources.jar"
+              ],
+              "downloaded_file_path": "com/github/docker-java/docker-java-transport-jersey/3.3.3/docker-java-transport-jersey-3.3.3-sources.jar"
+            }
+          },
+          "io_netty_netty_transport_native_unix_common_jar_sources_4_1_97_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_transport_native_unix_common_jar_sources_4_1_97_Final",
+              "sha256": "de1ea25a58fadbfa64061769281797cc9b133a48d0a039015d5b3d8f16cbfddc",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/netty/netty-transport-native-unix-common/4.1.97.Final/netty-transport-native-unix-common-4.1.97.Final-sources.jar"
+              ],
+              "downloaded_file_path": "io/netty/netty-transport-native-unix-common/4.1.97.Final/netty-transport-native-unix-common-4.1.97.Final-sources.jar"
+            }
+          },
+          "org_codehaus_mojo_animal_sniffer_annotations_1_23": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_codehaus_mojo_animal_sniffer_annotations_1_23",
+              "sha256": "9ffe526bf43a6348e9d8b33b9cd6f580a7f5eed0cf055913007eda263de974d0",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/codehaus/mojo/animal-sniffer-annotations/1.23/animal-sniffer-annotations-1.23.jar"
+              ],
+              "downloaded_file_path": "org/codehaus/mojo/animal-sniffer-annotations/1.23/animal-sniffer-annotations-1.23.jar"
+            }
+          },
+          "net_sf_jopt_simple_jopt_simple_jar_sources_5_0_4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~net_sf_jopt_simple_jopt_simple_jar_sources_5_0_4",
+              "sha256": "06b283801a5a94ef697b7f2c79a048c4e2f848b3daddda61cab74d882bdd97a5",
+              "urls": [
+                "https://repo1.maven.org/maven2/net/sf/jopt-simple/jopt-simple/5.0.4/jopt-simple-5.0.4-sources.jar"
+              ],
+              "downloaded_file_path": "net/sf/jopt-simple/jopt-simple/5.0.4/jopt-simple-5.0.4-sources.jar"
+            }
+          },
+          "com_fasterxml_jackson_dataformat_jackson_dataformat_cbor_2_12_6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_fasterxml_jackson_dataformat_jackson_dataformat_cbor_2_12_6",
+              "sha256": "cfa008d15f052e69221e8c3193056ff95c3c594271321ccac8d72dc1a770619c",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/fasterxml/jackson/dataformat/jackson-dataformat-cbor/2.12.6/jackson-dataformat-cbor-2.12.6.jar"
+              ],
+              "downloaded_file_path": "com/fasterxml/jackson/dataformat/jackson-dataformat-cbor/2.12.6/jackson-dataformat-cbor-2.12.6.jar"
+            }
+          },
+          "io_grpc_grpc_core_1_55_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_grpc_grpc_core_1_55_1",
+              "sha256": "c4782555fefb61c72898759a7d11f5f221811935bcf983efb478d796228b65dc",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/grpc/grpc-core/1.55.1/grpc-core-1.55.1.jar",
+                "https://maven.google.com/io/grpc/grpc-core/1.55.1/grpc-core-1.55.1.jar"
+              ],
+              "downloaded_file_path": "io/grpc/grpc-core/1.55.1/grpc-core-1.55.1.jar"
+            }
+          },
+          "com_kohlschutter_junixsocket_junixsocket_native_common_jar_sources_2_6_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_kohlschutter_junixsocket_junixsocket_native_common_jar_sources_2_6_1",
+              "sha256": "4cef32dce262263e247d783f4ed7d90c5376190321e829ba5e985a8a27fbda06",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/kohlschutter/junixsocket/junixsocket-native-common/2.6.1/junixsocket-native-common-2.6.1-sources.jar"
+              ],
+              "downloaded_file_path": "com/kohlschutter/junixsocket/junixsocket-native-common/2.6.1/junixsocket-native-common-2.6.1-sources.jar"
+            }
+          },
+          "io_netty_netty_transport_native_kqueue_jar_osx_x86_64_4_1_97_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_transport_native_kqueue_jar_osx_x86_64_4_1_97_Final",
+              "sha256": "6870051aca7fa4dc5d0f2938036215a269504c50d2e36c4af38fd00d22ad7d95",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/netty/netty-transport-native-kqueue/4.1.97.Final/netty-transport-native-kqueue-4.1.97.Final-osx-x86_64.jar"
+              ],
+              "downloaded_file_path": "io/netty/netty-transport-native-kqueue/4.1.97.Final/netty-transport-native-kqueue-4.1.97.Final-osx-x86_64.jar"
+            }
+          },
+          "io_reactivex_rxjava3_rxjava_jar_sources_3_1_6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_reactivex_rxjava3_rxjava_jar_sources_3_1_6",
+              "sha256": "4479ead52c21dbfeb23646e378f77b7b396eda170619027d4213975e368b14ca",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/reactivex/rxjava3/rxjava/3.1.6/rxjava-3.1.6-sources.jar"
+              ],
+              "downloaded_file_path": "io/reactivex/rxjava3/rxjava/3.1.6/rxjava-3.1.6-sources.jar"
+            }
+          },
+          "com_google_api_grpc_grpc_google_cloud_storage_v2_2_22_3_alpha": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_api_grpc_grpc_google_cloud_storage_v2_2_22_3_alpha",
+              "sha256": "c62c1c54e44d9e4622bd6f7f1285f8456efd50880c1e6d107f5e6680033138d0",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/api/grpc/grpc-google-cloud-storage-v2/2.22.3-alpha/grpc-google-cloud-storage-v2-2.22.3-alpha.jar",
+                "https://maven.google.com/com/google/api/grpc/grpc-google-cloud-storage-v2/2.22.3-alpha/grpc-google-cloud-storage-v2-2.22.3-alpha.jar"
+              ],
+              "downloaded_file_path": "com/google/api/grpc/grpc-google-cloud-storage-v2/2.22.3-alpha/grpc-google-cloud-storage-v2-2.22.3-alpha.jar"
+            }
+          },
+          "com_github_jnr_jnr_posix_jar_sources_3_1_17": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_jnr_jnr_posix_jar_sources_3_1_17",
+              "sha256": "91c102c59c1d775adbd65353f5a795c4f48f6a8546a1845c679100fd5336db23",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/github/jnr/jnr-posix/3.1.17/jnr-posix-3.1.17-sources.jar"
+              ],
+              "downloaded_file_path": "com/github/jnr/jnr-posix/3.1.17/jnr-posix-3.1.17-sources.jar"
+            }
+          },
+          "com_google_protobuf_protobuf_java_util_jar_sources_3_22_3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_protobuf_protobuf_java_util_jar_sources_3_22_3",
+              "sha256": "5bb8af97af2131a2594c836baf3aadc0fd9640bdcf386c99bab901f6065e518f",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java-util/3.22.3/protobuf-java-util-3.22.3-sources.jar"
+              ],
+              "downloaded_file_path": "com/google/protobuf/protobuf-java-util/3.22.3/protobuf-java-util-3.22.3-sources.jar"
+            }
+          },
+          "org_glassfish_hk2_hk2_api_2_6_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_glassfish_hk2_hk2_api_2_6_1",
+              "sha256": "c2cb80a01e58440ae57d5ee59af4d4d94e5180e04aff112b0cb611c07d61e773",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/glassfish/hk2/hk2-api/2.6.1/hk2-api-2.6.1.jar"
+              ],
+              "downloaded_file_path": "org/glassfish/hk2/hk2-api/2.6.1/hk2-api-2.6.1.jar"
+            }
+          },
+          "com_fasterxml_jackson_module_jackson_module_jaxb_annotations_2_10_3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_fasterxml_jackson_module_jackson_module_jaxb_annotations_2_10_3",
+              "sha256": "8099caad4ae189525ef94d337d72d3e888abefabbbacbc9f3d2f096d534f2fb5",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/fasterxml/jackson/module/jackson-module-jaxb-annotations/2.10.3/jackson-module-jaxb-annotations-2.10.3.jar"
+              ],
+              "downloaded_file_path": "com/fasterxml/jackson/module/jackson-module-jaxb-annotations/2.10.3/jackson-module-jaxb-annotations-2.10.3.jar"
+            }
+          },
+          "org_apache_httpcomponents_httpclient_jar_sources_4_5_13": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_apache_httpcomponents_httpclient_jar_sources_4_5_13",
+              "sha256": "b1e9194fd83ce135831e28346731d9644cb2a08dea37ada2aa56ceb8f1b0c566",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/apache/httpcomponents/httpclient/4.5.13/httpclient-4.5.13-sources.jar"
+              ],
+              "downloaded_file_path": "org/apache/httpcomponents/httpclient/4.5.13/httpclient-4.5.13-sources.jar"
+            }
+          },
+          "com_google_api_grpc_proto_google_iam_v1_1_14_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_api_grpc_proto_google_iam_v1_1_14_1",
+              "sha256": "65929519b53c68a1fba00091e34e441e11ee532bbe3790873f2b9e26f81cf98a",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-iam-v1/1.14.1/proto-google-iam-v1-1.14.1.jar",
+                "https://maven.google.com/com/google/api/grpc/proto-google-iam-v1/1.14.1/proto-google-iam-v1-1.14.1.jar"
+              ],
+              "downloaded_file_path": "com/google/api/grpc/proto-google-iam-v1/1.14.1/proto-google-iam-v1-1.14.1.jar"
+            }
+          },
+          "software_amazon_awssdk_netty_nio_client_2_20_78": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~software_amazon_awssdk_netty_nio_client_2_20_78",
+              "sha256": "56999d51ff6b3efdb5b09241a126a466c96f3d93f629e94b2db5634da2b6c659",
+              "urls": [
+                "https://repo1.maven.org/maven2/software/amazon/awssdk/netty-nio-client/2.20.78/netty-nio-client-2.20.78.jar",
+                "https://maven.google.com/software/amazon/awssdk/netty-nio-client/2.20.78/netty-nio-client-2.20.78.jar"
+              ],
+              "downloaded_file_path": "software/amazon/awssdk/netty-nio-client/2.20.78/netty-nio-client-2.20.78.jar"
+            }
+          },
+          "com_esotericsoftware_kryo_jar_sources_5_5_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_esotericsoftware_kryo_jar_sources_5_5_0",
+              "sha256": "a7fe17d9e5c3f18ba2070b1356aeafc3f1626e8ebb6161a70d84c2f17adcd072",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/esotericsoftware/kryo/5.5.0/kryo-5.5.0-sources.jar"
+              ],
+              "downloaded_file_path": "com/esotericsoftware/kryo/5.5.0/kryo-5.5.0-sources.jar"
+            }
+          },
+          "org_mockito_mockito_core": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_mockito_mockito_core",
+              "generating_repository": "maven",
+              "target_name": "org_mockito_mockito_core"
+            }
+          },
+          "io_grpc_grpc_context_1_55_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_grpc_grpc_context_1_55_1",
+              "sha256": "541ec1d7ad3389f0b302461432a44b16fc1329153cd0e16faf2d2028b446340d",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/grpc/grpc-context/1.55.1/grpc-context-1.55.1.jar",
+                "https://maven.google.com/io/grpc/grpc-context/1.55.1/grpc-context-1.55.1.jar"
+              ],
+              "downloaded_file_path": "io/grpc/grpc-context/1.55.1/grpc-context-1.55.1.jar"
+            }
+          },
+          "com_google_jimfs_jimfs_1_3_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_jimfs_jimfs_1_3_0",
+              "sha256": "82494408bb513f5512652e7b7f63d6f31f01eff57ce35c878644ffc2d25aee4f",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/jimfs/jimfs/1.3.0/jimfs-1.3.0.jar"
+              ],
+              "downloaded_file_path": "com/google/jimfs/jimfs/1.3.0/jimfs-1.3.0.jar"
+            }
+          },
+          "org_ow2_asm_asm_analysis_9_2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_ow2_asm_asm_analysis_9_2",
+              "sha256": "878fbe521731c072d14d2d65b983b1beae6ad06fda0007b6a8bae81f73f433c4",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/ow2/asm/asm-analysis/9.2/asm-analysis-9.2.jar"
+              ],
+              "downloaded_file_path": "org/ow2/asm/asm-analysis/9.2/asm-analysis-9.2.jar"
+            }
+          },
+          "com_esotericsoftware_reflectasm_jar_sources_1_11_9": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_esotericsoftware_reflectasm_jar_sources_1_11_9",
+              "sha256": "8fc29f5069a1a43c38eb28b54f6850995734f31962813b13ac8a9b7a0624b45b",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/esotericsoftware/reflectasm/1.11.9/reflectasm-1.11.9-sources.jar"
+              ],
+              "downloaded_file_path": "com/esotericsoftware/reflectasm/1.11.9/reflectasm-1.11.9-sources.jar"
+            }
+          },
+          "net_bytebuddy_byte_buddy_agent_jar_sources_1_9_7": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~net_bytebuddy_byte_buddy_agent_jar_sources_1_9_7",
+              "sha256": "f1ffcb60fb0cb3de2ab4ba36b3588f9c0f12b24e8eeb59f76c57664f42eaae80",
+              "urls": [
+                "https://repo1.maven.org/maven2/net/bytebuddy/byte-buddy-agent/1.9.7/byte-buddy-agent-1.9.7-sources.jar"
+              ],
+              "downloaded_file_path": "net/bytebuddy/byte-buddy-agent/1.9.7/byte-buddy-agent-1.9.7-sources.jar"
+            }
+          },
+          "org_mockito_mockito_core_2_25_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_mockito_mockito_core_2_25_0",
+              "sha256": "28028d70cc27d61442948fcb3d249d9df5b37c47aa0b82490a3d049094ff411f",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/mockito/mockito-core/2.25.0/mockito-core-2.25.0.jar"
+              ],
+              "downloaded_file_path": "org/mockito/mockito-core/2.25.0/mockito-core-2.25.0.jar"
+            }
+          },
+          "com_google_auth_google_auth_library_oauth2_http_1_17_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_auth_google_auth_library_oauth2_http_1_17_0",
+              "sha256": "b8148e1af0c4197aea707d0166b4ed70a75b8eee7246be7eb0228a4834095e70",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/auth/google-auth-library-oauth2-http/1.17.0/google-auth-library-oauth2-http-1.17.0.jar",
+                "https://maven.google.com/com/google/auth/google-auth-library-oauth2-http/1.17.0/google-auth-library-oauth2-http-1.17.0.jar"
+              ],
+              "downloaded_file_path": "com/google/auth/google-auth-library-oauth2-http/1.17.0/google-auth-library-oauth2-http-1.17.0.jar"
+            }
+          },
+          "io_netty_netty_buffer": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_buffer",
+              "generating_repository": "maven",
+              "target_name": "io_netty_netty_buffer"
+            }
+          },
+          "com_amazonaws_jmespath_java_1_12_544": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_amazonaws_jmespath_java_1_12_544",
+              "sha256": "b707d67e8fcc87ffdf426bbe61bbe60ae97e865d35d6cec429a934d47fa2976c",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/amazonaws/jmespath-java/1.12.544/jmespath-java-1.12.544.jar"
+              ],
+              "downloaded_file_path": "com/amazonaws/jmespath-java/1.12.544/jmespath-java-1.12.544.jar"
+            }
+          },
+          "com_google_errorprone_error_prone_check_api_jar_sources_2_22_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_errorprone_error_prone_check_api_jar_sources_2_22_0",
+              "sha256": "962656ccdd75e0f9891f5fbc5c53ea1ea381234eaadee50d3d04bafc094f0190",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/errorprone/error_prone_check_api/2.22.0/error_prone_check_api-2.22.0-sources.jar"
+              ],
+              "downloaded_file_path": "com/google/errorprone/error_prone_check_api/2.22.0/error_prone_check_api-2.22.0-sources.jar"
+            }
+          },
+          "org_glassfish_hk2_osgi_resource_locator_jar_sources_1_0_3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_glassfish_hk2_osgi_resource_locator_jar_sources_1_0_3",
+              "sha256": "603d0e07134189505c76a8c8d5d4451a91bf1327a05f1f5bcea09bad61bd507e",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/glassfish/hk2/osgi-resource-locator/1.0.3/osgi-resource-locator-1.0.3-sources.jar"
+              ],
+              "downloaded_file_path": "org/glassfish/hk2/osgi-resource-locator/1.0.3/osgi-resource-locator-1.0.3-sources.jar"
+            }
+          },
+          "io_opencensus_opencensus_contrib_http_util_jar_sources_0_31_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_opencensus_opencensus_contrib_http_util_jar_sources_0_31_1",
+              "sha256": "d55afd5f96dc724bd903a77a38b0a344d0e59f02a64b9ab2f32618bc582ea924",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/opencensus/opencensus-contrib-http-util/0.31.1/opencensus-contrib-http-util-0.31.1-sources.jar"
+              ],
+              "downloaded_file_path": "io/opencensus/opencensus-contrib-http-util/0.31.1/opencensus-contrib-http-util-0.31.1-sources.jar"
+            }
+          },
+          "io_grpc_grpc_testing_jar_sources_1_56_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_grpc_grpc_testing_jar_sources_1_56_1",
+              "sha256": "0e1ee432e6ec26940bce1726d47344772ba2afd60af93750d0fad54596c936ee",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/grpc/grpc-testing/1.56.1/grpc-testing-1.56.1-sources.jar"
+              ],
+              "downloaded_file_path": "io/grpc/grpc-testing/1.56.1/grpc-testing-1.56.1-sources.jar"
+            }
+          },
+          "io_prometheus_simpleclient_tracer_otel_0_15_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_prometheus_simpleclient_tracer_otel_0_15_0",
+              "sha256": "0595251da49aa7997777b365ffdf97f5e2e88cd7f0dacf49add91b4fc8222b50",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/prometheus/simpleclient_tracer_otel/0.15.0/simpleclient_tracer_otel-0.15.0.jar"
+              ],
+              "downloaded_file_path": "io/prometheus/simpleclient_tracer_otel/0.15.0/simpleclient_tracer_otel-0.15.0.jar"
+            }
+          },
+          "org_apache_httpcomponents_httpclient_4_5_13": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_apache_httpcomponents_httpclient_4_5_13",
+              "sha256": "6fe9026a566c6a5001608cf3fc32196641f6c1e5e1986d1037ccdbd5f31ef743",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/apache/httpcomponents/httpclient/4.5.13/httpclient-4.5.13.jar"
+              ],
+              "downloaded_file_path": "org/apache/httpcomponents/httpclient/4.5.13/httpclient-4.5.13.jar"
+            }
+          },
+          "org_apache_httpcomponents_httpclient_4_5_14": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_apache_httpcomponents_httpclient_4_5_14",
+              "sha256": "c8bc7e1c51a6d4ce72f40d2ebbabf1c4b68bfe76e732104b04381b493478e9d6",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/apache/httpcomponents/httpclient/4.5.14/httpclient-4.5.14.jar",
+                "https://maven.google.com/org/apache/httpcomponents/httpclient/4.5.14/httpclient-4.5.14.jar"
+              ],
+              "downloaded_file_path": "org/apache/httpcomponents/httpclient/4.5.14/httpclient-4.5.14.jar"
+            }
+          },
+          "com_google_guava_guava_jar_sources_32_1_1_jre": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_guava_guava_jar_sources_32_1_1_jre",
+              "sha256": "5e7b6cebd2e9087a536c1054bf52a2e6a49c284772421f146640cfadc54ba573",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/guava/guava/32.1.1-jre/guava-32.1.1-jre-sources.jar"
+              ],
+              "downloaded_file_path": "com/google/guava/guava/32.1.1-jre/guava-32.1.1-jre-sources.jar"
+            }
+          },
+          "com_github_docker_java_docker_java_api_3_3_3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_docker_java_docker_java_api_3_3_3",
+              "sha256": "8be2f41ddc33306b83f91e413fc1a07cee02db05e4c493456de3399e5bcb7b6c",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/github/docker-java/docker-java-api/3.3.3/docker-java-api-3.3.3.jar"
+              ],
+              "downloaded_file_path": "com/github/docker-java/docker-java-api/3.3.3/docker-java-api-3.3.3.jar"
+            }
+          },
+          "io_grpc_grpc_core_1_56_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_grpc_grpc_core_1_56_1",
+              "sha256": "fddeafc25019b7e5600028d6398e9ed7383056d9aecaf95aec5c39c5085a4830",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/grpc/grpc-core/1.56.1/grpc-core-1.56.1.jar"
+              ],
+              "downloaded_file_path": "io/grpc/grpc-core/1.56.1/grpc-core-1.56.1.jar"
+            }
+          },
+          "com_kohlschutter_junixsocket_junixsocket_native_common_2_6_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_kohlschutter_junixsocket_junixsocket_native_common_2_6_1",
+              "sha256": "61fbbd6cfd2b6df65c0e7b19b16ff4f755d6cb1d333b566f4286407f12f18670",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/kohlschutter/junixsocket/junixsocket-native-common/2.6.1/junixsocket-native-common-2.6.1.jar"
+              ],
+              "downloaded_file_path": "com/kohlschutter/junixsocket/junixsocket-native-common/2.6.1/junixsocket-native-common-2.6.1.jar"
+            }
+          },
+          "com_google_cloud_google_cloud_storage_2_22_3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_cloud_google_cloud_storage_2_22_3",
+              "sha256": "a9b6e2cf02c37dd3a09ca4b2a091fd07eb5487b95995691df898ec223bdad5ab",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/cloud/google-cloud-storage/2.22.3/google-cloud-storage-2.22.3.jar",
+                "https://maven.google.com/com/google/cloud/google-cloud-storage/2.22.3/google-cloud-storage-2.22.3.jar"
+              ],
+              "downloaded_file_path": "com/google/cloud/google-cloud-storage/2.22.3/google-cloud-storage-2.22.3.jar"
+            }
+          },
+          "io_prometheus_simpleclient_hotspot_jar_sources_0_15_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_prometheus_simpleclient_hotspot_jar_sources_0_15_0",
+              "sha256": "352f4a0940814a22691132e6b7abcea4add6a8ce322b22a88be5494064036437",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/prometheus/simpleclient_hotspot/0.15.0/simpleclient_hotspot-0.15.0-sources.jar"
+              ],
+              "downloaded_file_path": "io/prometheus/simpleclient_hotspot/0.15.0/simpleclient_hotspot-0.15.0-sources.jar"
+            }
+          },
+          "jakarta_xml_bind_jakarta_xml_bind_api_2_3_2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~jakarta_xml_bind_jakarta_xml_bind_api_2_3_2",
+              "sha256": "69156304079bdeed9fc0ae3b39389f19b3cc4ba4443bc80508995394ead742ea",
+              "urls": [
+                "https://repo1.maven.org/maven2/jakarta/xml/bind/jakarta.xml.bind-api/2.3.2/jakarta.xml.bind-api-2.3.2.jar"
+              ],
+              "downloaded_file_path": "jakarta/xml/bind/jakarta.xml.bind-api/2.3.2/jakarta.xml.bind-api-2.3.2.jar"
+            }
+          },
+          "com_google_errorprone_error_prone_annotation_jar_sources_2_22_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_errorprone_error_prone_annotation_jar_sources_2_22_0",
+              "sha256": "45507d9cb6e18174656fd09f5a34033700ba75562bfcb188ec1706da10c10157",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/errorprone/error_prone_annotation/2.22.0/error_prone_annotation-2.22.0-sources.jar"
+              ],
+              "downloaded_file_path": "com/google/errorprone/error_prone_annotation/2.22.0/error_prone_annotation-2.22.0-sources.jar"
+            }
+          },
+          "org_pcollections_pcollections_3_1_4": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_pcollections_pcollections_3_1_4",
+              "sha256": "34f579ba075c8da2c8a0fedd0f04e21eac2fb6c660d90d0fabb573e8b4dc6918",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/pcollections/pcollections/3.1.4/pcollections-3.1.4.jar"
+              ],
+              "downloaded_file_path": "org/pcollections/pcollections/3.1.4/pcollections-3.1.4.jar"
+            }
+          },
+          "io_grpc_grpc_context": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_grpc_grpc_context",
+              "generating_repository": "maven",
+              "target_name": "io_grpc_grpc_context"
+            }
+          },
+          "javax_cache_cache_api_1_1_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~javax_cache_cache_api_1_1_1",
+              "sha256": "9f34e007edfa82a7b2a2e1b969477dcf5099ce7f4f926fb54ce7e27c4a0cd54b",
+              "urls": [
+                "https://repo1.maven.org/maven2/javax/cache/cache-api/1.1.1/cache-api-1.1.1.jar"
+              ],
+              "downloaded_file_path": "javax/cache/cache-api/1.1.1/cache-api-1.1.1.jar"
+            }
+          },
+          "org_ow2_asm_asm_util_jar_sources_9_2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_ow2_asm_asm_util_jar_sources_9_2",
+              "sha256": "b631d4561a24e84eaeee2c0495added214e4961ed328b02300f7d9b1f407c853",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/ow2/asm/asm-util/9.2/asm-util-9.2-sources.jar"
+              ],
+              "downloaded_file_path": "org/ow2/asm/asm-util/9.2/asm-util-9.2-sources.jar"
+            }
+          },
+          "com_google_auth_google_auth_library_credentials_jar_sources_1_19_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_auth_google_auth_library_credentials_jar_sources_1_19_0",
+              "sha256": "f83533db6683adaf971f98dad16d74e8ac34909e5085b720e3c45542a3f1552c",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/auth/google-auth-library-credentials/1.19.0/google-auth-library-credentials-1.19.0-sources.jar"
+              ],
+              "downloaded_file_path": "com/google/auth/google-auth-library-credentials/1.19.0/google-auth-library-credentials-1.19.0-sources.jar"
+            }
+          },
+          "io_netty_netty_transport_classes_epoll_4_1_97_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_transport_classes_epoll_4_1_97_Final",
+              "sha256": "ee65fa17fe65f18fd22269f92bddad85bfb3a263cf65eba01e116a2f30b86ff5",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/netty/netty-transport-classes-epoll/4.1.97.Final/netty-transport-classes-epoll-4.1.97.Final.jar"
+              ],
+              "downloaded_file_path": "io/netty/netty-transport-classes-epoll/4.1.97.Final/netty-transport-classes-epoll-4.1.97.Final.jar"
+            }
+          },
+          "org_ow2_asm_asm_analysis_jar_sources_9_2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_ow2_asm_asm_analysis_jar_sources_9_2",
+              "sha256": "c5a6764bbcee9e4bcd8ee1ea33808f96b8b587371f329aa75a2f541f2ee1b0d5",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/ow2/asm/asm-analysis/9.2/asm-analysis-9.2-sources.jar"
+              ],
+              "downloaded_file_path": "org/ow2/asm/asm-analysis/9.2/asm-analysis-9.2-sources.jar"
+            }
+          },
+          "com_google_code_findbugs_jsr305": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_code_findbugs_jsr305",
+              "generating_repository": "maven",
+              "target_name": "com_google_code_findbugs_jsr305"
+            }
+          },
+          "com_amazonaws_aws_java_sdk_secretsmanager_jar_sources_1_12_544": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_amazonaws_aws_java_sdk_secretsmanager_jar_sources_1_12_544",
+              "sha256": "d264b64ad371a864f8ba3a0af6876abb8f4ab3fe293812bab84a24e27d0b0982",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-secretsmanager/1.12.544/aws-java-sdk-secretsmanager-1.12.544-sources.jar"
+              ],
+              "downloaded_file_path": "com/amazonaws/aws-java-sdk-secretsmanager/1.12.544/aws-java-sdk-secretsmanager-1.12.544-sources.jar"
+            }
+          },
+          "com_google_auth_google_auth_library_oauth2_http_jar_sources_1_19_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_auth_google_auth_library_oauth2_http_jar_sources_1_19_0",
+              "sha256": "3aabf134e1c21fb8b3573897f0aa9136ca58ebe0c76fb086ef9169b28e9f707e",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/auth/google-auth-library-oauth2-http/1.19.0/google-auth-library-oauth2-http-1.19.0-sources.jar"
+              ],
+              "downloaded_file_path": "com/google/auth/google-auth-library-oauth2-http/1.19.0/google-auth-library-oauth2-http-1.19.0-sources.jar"
+            }
+          },
+          "io_netty_netty_transport": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_transport",
+              "generating_repository": "maven",
+              "target_name": "io_netty_netty_transport"
+            }
+          },
+          "commons_logging_commons_logging_1_2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~commons_logging_commons_logging_1_2",
+              "sha256": "daddea1ea0be0f56978ab3006b8ac92834afeefbd9b7e4e6316fca57df0fa636",
+              "urls": [
+                "https://repo1.maven.org/maven2/commons-logging/commons-logging/1.2/commons-logging-1.2.jar"
+              ],
+              "downloaded_file_path": "commons-logging/commons-logging/1.2/commons-logging-1.2.jar"
+            }
+          },
+          "jakarta_ws_rs_jakarta_ws_rs_api_2_1_6": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~jakarta_ws_rs_jakarta_ws_rs_api_2_1_6",
+              "sha256": "4cea299c846c8a6e6470cbfc2f7c391bc29b9caa2f9264ac1064ba91691f4adf",
+              "urls": [
+                "https://repo1.maven.org/maven2/jakarta/ws/rs/jakarta.ws.rs-api/2.1.6/jakarta.ws.rs-api-2.1.6.jar"
+              ],
+              "downloaded_file_path": "jakarta/ws/rs/jakarta.ws.rs-api/2.1.6/jakarta.ws.rs-api-2.1.6.jar"
+            }
+          },
+          "com_github_jnr_jffi": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_jnr_jffi",
+              "generating_repository": "maven",
+              "target_name": "com_github_jnr_jffi"
+            }
+          },
+          "com_googlecode_json_simple_json_simple_jar_sources_1_1_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_googlecode_json_simple_json_simple_jar_sources_1_1_1",
+              "sha256": "26960e02aeb64dc06ada259495ad2a553dd53ded9aaf6a84c3f5974a56ce24d6",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/googlecode/json-simple/json-simple/1.1.1/json-simple-1.1.1-sources.jar"
+              ],
+              "downloaded_file_path": "com/googlecode/json-simple/json-simple/1.1.1/json-simple-1.1.1-sources.jar"
+            }
+          },
+          "com_google_api_gax_2_28_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_api_gax_2_28_1",
+              "sha256": "dddd191a2621bc5a747800c417005618f9c1f03d3d5056cb0208905400f17fac",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/api/gax/2.28.1/gax-2.28.1.jar",
+                "https://maven.google.com/com/google/api/gax/2.28.1/gax-2.28.1.jar"
+              ],
+              "downloaded_file_path": "com/google/api/gax/2.28.1/gax-2.28.1.jar"
+            }
+          },
+          "com_github_docker_java_docker_java_transport_jar_sources_3_3_3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_docker_java_docker_java_transport_jar_sources_3_3_3",
+              "sha256": "0ec44c8b9349365c3dd2740ad41f9e65af079fd9a68bfc68a2d3efe5776ff687",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/github/docker-java/docker-java-transport/3.3.3/docker-java-transport-3.3.3-sources.jar"
+              ],
+              "downloaded_file_path": "com/github/docker-java/docker-java-transport/3.3.3/docker-java-transport-3.3.3-sources.jar"
+            }
+          },
+          "software_amazon_awssdk_metrics_spi_2_20_78": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~software_amazon_awssdk_metrics_spi_2_20_78",
+              "sha256": "41680096cb566090be0504eaf207dab91d680c16d57f68239260860871d7ab8f",
+              "urls": [
+                "https://repo1.maven.org/maven2/software/amazon/awssdk/metrics-spi/2.20.78/metrics-spi-2.20.78.jar",
+                "https://maven.google.com/software/amazon/awssdk/metrics-spi/2.20.78/metrics-spi-2.20.78.jar"
+              ],
+              "downloaded_file_path": "software/amazon/awssdk/metrics-spi/2.20.78/metrics-spi-2.20.78.jar"
+            }
+          },
+          "org_conscrypt_conscrypt_openjdk_uber_2_5_2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_conscrypt_conscrypt_openjdk_uber_2_5_2",
+              "sha256": "eaf537d98e033d0f0451cd1b8cc74e02d7b55ec882da63c88060d806ba89c348",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/conscrypt/conscrypt-openjdk-uber/2.5.2/conscrypt-openjdk-uber-2.5.2.jar",
+                "https://maven.google.com/org/conscrypt/conscrypt-openjdk-uber/2.5.2/conscrypt-openjdk-uber-2.5.2.jar"
+              ],
+              "downloaded_file_path": "org/conscrypt/conscrypt-openjdk-uber/2.5.2/conscrypt-openjdk-uber-2.5.2.jar"
+            }
+          },
+          "com_github_ben_manes_caffeine_caffeine_jar_sources_3_0_5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_ben_manes_caffeine_caffeine_jar_sources_3_0_5",
+              "sha256": "2cca8d1cdfdf33c1d0eec0214cdc6d93ff8a95136bf798465b10a5924a69bc65",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/github/ben-manes/caffeine/caffeine/3.0.5/caffeine-3.0.5-sources.jar"
+              ],
+              "downloaded_file_path": "com/github/ben-manes/caffeine/caffeine/3.0.5/caffeine-3.0.5-sources.jar"
+            }
+          },
+          "com_github_docker_java_docker_java_api_jar_sources_3_3_3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_docker_java_docker_java_api_jar_sources_3_3_3",
+              "sha256": "cb262504c43a1ed7f79235a9f93611c322016bd6ca91a0ab37cfe21a55460a8b",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/github/docker-java/docker-java-api/3.3.3/docker-java-api-3.3.3-sources.jar"
+              ],
+              "downloaded_file_path": "com/github/docker-java/docker-java-api/3.3.3/docker-java-api-3.3.3-sources.jar"
+            }
+          },
+          "org_checkerframework_checker_qual": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_checkerframework_checker_qual",
+              "generating_repository": "maven",
+              "target_name": "org_checkerframework_checker_qual"
+            }
+          },
+          "org_glassfish_hk2_hk2_api_jar_sources_2_6_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_glassfish_hk2_hk2_api_jar_sources_2_6_1",
+              "sha256": "636e56f6454a7c680271dd8e2e49d1fd50625bb9e206555a14ccf900188cc18c",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/glassfish/hk2/hk2-api/2.6.1/hk2-api-2.6.1-sources.jar"
+              ],
+              "downloaded_file_path": "org/glassfish/hk2/hk2-api/2.6.1/hk2-api-2.6.1-sources.jar"
+            }
+          },
+          "io_grpc_grpc_netty_jar_sources_1_56_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_grpc_grpc_netty_jar_sources_1_56_1",
+              "sha256": "3ce30acc50ab39f160948bae09c1c832093d6b23a533a20d1473466ca30a3783",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/grpc/grpc-netty/1.56.1/grpc-netty-1.56.1-sources.jar"
+              ],
+              "downloaded_file_path": "io/grpc/grpc-netty/1.56.1/grpc-netty-1.56.1-sources.jar"
+            }
+          },
+          "junit_junit_jar_sources_4_13_2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~junit_junit_jar_sources_4_13_2",
+              "sha256": "34181df6482d40ea4c046b063cb53c7ffae94bdf1b1d62695bdf3adf9dea7e3a",
+              "urls": [
+                "https://repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2-sources.jar"
+              ],
+              "downloaded_file_path": "junit/junit/4.13.2/junit-4.13.2-sources.jar"
+            }
+          },
+          "org_ow2_asm_asm_commons_9_2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_ow2_asm_asm_commons_9_2",
+              "sha256": "be4ce53138a238bb522cd781cf91f3ba5ce2f6ca93ec62d46a162a127225e0a6",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/ow2/asm/asm-commons/9.2/asm-commons-9.2.jar"
+              ],
+              "downloaded_file_path": "org/ow2/asm/asm-commons/9.2/asm-commons-9.2.jar"
+            }
+          },
+          "com_google_protobuf_protobuf_java_3_23_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_protobuf_protobuf_java_3_23_1",
+              "sha256": "d9fd335a65165c760f53ae718878448627ce742ab6e9102dffe9bc2ea7b136ca",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.23.1/protobuf-java-3.23.1.jar",
+                "https://maven.google.com/com/google/protobuf/protobuf-java/3.23.1/protobuf-java-3.23.1.jar"
+              ],
+              "downloaded_file_path": "com/google/protobuf/protobuf-java/3.23.1/protobuf-java-3.23.1.jar"
+            }
+          },
+          "org_luaj_luaj_jse_3_0_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_luaj_luaj_jse_3_0_1",
+              "sha256": "9b1f0a3e8f68427c6d74c2bf00ae0e6dbfce35994d3001fed4cef6ecda50be55",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/luaj/luaj-jse/3.0.1/luaj-jse-3.0.1.jar"
+              ],
+              "downloaded_file_path": "org/luaj/luaj-jse/3.0.1/luaj-jse-3.0.1.jar"
+            }
+          },
+          "org_glassfish_hk2_hk2_locator_jar_sources_2_6_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_glassfish_hk2_hk2_locator_jar_sources_2_6_1",
+              "sha256": "d76811aeabe487e35001fb4a0ab3d986a091c331f4d61962c33f6c98f94e5053",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/glassfish/hk2/hk2-locator/2.6.1/hk2-locator-2.6.1-sources.jar"
+              ],
+              "downloaded_file_path": "org/glassfish/hk2/hk2-locator/2.6.1/hk2-locator-2.6.1-sources.jar"
+            }
+          },
+          "org_reflections_reflections_jar_sources_0_10_2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_reflections_reflections_jar_sources_0_10_2",
+              "sha256": "7c8f0b91e298556ac8eebcbbb33de537baa146d80a7e5a6500e44cd8f76a91f4",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/reflections/reflections/0.10.2/reflections-0.10.2-sources.jar"
+              ],
+              "downloaded_file_path": "org/reflections/reflections/0.10.2/reflections-0.10.2-sources.jar"
+            }
+          },
+          "org_apache_commons_commons_pool2": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_apache_commons_commons_pool2",
+              "generating_repository": "maven",
+              "target_name": "org_apache_commons_commons_pool2"
+            }
+          },
+          "io_github_java_diff_utils_java_diff_utils_4_12": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_github_java_diff_utils_java_diff_utils_4_12",
+              "sha256": "9990a2039778f6b4cc94790141c2868864eacee0620c6c459451121a901cd5b5",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/github/java-diff-utils/java-diff-utils/4.12/java-diff-utils-4.12.jar"
+              ],
+              "downloaded_file_path": "io/github/java-diff-utils/java-diff-utils/4.12/java-diff-utils-4.12.jar"
+            }
+          },
+          "maven": {
+            "bzlFile": "@@rules_jvm_external~5.3//:coursier.bzl",
+            "ruleClassName": "pinned_coursier_fetch",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~maven",
+              "repositories": [
+                "{ \"repo_url\": \"https://repo1.maven.org/maven2\" }"
+              ],
+              "artifacts": [
+                "{ \"group\": \"com.amazonaws\", \"artifact\": \"aws-java-sdk-s3\", \"version\": \"1.12.544\" }",
+                "{ \"group\": \"com.amazonaws\", \"artifact\": \"aws-java-sdk-secretsmanager\", \"version\": \"1.12.544\" }",
+                "{ \"group\": \"com.fasterxml.jackson.core\", \"artifact\": \"jackson-databind\", \"version\": \"2.15.0\" }",
+                "{ \"group\": \"com.github.ben-manes.caffeine\", \"artifact\": \"caffeine\", \"version\": \"2.9.0\" }",
+                "{ \"group\": \"com.github.docker-java\", \"artifact\": \"docker-java\", \"version\": \"3.3.3\" }",
+                "{ \"group\": \"com.github.fppt\", \"artifact\": \"jedis-mock\", \"version\": \"1.0.10\" }",
+                "{ \"group\": \"com.github.jnr\", \"artifact\": \"jffi\", \"version\": \"1.3.11\" }",
+                "{ \"group\": \"com.github.jnr\", \"artifact\": \"jffi\", \"version\": \"1.3.11\", \"packaging\": \"jar\", \"classifier\": \"native\" }",
+                "{ \"group\": \"com.github.jnr\", \"artifact\": \"jnr-constants\", \"version\": \"0.10.4\" }",
+                "{ \"group\": \"com.github.jnr\", \"artifact\": \"jnr-ffi\", \"version\": \"2.2.14\" }",
+                "{ \"group\": \"com.github.jnr\", \"artifact\": \"jnr-posix\", \"version\": \"3.1.17\" }",
+                "{ \"group\": \"com.github.pcj\", \"artifact\": \"google-options\", \"version\": \"1.0.0\" }",
+                "{ \"group\": \"com.github.serceman\", \"artifact\": \"jnr-fuse\", \"version\": \"0.5.7\" }",
+                "{ \"group\": \"com.github.luben\", \"artifact\": \"zstd-jni\", \"version\": \"1.5.5-7\" }",
+                "{ \"group\": \"com.github.oshi\", \"artifact\": \"oshi-core\", \"version\": \"6.4.5\" }",
+                "{ \"group\": \"com.google.auth\", \"artifact\": \"google-auth-library-credentials\", \"version\": \"1.19.0\" }",
+                "{ \"group\": \"com.google.auth\", \"artifact\": \"google-auth-library-oauth2-http\", \"version\": \"1.19.0\" }",
+                "{ \"group\": \"com.google.code.findbugs\", \"artifact\": \"jsr305\", \"version\": \"3.0.2\" }",
+                "{ \"group\": \"com.google.code.gson\", \"artifact\": \"gson\", \"version\": \"2.10.1\" }",
+                "{ \"group\": \"com.google.errorprone\", \"artifact\": \"error_prone_annotations\", \"version\": \"2.22.0\" }",
+                "{ \"group\": \"com.google.errorprone\", \"artifact\": \"error_prone_core\", \"version\": \"2.22.0\" }",
+                "{ \"group\": \"com.google.guava\", \"artifact\": \"failureaccess\", \"version\": \"1.0.1\" }",
+                "{ \"group\": \"com.google.guava\", \"artifact\": \"guava\", \"version\": \"32.1.1-jre\" }",
+                "{ \"group\": \"com.google.j2objc\", \"artifact\": \"j2objc-annotations\", \"version\": \"2.8\" }",
+                "{ \"group\": \"com.google.jimfs\", \"artifact\": \"jimfs\", \"version\": \"1.3.0\" }",
+                "{ \"group\": \"com.google.protobuf\", \"artifact\": \"protobuf-java-util\", \"version\": \"3.19.1\" }",
+                "{ \"group\": \"com.google.protobuf\", \"artifact\": \"protobuf-java\", \"version\": \"3.19.1\" }",
+                "{ \"group\": \"com.google.truth\", \"artifact\": \"truth\", \"version\": \"1.1.5\" }",
+                "{ \"group\": \"org.slf4j\", \"artifact\": \"slf4j-simple\", \"version\": \"2.0.9\" }",
+                "{ \"group\": \"com.googlecode.json-simple\", \"artifact\": \"json-simple\", \"version\": \"1.1.1\" }",
+                "{ \"group\": \"com.jayway.jsonpath\", \"artifact\": \"json-path\", \"version\": \"2.8.0\" }",
+                "{ \"group\": \"org.bouncycastle\", \"artifact\": \"bcprov-jdk15on\", \"version\": \"1.70\" }",
+                "{ \"group\": \"net.jcip\", \"artifact\": \"jcip-annotations\", \"version\": \"1.0\" }",
+                "{ \"group\": \"io.netty\", \"artifact\": \"netty-buffer\", \"version\": \"4.1.97.Final\" }",
+                "{ \"group\": \"io.netty\", \"artifact\": \"netty-codec\", \"version\": \"4.1.97.Final\" }",
+                "{ \"group\": \"io.netty\", \"artifact\": \"netty-codec-http\", \"version\": \"4.1.97.Final\" }",
+                "{ \"group\": \"io.netty\", \"artifact\": \"netty-codec-http2\", \"version\": \"4.1.97.Final\" }",
+                "{ \"group\": \"io.netty\", \"artifact\": \"netty-codec-socks\", \"version\": \"4.1.97.Final\" }",
+                "{ \"group\": \"io.netty\", \"artifact\": \"netty-common\", \"version\": \"4.1.97.Final\" }",
+                "{ \"group\": \"io.netty\", \"artifact\": \"netty-handler\", \"version\": \"4.1.97.Final\" }",
+                "{ \"group\": \"io.netty\", \"artifact\": \"netty-handler-proxy\", \"version\": \"4.1.97.Final\" }",
+                "{ \"group\": \"io.netty\", \"artifact\": \"netty-resolver\", \"version\": \"4.1.97.Final\" }",
+                "{ \"group\": \"io.netty\", \"artifact\": \"netty-transport\", \"version\": \"4.1.97.Final\" }",
+                "{ \"group\": \"io.netty\", \"artifact\": \"netty-transport-native-epoll\", \"version\": \"4.1.97.Final\" }",
+                "{ \"group\": \"io.netty\", \"artifact\": \"netty-transport-native-kqueue\", \"version\": \"4.1.97.Final\" }",
+                "{ \"group\": \"io.netty\", \"artifact\": \"netty-transport-native-unix-common\", \"version\": \"4.1.97.Final\" }",
+                "{ \"group\": \"io.grpc\", \"artifact\": \"grpc-api\", \"version\": \"1.56.1\" }",
+                "{ \"group\": \"io.grpc\", \"artifact\": \"grpc-auth\", \"version\": \"1.56.1\" }",
+                "{ \"group\": \"io.grpc\", \"artifact\": \"grpc-core\", \"version\": \"1.56.1\" }",
+                "{ \"group\": \"io.grpc\", \"artifact\": \"grpc-context\", \"version\": \"1.56.1\" }",
+                "{ \"group\": \"io.grpc\", \"artifact\": \"grpc-netty\", \"version\": \"1.56.1\" }",
+                "{ \"group\": \"io.grpc\", \"artifact\": \"grpc-stub\", \"version\": \"1.56.1\" }",
+                "{ \"group\": \"io.grpc\", \"artifact\": \"grpc-protobuf\", \"version\": \"1.56.1\" }",
+                "{ \"group\": \"io.grpc\", \"artifact\": \"grpc-testing\", \"version\": \"1.56.1\" }",
+                "{ \"group\": \"io.grpc\", \"artifact\": \"grpc-services\", \"version\": \"1.56.1\" }",
+                "{ \"group\": \"io.grpc\", \"artifact\": \"grpc-netty-shaded\", \"version\": \"1.56.1\" }",
+                "{ \"group\": \"io.prometheus\", \"artifact\": \"simpleclient\", \"version\": \"0.15.0\" }",
+                "{ \"group\": \"io.prometheus\", \"artifact\": \"simpleclient_hotspot\", \"version\": \"0.15.0\" }",
+                "{ \"group\": \"io.prometheus\", \"artifact\": \"simpleclient_httpserver\", \"version\": \"0.15.0\" }",
+                "{ \"group\": \"junit\", \"artifact\": \"junit\", \"version\": \"4.13.2\" }",
+                "{ \"group\": \"javax.annotation\", \"artifact\": \"javax.annotation-api\", \"version\": \"1.3.2\" }",
+                "{ \"group\": \"net.javacrumbs.future-converter\", \"artifact\": \"future-converter-java8-guava\", \"version\": \"1.2.0\" }",
+                "{ \"group\": \"org.apache.commons\", \"artifact\": \"commons-compress\", \"version\": \"1.23.0\" }",
+                "{ \"group\": \"org.apache.commons\", \"artifact\": \"commons-pool2\", \"version\": \"2.11.1\" }",
+                "{ \"group\": \"org.apache.commons\", \"artifact\": \"commons-lang3\", \"version\": \"3.13.0\" }",
+                "{ \"group\": \"commons-io\", \"artifact\": \"commons-io\", \"version\": \"2.13.0\" }",
+                "{ \"group\": \"me.dinowernli\", \"artifact\": \"java-grpc-prometheus\", \"version\": \"0.6.0\" }",
+                "{ \"group\": \"org.apache.tomcat\", \"artifact\": \"annotations-api\", \"version\": \"6.0.53\" }",
+                "{ \"group\": \"org.checkerframework\", \"artifact\": \"checker-qual\", \"version\": \"3.38.0\" }",
+                "{ \"group\": \"org.mockito\", \"artifact\": \"mockito-core\", \"version\": \"2.25.0\" }",
+                "{ \"group\": \"org.openjdk.jmh\", \"artifact\": \"jmh-core\", \"version\": \"1.37\" }",
+                "{ \"group\": \"org.openjdk.jmh\", \"artifact\": \"jmh-generator-annprocess\", \"version\": \"1.37\" }",
+                "{ \"group\": \"org.redisson\", \"artifact\": \"redisson\", \"version\": \"3.23.4\" }",
+                "{ \"group\": \"org.threeten\", \"artifact\": \"threetenbp\", \"version\": \"1.6.8\" }",
+                "{ \"group\": \"org.xerial\", \"artifact\": \"sqlite-jdbc\", \"version\": \"3.34.0\" }",
+                "{ \"group\": \"org.jetbrains\", \"artifact\": \"annotations\", \"version\": \"16.0.2\" }",
+                "{ \"group\": \"org.yaml\", \"artifact\": \"snakeyaml\", \"version\": \"2.2\" }",
+                "{ \"group\": \"org.projectlombok\", \"artifact\": \"lombok\", \"version\": \"1.18.30\" }"
+              ],
+              "fetch_sources": true,
+              "fetch_javadoc": false,
+              "generate_compat_repositories": false,
+              "maven_install_json": "@@//:maven_install.json",
+              "override_targets": {},
+              "strict_visibility": false,
+              "strict_visibility_value": [
+                "@@//visibility:private"
+              ],
+              "jetify": false,
+              "jetify_include_list": [
+                "*"
+              ],
+              "additional_netrc_lines": [],
+              "fail_if_repin_required": true,
+              "use_starlark_android_rules": false,
+              "aar_import_bzl_label": "@build_bazel_rules_android//android:rules.bzl",
+              "duplicate_version_warning": "warn"
+            }
+          },
+          "com_github_jnr_jnr_a64asm_1_0_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_jnr_jnr_a64asm_1_0_0",
+              "sha256": "53ae5ea7fa5c284e8279aa348e7b9de4548b0cae10bfd058fa217c791875e4cf",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/github/jnr/jnr-a64asm/1.0.0/jnr-a64asm-1.0.0.jar"
+              ],
+              "downloaded_file_path": "com/github/jnr/jnr-a64asm/1.0.0/jnr-a64asm-1.0.0.jar"
+            }
+          },
+          "io_grpc_grpc_protobuf_jar_sources_1_56_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_grpc_grpc_protobuf_jar_sources_1_56_1",
+              "sha256": "62b6675a187374f8f4ea8d645d602930b587383fbb0979fa19e708f885499934",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/grpc/grpc-protobuf/1.56.1/grpc-protobuf-1.56.1-sources.jar"
+              ],
+              "downloaded_file_path": "io/grpc/grpc-protobuf/1.56.1/grpc-protobuf-1.56.1-sources.jar"
+            }
+          },
+          "com_esotericsoftware_kryo_5_5_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_esotericsoftware_kryo_5_5_0",
+              "sha256": "4b902a21d99f7b4c32e6f7400e91f9284fd184db881bb9e18328e14d8127f7f9",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/esotericsoftware/kryo/5.5.0/kryo-5.5.0.jar"
+              ],
+              "downloaded_file_path": "com/esotericsoftware/kryo/5.5.0/kryo-5.5.0.jar"
+            }
+          },
+          "io_prometheus_simpleclient_httpserver": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_prometheus_simpleclient_httpserver",
+              "generating_repository": "maven",
+              "target_name": "io_prometheus_simpleclient_httpserver"
+            }
+          },
+          "io_prometheus_simpleclient_0_15_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_prometheus_simpleclient_0_15_0",
+              "sha256": "a43d6c00e3964a7063c1360ddcddc598df4f8e659a8313b27f90e4c555badb1d",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/prometheus/simpleclient/0.15.0/simpleclient-0.15.0.jar"
+              ],
+              "downloaded_file_path": "io/prometheus/simpleclient/0.15.0/simpleclient-0.15.0.jar"
+            }
+          },
+          "com_google_cloud_google_cloud_core_grpc_2_18_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_cloud_google_cloud_core_grpc_2_18_1",
+              "sha256": "3021f5ac856552155edfb459a1f4c0b0bf3c5363e6fa4923a82af3e531ff33ad",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/cloud/google-cloud-core-grpc/2.18.1/google-cloud-core-grpc-2.18.1.jar",
+                "https://maven.google.com/com/google/cloud/google-cloud-core-grpc/2.18.1/google-cloud-core-grpc-2.18.1.jar"
+              ],
+              "downloaded_file_path": "com/google/cloud/google-cloud-core-grpc/2.18.1/google-cloud-core-grpc-2.18.1.jar"
+            }
+          },
+          "jakarta_annotation_jakarta_annotation_api_1_3_5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~jakarta_annotation_jakarta_annotation_api_1_3_5",
+              "sha256": "85fb03fc054cdf4efca8efd9b6712bbb418e1ab98241c4539c8585bbc23e1b8a",
+              "urls": [
+                "https://repo1.maven.org/maven2/jakarta/annotation/jakarta.annotation-api/1.3.5/jakarta.annotation-api-1.3.5.jar"
+              ],
+              "downloaded_file_path": "jakarta/annotation/jakarta.annotation-api/1.3.5/jakarta.annotation-api-1.3.5.jar"
+            }
+          },
+          "org_bouncycastle_bcprov_jdk15on": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_bouncycastle_bcprov_jdk15on",
+              "generating_repository": "maven",
+              "target_name": "org_bouncycastle_bcprov_jdk15on"
+            }
+          },
+          "io_grpc_grpc_auth": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_grpc_grpc_auth",
+              "generating_repository": "maven",
+              "target_name": "io_grpc_grpc_auth"
+            }
+          },
+          "org_glassfish_hk2_external_aopalliance_repackaged_jar_sources_2_6_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_glassfish_hk2_external_aopalliance_repackaged_jar_sources_2_6_1",
+              "sha256": "13392e5ad2540a5718abb1dc7c380ebd754c1b95c7d6140dd38bfeade1e6dd21",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/glassfish/hk2/external/aopalliance-repackaged/2.6.1/aopalliance-repackaged-2.6.1-sources.jar"
+              ],
+              "downloaded_file_path": "org/glassfish/hk2/external/aopalliance-repackaged/2.6.1/aopalliance-repackaged-2.6.1-sources.jar"
+            }
+          },
+          "net_jcip_jcip_annotations_jar_sources_1_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~net_jcip_jcip_annotations_jar_sources_1_0",
+              "sha256": "e3ad6ae439e3cf8a25372de838efaa1a95f8ef9b5053d5d94fafe89c8c09814e",
+              "urls": [
+                "https://repo1.maven.org/maven2/net/jcip/jcip-annotations/1.0/jcip-annotations-1.0-sources.jar"
+              ],
+              "downloaded_file_path": "net/jcip/jcip-annotations/1.0/jcip-annotations-1.0-sources.jar"
+            }
+          },
+          "org_glassfish_jersey_core_jersey_common_jar_sources_2_30_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_glassfish_jersey_core_jersey_common_jar_sources_2_30_1",
+              "sha256": "bbc91b531c2aa801e578fc6737498159071f3030688714e44ed80001e17813f7",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/glassfish/jersey/core/jersey-common/2.30.1/jersey-common-2.30.1-sources.jar"
+              ],
+              "downloaded_file_path": "org/glassfish/jersey/core/jersey-common/2.30.1/jersey-common-2.30.1-sources.jar"
+            }
+          },
+          "org_yaml_snakeyaml_2_2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_yaml_snakeyaml_2_2",
+              "sha256": "1467931448a0817696ae2805b7b8b20bfb082652bf9c4efaed528930dc49389b",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/yaml/snakeyaml/2.2/snakeyaml-2.2.jar"
+              ],
+              "downloaded_file_path": "org/yaml/snakeyaml/2.2/snakeyaml-2.2.jar"
+            }
+          },
+          "org_glassfish_jersey_connectors_jersey_apache_connector_2_30_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_glassfish_jersey_connectors_jersey_apache_connector_2_30_1",
+              "sha256": "28e87f2edc5284e293072941cea5e8ff462bb60f41c67b4ad7b906de2a7a8bd8",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/glassfish/jersey/connectors/jersey-apache-connector/2.30.1/jersey-apache-connector-2.30.1.jar"
+              ],
+              "downloaded_file_path": "org/glassfish/jersey/connectors/jersey-apache-connector/2.30.1/jersey-apache-connector-2.30.1.jar"
+            }
+          },
+          "com_fasterxml_jackson_dataformat_jackson_dataformat_yaml_2_15_2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_fasterxml_jackson_dataformat_jackson_dataformat_yaml_2_15_2",
+              "sha256": "37795cc1e8cb94b18d860dc3abd2e593617ce402149ae45aa89ed8bfb881c851",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/fasterxml/jackson/dataformat/jackson-dataformat-yaml/2.15.2/jackson-dataformat-yaml-2.15.2.jar"
+              ],
+              "downloaded_file_path": "com/fasterxml/jackson/dataformat/jackson-dataformat-yaml/2.15.2/jackson-dataformat-yaml-2.15.2.jar"
+            }
+          },
+          "org_redisson_redisson": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_redisson_redisson",
+              "generating_repository": "maven",
+              "target_name": "org_redisson_redisson"
+            }
+          },
+          "org_glassfish_jersey_core_jersey_common_2_30_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_glassfish_jersey_core_jersey_common_2_30_1",
+              "sha256": "273c3ea4e3ff9b960eb8dbb7c74e0127436678e486ccd94a351729f22a249830",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/glassfish/jersey/core/jersey-common/2.30.1/jersey-common-2.30.1.jar"
+              ],
+              "downloaded_file_path": "org/glassfish/jersey/core/jersey-common/2.30.1/jersey-common-2.30.1.jar"
+            }
+          },
+          "org_xerial_sqlite_jdbc": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_xerial_sqlite_jdbc",
+              "generating_repository": "maven",
+              "target_name": "org_xerial_sqlite_jdbc"
+            }
+          },
+          "com_amazonaws_aws_java_sdk_kms_1_12_544": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_amazonaws_aws_java_sdk_kms_1_12_544",
+              "sha256": "a79a3768887ea675f2e7b617b361d5250b2128413dbd5d8fa43755a9ecc1b032",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-kms/1.12.544/aws-java-sdk-kms-1.12.544.jar"
+              ],
+              "downloaded_file_path": "com/amazonaws/aws-java-sdk-kms/1.12.544/aws-java-sdk-kms-1.12.544.jar"
+            }
+          },
+          "net_bytebuddy_byte_buddy_1_14_5": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~net_bytebuddy_byte_buddy_1_14_5",
+              "sha256": "e99761a526df0fefbbd3fe14436b0f953000cdfa5151dc63c0b18d37d9c46f1c",
+              "urls": [
+                "https://repo1.maven.org/maven2/net/bytebuddy/byte-buddy/1.14.5/byte-buddy-1.14.5.jar"
+              ],
+              "downloaded_file_path": "net/bytebuddy/byte-buddy/1.14.5/byte-buddy-1.14.5.jar"
+            }
+          },
+          "junit_junit": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~junit_junit",
+              "generating_repository": "maven",
+              "target_name": "junit_junit"
+            }
+          },
+          "com_google_auto_service_auto_service_annotations_jar_sources_1_0_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_auto_service_auto_service_annotations_jar_sources_1_0_1",
+              "sha256": "b013ca159b0fea3a0041d3d5fbb3b7e49a819da80a172a01fb17dd28fd98e72b",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/auto/service/auto-service-annotations/1.0.1/auto-service-annotations-1.0.1-sources.jar"
+              ],
+              "downloaded_file_path": "com/google/auto/service/auto-service-annotations/1.0.1/auto-service-annotations-1.0.1-sources.jar"
+            }
+          },
+          "com_fasterxml_jackson_jaxrs_jackson_jaxrs_base_jar_sources_2_10_3": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_fasterxml_jackson_jaxrs_jackson_jaxrs_base_jar_sources_2_10_3",
+              "sha256": "6b979c532efa4f68686d85779d7d1f6d4c3de1fa53fbe6996132812b813b1349",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/fasterxml/jackson/jaxrs/jackson-jaxrs-base/2.10.3/jackson-jaxrs-base-2.10.3-sources.jar"
+              ],
+              "downloaded_file_path": "com/fasterxml/jackson/jaxrs/jackson-jaxrs-base/2.10.3/jackson-jaxrs-base-2.10.3-sources.jar"
+            }
+          },
+          "org_apache_commons_commons_pool2_2_11_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_apache_commons_commons_pool2_2_11_1",
+              "sha256": "ea0505ee7515e58b1ac0e686e4d1a5d9f7d808e251a61bc371aa0595b9963f83",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/apache/commons/commons-pool2/2.11.1/commons-pool2-2.11.1.jar"
+              ],
+              "downloaded_file_path": "org/apache/commons/commons-pool2/2.11.1/commons-pool2-2.11.1.jar"
+            }
+          },
+          "com_google_errorprone_error_prone_annotations_2_22_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_errorprone_error_prone_annotations_2_22_0",
+              "sha256": "82a027b86541f58d1f9ee020cdf6bebe82acc7a267d3c53a2ea5cd6335932bbd",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/errorprone/error_prone_annotations/2.22.0/error_prone_annotations-2.22.0.jar"
+              ],
+              "downloaded_file_path": "com/google/errorprone/error_prone_annotations/2.22.0/error_prone_annotations-2.22.0.jar"
+            }
+          },
+          "io_netty_netty_codec_http": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_codec_http",
+              "generating_repository": "maven",
+              "target_name": "io_netty_netty_codec_http"
+            }
+          },
+          "io_grpc_grpc_services": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_grpc_grpc_services",
+              "generating_repository": "maven",
+              "target_name": "io_grpc_grpc_services"
+            }
+          },
+          "org_glassfish_jersey_core_jersey_client_2_30_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_glassfish_jersey_core_jersey_client_2_30_1",
+              "sha256": "fe0aa736ce216e9efb6e17392142b87e704cf09e75a0cb6b3fd2d146937225c1",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/glassfish/jersey/core/jersey-client/2.30.1/jersey-client-2.30.1.jar"
+              ],
+              "downloaded_file_path": "org/glassfish/jersey/core/jersey-client/2.30.1/jersey-client-2.30.1.jar"
+            }
+          },
+          "org_ow2_asm_asm_commons_jar_sources_9_2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_ow2_asm_asm_commons_jar_sources_9_2",
+              "sha256": "6d98839136be45d5b1ffdca0fd2647eb8eaf92cff576648cbbf96f08afd3ed6d",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/ow2/asm/asm-commons/9.2/asm-commons-9.2-sources.jar"
+              ],
+              "downloaded_file_path": "org/ow2/asm/asm-commons/9.2/asm-commons-9.2-sources.jar"
+            }
+          },
+          "net_jcip_jcip_annotations": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~net_jcip_jcip_annotations",
+              "generating_repository": "maven",
+              "target_name": "net_jcip_jcip_annotations"
+            }
+          },
+          "org_bouncycastle_bcprov_jdk18on_1_75": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_bouncycastle_bcprov_jdk18on_1_75",
+              "sha256": "7f24018e9212dbda61c69212f8d7b1524c28efb978f10df590df3b4ccac47bd5",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/bouncycastle/bcprov-jdk18on/1.75/bcprov-jdk18on-1.75.jar"
+              ],
+              "downloaded_file_path": "org/bouncycastle/bcprov-jdk18on/1.75/bcprov-jdk18on-1.75.jar"
+            }
+          },
+          "org_apache_commons_commons_compress": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_apache_commons_commons_compress",
+              "generating_repository": "maven",
+              "target_name": "org_apache_commons_commons_compress"
+            }
+          },
+          "net_javacrumbs_future_converter_future_converter_java8_common_jar_sources_1_2_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~net_javacrumbs_future_converter_future_converter_java8_common_jar_sources_1_2_0",
+              "sha256": "8a0f6e7ead50cf9687ae7093bdd8e7f20cd26e42b848105206e18b245ebbc107",
+              "urls": [
+                "https://repo1.maven.org/maven2/net/javacrumbs/future-converter/future-converter-java8-common/1.2.0/future-converter-java8-common-1.2.0-sources.jar"
+              ],
+              "downloaded_file_path": "net/javacrumbs/future-converter/future-converter-java8-common/1.2.0/future-converter-java8-common-1.2.0-sources.jar"
+            }
+          },
+          "com_fasterxml_jackson_core_jackson_databind_jar_sources_2_15_2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_fasterxml_jackson_core_jackson_databind_jar_sources_2_15_2",
+              "sha256": "6dafb34ba03f003c998dac3f786bcfd468dfcec39eaf465180bc433ce8566d30",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.15.2/jackson-databind-2.15.2-sources.jar"
+              ],
+              "downloaded_file_path": "com/fasterxml/jackson/core/jackson-databind/2.15.2/jackson-databind-2.15.2-sources.jar"
+            }
+          },
+          "com_google_api_gax_grpc_2_28_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_api_gax_grpc_2_28_1",
+              "sha256": "e9e40d1d7354e8f857b05be2208c11722c1b97dc7aaa4b4b125fcf0457b45a03",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/api/gax-grpc/2.28.1/gax-grpc-2.28.1.jar",
+                "https://maven.google.com/com/google/api/gax-grpc/2.28.1/gax-grpc-2.28.1.jar"
+              ],
+              "downloaded_file_path": "com/google/api/gax-grpc/2.28.1/gax-grpc-2.28.1.jar"
+            }
+          },
+          "com_github_oshi_oshi_core": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_oshi_oshi_core",
+              "generating_repository": "maven",
+              "target_name": "com_github_oshi_oshi_core"
+            }
+          },
+          "com_google_errorprone_error_prone_core": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_errorprone_error_prone_core",
+              "generating_repository": "maven",
+              "target_name": "com_google_errorprone_error_prone_core"
+            }
+          },
+          "com_amazonaws_aws_java_sdk_secretsmanager_1_12_544": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_amazonaws_aws_java_sdk_secretsmanager_1_12_544",
+              "sha256": "b6a0953948949282b46769896c9d1eb1660ed77632c52137fdb72b8372fe685e",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-secretsmanager/1.12.544/aws-java-sdk-secretsmanager-1.12.544.jar"
+              ],
+              "downloaded_file_path": "com/amazonaws/aws-java-sdk-secretsmanager/1.12.544/aws-java-sdk-secretsmanager-1.12.544.jar"
+            }
+          },
+          "software_amazon_ion_ion_java_1_0_2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~software_amazon_ion_ion_java_1_0_2",
+              "sha256": "0d127b205a1fce0abc2a3757a041748651bc66c15cf4c059bac5833b27d471a5",
+              "urls": [
+                "https://repo1.maven.org/maven2/software/amazon/ion/ion-java/1.0.2/ion-java-1.0.2.jar"
+              ],
+              "downloaded_file_path": "software/amazon/ion/ion-java/1.0.2/ion-java-1.0.2.jar"
+            }
+          },
+          "com_amazonaws_aws_java_sdk_kms_jar_sources_1_12_544": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_amazonaws_aws_java_sdk_kms_jar_sources_1_12_544",
+              "sha256": "cc195a2be0a245eaee362cacd7c2f119522cea9c8f8b89db49f0634f05b15831",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-kms/1.12.544/aws-java-sdk-kms-1.12.544-sources.jar"
+              ],
+              "downloaded_file_path": "com/amazonaws/aws-java-sdk-kms/1.12.544/aws-java-sdk-kms-1.12.544-sources.jar"
+            }
+          },
+          "org_yaml_snakeyaml_jar_sources_2_2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_yaml_snakeyaml_jar_sources_2_2",
+              "sha256": "8f7cf911cf63db55fd980a926d155bd846317737351a2f48ef1c1088c414538a",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/yaml/snakeyaml/2.2/snakeyaml-2.2-sources.jar"
+              ],
+              "downloaded_file_path": "org/yaml/snakeyaml/2.2/snakeyaml-2.2-sources.jar"
+            }
+          },
+          "com_github_docker_java_docker_java": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_github_docker_java_docker_java",
+              "generating_repository": "maven",
+              "target_name": "com_github_docker_java_docker_java"
+            }
+          },
+          "commons_codec_commons_codec_1_15": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~commons_codec_commons_codec_1_15",
+              "sha256": "b3e9f6d63a790109bf0d056611fbed1cf69055826defeb9894a71369d246ed63",
+              "urls": [
+                "https://repo1.maven.org/maven2/commons-codec/commons-codec/1.15/commons-codec-1.15.jar"
+              ],
+              "downloaded_file_path": "commons-codec/commons-codec/1.15/commons-codec-1.15.jar"
+            }
+          },
+          "io_grpc_grpc_googleapis_1_55_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_grpc_grpc_googleapis_1_55_1",
+              "sha256": "d77f33f3c78b99c0c604def7efe27f912b9cee49219698180101a064d67bd268",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/grpc/grpc-googleapis/1.55.1/grpc-googleapis-1.55.1.jar",
+                "https://maven.google.com/io/grpc/grpc-googleapis/1.55.1/grpc-googleapis-1.55.1.jar"
+              ],
+              "downloaded_file_path": "io/grpc/grpc-googleapis/1.55.1/grpc-googleapis-1.55.1.jar"
+            }
+          },
+          "org_apache_commons_commons_lang3": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_apache_commons_commons_lang3",
+              "generating_repository": "maven",
+              "target_name": "org_apache_commons_commons_lang3"
+            }
+          },
+          "com_google_guava_guava": {
+            "bzlFile": "@@rules_jvm_external~5.3//private:compat_repository.bzl",
+            "ruleClassName": "compat_repository",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_guava_guava",
+              "generating_repository": "maven",
+              "target_name": "com_google_guava_guava"
+            }
+          },
+          "com_google_code_findbugs_jsr305_jar_sources_3_0_2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~com_google_code_findbugs_jsr305_jar_sources_3_0_2",
+              "sha256": "1c9e85e272d0708c6a591dc74828c71603053b48cc75ae83cce56912a2aa063b",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2-sources.jar"
+              ],
+              "downloaded_file_path": "com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2-sources.jar"
+            }
+          },
+          "io_netty_netty_common_4_1_97_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_common_4_1_97_Final",
+              "sha256": "a8aca0c8e9347acc75c885ecc749195d9775369aa520b9276f2d1128210a6c17",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/netty/netty-common/4.1.97.Final/netty-common-4.1.97.Final.jar"
+              ],
+              "downloaded_file_path": "io/netty/netty-common/4.1.97.Final/netty-common-4.1.97.Final.jar"
+            }
+          },
+          "io_netty_netty_handler_4_1_86_Final": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~io_netty_netty_handler_4_1_86_Final",
+              "sha256": "e69b42292929b278dc522e25177ddf7c54025484b55879f8227349adfbe1c04d",
+              "urls": [
+                "https://repo1.maven.org/maven2/io/netty/netty-handler/4.1.86.Final/netty-handler-4.1.86.Final.jar",
+                "https://maven.google.com/io/netty/netty-handler/4.1.86.Final/netty-handler-4.1.86.Final.jar"
+              ],
+              "downloaded_file_path": "io/netty/netty-handler/4.1.86.Final/netty-handler-4.1.86.Final.jar"
+            }
+          },
+          "org_slf4j_slf4j_api_jar_sources_2_0_9": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_slf4j_slf4j_api_jar_sources_2_0_9",
+              "sha256": "0d83bc49452416dd121ee41cebf41cdc64b69e7f7fdc97c2762ec406336c7ad3",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/slf4j/slf4j-api/2.0.9/slf4j-api-2.0.9-sources.jar"
+              ],
+              "downloaded_file_path": "org/slf4j/slf4j-api/2.0.9/slf4j-api-2.0.9-sources.jar"
+            }
+          },
+          "redis_clients_jedis_4_3_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~redis_clients_jedis_4_3_1",
+              "sha256": "597894244e42e1b3171470e9294781824dbf617949e77aa0230eaa3ec4772db4",
+              "urls": [
+                "https://repo1.maven.org/maven2/redis/clients/jedis/4.3.1/jedis-4.3.1.jar"
+              ],
+              "downloaded_file_path": "redis/clients/jedis/4.3.1/jedis-4.3.1.jar"
+            }
+          },
+          "org_glassfish_jersey_connectors_jersey_apache_connector_jar_sources_2_30_1": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_glassfish_jersey_connectors_jersey_apache_connector_jar_sources_2_30_1",
+              "sha256": "189accdc78e1ac392d6ae16d62d98b3567ca4fb836524d4f79e485c5455a9b93",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/glassfish/jersey/connectors/jersey-apache-connector/2.30.1/jersey-apache-connector-2.30.1-sources.jar"
+              ],
+              "downloaded_file_path": "org/glassfish/jersey/connectors/jersey-apache-connector/2.30.1/jersey-apache-connector-2.30.1-sources.jar"
+            }
+          },
+          "org_xerial_sqlite_jdbc_jar_sources_3_34_0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_jvm_external~5.3~maven~org_xerial_sqlite_jdbc_jar_sources_3_34_0",
+              "sha256": "e0c494fe9e7b719a0fe270bf19e63b26c821fce0a29c9066f5d1c39b9d38a6c0",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/xerial/sqlite-jdbc/3.34.0/sqlite-jdbc-3.34.0-sources.jar"
+              ],
+              "downloaded_file_path": "org/xerial/sqlite-jdbc/3.34.0/sqlite-jdbc-3.34.0-sources.jar"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/deps.bzl
+++ b/deps.bzl
@@ -5,26 +5,8 @@ buildfarm dependencies that can be imported into other WORKSPACE files
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file", "http_jar")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
-RULES_JVM_EXTERNAL_TAG = "5.3"
-RULES_JVM_EXTERNAL_SHA = "d31e369b854322ca5098ea12c69d7175ded971435e55c18dd9dd5f29cc5249ac"
-
 def archive_dependencies(third_party):
     return [
-        {
-            "name": "platforms",
-            "urls": [
-                "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.7/platforms-0.0.7.tar.gz",
-                "https://github.com/bazelbuild/platforms/releases/download/0.0.7/platforms-0.0.7.tar.gz",
-            ],
-            "sha256": "3a561c99e7bdbe9173aa653fd579fe849f1d8d67395780ab4770b1f381431d51",
-        },
-        {
-            "name": "rules_jvm_external",
-            "strip_prefix": "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
-            "sha256": RULES_JVM_EXTERNAL_SHA,
-            "url": "https://github.com/bazelbuild/rules_jvm_external/releases/download/%s/rules_jvm_external-%s.tar.gz" % (RULES_JVM_EXTERNAL_TAG, RULES_JVM_EXTERNAL_TAG),
-        },
-
         # Needed for "well-known protos" and @com_google_protobuf//:protoc.
         {
             "name": "com_google_protobuf",
@@ -54,14 +36,6 @@ def archive_dependencies(third_party):
                 "https://github.com/bazelbuild/rules_pkg/releases/download/0.9.0/rules_pkg-0.9.0.tar.gz",
             ],
         },
-        {
-            "name": "rules_license",
-            "sha256": "4531deccb913639c30e5c7512a054d5d875698daeb75d8cf90f284375fe7c360",
-            "urls": [
-                "https://mirror.bazel.build/github.com/bazelbuild/rules_license/releases/download/0.0.7/rules_license-0.0.7.tar.gz",
-                "https://github.com/bazelbuild/rules_license/releases/download/0.0.7/rules_license-0.0.7.tar.gz",
-            ],
-        },
 
         # The APIs that we implement.
         {
@@ -81,12 +55,6 @@ def archive_dependencies(third_party):
             "sha256": "743d2d5b5504029f3f825beb869ce0ec2330b647b3ee465a4f39ca82df83f8bf",
             "strip_prefix": "remote-apis-636121a32fa7b9114311374e4786597d8e7a69f3",
             "url": "https://github.com/bazelbuild/remote-apis/archive/636121a32fa7b9114311374e4786597d8e7a69f3.zip",
-        },
-        {
-            "name": "rules_cc",
-            "sha256": "2037875b9a4456dce4a79d112a8ae885bbc4aad968e6587dca6e64f3a0900cdf",
-            "strip_prefix": "rules_cc-0.0.9",
-            "url": "https://github.com/bazelbuild/rules_cc/releases/download/0.0.9/rules_cc-0.0.9.tar.gz",
         },
 
         # Used to format proto files

--- a/deps.bzl
+++ b/deps.bzl
@@ -14,14 +14,6 @@ def archive_dependencies(third_party):
             "strip_prefix": "protobuf-25.0",
             "urls": ["https://github.com/protocolbuffers/protobuf/archive/v25.0.zip"],
         },
-        {
-            "name": "com_github_bazelbuild_buildtools",
-            "sha256": "a02ba93b96a8151b5d8d3466580f6c1f7e77212c4eb181cba53eb2cae7752a23",
-            "strip_prefix": "buildtools-3.5.0",
-            "urls": ["https://github.com/bazelbuild/buildtools/archive/3.5.0.tar.gz"],
-            # Bzlmod: Waiting for https://github.com/bazelbuild/bazel-central-registry/issues/380
-        },
-
         # Needed for @grpc_java//compiler:grpc_java_plugin.
         {
             "name": "io_grpc_grpc_java",

--- a/deps.bzl
+++ b/deps.bzl
@@ -75,16 +75,6 @@ def archive_dependencies(third_party):
             "patch_args": ["-p0"],
             "patches": ["%s:docker_go_toolchain.patch" % third_party],
         },
-
-        # Updated versions of io_bazel_rules_docker dependencies for bazel compatibility
-        {
-            "name": "io_bazel_rules_go",
-            "sha256": "d6ab6b57e48c09523e93050f13698f708428cfd5e619252e369d377af6597707",
-            "urls": [
-                "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.43.0/rules_go-v0.43.0.zip",
-                "https://github.com/bazelbuild/rules_go/releases/download/v0.43.0/rules_go-v0.43.0.zip",
-            ],
-        },
         {
             "name": "bazel_gazelle",
             "sha256": "b7387f72efb59f876e4daae42f1d3912d0d45563eac7cb23d1de0b094ab588cf",

--- a/deps.bzl
+++ b/deps.bzl
@@ -75,15 +75,6 @@ def archive_dependencies(third_party):
             "patch_args": ["-p0"],
             "patches": ["%s:docker_go_toolchain.patch" % third_party],
         },
-        {
-            "name": "bazel_gazelle",
-            "sha256": "b7387f72efb59f876e4daae42f1d3912d0d45563eac7cb23d1de0b094ab588cf",
-            "urls": [
-                "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.34.0/bazel-gazelle-v0.34.0.tar.gz",
-                "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.34.0/bazel-gazelle-v0.34.0.tar.gz",
-            ],
-        },
-
         # Bazel is referenced as a dependency so that buildfarm can access the linux-sandbox as a potential execution wrapper.
         {
             "name": "bazel",

--- a/deps.bzl
+++ b/deps.bzl
@@ -19,6 +19,7 @@ def archive_dependencies(third_party):
             "sha256": "a02ba93b96a8151b5d8d3466580f6c1f7e77212c4eb181cba53eb2cae7752a23",
             "strip_prefix": "buildtools-3.5.0",
             "urls": ["https://github.com/bazelbuild/buildtools/archive/3.5.0.tar.gz"],
+            # Bzlmod: Waiting for https://github.com/bazelbuild/bazel-central-registry/issues/380
         },
 
         # Needed for @grpc_java//compiler:grpc_java_plugin.
@@ -27,6 +28,7 @@ def archive_dependencies(third_party):
             "sha256": "b8fb7ae4824fb5a5ae6e6fa26ffe2ad7ab48406fdeee54e8965a3b5948dd957e",
             "strip_prefix": "grpc-java-1.56.1",
             "urls": ["https://github.com/grpc/grpc-java/archive/v1.56.1.zip"],
+            # Bzlmod: Waiting for https://github.com/bazelbuild/bazel-central-registry/issues/353
         },
         {
             "name": "rules_pkg",
@@ -35,6 +37,7 @@ def archive_dependencies(third_party):
                 "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.9.0/rules_pkg-0.9.0.tar.gz",
                 "https://github.com/bazelbuild/rules_pkg/releases/download/0.9.0/rules_pkg-0.9.0.tar.gz",
             ],
+            # Bzlmod : Waiting for >0.9.1 for https://github.com/bazelbuild/rules_pkg/pull/766 to be released
         },
 
         # The APIs that we implement.

--- a/src/test/java/build/buildfarm/examples/ExampleConfigsTest.java
+++ b/src/test/java/build/buildfarm/examples/ExampleConfigsTest.java
@@ -35,16 +35,14 @@ public class ExampleConfigsTest {
   @Test
   public void shardWorkerConfig() throws IOException {
     Path configPath =
-        Paths.get(
-            System.getenv("TEST_SRCDIR"), "build_buildfarm", "examples", "config.minimal.yml");
+        Paths.get(System.getenv("TEST_SRCDIR"), "_main", "examples", "config.minimal.yml");
     BuildfarmConfigs configs = BuildfarmConfigs.getInstance();
     configs.loadConfigs(configPath);
   }
 
   @Test
   public void fullConfig() throws IOException {
-    Path configPath =
-        Paths.get(System.getenv("TEST_SRCDIR"), "build_buildfarm", "examples", "config.yml");
+    Path configPath = Paths.get(System.getenv("TEST_SRCDIR"), "_main", "examples", "config.yml");
     BuildfarmConfigs configs = BuildfarmConfigs.getInstance();
     configs.loadConfigs(configPath);
   }


### PR DESCRIPTION
Only four bazel dependencies were found in the existing bzlmod registry (https://registry.bazel.build/)

Fixes: https://github.com/bazelbuild/bazel-buildfarm/issues/1479