### PR TITLE
Fix link to IJ screenshot

### DIFF
--- a/_site/docs/contribute/local_development.md
+++ b/_site/docs/contribute/local_development.md
@@ -75,4 +75,4 @@ bazel run //src/main/java/build/buildfarm:buildfarm-shard-worker $PWD/examples/c
 Now, you should have something like this, and you can now run / debug Buildfarm
 Server from inside of IntelliJ, just like any other program:
 
-![IntelliJ Buildfarm Server run configuration]]({{site.url}}{{site.baseurl}}/assets/images/intellij-server-run-config.png)
+![IntelliJ Buildfarm Server run configuration]({{site.url}}{{site.baseurl}}/assets/images/intellij-server-run-config.png)


### PR DESCRIPTION
### Before

<img width="1725" alt="Screenshot 2024-03-20 at 16 41 13" src="https://github.com/bazelbuild/bazel-buildfarm/assets/1374489/161382ce-6715-4aa1-9a3d-89b16c370598">

### After

<img width="1728" alt="Screenshot 2024-03-20 at 16 41 51" src="https://github.com/bazelbuild/bazel-buildfarm/assets/1374489/f01a8feb-103b-474c-b331-283ef524247d">
