### PR TITLE
publish Helm chart as OCI artifact to ghcr.io

### DIFF
--- a/.github/workflows/buildfarm-helm-chart-publish.yml
+++ b/.github/workflows/buildfarm-helm-chart-publish.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   CHART_ROOT: "${{ github.workspace }}/kubernetes/helm-charts/buildfarm"
-  GCR_IMAGE: ghcr.io/${{ github.repository_owner }}/buildfarm
+  GCR_IMAGE: ghcr.io/${{ github.repository_owner }}/bazel-buildfarm
 
 jobs:
   build:

--- a/.github/workflows/buildfarm-helm-chart-publish.yml
+++ b/.github/workflows/buildfarm-helm-chart-publish.yml
@@ -7,8 +7,8 @@ on:
       - 'helm/*'
 
 env:
-  GH_TOKEN: ${{ github.token }}
-  CHART_ROOT: kubernetes/helm-charts/buildfarm
+  CHART_ROOT: "${{ github.workspace }}/kubernetes/helm-charts/buildfarm"
+  GCR_IMAGE: ghcr.io/${{ github.repository_owner }}/buildfarm
 
 jobs:
   build:
@@ -32,11 +32,27 @@ jobs:
           yq -i \
             '.version |= "${{ steps.get-chart-ver.outputs.chart_ver }}"' \
             ${CHART_ROOT}/Chart.yaml
-      - id: helm-lint-package-release
+      - id: helm-lint
         name: Helm Chart Lint, Package, and Release
         run: |-
           set -ex
           helm dep up "${CHART_ROOT}"
           helm lint "${CHART_ROOT}"
-          helm package "${CHART_ROOT}"
-          gh release create "${{ github.ref_name }}" *.tgz
+      - id: helm-bundle-push
+        name: Helm Chart Lint, Package, and Release
+        run: |-
+          set -e
+          echo ${{ secrets.GITHUB_TOKEN }} | \
+            helm registry \
+              login ${{ env.GCR_IMAGE }} \
+              --username ${{ github.repository_owner }} \
+              --password-stdin
+          set -ex
+          helm dep up "${CHART_ROOT}"
+          helm lint "${CHART_ROOT}"
+          export FQ_IMAGE="${{ env.GCR_IMAGE }}:${{ steps.get-chart-ver.outputs.chart_ver }}"
+          helm chart save \
+            "${CHART_ROOT}" \
+            "${FQ_IMAGE}"
+          helm chart push \
+            "${FQ_IMAGE}"

--- a/.github/workflows/buildfarm-helm-chart-publish.yml
+++ b/.github/workflows/buildfarm-helm-chart-publish.yml
@@ -34,13 +34,13 @@ jobs:
             '.version |= "${{ steps.get-chart-ver.outputs.chart_ver }}"' \
             ${CHART_ROOT}/Chart.yaml
       - id: helm-lint
-        name: Helm Chart Lint, Package, and Release
+        name: Helm Chart Lint
         run: |-
           set -ex
           helm dep up "${CHART_ROOT}"
           helm lint "${CHART_ROOT}"
       - id: helm-bundle-push
-        name: Helm Chart Package, and Release
+        name: Helm Chart Package and Release
         run: |-
           set -e
           echo ${{ secrets.GITHUB_TOKEN }} | \
@@ -50,7 +50,6 @@ jobs:
               --password-stdin
           set -ex
           helm dep up "${CHART_ROOT}"
-          helm lint "${CHART_ROOT}"
           helm package "${CHART_ROOT}"
           export CHART_BUNDLE="${CHART_NAME}-${{ steps.get-chart-ver.outputs.chart_ver }}.tgz"
           ls -l "${CHART_BUNDLE}"

--- a/.github/workflows/buildfarm-helm-chart-publish.yml
+++ b/.github/workflows/buildfarm-helm-chart-publish.yml
@@ -8,7 +8,8 @@ on:
 
 env:
   CHART_NAME: buildfarm
-  CHART_ROOT: "${{ github.workspace }}/kubernetes/helm-charts/buildfarm"
+  CHART_ROOT: ${{ github.workspace }}/kubernetes/helm-charts/buildfarm
+  GHCR_REPO: ghcr.io/${{ github.repository_owner }}
 
 jobs:
   build:
@@ -44,8 +45,8 @@ jobs:
           set -e
           echo ${{ secrets.GITHUB_TOKEN }} | \
             helm registry \
-              login ${{ env.GCR_IMAGE }} \
-              --username ${{ github.repository_owner }} \
+              login "${GHCR_REPO}" \
+              --username "${{ github.repository_owner }}" \
               --password-stdin
           set -ex
           helm dep up "${CHART_ROOT}"
@@ -55,4 +56,4 @@ jobs:
           ls -l "${CHART_BUNDLE}"
           helm push \
             "${CHART_BUNDLE}" \
-            "ghcr.io/${{ github.repository_owner }}"
+            "${GHCR_REPO}"

