### PR TITLE
build: add cgroup-tools to the ubuntu base images

### DIFF
--- a/ci/base-worker-image/jammy/Dockerfile
+++ b/ci/base-worker-image/jammy/Dockerfile
@@ -3,4 +3,4 @@
 FROM ubuntu:22.04
 
 RUN apt-get update
-RUN apt-get -y install default-jre default-jdk build-essential libfuse2
+RUN apt-get -y install default-jre default-jdk build-essential libfuse2 cgroup-tools

--- a/ci/base-worker-image/mantic/Dockerfile
+++ b/ci/base-worker-image/mantic/Dockerfile
@@ -3,4 +3,4 @@
 FROM ubuntu:23.04
 
 RUN apt-get update
-RUN apt-get -y install default-jre default-jdk build-essential libfuse2
+RUN apt-get -y install default-jre default-jdk build-essential libfuse2 cgroup-tools


### PR DESCRIPTION
This is part 1 of a two-part PR to remove [`download_pkgs()`](https://github.com/bazelbuild/bazel-buildfarm/blob/cf5f08f1c6a643f6d092beb4747449d9a6d6657f/BUILD#L142C1-L142C14) and [`install_pkgs()`](https://github.com/bazelbuild/bazel-buildfarm/blob/cf5f08f1c6a643f6d092beb4747449d9a6d6657f/BUILD#L149) from `/BUILD.bazel`