### PR TITLE
Disable action cache write in default config

### DIFF
--- a/examples/config.yml
+++ b/examples/config.yml
@@ -7,7 +7,7 @@ allowSymlinkTargetAbsolute: false
 server:
   instanceType: SHARD
   name: shard
-  actionCacheReadOnly: false
+  actionCacheReadOnly: true
   port: 8980
   grpcMetrics:
     enabled: true


### PR DESCRIPTION
Ability to write to action cache is a security risk. Set it to read only in default configuration.