### PR TITLE
Expand Asset Fetch Qualifier support

### DIFF
--- a/.bazelci/format.sh
+++ b/.bazelci/format.sh
@@ -5,8 +5,8 @@
 
 FORMAT_JAVA=true
 REMOVE_NEWLINES_AFTER_START_BRACKET=true
-JAVA_FORMATTER_URL=https://github.com/google/google-java-format/releases/download/v1.22.0/google-java-format-1.22.0-all-deps.jar
-LOCAL_FORMATTER="java_formatter.jar"
+JAVA_FORMATTER_URL=https://github.com/google/google-java-format/releases/download/v1.22.0/google-java-format_linux-x86-64
+LOCAL_FORMATTER="./google-java-format_linux-x86-64"
 
 if [ -z "$BAZEL" ]; then
   BAZEL=bazel
@@ -38,6 +38,7 @@ run_java_formatter () {
      # Download the formatter if we don't already have it.
     if [ ! -f "$LOCAL_FORMATTER" ] ; then
         wget -O $LOCAL_FORMATTER $JAVA_FORMATTER_URL
+        chmod +x $LOCAL_FORMATTER
     fi
     
      # Get all the files to format and format them
@@ -47,7 +48,7 @@ run_java_formatter () {
     # This is intended to be done by the CI.
     if [[ "$@" == "--check" ]]
     then
-        java -jar $LOCAL_FORMATTER --dry-run --set-exit-if-changed $files
+        $LOCAL_FORMATTER --dry-run --set-exit-if-changed $files
         handle_format_error_check
         return
     fi
@@ -66,7 +67,7 @@ run_java_formatter () {
     fi;
 
     # Fixes formatting issues
-    java -jar $LOCAL_FORMATTER -i $files
+    $LOCAL_FORMATTER -i $files
 }
 
 run_buildifier () {

--- a/.bazelci/run_checkstyle.sh
+++ b/.bazelci/run_checkstyle.sh
@@ -2,7 +2,7 @@
 # Run from the root of repository.
 # This script will perform static analysis on all of the java source files.
 
-TOOL_URL=https://github.com/checkstyle/checkstyle/releases/download/checkstyle-10.6.0/checkstyle-10.6.0-all.jar
+TOOL_URL=https://github.com/checkstyle/checkstyle/releases/download/checkstyle-10.17.0/checkstyle-10.17.0-all.jar
 LOCAL_DOWNLOAD_NAME="checkstyle.jar"
 TOOL_FOLDER="checkstyle"
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,8 +1,8 @@
-build --java_language_version=17
-build --java_runtime_version=remotejdk_17
+build --java_language_version=21
+build --java_runtime_version=remotejdk_21
 
-build --tool_java_language_version=17
-build --tool_java_runtime_version=remotejdk_17
+build --tool_java_language_version=21
+build --tool_java_runtime_version=remotejdk_21
 
 
 common --enable_platform_specific_config

--- a/ij.bazelproject
+++ b/ij.bazelproject
@@ -15,7 +15,7 @@ targets:
 
 workspace_type: java
 
-java_language_level: 17
+java_language_level: 21
 
 test_sources:
   src/test/*

--- a/src/main/java/build/buildfarm/common/redis/RedisSSL.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisSSL.java
@@ -31,7 +31,6 @@ import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 
 public final class RedisSSL {
-
   private RedisSSL() {
     // do not construct this helper class.
   }

--- a/src/main/java/build/buildfarm/instance/Instance.java
+++ b/src/main/java/build/buildfarm/instance/Instance.java
@@ -49,6 +49,7 @@ import io.grpc.stub.ServerCallStreamObserver;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -108,7 +109,10 @@ public interface Instance {
       throws IOException, IllegalArgumentException, InterruptedException;
 
   ListenableFuture<Digest> fetchBlob(
-      Iterable<String> uris, Digest expectedDigest, RequestMetadata requestMetadata);
+      Iterable<String> uris,
+      Map<String, String> headers,
+      Digest expectedDigest,
+      RequestMetadata requestMetadata);
 
   Write getOperationStreamWrite(String name);
 

--- a/src/main/java/build/buildfarm/instance/stub/StubInstance.java
+++ b/src/main/java/build/buildfarm/instance/stub/StubInstance.java
@@ -143,6 +143,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -494,7 +495,10 @@ public class StubInstance implements Instance {
 
   @Override
   public ListenableFuture<Digest> fetchBlob(
-      Iterable<String> uris, Digest expectedDigest, RequestMetadata requestMetadata) {
+      Iterable<String> uris,
+      Map<String, String> headers,
+      Digest expectedDigest,
+      RequestMetadata requestMetadata) {
     throw new UnsupportedOperationException();
   }
 

--- a/src/main/java/build/buildfarm/server/services/FetchService.java
+++ b/src/main/java/build/buildfarm/server/services/FetchService.java
@@ -14,8 +14,8 @@ import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.RequestMetadata;
 import build.buildfarm.common.DigestUtil;
 import build.buildfarm.common.grpc.TracingMetadataUtils;
-import build.buildfarm.v1test.FetchQualifiers;
 import build.buildfarm.instance.Instance;
+import build.buildfarm.v1test.FetchQualifiers;
 import com.google.common.io.BaseEncoding;
 import com.google.common.util.concurrent.FutureCallback;
 import io.grpc.Status;
@@ -52,11 +52,13 @@ public class FetchService extends FetchImplBase {
     }
   }
 
-  private static void parseQualifier(String name, String value, FetchQualifiers.Builder fetchQualifiers) {
+  private static void parseQualifier(
+      String name, String value, FetchQualifiers.Builder fetchQualifiers) {
     switch (name) {
       case QUALIFIER_CANONICAL_ID -> fetchQualifiers.setCanonicalId(value);
       case QUALIFIER_CHECKSUM_SRI -> fetchQualifiers.setDigest(parseChecksumSRI(value));
-      case String s when s.startsWith(QUALIFIER_HTTP_HEADER_PREFIX) -> fetchQualifiers.putHeaders(s.substring(QUALIFIER_HTTP_HEADER_PREFIX.length()), value);
+      case String s when s.startsWith(QUALIFIER_HTTP_HEADER_PREFIX) ->
+          fetchQualifiers.putHeaders(s.substring(QUALIFIER_HTTP_HEADER_PREFIX.length()), value);
       default -> {
         // ignore unknown qualifiers
       }
@@ -100,14 +102,14 @@ public class FetchService extends FetchImplBase {
 
     Digest.Builder result = Digest.newBuilder();
     if (instance.containsBlob(expectedDigest, result, requestMetadata)) {
-      responseObserver.onNext(
-          FetchBlobResponse.newBuilder().setBlobDigest(result.build()).build());
+      responseObserver.onNext(FetchBlobResponse.newBuilder().setBlobDigest(result.build()).build());
       responseObserver.onCompleted();
       return;
     }
 
     addCallback(
-        instance.fetchBlob(request.getUrisList(), qualifiers.getHeadersMap(), expectedDigest, requestMetadata),
+        instance.fetchBlob(
+            request.getUrisList(), qualifiers.getHeadersMap(), expectedDigest, requestMetadata),
         new FutureCallback<Digest>() {
           @Override
           public void onSuccess(Digest actualDigest) {

--- a/src/main/java/build/buildfarm/server/services/FetchService.java
+++ b/src/main/java/build/buildfarm/server/services/FetchService.java
@@ -14,6 +14,7 @@ import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.RequestMetadata;
 import build.buildfarm.common.DigestUtil;
 import build.buildfarm.common.grpc.TracingMetadataUtils;
+import build.buildfarm.v1test.FetchQualifiers;
 import build.buildfarm.instance.Instance;
 import com.google.common.io.BaseEncoding;
 import com.google.common.util.concurrent.FutureCallback;
@@ -25,6 +26,17 @@ import lombok.extern.java.Log;
 @Log
 public class FetchService extends FetchImplBase {
   private final Instance instance;
+
+  // The `Qualifier::name` field uses well-known string keys to attach arbitrary
+  // key-value metadata to download requests. These are the qualifier names
+  // supported by Bazel.
+  public static final String QUALIFIER_CHECKSUM_SRI = "checksum.sri";
+  public static final String QUALIFIER_CANONICAL_ID = "bazel.canonical_id";
+
+  // The `:` character is not permitted in an HTTP header name. So, we use it to
+  // delimit the qualifier prefix which denotes an HTTP header qualifer from the
+  // header name itself.
+  public static final String QUALIFIER_HTTP_HEADER_PREFIX = "http_header:";
 
   public FetchService(Instance instance) {
     this.instance = instance;
@@ -40,6 +52,25 @@ public class FetchService extends FetchImplBase {
     }
   }
 
+  private static void parseQualifier(String name, String value, FetchQualifiers.Builder fetchQualifiers) {
+    switch (name) {
+      case QUALIFIER_CANONICAL_ID -> fetchQualifiers.setCanonicalId(value);
+      case QUALIFIER_CHECKSUM_SRI -> fetchQualifiers.setDigest(parseChecksumSRI(value));
+      case String s when s.startsWith(QUALIFIER_HTTP_HEADER_PREFIX) -> fetchQualifiers.putHeaders(s.substring(QUALIFIER_HTTP_HEADER_PREFIX.length()), value);
+      default -> {
+        // ignore unknown qualifiers
+      }
+    }
+  }
+
+  private static FetchQualifiers parseQualifiers(Iterable<Qualifier> qualifiers) {
+    FetchQualifiers.Builder fetchQualifiers = FetchQualifiers.newBuilder();
+    for (Qualifier qualifier : qualifiers) {
+      parseQualifier(qualifier.getName(), qualifier.getValue(), fetchQualifiers);
+    }
+    return fetchQualifiers.build();
+  }
+
   private void fetchBlob(
       Instance instance,
       FetchBlobRequest request,
@@ -47,65 +78,61 @@ public class FetchService extends FetchImplBase {
       throws InterruptedException {
     Digest expectedDigest = null;
     RequestMetadata requestMetadata = TracingMetadataUtils.fromCurrentContext();
-    if (request.getQualifiersCount() == 0) {
-      throw Status.INVALID_ARGUMENT.withDescription("Empty qualifier list").asRuntimeException();
-    }
-    for (Qualifier qualifier : request.getQualifiersList()) {
-      String name = qualifier.getName();
-      if (name.equals("checksum.sri")) {
-        expectedDigest = parseChecksumSRI(qualifier.getValue());
-        Digest.Builder result = Digest.newBuilder();
-        if (instance.containsBlob(expectedDigest, result, requestMetadata)) {
-          responseObserver.onNext(
-              FetchBlobResponse.newBuilder().setBlobDigest(result.build()).build());
-          responseObserver.onCompleted();
-          return;
-        }
-      } else {
-        responseObserver.onError(
-            Status.INVALID_ARGUMENT
-                .withDescription(format("Invalid qualifier '%s'", name))
-                .asException());
-        return;
-      }
-    }
-    if (expectedDigest == null) {
-      responseObserver.onError(
-          Status.INVALID_ARGUMENT
-              .withDescription("Missing qualifier 'checksum.sri'")
-              .asException());
-    } else if (request.getUrisCount() != 0) {
-      addCallback(
-          instance.fetchBlob(request.getUrisList(), expectedDigest, requestMetadata),
-          new FutureCallback<Digest>() {
-            @Override
-            public void onSuccess(Digest actualDigest) {
-              log.log(
-                  Level.INFO,
-                  format(
-                      "fetch blob succeeded: %s inserted into CAS",
-                      DigestUtil.toString(actualDigest)));
-              responseObserver.onNext(
-                  FetchBlobResponse.newBuilder().setBlobDigest(actualDigest).build());
-              responseObserver.onCompleted();
-            }
 
-            @SuppressWarnings("NullableProblems")
-            @Override
-            public void onFailure(Throwable t) {
-              // handle NoSuchFileException
-              log.log(Level.SEVERE, "fetch blob failed", t);
-              responseObserver.onError(t);
-            }
-          },
-          directExecutor());
-    } else {
+    if (request.getUrisCount() == 0) {
       responseObserver.onError(
           Status.INVALID_ARGUMENT.withDescription("Empty uris list").asRuntimeException());
+      return;
     }
+
+    FetchQualifiers qualifiers = parseQualifiers(request.getQualifiersList());
+
+    expectedDigest = qualifiers.getDigest();
+    if (expectedDigest.equals(Digest.getDefaultInstance())) {
+      responseObserver.onError(
+          Status.INVALID_ARGUMENT
+              .withDescription(format("Missing qualifier '%s'", QUALIFIER_CHECKSUM_SRI))
+              .asException());
+      return;
+    }
+
+    // TODO consider doing something with QUALIFIER_CANONICAL_ID
+
+    Digest.Builder result = Digest.newBuilder();
+    if (instance.containsBlob(expectedDigest, result, requestMetadata)) {
+      responseObserver.onNext(
+          FetchBlobResponse.newBuilder().setBlobDigest(result.build()).build());
+      responseObserver.onCompleted();
+      return;
+    }
+
+    addCallback(
+        instance.fetchBlob(request.getUrisList(), qualifiers.getHeadersMap(), expectedDigest, requestMetadata),
+        new FutureCallback<Digest>() {
+          @Override
+          public void onSuccess(Digest actualDigest) {
+            log.log(
+                Level.INFO,
+                format(
+                    "fetch blob succeeded: %s inserted into CAS",
+                    DigestUtil.toString(actualDigest)));
+            responseObserver.onNext(
+                FetchBlobResponse.newBuilder().setBlobDigest(actualDigest).build());
+            responseObserver.onCompleted();
+          }
+
+          @SuppressWarnings("NullableProblems")
+          @Override
+          public void onFailure(Throwable t) {
+            // handle NoSuchFileException
+            log.log(Level.SEVERE, "fetch blob failed", t);
+            responseObserver.onError(t);
+          }
+        },
+        directExecutor());
   }
 
-  private Digest parseChecksumSRI(String checksum) {
+  private static Digest parseChecksumSRI(String checksum) {
     String[] components = checksum.split("-");
     if (components.length != 2) {
       throw Status.INVALID_ARGUMENT

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -682,3 +682,11 @@ service ShutDownWorker {
   rpc PrepareWorkerForGracefulShutdown(PrepareWorkerForGracefulShutDownRequest)
       returns (PrepareWorkerForGracefulShutDownRequestResults) {}
 }
+
+message FetchQualifiers {
+  build.bazel.remote.execution.v2.Digest digest = 1;
+
+  string canonical_id = 2;
+
+  map<string, string> headers = 3;
+}

--- a/src/test/java/build/buildfarm/common/ZstdCompressingInputStreamTest.java
+++ b/src/test/java/build/buildfarm/common/ZstdCompressingInputStreamTest.java
@@ -13,7 +13,6 @@ import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class ZstdCompressingInputStreamTest {
-
   @Test
   public void testSkip() throws IOException {
     String blobToSkip = "AAAAA"; // 5 bytes


### PR DESCRIPTION
Support the now-default `bazel.canonical_id` presented by the bazel client intended to identify the url content uniquely - we currently discard this, as our only association is content digest based.
Support http headers specified by client via the http_headers: prefix.

Bump to Java 21 to support Guarded patterns in switch with `when` for cleaner code.

Fixes #1768, #1769