### PR TITLE
chore: bump rules_license to 0.0.7

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -64,10 +64,10 @@ def archive_dependencies(third_party):
         },
         {
             "name": "rules_license",
-            "sha256": "6157e1e68378532d0241ecd15d3c45f6e5cfd98fc10846045509fb2a7cc9e381",
+            "sha256": "4531deccb913639c30e5c7512a054d5d875698daeb75d8cf90f284375fe7c360",
             "urls": [
-                "https://github.com/bazelbuild/rules_license/releases/download/0.0.4/rules_license-0.0.4.tar.gz",
-                "https://mirror.bazel.build/github.com/bazelbuild/rules_license/releases/download/0.0.4/rules_license-0.0.4.tar.gz",
+                "https://mirror.bazel.build/github.com/bazelbuild/rules_license/releases/download/0.0.7/rules_license-0.0.7.tar.gz",
+                "https://github.com/bazelbuild/rules_license/releases/download/0.0.7/rules_license-0.0.7.tar.gz",
             ],
         },
 


### PR DESCRIPTION
Updating rules_license

https://github.com/bazelbuild/rules_license/releases/tag/0.0.7