--- a/.github/workflows/buildfarm-helm-chart-publish.yml
+++ b/.github/workflows/buildfarm-helm-chart-publish.yml
@@ -40,7 +40,7 @@ jobs:
           helm dep up "${CHART_ROOT}"
           helm lint "${CHART_ROOT}"
       - id: helm-bundle-push
-        name: Helm Chart Package and Release
+        name: Helm Chart Bundle and Push
         run: |-
           set -e
           echo ${{ secrets.GITHUB_TOKEN }} | \

--- a/.github/workflows/buildfarm-helm-chart-publish.yml
+++ b/.github/workflows/buildfarm-helm-chart-publish.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   CHART_NAME: buildfarm
-  CHART_ROOT: "${{ github.workspace }}/kubernetes/helm-charts/${{ env.CHART_NAME }}"
+  CHART_ROOT: "${{ github.workspace }}/kubernetes/helm-charts/buildfarm"
 
 jobs:
   build:

--- a/.github/workflows/buildfarm-helm-chart-publish.yml
+++ b/.github/workflows/buildfarm-helm-chart-publish.yml
@@ -56,4 +56,4 @@ jobs:
           ls -l "${CHART_BUNDLE}"
           helm push \
             "${CHART_BUNDLE}" \
-            "${GHCR_REPO}"
+            "oci://${GHCR_REPO}"

--- a/.github/workflows/buildfarm-helm-chart-publish.yml
+++ b/.github/workflows/buildfarm-helm-chart-publish.yml
@@ -7,8 +7,8 @@ on:
       - 'helm/*'
 
 env:
-  CHART_ROOT: "${{ github.workspace }}/kubernetes/helm-charts/buildfarm"
-  GCR_IMAGE: ghcr.io/${{ github.repository_owner }}/bazel-buildfarm
+  CHART_NAME: buildfarm
+  CHART_ROOT: "${{ github.workspace }}/kubernetes/helm-charts/${{ env.CHART_NAME }}"
 
 jobs:
   build:
@@ -39,7 +39,7 @@ jobs:
           helm dep up "${CHART_ROOT}"
           helm lint "${CHART_ROOT}"
       - id: helm-bundle-push
-        name: Helm Chart Lint, Package, and Release
+        name: Helm Chart Package, and Release
         run: |-
           set -e
           echo ${{ secrets.GITHUB_TOKEN }} | \
@@ -50,9 +50,9 @@ jobs:
           set -ex
           helm dep up "${CHART_ROOT}"
           helm lint "${CHART_ROOT}"
-          export FQ_IMAGE="${{ env.GCR_IMAGE }}:${{ steps.get-chart-ver.outputs.chart_ver }}"
-          helm chart save \
-            "${CHART_ROOT}" \
-            "${FQ_IMAGE}"
-          helm chart push \
-            "${FQ_IMAGE}"
+          helm package "${CHART_ROOT}"
+          export CHART_BUNDLE="${CHART_NAME}-${{ steps.get-chart-ver.outputs.chart_ver }}.tgz"
+          ls -l "${CHART_BUNDLE}"
+          helm push \
+            "${CHART_BUNDLE}" \
+            "ghcr.io/${{ github.repository_owner }}"

--- a/README.md
+++ b/README.md
@@ -147,5 +147,6 @@ helm install \
   -n bazel-buildfarm \
   --create-namespace \
   bazel-buildfarm \
-  ghcr.io/bazelbuild/buildfarm
+  oci://ghcr.io/bazelbuild/buildfarm \
+  --version "2.3.1"
 ```

--- a/README.md
+++ b/README.md
@@ -140,14 +140,12 @@ buildfarm_images()
 
 ### Helm Chart
 
-To install with helm:
+To install OCI bundled Helm chart:
 
 ```bash
-# https://github.com/bazelbuild/bazel-buildfarm/releases/download/helm%2F0.3.0/buildfarm-0.3.0.tgz
-CHART_VER="0.3.0"
 helm install \
   -n bazel-buildfarm \
   --create-namespace \
   bazel-buildfarm \
-  "https://github.com/bazelbuild/bazel-buildfarm/releases/download/helm%2F${CHART_VER}/buildfarm-${CHART_VER}.tgz"
+  ghcr.io/bazelbuild/buildfarm
 ```

--- a/README.md
+++ b/README.md
@@ -148,5 +148,5 @@ helm install \
   --create-namespace \
   bazel-buildfarm \
   oci://ghcr.io/bazelbuild/buildfarm \
-  --version "2.3.1"
+  --version "0.2.4"
 ```

--- a/kubernetes/helm-charts/buildfarm/Chart.yaml
+++ b/kubernetes/helm-charts/buildfarm/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 2.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/kubernetes/helm-charts/buildfarm/Chart.yaml
+++ b/kubernetes/helm-charts/buildfarm/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.3.1
+version: 0.2.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
in lieu of publishing a tgz as a GitHub release artifact, this change publishes (on tag `helm/${semver}`) the Helm chart bundled as an OCI artifact to the GitHub container registry, i.e. ghcr.io. I also updated the installation instructions which are now less gory. This change requires granting public read access to the corresponding buildfarm "package" within the bazel-buildfarm project. It defaults to private.