### PR TITLE
docs(README): fix example code URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ bazel_dep(name = "build_buildfarm")
 git_override(
     module_name = "build_buildfarm",
     commit = "<COMMIT-SHA>",
-    remote = "https://github.com/bazel/bazel-buildfarm.git",
+    remote = "https://github.com/bazelbuild/bazel-buildfarm.git",
 )
 
 # Transitive!


### PR DESCRIPTION
the github org was typo'd

Fixes: https://github.com/bazelbuild/bazel-buildfarm/issues/1770