### PR TITLE
Disable rules_docker transitions

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -4,6 +4,9 @@ build --java_runtime_version=remotejdk_17
 build --tool_java_language_version=17
 build --tool_java_runtime_version=remotejdk_17
 
+# Prevents rules_docker issues when building with bazel 7
+build --@io_bazel_rules_docker//transitions:enable=false
+
 common --enable_platform_specific_config
 
 build:fuse --define=fuse=true


### PR DESCRIPTION
This PR fixes the issues introduced by setting default bazel version to 7, which is now breaking CI.

Example errors:

```
in constraint_values attribute of platform rule @@io_bazel_rules_docker//platforms:image_transition: '@@io_bazel_rules_docker//platforms:image_transition_cpu' does not have mandatory providers: 'ConstraintValueInfo'

Analysis of target '@@io_bazel_rules_docker//platforms:image_transition' failed ERROR: /home/yuriyb/bazel-buildfarm/BUILD:119:11: Target @@io_bazel_rules_docker//platforms:image_transition was referenced as a platform, but does not provide PlatformInfo
```