### PR TITLE
chore: remove un-implemented interface

### DIFF
--- a/src/main/java/build/buildfarm/worker/WorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/WorkerContext.java
@@ -83,10 +83,6 @@ public interface WorkerContext {
 
   boolean hasMaximumActionTimeout();
 
-  boolean getStreamStdout();
-
-  boolean getStreamStderr();
-
   Duration getDefaultActionTimeout();
 
   Duration getMaximumActionTimeout();

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -447,16 +447,6 @@ class ShardWorkerContext implements WorkerContext {
   }
 
   @Override
-  public boolean getStreamStdout() {
-    return true;
-  }
-
-  @Override
-  public boolean getStreamStderr() {
-    return true;
-  }
-
-  @Override
   public Duration getDefaultActionTimeout() {
     return defaultActionTimeout;
   }

--- a/src/test/java/build/buildfarm/worker/StubWorkerContext.java
+++ b/src/test/java/build/buildfarm/worker/StubWorkerContext.java
@@ -117,16 +117,6 @@ class StubWorkerContext implements WorkerContext {
   }
 
   @Override
-  public boolean getStreamStdout() {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public boolean getStreamStderr() {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
   public Duration getDefaultActionTimeout() {
     throw new UnsupportedOperationException();
   }


### PR DESCRIPTION
This isn't used anywhere. Can we remove it?