### PR TITLE
Write onNext requires onCompleted to follow

### DIFF
--- a/src/main/java/build/buildfarm/common/services/WriteStreamObserver.java
+++ b/src/main/java/build/buildfarm/common/services/WriteStreamObserver.java
@@ -205,6 +205,7 @@ public class WriteStreamObserver implements StreamObserver<WriteRequest> {
         log.log(
             Level.FINEST, format("delivering committed_size for %s of %d", name, committedSize));
         responseObserver.onNext(response);
+        responseObserver.onCompleted();
       } catch (Exception e) {
         log.log(Level.SEVERE, format("error delivering committed_size to %s", name), e);
       }
@@ -479,21 +480,6 @@ public class WriteStreamObserver implements StreamObserver<WriteRequest> {
     log.log(Level.FINER, format("write completed for %s", name));
     if (write == null) {
       responseObserver.onCompleted();
-    } else {
-      Futures.addCallback(
-          write.getFuture(),
-          new FutureCallback<Long>() {
-            @Override
-            public void onSuccess(Long committedSize) {
-              responseObserver.onCompleted();
-            }
-
-            @Override
-            public void onFailure(Throwable t) {
-              // ignore
-            }
-          },
-          withCancellation.fixedContextExecutor(directExecutor()));
     }
   }
 }

--- a/src/test/java/build/buildfarm/common/services/ByteStreamServiceTest.java
+++ b/src/test/java/build/buildfarm/common/services/ByteStreamServiceTest.java
@@ -183,7 +183,7 @@ public class ByteStreamServiceTest {
     verify(write, atLeastOnce())
         .getOutput(any(Long.class), any(TimeUnit.class), any(Runnable.class));
     verify(write, times(2)).reset();
-    verify(write, times(2)).getFuture();
+    verify(write, times(1)).getFuture();
   }
 
   @Test
@@ -264,7 +264,7 @@ public class ByteStreamServiceTest {
     verify(write, atLeastOnce()).getCommittedSize();
     verify(write, atLeastOnce())
         .getOutput(any(Long.class), any(TimeUnit.class), any(Runnable.class));
-    verify(write, times(3)).getFuture();
+    verify(write, times(2)).getFuture();
   }
 
   static class CountingReadObserver implements StreamObserver<ReadResponse> {

--- a/src/test/java/build/buildfarm/common/services/WriteStreamObserverTest.java
+++ b/src/test/java/build/buildfarm/common/services/WriteStreamObserverTest.java
@@ -1,14 +1,11 @@
 package build.buildfarm.common.services;
 
 import static build.buildfarm.common.resources.ResourceParser.uploadResourceName;
-import static com.google.common.truth.Truth.assertThat;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
@@ -140,67 +137,5 @@ public class WriteStreamObserverTest {
             eq(uuid),
             any(RequestMetadata.class));
     verifyZeroInteractions(responseObserver);
-  }
-
-  @Test
-  public void observerCalledInRequestContext() throws Exception {
-    Context.Key<String> REQ_KEY = Context.key("requester");
-    Instance instance = mock(Instance.class);
-    StreamObserver<WriteResponse> responseObserver =
-        spy(
-            new StreamObserver<WriteResponse>() {
-              @Override
-              public void onNext(WriteResponse response) {
-                assertThat(REQ_KEY.get()).isEqualTo("true");
-              }
-
-              @Override
-              public void onError(Throwable t) {
-                assertThat(REQ_KEY.get()).isEqualTo("true");
-              }
-
-              @Override
-              public void onCompleted() {
-                assertThat(REQ_KEY.get()).isEqualTo("true");
-              }
-            });
-    ByteString data = ByteString.copyFromUtf8("contextual data");
-    Digest digest = DIGEST_UTIL.compute(data);
-    UUID uuid = UUID.randomUUID();
-    UploadBlobRequest uploadBlobRequest =
-        UploadBlobRequest.newBuilder()
-            .setBlob(BlobInformation.newBuilder().setDigest(digest))
-            .setUuid(uuid.toString())
-            .build();
-    SettableFuture<Long> future = SettableFuture.create();
-    Write write = mock(Write.class);
-    when(write.getFuture()).thenReturn(future);
-    when(write.isComplete()).thenReturn(Boolean.TRUE);
-    when(instance.getBlobWrite(
-            eq(Compressor.Value.IDENTITY), eq(digest), eq(uuid), any(RequestMetadata.class)))
-        .thenReturn(write);
-
-    Context requester = Context.current().withValue(REQ_KEY, "true");
-    assertThat(REQ_KEY.get()).isNull();
-    WriteStreamObserver observer =
-        requester.call(
-            () -> new WriteStreamObserver(instance, 1, SECONDS, () -> {}, responseObserver));
-    requester.run(
-        () ->
-            observer.onNext(
-                WriteRequest.newBuilder()
-                    .setResourceName(uploadResourceName(uploadBlobRequest))
-                    .setData(data)
-                    .build()));
-    requester.run(observer::onCompleted);
-    verify(responseObserver, never()).onCompleted();
-
-    future.set(digest.getSizeBytes());
-
-    verify(write, times(1)).isComplete();
-    verify(instance, times(1))
-        .getBlobWrite(
-            eq(Compressor.Value.IDENTITY), eq(digest), eq(uuid), any(RequestMetadata.class));
-    verify(responseObserver, times(1)).onCompleted();
   }
 }


### PR DESCRIPTION
For reasons passing understanding, a WriteResponse is not delivered to a client solely from onNext to be received by a client called via bsStub. onCompleted must follow the onNext for a timely delivery of the response, particularly when it occurs before an onCompleted from the client. This does not seem to affect the bazel client, which could indicate a difference in behavior between grpc versions, or simply that it manages to complete its upload completely ignorant of the early return status. More investigation is required.

This will fix hanging builds which occur with exec-only workers failing to complete uploads to shard peers.