### PR TITLE
Properly balance over nodes, not slot ranges

### DIFF
--- a/src/main/java/build/buildfarm/common/redis/RedisNodeHashes.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisNodeHashes.java
@@ -15,8 +15,10 @@
 package build.buildfarm.common.redis;
 
 import com.google.common.collect.ImmutableList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.JedisPool;
@@ -41,7 +43,7 @@ public class RedisNodeHashes {
   @SuppressWarnings({"unchecked", "rawtypes"})
   public static List<String> getEvenlyDistributedHashes(JedisCluster jedis) {
     try {
-      List<List<Long>> slotRanges = getSlotRanges(jedis);
+      List<List<Long>> slotRanges = getNodeSlotRanges(jedis);
       ImmutableList.Builder hashTags = ImmutableList.builder();
       for (List<Long> slotRange : slotRanges) {
         // we can use any slot that is in range for the node.
@@ -66,7 +68,7 @@ public class RedisNodeHashes {
   public static List<String> getEvenlyDistributedHashesWithPrefix(
       JedisCluster jedis, String prefix) {
     try {
-      List<List<Long>> slotRanges = getSlotRanges(jedis);
+      List<List<Long>> slotRanges = getNodeSlotRanges(jedis);
       ImmutableList.Builder hashTags = ImmutableList.builder();
       for (List<Long> slotRange : slotRanges) {
         // we can use any slot that is in range for the node.
@@ -88,16 +90,22 @@ public class RedisNodeHashes {
    * @note Suggested return identifier: slotRanges.
    */
   @SuppressWarnings("unchecked")
-  private static List<List<Long>> getSlotRanges(JedisCluster jedis) {
+  private static List<List<Long>> getNodeSlotRanges(JedisCluster jedis) {
     // get slot information for each node
     List<Object> slots = getClusterSlots(jedis);
+    Set<String> nodes = new HashSet<>();
 
     // convert slot information into a list of slot ranges
     ImmutableList.Builder<List<Long>> slotRanges = ImmutableList.builder();
     for (Object slotInfoObj : slots) {
       List<Object> slotInfo = (List<Object>) slotInfoObj;
-      List<Long> slotNums = slotInfoToSlotRange(slotInfo);
-      slotRanges.add(slotNums);
+      List<Object> slotRangeNodes = (List<Object>) slotInfo.get(2);
+      // 2 is primary node id
+      String nodeId = (String) slotRangeNodes.get(2);
+      if (nodes.add(nodeId)) {
+        List<Long> slotNums = slotInfoToSlotRange(slotInfo);
+        slotRanges.add(slotNums);
+      }
     }
 
     return slotRanges.build();

--- a/src/test/java/build/buildfarm/common/redis/RedisNodeHashesMockTest.java
+++ b/src/test/java/build/buildfarm/common/redis/RedisNodeHashesMockTest.java
@@ -47,7 +47,10 @@ public class RedisNodeHashesMockTest {
   public void getEvenlyDistributedHashesCanRetrieveDistributedHashes() throws Exception {
     // ARRANGE
     Jedis node = mock(Jedis.class);
-    when(node.clusterSlots()).thenReturn(Collections.singletonList(Arrays.asList(0L, 100L)));
+    when(node.clusterSlots())
+        .thenReturn(
+            Collections.singletonList(
+                Arrays.asList(0L, 100L, Arrays.asList(null, null, "nodeId"))));
 
     JedisPool pool = mock(JedisPool.class);
     when(pool.getResource()).thenReturn(node);
@@ -97,7 +100,10 @@ public class RedisNodeHashesMockTest {
     // ARRANGE
     Jedis node = mock(Jedis.class);
     when(node.clusterSlots())
-        .thenReturn(Arrays.asList(Arrays.asList(0L, 100L), Arrays.asList(101L, 200L)));
+        .thenReturn(
+            Arrays.asList(
+                Arrays.asList(0L, 100L, Arrays.asList(null, null, "nodeId1")),
+                Arrays.asList(101L, 200L, Arrays.asList(null, null, "nodeId2"))));
 
     JedisPool pool = mock(JedisPool.class);
     when(pool.getResource()).thenReturn(node);


### PR DESCRIPTION
Slot ranges must not associate multiple times on a single node for use with balanced queues designed to be load balanced.