### PR TITLE
fix: metrics math was not including seconds portion of Timestamp

### DIFF
--- a/src/main/java/build/buildfarm/common/Time.java
+++ b/src/main/java/build/buildfarm/common/Time.java
@@ -14,8 +14,12 @@
 
 package build.buildfarm.common;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.google.protobuf.Duration;
+import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Durations;
+import com.google.protobuf.util.Timestamps;
 import io.grpc.Deadline;
 import java.util.concurrent.TimeUnit;
 
@@ -68,5 +72,19 @@ public class Time {
    */
   public static long millisecondsToSeconds(long milliseconds) {
     return milliseconds / 1000L;
+  }
+
+  /**
+   * Converts the difference in two timestamps, into milliseconds
+   *
+   * @param start
+   * @param end
+   * @return The difference, in milliseconds
+   * @throws IllegalArgumentException if start > end.
+   */
+  public static double toDurationMs(Timestamp start, Timestamp end) {
+    // start must be <= end
+    checkArgument(Timestamps.compare(start, end) <= 0);
+    return Durations.toMillis(Timestamps.between(start, end));
   }
 }

--- a/src/main/java/build/buildfarm/metrics/BUILD
+++ b/src/main/java/build/buildfarm/metrics/BUILD
@@ -4,6 +4,7 @@ java_library(
     plugins = ["//src/main/java/build/buildfarm/common:lombok"],
     visibility = ["//visibility:public"],
     deps = [
+        "//src/main/java/build/buildfarm/common",
         "//src/main/protobuf:build_buildfarm_v1test_buildfarm_java_proto",
         "@com_google_googleapis//google/rpc:rpc_java_proto",
         "@maven//:com_google_guava_guava",

--- a/src/main/java/build/buildfarm/worker/PutOperationStage.java
+++ b/src/main/java/build/buildfarm/worker/PutOperationStage.java
@@ -242,13 +242,5 @@ public class PutOperationStage extends PipelineStage.NullStage {
 
       return average;
     }
-
-    private static float millisecondBetween(Timestamp from, Timestamp to) {
-      // The time unit we want is millisecond.
-      // 1 second = 1000 milliseconds
-      // 1 millisecond = 1000,000 nanoseconds
-      Duration d = Timestamps.between(from, to);
-      return d.getSeconds() * 1000.0f + d.getNanos() / (1000.0f * 1000.0f);
-    }
   }
 }

