### PR TITLE
Declare stat block information for FuseCAS

### DIFF
--- a/src/main/java/build/buildfarm/worker/FuseCAS.java
+++ b/src/main/java/build/buildfarm/worker/FuseCAS.java
@@ -547,6 +547,9 @@ public class FuseCAS extends FuseStubFS {
       return -ErrorCodes.ENOENT();
     }
 
+    // stock block size
+    stat.st_blksize.set(4096);
+
     if (entry.isSymlink()) {
       stat.st_mode.set(FileStat.S_IFLNK | 0777);
     } else if (entry.isDirectory()) {
@@ -554,9 +557,13 @@ public class FuseCAS extends FuseStubFS {
     } else {
       int mode = entry.isExecutable() ? 0555 : 0444;
       stat.st_mode.set(FileStat.S_IFREG | mode);
-      stat.st_nlink.set(1);
-      stat.st_size.set(entry.size());
+      stat.st_nlink.set(1); // should fix this for number of digests pointing to it
     }
+    long size = entry.size();
+    long blksize = stat.st_blksize.get();
+    long blocks = (size + blksize - 1) / blksize;
+    stat.st_size.set(size);
+    stat.st_blocks.set(blocks);
     return 0;
   }
 


### PR DESCRIPTION
Useful so that a `du` and other block related tools work on the mounted directory.