### PR TITLE
fix(helm-chart): nodeSelector for shard worker

### DIFF
--- a/kubernetes/helm-charts/buildfarm/templates/shard-worker/statefulsets.yaml
+++ b/kubernetes/helm-charts/buildfarm/templates/shard-worker/statefulsets.yaml
@@ -79,7 +79,8 @@ spec:
             {{- end }}
 
       {{- with .Values.shardWorker.nodeSelector }}
-      {{- tpl (toYaml .) $ | nindent 6 -}}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
       {{- end }}
 
       {{- with .Values.shardWorker.affinity }}


### PR DESCRIPTION
`shard-worker/statefulsets.yaml` manifest would fails to apply without this fix.

Before:
```
...
             - mountPath: /tmp/worker
               name: buildfarm-shard-worker-data
       node-type: buildfarm-node
       volumes:
...
```

After:
```
...
             - mountPath: /tmp/worker
               name: buildfarm-shard-worker-data
       nodeSelector:
         node-type: buildfarm-node
       volumes:
...
```