--- a/src/test/java/build/buildfarm/common/TimeTest.java
+++ b/src/test/java/build/buildfarm/common/TimeTest.java
@@ -1,4 +1,18 @@
-package build.buildfarm.metrics;
+// Copyright 2024 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.common;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
@@ -9,14 +23,15 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
-public class AbstractMetricsPublisherTest {
+public class TimeTest {
 
   @Test
   public void toDurationMs() {
     Timestamp t1 = Timestamp.newBuilder().setSeconds(123).setNanos(100).build();
     Timestamp t2 = Timestamp.newBuilder().setSeconds(t1.getSeconds() + 120).setNanos(200).build();
     // t2 is 60sec+100ns after t1.
-    assertThat(AbstractMetricsPublisher.toDurationMs(t1, t2)).isEqualTo(120000.0001);
+    // The result is rounded to the nearest millisecond.
+    assertThat(Time.toDurationMs(t1, t2)).isEqualTo(120000.0);
   }
 
   @Test
@@ -25,7 +40,7 @@ public class AbstractMetricsPublisherTest {
     Timestamp t1 = Timestamp.newBuilder().setSeconds(123).setNanos(100).build();
     Timestamp t2 = Timestamp.newBuilder().setSeconds(111).setNanos(t1.getNanos()).build();
     // t2 is _before_ t1, which is a precondition failure
-    assertThrows(IllegalStateException.class, () -> AbstractMetricsPublisher.toDurationMs(t1, t2));
+    assertThrows(IllegalArgumentException.class, () -> Time.toDurationMs(t1, t2));
   }
 
   @Test
@@ -34,7 +49,7 @@ public class AbstractMetricsPublisherTest {
     Timestamp t1 = Timestamp.newBuilder().setSeconds(123).setNanos(777).build();
     Timestamp t2 = Timestamp.newBuilder().setSeconds(t1.getSeconds()).setNanos(222).build();
     // t2 is _before_ t1, which is a precondition failure
-    assertThrows(IllegalStateException.class, () -> AbstractMetricsPublisher.toDurationMs(t1, t2));
+    assertThrows(IllegalArgumentException.class, () -> Time.toDurationMs(t1, t2));
   }
 
   /** "Borrow" from the seconds units into 1e9 more nanoseconds. */
@@ -46,7 +61,8 @@ public class AbstractMetricsPublisherTest {
             .setNanos(999999800)
             .build(); // 200 nanoseconds short of a full second.
     Timestamp t2 = Timestamp.newBuilder().setSeconds(125).setNanos(0).build();
-    assertThat(AbstractMetricsPublisher.toDurationMs(t1, t2)).isEqualTo(1000.0002);
+    // The result is rounded to the nearest millisecond.
+    assertThat(Time.toDurationMs(t1, t2)).isEqualTo(1000.0);
   }
 
   @Test
@@ -56,6 +72,6 @@ public class AbstractMetricsPublisherTest {
     assertThat(t1).isNotSameInstanceAs(t2);
     assertThat(t1.getSeconds()).isEqualTo(t2.getSeconds());
     assertThat(t1.getNanos()).isEqualTo(t2.getNanos());
-    assertThat(AbstractMetricsPublisher.toDurationMs(t1, t2)).isEqualTo(0);
+    assertThat(Time.toDurationMs(t1, t2)).isEqualTo(0);
   }
 }

--- a/src/test/java/build/buildfarm/metrics/AbstractMetricsPublisherTest.java
+++ b/src/test/java/build/buildfarm/metrics/AbstractMetricsPublisherTest.java
@@ -1,0 +1,61 @@
+package build.buildfarm.metrics;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.google.protobuf.Timestamp;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class AbstractMetricsPublisherTest {
+
+  @Test
+  public void toDurationMs() {
+    Timestamp t1 = Timestamp.newBuilder().setSeconds(123).setNanos(100).build();
+    Timestamp t2 = Timestamp.newBuilder().setSeconds(t1.getSeconds() + 120).setNanos(200).build();
+    // t2 is 60sec+100ns after t1.
+    assertThat(AbstractMetricsPublisher.toDurationMs(t1, t2)).isEqualTo(120000.0001);
+  }
+
+  @Test
+  public void toDurationMsEndBeforeStart_Seconds() {
+    // Seconds
+    Timestamp t1 = Timestamp.newBuilder().setSeconds(123).setNanos(100).build();
+    Timestamp t2 = Timestamp.newBuilder().setSeconds(111).setNanos(t1.getNanos()).build();
+    // t2 is _before_ t1, which is a precondition failure
+    assertThrows(IllegalStateException.class, () -> AbstractMetricsPublisher.toDurationMs(t1, t2));
+  }
+
+  @Test
+  public void toDurationMsEndBeforeStart_Nanoseconds() {
+    // Nanoseconds
+    Timestamp t1 = Timestamp.newBuilder().setSeconds(123).setNanos(777).build();
+    Timestamp t2 = Timestamp.newBuilder().setSeconds(t1.getSeconds()).setNanos(222).build();
+    // t2 is _before_ t1, which is a precondition failure
+    assertThrows(IllegalStateException.class, () -> AbstractMetricsPublisher.toDurationMs(t1, t2));
+  }
+
+  /** "Borrow" from the seconds units into 1e9 more nanoseconds. */
+  @Test
+  public void toDurationBorrow() {
+    Timestamp t1 =
+        Timestamp.newBuilder()
+            .setSeconds(123)
+            .setNanos(999999800)
+            .build(); // 200 nanoseconds short of a full second.
+    Timestamp t2 = Timestamp.newBuilder().setSeconds(125).setNanos(0).build();
+    assertThat(AbstractMetricsPublisher.toDurationMs(t1, t2)).isEqualTo(1000.0002);
+  }
+
+  @Test
+  public void toDurationMsEqual() {
+    Timestamp t1 = Timestamp.newBuilder().setSeconds(123).setNanos(100).build();
+    Timestamp t2 = Timestamp.newBuilder(t1).build();
+    assertThat(t1).isNotSameInstanceAs(t2);
+    assertThat(t1.getSeconds()).isEqualTo(t2.getSeconds());
+    assertThat(t1.getNanos()).isEqualTo(t2.getNanos());
+    assertThat(AbstractMetricsPublisher.toDurationMs(t1, t2)).isEqualTo(0);
+  }
+}


### PR DESCRIPTION
The metrics math was only looking at the `getNanos()` part of com.google.protobuf.Timestamp . This adds a helper and adds a unit test.