### PR TITLE
Decode nodeId with jedis util SafeEncoder

### DIFF
--- a/src/main/java/build/buildfarm/common/redis/RedisNodeHashes.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisNodeHashes.java
@@ -24,6 +24,7 @@ import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.exceptions.JedisException;
 import redis.clients.jedis.exceptions.JedisNoReachableClusterNodeException;
+import redis.clients.jedis.util.SafeEncoder;
 
 /**
  * @class RedisNodeHashes
@@ -101,7 +102,7 @@ public class RedisNodeHashes {
       List<Object> slotInfo = (List<Object>) slotInfoObj;
       List<Object> slotRangeNodes = (List<Object>) slotInfo.get(2);
       // 2 is primary node id
-      String nodeId = (String) slotRangeNodes.get(2);
+      String nodeId = (String) SafeEncoder.encode((byte[]) slotRangeNodes.get(2));
       if (nodes.add(nodeId)) {
         List<Long> slotNums = slotInfoToSlotRange(slotInfo);
         slotRanges.add(slotNums);

--- a/src/test/java/build/buildfarm/common/redis/RedisNodeHashesMockTest.java
+++ b/src/test/java/build/buildfarm/common/redis/RedisNodeHashesMockTest.java
@@ -29,6 +29,7 @@ import org.junit.runners.JUnit4;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.util.SafeEncoder;
 
 /**
  * @class RedisNodeHashesMockTest
@@ -50,7 +51,7 @@ public class RedisNodeHashesMockTest {
     when(node.clusterSlots())
         .thenReturn(
             Collections.singletonList(
-                Arrays.asList(0L, 100L, Arrays.asList(null, null, "nodeId"))));
+                Arrays.asList(0L, 100L, Arrays.asList(null, null, SafeEncoder.encode("nodeId")))));
 
     JedisPool pool = mock(JedisPool.class);
     when(pool.getResource()).thenReturn(node);
@@ -102,8 +103,9 @@ public class RedisNodeHashesMockTest {
     when(node.clusterSlots())
         .thenReturn(
             Arrays.asList(
-                Arrays.asList(0L, 100L, Arrays.asList(null, null, "nodeId1")),
-                Arrays.asList(101L, 200L, Arrays.asList(null, null, "nodeId2"))));
+                Arrays.asList(0L, 100L, Arrays.asList(null, null, SafeEncoder.encode("nodeId1"))),
+                Arrays.asList(
+                    101L, 200L, Arrays.asList(null, null, SafeEncoder.encode("nodeId2")))));
 
     JedisPool pool = mock(JedisPool.class);
     when(pool.getResource()).thenReturn(node);


### PR DESCRIPTION
Node name strings provided via `cluster slots` will be byte arrays that require decoding. Use the inbuilt SafeEncoder from jedis which is used to decode all other strings.