### PR TITLE
fix: Memorystore compatibility mode

### DIFF
--- a/src/main/java/build/buildfarm/common/redis/BUILD
+++ b/src/main/java/build/buildfarm/common/redis/BUILD
@@ -1,6 +1,7 @@
 java_library(
     name = "redis",
     srcs = glob(["*.java"]),
+    plugins = ["//src/main/java/build/buildfarm/common:lombok"],
     visibility = ["//visibility:public"],
     deps = [
         "//src/main/java/build/buildfarm/common",
@@ -9,6 +10,7 @@ java_library(
         "@maven//:com_google_code_findbugs_jsr305",
         "@maven//:com_google_guava_guava",
         "@maven//:io_grpc_grpc_api",
+        "@maven//:org_projectlombok_lombok",
         "@maven//:org_redisson_redisson",
         "@maven//:redis_clients_jedis",
     ],

--- a/src/main/java/build/buildfarm/common/redis/RedisNodeHashes.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisNodeHashes.java
@@ -44,7 +44,7 @@ import redis.clients.jedis.util.SafeEncoder;
 @Log
 public class RedisNodeHashes {
   private static final Iterable<List<List<Long>>> SINGLETON_NODE_SLOT_RANGES =
-      ImmutableList.of(ImmutableList.of(ImmutableList.of(0l, CLUSTER_HASHSLOTS - 1l)));
+      Collections.singleton(ImmutableList.of(ImmutableList.of(0l, CLUSTER_HASHSLOTS - 1l)));
 
   /**
    * @brief Get a list of evenly distributing hashtags for the provided redis cluster.
@@ -57,7 +57,7 @@ public class RedisNodeHashes {
     if (jedis instanceof JedisCluster) {
       try {
         Iterable<List<List<Long>>> nodeSlotRanges = getNodeSlotRanges(jedis);
-        ImmutableList.Builder hashTags = ImmutableList.builder();
+        ImmutableList.Builder<String> hashTags = ImmutableList.builder();
         for (List<List<Long>> slotRanges : nodeSlotRanges) {
           // we can use any slot that is in range for the node.
           // in this case, we will use the first slot in the first range.
@@ -86,7 +86,7 @@ public class RedisNodeHashes {
       JedisCluster cluster = (JedisCluster) jedis;
       Iterable<List<List<Long>>> nodeSlotRanges = getNodeSlotRanges(cluster);
       try {
-        ImmutableList.Builder hashTags = ImmutableList.builder();
+        ImmutableList.Builder<String> hashTags = ImmutableList.builder();
         for (List<List<Long>> slotRanges : nodeSlotRanges) {
           // we can use any slot that is in range for the node.
           // in this case, we will use the first slot.
@@ -130,7 +130,7 @@ public class RedisNodeHashes {
    * @return Cluster slot information.
    * @note Suggested return identifier: clusterShards.
    */
-  private static List<ClusterShardInfo> getClusterShards(JedisCluster jedis) {
+  private static Iterable<ClusterShardInfo> getClusterShards(JedisCluster jedis) {
     JedisException nodeException = null;
 
     for (Map.Entry<String, ConnectionPool> node : jedis.getClusterNodes().entrySet()) {

--- a/src/main/java/build/buildfarm/common/redis/RedisNodeHashes.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisNodeHashes.java
@@ -18,8 +18,13 @@ import static com.google.common.collect.Iterables.transform;
 import static redis.clients.jedis.Protocol.CLUSTER_HASHSLOTS;
 
 import com.google.common.collect.ImmutableList;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.logging.Level;
+import lombok.extern.java.Log;
 import redis.clients.jedis.ConnectionPool;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisCluster;
@@ -27,6 +32,7 @@ import redis.clients.jedis.UnifiedJedis;
 import redis.clients.jedis.exceptions.JedisClusterOperationException;
 import redis.clients.jedis.exceptions.JedisException;
 import redis.clients.jedis.resps.ClusterShardInfo;
+import redis.clients.jedis.util.SafeEncoder;
 
 /**
  * @class RedisNodeHashes
@@ -35,6 +41,7 @@ import redis.clients.jedis.resps.ClusterShardInfo;
  *     which each hashtag hashes to a particular slot owned by a particular worker. This class is
  *     used to obtain the hashtags needed to hit every node in the cluster.
  */
+@Log
 public class RedisNodeHashes {
   private static final Iterable<List<List<Long>>> SINGLETON_NODE_SLOT_RANGES =
       ImmutableList.of(ImmutableList.of(ImmutableList.of(0l, CLUSTER_HASHSLOTS - 1l)));
@@ -104,7 +111,13 @@ public class RedisNodeHashes {
   private static Iterable<List<List<Long>>> getNodeSlotRanges(UnifiedJedis jedis) {
     if (jedis instanceof JedisCluster) {
       // get slot range information for each shard
-      return transform(getClusterShards((JedisCluster) jedis), ClusterShardInfo::getSlots);
+      try {
+        return transform(getClusterShards((JedisCluster) jedis), ClusterShardInfo::getSlots);
+      } catch (RuntimeException re) {
+        log.log(
+            Level.WARNING, "CLUSTER SHARDS failed. Falling back to CLUSTER NODES (deprecated)", re);
+        return Collections.singleton(getNodeSlotRangesDeprecated((JedisCluster) jedis));
+      }
     } else {
       return SINGLETON_NODE_SLOT_RANGES;
     }
@@ -119,10 +132,81 @@ public class RedisNodeHashes {
    */
   private static List<ClusterShardInfo> getClusterShards(JedisCluster jedis) {
     JedisException nodeException = null;
+
     for (Map.Entry<String, ConnectionPool> node : jedis.getClusterNodes().entrySet()) {
       ConnectionPool pool = node.getValue();
       try (Jedis resource = new Jedis(pool.getResource())) {
         return resource.clusterShards();
+      } catch (JedisException e) {
+        nodeException = e;
+        // log error with node
+      }
+    }
+    if (nodeException != null) {
+      throw nodeException;
+    }
+    throw new JedisClusterOperationException("No reachable node in cluster");
+  }
+
+  /*
+   * The code below is old and only for compatibility reasons with Google Memorystore Redis Cluster
+   * See also: https://github.com/redis/jedis/issues/3837
+   */
+
+  /**
+   * @brief Get a list of slot ranges for each of the nodes in the cluster.
+   * @details This information can be found from any of the redis nodes in the cluster.
+   * @param jedis An established jedis client.
+   * @return Slot ranges for all the nodes in the cluster.
+   * @note Suggested return identifier: slotRanges.
+   */
+  @SuppressWarnings("unchecked")
+  private static List<List<Long>> getNodeSlotRangesDeprecated(JedisCluster jedis) {
+    // get slot information for each node
+    List<Object> slots = getClusterSlots(jedis);
+    Set<String> nodes = new HashSet<>();
+
+    // convert slot information into a list of slot ranges
+    ImmutableList.Builder<List<Long>> slotRanges = ImmutableList.builder();
+    for (Object slotInfoObj : slots) {
+      List<Object> slotInfo = (List<Object>) slotInfoObj;
+      List<Object> slotRangeNodes = (List<Object>) slotInfo.get(2);
+      // 2 is primary node id
+      String nodeId = SafeEncoder.encode((byte[]) slotRangeNodes.get(2));
+      if (nodes.add(nodeId)) {
+        List<Long> slotNums = slotInfoToSlotRange(slotInfo);
+        slotRanges.add(slotNums);
+      }
+    }
+
+    return slotRanges.build();
+  }
+
+  /**
+   * @brief Convert a jedis slotInfo object to a range or slot numbers.
+   * @details Every redis node has a range of slots represented as integers.
+   * @param slotInfo Slot info objects from a redis node.
+   * @return The slot number range for the particular redis node.
+   * @note Suggested return identifier: slotRange.
+   */
+  private static List<Long> slotInfoToSlotRange(List<Object> slotInfo) {
+    return ImmutableList.of((Long) slotInfo.get(0), (Long) slotInfo.get(1));
+  }
+
+  /**
+   * @brief Query slot information for each redis node.
+   * @details Obtains cluster information for understanding slot ranges for balancing.
+   * @param jedis An established jedis client.
+   * @return Cluster slot information.
+   * @note Suggested return identifier: clusterSlots.
+   */
+  @SuppressWarnings("Deprecated")
+  private static List<Object> getClusterSlots(JedisCluster jedis) {
+    JedisException nodeException = null;
+    for (Map.Entry<String, ConnectionPool> node : jedis.getClusterNodes().entrySet()) {
+      ConnectionPool pool = node.getValue();
+      try (Jedis resource = new Jedis(pool.getResource())) {
+        return resource.clusterSlots();
       } catch (JedisException e) {
         nodeException = e;
         // log error with node


### PR DESCRIPTION
Google Memorystore's `CLUSTER SHARDS` reply is confusing Jedis. Fall back to using `CLUSTER SLOTS` if `CLUSTER SHARDS` throws any `RuntimeException`s.

The bulk of the implementation is resurrected from the implementation pre-https://github.com/bazelbuild/bazel-buildfarm/pull/1677

See also: https://github.com/redis/jedis/issues/3837