### PR TITLE
Rename mantic to lunar Dockerfile, jdk 21

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -194,7 +194,7 @@ oci_image_env(
 
 oci_image(
     name = "buildfarm-worker_linux_amd64",
-    base = "@ubuntu_mantic",
+    base = "@ubuntu_lunar",
     entrypoint = [
         # do not sort
         "/tini",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -174,14 +174,14 @@ oci.pull(
 
 # Worker base image
 oci.pull(
-    name = "ubuntu_mantic",
-    digest = "sha256:2520e0725493c8f63452dd8aa153fbf0b489a9442096b7693641193709a765b7",  # tag: mantic
+    name = "ubuntu_lunar",
+    digest = "sha256:303223fbebbd1095df7299707ed8b0a51be5c0a7eee78292fc65ee2201c2e138",  # tag: lunar
     image = "index.docker.io/bazelbuild/buildfarm-worker-base",
 )
 use_repo(
     oci,
     "amazon_corretto_java_image_base",
-    "ubuntu_mantic",
+    "ubuntu_lunar",
 )
 
 # https://github.com/bazelbuild/rules_python/pull/713#issuecomment-1885628496

--- a/ci/base-worker-image/lunar/Dockerfile
+++ b/ci/base-worker-image/lunar/Dockerfile
@@ -3,4 +3,4 @@
 FROM ubuntu:23.04
 
 RUN apt-get update
-RUN apt-get -y install default-jre default-jdk build-essential libfuse2 cgroup-tools
+RUN apt-get -y install openjdk-21-jdk build-essential libfuse2 cgroup-tools


### PR DESCRIPTION
Install the version 21 java image from ubuntu for the buildfarm-worker-base, and use this new image in buildfarm-shard-worker