### PR TITLE
Bump rules_go and gazelle

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -119,10 +119,10 @@ def archive_dependencies(third_party):
         # Updated versions of io_bazel_rules_docker dependencies for bazel compatibility
         {
             "name": "io_bazel_rules_go",
-            "sha256": "278b7ff5a826f3dc10f04feaf0b70d48b68748ccd512d7f98bf442077f043fe3",
+            "sha256": "d6ab6b57e48c09523e93050f13698f708428cfd5e619252e369d377af6597707",
             "urls": [
-                "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.41.0/rules_go-v0.41.0.zip",
-                "https://github.com/bazelbuild/rules_go/releases/download/v0.41.0/rules_go-v0.41.0.zip",
+                "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.43.0/rules_go-v0.43.0.zip",
+                "https://github.com/bazelbuild/rules_go/releases/download/v0.43.0/rules_go-v0.43.0.zip",
             ],
         },
         {

--- a/deps.bzl
+++ b/deps.bzl
@@ -127,8 +127,11 @@ def archive_dependencies(third_party):
         },
         {
             "name": "bazel_gazelle",
-            "sha256": "d3fa66a39028e97d76f9e2db8f1b0c11c099e8e01bf363a923074784e451f809",
-            "urls": ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.33.0/bazel-gazelle-v0.33.0.tar.gz"],
+            "sha256": "b7387f72efb59f876e4daae42f1d3912d0d45563eac7cb23d1de0b094ab588cf",
+            "urls": [
+                "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.34.0/bazel-gazelle-v0.34.0.tar.gz",
+                "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.34.0/bazel-gazelle-v0.34.0.tar.gz",
+            ],
         },
 
         # Bazel is referenced as a dependency so that buildfarm can access the linux-sandbox as a potential execution wrapper.


### PR DESCRIPTION
Updated two rules. These versions are also available in the Bazel Central Registry:

- https://registry.bazel.build/modules/rules_go
- https://registry.bazel.build/modules/gazelle