### PR TITLE
Provide hashedName in BackplaneStatus Queue Name

### DIFF
--- a/src/main/java/build/buildfarm/common/redis/BalancedRedisQueue.java
+++ b/src/main/java/build/buildfarm/common/redis/BalancedRedisQueue.java
@@ -330,7 +330,11 @@ public class BalancedRedisQueue {
     }
 
     // build proto
-    return QueueStatus.newBuilder().setName(name).setSize(size).addAllInternalSizes(sizes).build();
+    return QueueStatus.newBuilder()
+        .setName(RedisHashtags.hashedName(name, originalHashtag))
+        .setSize(size)
+        .addAllInternalSizes(sizes)
+        .build();
   }
 
   /**


### PR DESCRIPTION
Avoid stripping the existingHash, used to calculate the slot with suffix modifiers for queue balancing. Client presentation may also move to presenting each balanced queue name, removing the coordinated calculation on the client.

The name could only have been used by a client prior for name presentation or determination of queue names in redis from slot arrangement.