### PR TITLE
build(docs): don't publish github site for buildfarm forks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build_and_deploy:
+    if: github.repository == 'bazelbuild/bazel-buildfarm'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Whenever pushing the default branch to my fork, GitHub Actions tries to publish the doc site. Since it's an error, we might as well turn it off.