### PR TITLE
Use integer ids for Sqlite bidirectional index

### DIFF
--- a/src/test/java/build/buildfarm/cas/cfc/DirectoriesIndexTest.java
+++ b/src/test/java/build/buildfarm/cas/cfc/DirectoriesIndexTest.java
@@ -51,6 +51,7 @@ public class DirectoriesIndexTest {
     } else {
       throw new IllegalArgumentException("DirectoriesIndex type is not supported.");
     }
+    directoriesIndex.start();
   }
 
   @Before


### PR DESCRIPTION
The cost in size for a single table bidirectional index is vast compared to the use of 3nf integer keys. Experimental estimates offer a decrease in file size of 90%.