### PR TITLE
ci: Fix rules_oci docker publish

### DIFF
--- a/.github/workflows/buildfarm-images-build-and-deploy.yml
+++ b/.github/workflows/buildfarm-images-build-and-deploy.yml
@@ -24,8 +24,8 @@ jobs:
 
       - name: Build Server Image
         id: buildAndPushServerImage
-        run: bazel run public_push_buildfarm-server --define release_version=latest
+        run: bazel run public_push_buildfarm-server -- --tag latest
 
       - name: Build Worker Image
         id: buildAndPushWorkerImage
-        run: bazel run public_push_buildfarm-worker --define release_version=latest
+        run: bazel run public_push_buildfarm-worker -- --tag latest

--- a/.github/workflows/buildfarm-release-build-and-deploy.yml
+++ b/.github/workflows/buildfarm-release-build-and-deploy.yml
@@ -23,8 +23,8 @@ jobs:
     
       - name: Build Server Image
         id: buildAndPushServerImage
-        run: bazel run public_push_buildfarm-server --define release_version=${{ github.event.release.tag_name }}
+        run: bazel run public_push_buildfarm-server -- --tag ${{ github.event.release.tag_name }}
     
       - name: Build Worker Image
         id: buildAndPushWorkerImage
-        run: bazel run public_push_buildfarm-worker --define release_version=${{ github.event.release.tag_name }}
+        run: bazel run public_push_buildfarm-worker -- --tag ${{ github.event.release.tag_name }}

--- a/BUILD
+++ b/BUILD
@@ -239,7 +239,7 @@ oci_image(
 ######
 # Helpers to write to the local Docker Desktop's registry
 # Usage: `bazel run //:tarball_server_amd64 && docker run --rm buildfarm-server:amd64`
-# ####
+######
 [
     [
         oci_tarball(
@@ -252,10 +252,8 @@ oci_image(
         oci_push(
             name = "public_push_buildfarm-%s" % image,
             image = ":buildfarm-%s" % image,
-            remote_tags = [
-                "$(release_version)",
-            ],
             repository = "index.docker.io/bazelbuild/buildfarm-%s" % image,
+            # Specify the tag with `bazel run public_push_buildfarm-server public_push_buildfarm-worker -- --tag latest`
             tags = ["container"],
         ),
     ]

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/bazelbuild/bazel-buildfarm/badge)](https://securityscorecards.dev/viewer/?uri=github.com/bazelbuild/bazel-buildfarm)
 ![GitHub License](https://img.shields.io/github/license/bazelbuild/bazel-buildfarm)
 ![GitHub Release](https://img.shields.io/github/v/release/bazelbuild/bazel-buildfarm)
+![Docker Pulls](https://img.shields.io/docker/pulls/bazelbuild/buildfarm-server)
 
 
 This repository hosts the [Bazel](https://bazel.build) remote caching and execution system.


### PR DESCRIPTION
Mistakenly tried to publish to tag `$%28release_version%29` when we intended to publish `latest`