### PR TITLE
chore: set java_language_level to 17 for IntelliJ

### DIFF
--- a/ij.bazelproject
+++ b/ij.bazelproject
@@ -15,7 +15,7 @@ targets:
 
 workspace_type: java
 
-java_language_level: 8
+java_language_level: 17
 
 test_sources:
   src/test/*


### PR DESCRIPTION
Give intelliJ hints that it's OK to use Java 17 language features (such as JEP-394 from https://github.com/bazelbuild/bazel-buildfarm/pull/1745)