### PR TITLE
Helm Chart: latest image tags not v-prefixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,5 +142,5 @@ helm install \
   -n bazel-buildfarm \
   --create-namespace \
   bazel-buildfarm \
-  "https://github.com/bazelbuild/bazel-buildfarm/releases/download/${BUILDFARM_VERSION:-2.7.1}/buildfarm-${CHART_VERSION:-0.1.0}.tgz"
+  "https://github.com/bazelbuild/bazel-buildfarm/releases/download/${BUILDFARM_VERSION:-2.8.0}/buildfarm-${CHART_VERSION:-0.2.0}.tgz"
 ```

--- a/kubernetes/helm-charts/buildfarm/Chart.yaml
+++ b/kubernetes/helm-charts/buildfarm/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/kubernetes/helm-charts/buildfarm/Chart.yaml
+++ b/kubernetes/helm-charts/buildfarm/Chart.yaml
@@ -21,7 +21,7 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v2.5.0"
+appVersion: 2.8.0
 
 dependencies:
   - condition: redis.enabled


### PR DESCRIPTION
the default images for both the server and shared worker used in the helm chart compute their image tags from the appVersion in Chart.yaml. With at least version 2.8.0 the imagery stopped getting tags prefixed with v. this change both switches to version 2.8.0 of the published imagery as well removes the v from the appVersion in Chart.yaml.