### PR TITLE
fix(common): guard against empty RedisURI

### DIFF
--- a/src/main/java/build/buildfarm/common/config/Backplane.java
+++ b/src/main/java/build/buildfarm/common/config/Backplane.java
@@ -78,7 +78,11 @@ public class Backplane {
    * @return The redis password, or <c>null</c> if unset.
    */
   public @Nullable String getRedisPassword() {
-    URI redisProperUri = URI.create(getRedisUri());
+    String r = getRedisUri();
+    if (r == null) {
+      return null;
+    }
+    URI redisProperUri = URI.create(r);
     if (!Strings.isNullOrEmpty(JedisURIHelper.getPassword(redisProperUri))) {
       return JedisURIHelper.getPassword(redisProperUri);
     }


### PR DESCRIPTION
If a customer does not use `redisUri:` in the configuration, and instead uses `redisNodes:`, this can throw a NPE.