### PR TITLE
Prevent write completion starvation for duplicates

### DIFF
--- a/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
+++ b/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
@@ -2616,6 +2616,9 @@ public abstract class CASFileCache implements ContentAddressableStorage {
             onInsert,
             isReset);
     if (out == DUPLICATE_OUTPUT_STREAM) {
+      log.log(Level.FINER, format("duplicate output stream, completing %s for %s", key, writeId));
+      writeWinner.get();
+      onInsert.run();
       return null;
     }
     log.log(Level.FINER, format("entry %s is missing, downloading and populating", key));


### PR DESCRIPTION
When a duplicate output stream is detected, we must signal the writeWinner (because the write exists) and onInsert (because it was inserted) for an output stream creation. If we're racing, we should be eventually convergent, but this absolutely fixes a hang which occurs on this sentinel stream's return into getOutput, where the future might never be triggered otherwise.