### PR TITLE
fix(shard-worker): log root exceptions when main() cannot start

### DIFF
--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -788,6 +788,8 @@ public final class Worker extends LoggingMain {
       log.severe(formatIOError(e));
     } catch (InterruptedException e) {
       log.log(Level.WARNING, "interrupted", e);
+    } catch (Exception e) {
+      log.log(Level.SEVERE, "Error running application", e);
     } finally {
       worker.stop();
     }


### PR DESCRIPTION
Lines copy/pasted from [`BuildfarmServer.java`](https://github.com/bazelbuild/bazel-buildfarm/blob/79db673323531da93707c5c483e9900ba6acec38/src/main/java/build/buildfarm/server/BuildFarmServer.java#L275-L276) for consistency.