### PR TITLE
[helm] Add apiVersion and kind to the StatefulSets volumeClaimTemplates.

### DIFF
--- a/kubernetes/helm-charts/buildfarm/templates/shard-worker/statefulsets.yaml
+++ b/kubernetes/helm-charts/buildfarm/templates/shard-worker/statefulsets.yaml
@@ -99,7 +99,9 @@ spec:
         {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: {{ include "buildfarm.fullname" . }}-shard-worker-data
       spec:
         accessModes: ["ReadWriteOnce"]


### PR DESCRIPTION
When you deploy this Helm chart via ArgoCD it continually shows as out of sync because the apiVersion and kind are missing in those volumeClaimTemplates.
Similar issues are known in other charts. for example: https://github.com/minio/minio/pull/18770 .
