### PR TITLE
chore: update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @werkt @ulfjack
+*   @werkt


### PR DESCRIPTION
Removing a stale codeowner that's not part of the repo anymore, per GitHub warning.