### PR TITLE
Update helm values to use safe defaults

### DIFF
--- a/kubernetes/helm-charts/buildfarm/values.yaml
+++ b/kubernetes/helm-charts/buildfarm/values.yaml
@@ -27,16 +27,6 @@ config:
     recordBesEvents: true
   worker:
     port: 8982
-    publicName: "localhost:8982"
-    executeStageWidth: 80
-    inputFetchStageWidth: 8
-    realInputDirectories:
-      - "external"
-    root: "/tmp/worker"
-    storages:
-      - type: FILESYSTEM
-        path: "cache"
-        maxSizeBytes: 536870912000 # 500 * 1024 * 1024 * 1024
 
 server:
   image:


### PR DESCRIPTION
Removed values which will likely cause problems for execution and CFC saturation from helm chart:
inputFetchStage_width and execute_stage_width both can be discovered from available processors
maxSizeBytes for filesystem cas is automatically 90% of underlying file storage, down from a value 10x the actual bytes on storage requested below.
path, names, and configuration for root, filesystem, and publicName can all be defaulted/derived safely.