### PR TITLE
Determine PipelineStage exception severity

### DIFF
--- a/src/main/java/build/buildfarm/worker/PipelineStage.java
+++ b/src/main/java/build/buildfarm/worker/PipelineStage.java
@@ -46,7 +46,7 @@ public abstract class PipelineStage implements Runnable {
     return name;
   }
 
-  private void runInterruptible() throws InterruptedException {
+  protected void runInterruptible() throws InterruptedException {
     while (!output.isClosed() || isClaimed()) {
       iterate();
     }
@@ -58,23 +58,44 @@ public abstract class PipelineStage implements Runnable {
 
   @Override
   public void run() {
-    try {
-      runInterruptible();
-    } catch (InterruptedException e) {
-      // ignore
-    } catch (Exception e) {
-      getLogger()
-          .log(Level.SEVERE, format("%s::run(): stage terminated due to exception", name), e);
-    } finally {
-      boolean wasInterrupted = Thread.interrupted();
+    boolean keepRunningStage = true;
+    while (keepRunningStage) {
       try {
-        close();
-      } finally {
-        if (wasInterrupted) {
-          Thread.currentThread().interrupt();
-        }
+        runInterruptible();
+
+        // If the run finishes without exception, the stage can also stop running.
+        keepRunningStage = false;
+
+      } catch (Exception e) {
+        keepRunningStage = decideTermination(e);
       }
     }
+
+    close();
+  }
+
+  /**
+   * @brief When the stage has an uncaught exception, this method determines whether the pipeline
+   *     stage should terminate.
+   * @details This is a customization of the pipeline stage to allow logging exceptions but keeping
+   *     the pipeline stage running.
+   * @return Whether the stage should terminate or continue running.
+   */
+  private boolean decideTermination(Exception e) {
+    // This is a normal way for the pipeline stage to terminate.
+    // If an interrupt is received, there is no reason to continue the pipeline stage.
+    if (e instanceof InterruptedException) {
+      getLogger()
+          .log(Level.INFO, String.format("%s::run(): stage terminated due to interrupt", name));
+      return false;
+    }
+
+    // On the other hand, this is an abnormal way for a pipeline stage to terminate.
+    // For robustness of the distributed system, we may want to log the error but continue the
+    // pipeline stage.
+    getLogger()
+        .log(Level.SEVERE, String.format("%s::run(): stage terminated due to exception", name), e);
+    return true;
   }
 
   public String name() {

--- a/src/test/java/build/buildfarm/worker/PipelineTest.java
+++ b/src/test/java/build/buildfarm/worker/PipelineTest.java
@@ -14,6 +14,11 @@
 
 package build.buildfarm.worker;
 
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.logging.Logger;
 import lombok.extern.java.Log;
 import org.junit.Test;
@@ -70,5 +75,95 @@ public class PipelineTest {
         1);
     pipeline.start();
     pipeline.join();
+  }
+
+  // Create a test stage that exists because of an interrupt.
+  // This proves the stage can be interupted.
+  public class TestStage extends PipelineStage {
+    public TestStage(String name) {
+      super(name, null, null, null);
+    }
+
+    @Override
+    protected void runInterruptible() throws InterruptedException {
+      throw new InterruptedException("Interrupt");
+    }
+
+    @Override
+    public void put(OperationContext operationContext) throws InterruptedException {}
+
+    @Override
+    OperationContext take() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Logger getLogger() {
+      return log;
+    }
+  }
+
+  // This test demonstrates that the stage will end and the pipeline will finish because it was
+  // interrupted.
+  @Test
+  public void stageExitsOnInterrupt() throws InterruptedException {
+    Pipeline pipeline = new Pipeline();
+    TestStage stage = new TestStage("test");
+    pipeline.add(stage, 1);
+    pipeline.start();
+    pipeline.join();
+  }
+
+  // Create a test stage that doesn't exit because of an a non-interrupt exception.
+  // This proves the stage is robust enough continue running when experiencing an exception.
+  public class ContinueStage extends PipelineStage {
+    public ContinueStage(String name) {
+      super(name, null, null, null);
+    }
+
+    @Override
+    protected void runInterruptible() throws InterruptedException {
+      throw new RuntimeException("Exception");
+    }
+
+    @Override
+    public void put(OperationContext operationContext) throws InterruptedException {}
+
+    @Override
+    OperationContext take() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Logger getLogger() {
+      return log;
+    }
+  }
+
+  // This test demonstrates that the stage will NOT end and the pipeline will NOT finish because a
+  // non-interrupt exception was thrown.
+  @Test
+  public void stageContinuesOnException() throws InterruptedException {
+    Pipeline pipeline = new Pipeline();
+    ContinueStage stage = new ContinueStage("test");
+    pipeline.add(stage, 1);
+    pipeline.start();
+
+    boolean didNotThrow = false;
+    try {
+      CompletableFuture.runAsync(
+              () -> {
+                try {
+                  pipeline.join();
+                } catch (InterruptedException e) {
+                }
+                return;
+              })
+          .get(1, TimeUnit.SECONDS);
+    } catch (TimeoutException e) {
+      didNotThrow = true;
+    } catch (Exception e) {
+    }
+    assertThat(didNotThrow).isTrue();
   }
 }


### PR DESCRIPTION
Select pipeline stage terminations based on exception type. InterruptedExceptions are terminable.
Errors are uncaught and will terminate the stage.
All others are logged with the pipeline continuing.