### PR TITLE
refactor: swap HealthStatusManager

### DIFF
--- a/src/main/java/build/buildfarm/server/BuildFarmServer.java
+++ b/src/main/java/build/buildfarm/server/BuildFarmServer.java
@@ -41,8 +41,8 @@ import build.buildfarm.server.services.PublishBuildEventService;
 import io.grpc.ServerBuilder;
 import io.grpc.ServerInterceptor;
 import io.grpc.health.v1.HealthCheckResponse.ServingStatus;
+import io.grpc.protobuf.services.HealthStatusManager;
 import io.grpc.protobuf.services.ProtoReflectionService;
-import io.grpc.services.HealthStatusManager;
 import io.grpc.util.TransmitStatusRuntimeExceptionInterceptor;
 import io.prometheus.client.Counter;
 import java.io.File;
@@ -55,7 +55,6 @@ import javax.naming.ConfigurationException;
 import lombok.extern.java.Log;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
-@SuppressWarnings("deprecation")
 @Log
 public class BuildFarmServer extends LoggingMain {
   private static final java.util.logging.Logger nettyLogger =
@@ -88,8 +87,7 @@ public class BuildFarmServer extends LoggingMain {
    */
   public void prepareServerForGracefulShutdown() {
     if (configs.getServer().getGracefulShutdownSeconds() == 0) {
-      log.info(
-          String.format("Graceful Shutdown is not enabled. Server is shutting down immediately."));
+      log.info("Graceful Shutdown is not enabled. Server is shutting down immediately.");
     } else {
       try {
         log.info(

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -70,8 +70,8 @@ import io.grpc.ServerBuilder;
 import io.grpc.Status;
 import io.grpc.Status.Code;
 import io.grpc.health.v1.HealthCheckResponse.ServingStatus;
+import io.grpc.protobuf.services.HealthStatusManager;
 import io.grpc.protobuf.services.ProtoReflectionService;
-import io.grpc.services.HealthStatusManager;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Gauge;
 import java.io.File;
@@ -125,7 +125,6 @@ public final class Worker extends LoggingMain {
 
   private WorkerInstance instance;
 
-  @SuppressWarnings("deprecation")
   private final HealthStatusManager healthStatusManager = new HealthStatusManager();
 
   private Server server;


### PR DESCRIPTION
Swapping to the recommended class that isn't deprecated.

Also, remove unnecessary `String.format(...)` with no format args.