### PR TITLE
[helm] Support autoscaling/{v2beta2,v2} for HPA.

### DIFF
--- a/kubernetes/helm-charts/buildfarm/templates/_helpers.tpl
+++ b/kubernetes/helm-charts/buildfarm/templates/_helpers.tpl
@@ -61,6 +61,18 @@ Create the name of the service account to use
 {{- end }}
 {{- end }}
 
+{{/*
+Create the APIsersion of the holizontal pod autoscaler
+*/}}
+{{- define "buildfarm.autoscalingVersion" -}}
+{{- if (.Capabilities.APIVersions.Has "autoscaling/v2") -}}
+autoscaling/v2
+{{- else if (.Capabilities.APIVersions.Has "autoscaling/v2beta2") -}}
+autoscaling/v2beta2
+{{- else -}}
+autoscaling/v1
+{{- end -}}
+{{- end -}}
 
 {{/* Checks for `externalRedis` */}}
 {{- if .Values.externalRedis.host }}

--- a/kubernetes/helm-charts/buildfarm/templates/shard-worker/autoscaler.yaml
+++ b/kubernetes/helm-charts/buildfarm/templates/shard-worker/autoscaler.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.shardWorker.autoscaling.enabled -}}
-apiVersion: autoscaling/v1
+apiVersion: {{ include "buildfarm.autoscalingVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "buildfarm.fullname" . }}-shard-worker
@@ -17,5 +17,14 @@ spec:
     apiVersion: apps/v1
     kind: StatefulSet
     name:  {{ include "buildfarm.fullname" . }}-shard-worker
+  {{- if contains "autoscaling/v2" (include "buildfarm.autoscalingVersion" . ) }}
+    {{- if .Values.shardWorker.autoscaling.behavior }}
+  behavior:
+      {{- toYaml .Values.shardWorker.autoscaling.behavior | nindent 4 }}
+    {{- end }}
+  metrics:
+    {{- toYaml .Values.shardWorker.autoscaling.metrics | nindent 4 }}
+  {{- else }}
   targetCPUUtilizationPercentage: {{ .Values.shardWorker.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
 {{- end }}

--- a/kubernetes/helm-charts/buildfarm/values.yaml
+++ b/kubernetes/helm-charts/buildfarm/values.yaml
@@ -109,7 +109,15 @@ shardWorker:
     enabled: true
     minReplicas: 2
     maxReplicas: 4
-    targetCPUUtilizationPercentage: 50
+    behavior: {} # effective only in `v2*`
+    metrics: # effective only in `v2*`
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 50
+    targetCPUUtilizationPercentage: 50 # effective only in `v1`
 
   resources: { }
     # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
Currently the Helm chart supports HPA v1 only.
That API version is too old. 

I tested this with AKS 1.28.5.

```
$ kubectl version --short
Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.
Client Version: v1.26.13
Kustomize Version: v4.5.7
Server Version: v1.28.5
```