### PR TITLE
Update log level for blob location adjust

### DIFF
--- a/src/main/java/build/buildfarm/instance/shard/ServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ServerInstance.java
@@ -795,7 +795,7 @@ public class ServerInstance extends NodeInstance {
             .immutableCopy();
     if (!workersToBeRemoved.isEmpty()) {
       try {
-        log.log(Level.INFO, format("adjusting locations for the digest %s", digest));
+        log.log(Level.FINE, format("adjusting locations for the digest %s", digest));
         backplane.adjustBlobLocations(digest, Collections.emptySet(), workersToBeRemoved);
       } catch (IOException e) {
         log.log(


### PR DESCRIPTION
Adjusted log level from Info to FINE to record the correction of the worker list for the digest. It was polluting the log.