### PR TITLE
Write cleanups

### DIFF
--- a/src/main/java/build/buildfarm/common/grpc/StubWriteOutputStream.java
+++ b/src/main/java/build/buildfarm/common/grpc/StubWriteOutputStream.java
@@ -238,14 +238,16 @@ public class StubWriteOutputStream extends FeedbackOutputStream implements Write
 
                     @Override
                     public void onError(Throwable t) {
-                      log.log(
-                          WARNING,
-                          format(
-                              "%s: write(%s) on worker %s after %d bytes of content",
-                              Status.fromThrowable(t).getCode().name(),
-                              resourceName,
-                              bsStub.get().getChannel().authority(),
-                              writtenBytes));
+                      if (Status.fromThrowable(t).getCode() != Code.CANCELLED) {
+                        log.log(
+                            WARNING,
+                            format(
+                                "%s: write(%s) on worker %s after %d bytes of content",
+                                Status.fromThrowable(t).getCode().name(),
+                                resourceName,
+                                bsStub.get().getChannel().authority(),
+                                writtenBytes));
+                      }
                       writeFuture.setException(exceptionTranslator.apply(t));
                     }
 

--- a/src/main/java/build/buildfarm/worker/shard/RemoteCasWriter.java
+++ b/src/main/java/build/buildfarm/worker/shard/RemoteCasWriter.java
@@ -84,6 +84,7 @@ public class RemoteCasWriter implements CasWriter {
     String workerName = getRandomWorker();
     Write write = getCasMemberWrite(digest, workerName);
 
+    write.reset();
     try {
       return streamIntoWriteFuture(in, write, digest).get();
     } catch (ExecutionException e) {


### PR DESCRIPTION
    Reset remote CAS write on initial
    
    Prevents the StubWriteOutputStream from issuing an unnecessary initial
    queryWriteStatus.

    Guarantee null write response for onCompleted
    
    Avoid a complaint by gRPC that a client-streaming request was
    completed without a response

    Avoid cancellation log for StubWriteOutputStream
    
    Cancels will happen for all server->worker uploads on context cancels
    initiated by clients, and are normal behaviors.

    Guard against writeObserver null race