### PR TITLE
feat: change `operation_status` Prometheus metric labels

### DIFF
--- a/_site/docs/metrics/metrics.md
+++ b/_site/docs/metrics/metrics.md
@@ -78,7 +78,7 @@ Counter for the number of operations in each stage (using a `stage_name` for eac
 
 **operation_status**
 
-Counter for the completed operations status (using a `status_code` label for each individual GRPC code)
+Counter for the completed operations status (using a `code` label for each individual [GRPC status code](https://grpc.github.io/grpc/core/md_doc_statuscodes.html))
 
 **operation_exit_code**
 

--- a/src/main/java/build/buildfarm/metrics/AbstractMetricsPublisher.java
+++ b/src/main/java/build/buildfarm/metrics/AbstractMetricsPublisher.java
@@ -22,6 +22,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.longrunning.Operation;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
+import com.google.rpc.Code;
 import com.google.rpc.PreconditionFailure;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Histogram;
@@ -41,7 +42,7 @@ public abstract class AbstractMetricsPublisher implements MetricsPublisher {
   private static final Counter operationStatus =
       Counter.build()
           .name("operation_status")
-          .labelNames("status_code")
+          .labelNames("code")
           .help("Operation execution status.")
           .register();
   private static final Counter operationsPerWorker =
@@ -99,8 +100,8 @@ public abstract class AbstractMetricsPublisher implements MetricsPublisher {
                 .build();
         operationStatus
             .labels(
-                Integer.toString(
-                    operationRequestMetadata.getExecuteResponse().getStatus().getCode()))
+                Code.forNumber(operationRequestMetadata.getExecuteResponse().getStatus().getCode())
+                    .name())
             .inc();
         operationExitCode
             .labels(


### PR DESCRIPTION
Prefer to use the GRPC status Code name instead of int.