### PR TITLE
build(protobuf): switch to protobuf from BCR

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,7 +4,8 @@ module(
 )
 
 bazel_dep(name = "gazelle", version = "0.34.0", repo_name = "bazel_gazelle")
-bazel_dep(name = "platforms", version = "0.0.7")
+bazel_dep(name = "platforms", version = "0.0.8")
+bazel_dep(name = "protobuf", version = "23.1", repo_name = "com_google_protobuf")
 bazel_dep(name = "rules_cc", version = "0.0.9")
 bazel_dep(name = "rules_go", version = "0.43.0", repo_name = "io_bazel_rules_go")
 bazel_dep(name = "rules_jvm_external", version = "5.3")

--- a/deps.bzl
+++ b/deps.bzl
@@ -7,13 +7,6 @@ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
 def archive_dependencies(third_party):
     return [
-        # Needed for "well-known protos" and @com_google_protobuf//:protoc.
-        {
-            "name": "com_google_protobuf",
-            "sha256": "79082dc68d8bab2283568ce0be3982b73e19ddd647c2411d1977ca5282d2d6b3",
-            "strip_prefix": "protobuf-25.0",
-            "urls": ["https://github.com/protocolbuffers/protobuf/archive/v25.0.zip"],
-        },
         # Needed for @grpc_java//compiler:grpc_java_plugin.
         {
             "name": "io_grpc_grpc_java",


### PR DESCRIPTION
Swap to using the protobuf dependency directly from Bazel Central Registry (BCR) at http://registry.bazel.build

This is a downgrade (25.0->23.1), but 23.1 is the latest in the BCR today.