### PR TITLE
Authored sandbox asNobody behavior

### DIFF
--- a/src/main/java/build/buildfarm/common/config/SandboxSettings.java
+++ b/src/main/java/build/buildfarm/common/config/SandboxSettings.java
@@ -33,6 +33,13 @@ public class SandboxSettings {
   public boolean alwaysUseSandbox = false;
 
   /**
+   * @field alwaysUseAsNobody
+   * @brief Whether or not to always use the as-nobody wrapper when running actions.
+   * @details It may be preferred to enforce this wrapper instead of relying on client selection.
+   */
+  public boolean alwaysUseAsNobody = false;
+
+  /**
    * @field alwaysUseCgroups
    * @brief Whether or not to use cgroups when sandboxing actions.
    * @details It may be preferred to enforce cgroup usage.

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -979,6 +979,10 @@ class ShardWorkerContext implements WorkerContext {
       addLinuxSandboxCli(arguments, options);
     }
 
+    if (configs.getWorker().getSandboxSettings().isAlwaysUseAsNobody() || limits.fakeUsername) {
+      arguments.add(configs.getExecutionWrappers().getAsNobody());
+    }
+
     if (limits.time.skipSleep) {
       arguments.add(configs.getExecutionWrappers().getSkipSleep());
 
@@ -1043,8 +1047,6 @@ class ShardWorkerContext implements WorkerContext {
 
   private void addLinuxSandboxCli(
       ImmutableList.Builder<String> arguments, LinuxSandboxOptions options) {
-    arguments.add(configs.getExecutionWrappers().getAsNobody());
-
     // Choose the sandbox which is built and deployed with the worker image.
     arguments.add(configs.getExecutionWrappers().getLinuxSandbox());
 


### PR DESCRIPTION
Describe a boolean authored to supply the as-nobody wrapper published with buildfarm deployments that should serve as a quick mechanism for any install to use non-buildfarm (typically root) uids for actions.