### PR TITLE
Separate fields for storage and execute workers in BackplaneStatus

### DIFF
--- a/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
@@ -1468,7 +1468,11 @@ public class RedisShardBackplane implements Backplane {
   @Override
   public BackplaneStatus backplaneStatus() throws IOException {
     BackplaneStatus.Builder builder = BackplaneStatus.newBuilder();
-    builder.addAllActiveWorkers(Sets.union(getExecuteWorkers(), getStorageWorkers()));
+    Set<String> executeWorkers = getExecuteWorkers();
+    Set<String> storageWorkers = getStorageWorkers();
+    builder.addAllActiveExecuteWorkers(executeWorkers);
+    builder.addAllActiveStorageWorkers(storageWorkers);
+    builder.addAllActiveWorkers(Sets.union(executeWorkers, storageWorkers));
     builder.setDispatchedSize(client.call(jedis -> state.dispatchedOperations.size(jedis)));
     builder.setOperationQueue(state.operationQueue.status(client.call(jedis -> jedis)));
     builder.setPrequeue(state.prequeue.status(client.call(jedis -> jedis)));

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -448,7 +448,12 @@ message BackplaneStatus {
 
   DispatchedOperationsStatus dispatched_operations = 9;
 
+  // Maintained for backward compatibility.
   repeated string active_workers = 4;
+
+  repeated string active_storage_workers = 12;
+
+  repeated string active_execute_workers = 13;
 
   int64 cas_lookup_size = 5;
 


### PR DESCRIPTION
Add ability to identify storage workers and execute workers in BackplaneStatus. 

Motivation:
WorkerProfileService is only implemented for Execution Workers and call to Storage workers fails with `rpc error: code = Unimplemented desc = Method not found:`.
