### PR TITLE
Report partial_execution_metadata for operations

### DIFF
--- a/admin/main/src/main/resources/proto/buildfarm.proto
+++ b/admin/main/src/main/resources/proto/buildfarm.proto
@@ -808,26 +808,6 @@ message QueuedOperation {
   Tree tree = 5;
 }
 
-message ExecutingOperationMetadata {
-  build.bazel.remote.execution.v2.ExecuteOperationMetadata
-      execute_operation_metadata = 1;
-
-  build.bazel.remote.execution.v2.RequestMetadata request_metadata = 2;
-
-  int64 started_at = 3;
-
-  string executing_on = 4;
-}
-
-message CompletedOperationMetadata {
-  build.bazel.remote.execution.v2.ExecuteOperationMetadata
-      execute_operation_metadata = 1;
-
-  build.bazel.remote.execution.v2.RequestMetadata request_metadata = 2;
-
-  reserved 3 to 8; // fields now in ExecutedActionMetadata
-}
-
 message OperationRequestMetadata {
   string operation_name = 1;
 

--- a/src/main/java/build/buildfarm/worker/OperationContext.java
+++ b/src/main/java/build/buildfarm/worker/OperationContext.java
@@ -19,6 +19,7 @@ import build.bazel.remote.execution.v2.Command;
 import build.bazel.remote.execution.v2.ExecuteResponse;
 import build.buildfarm.common.Poller;
 import build.buildfarm.v1test.QueueEntry;
+import build.buildfarm.v1test.QueuedOperationMetadata;
 import build.buildfarm.v1test.Tree;
 import com.google.longrunning.Operation;
 import java.nio.file.Path;
@@ -26,6 +27,7 @@ import java.nio.file.Path;
 public final class OperationContext {
   final ExecuteResponse.Builder executeResponse;
   final Operation operation;
+  final QueuedOperationMetadata.Builder metadata;
   final Poller poller;
   final Path execDir;
   final Action action;
@@ -36,6 +38,7 @@ public final class OperationContext {
   private OperationContext(
       ExecuteResponse.Builder executeResponse,
       Operation operation,
+      QueuedOperationMetadata.Builder metadata,
       Poller poller,
       Path execDir,
       Action action,
@@ -44,6 +47,7 @@ public final class OperationContext {
       QueueEntry queueEntry) {
     this.executeResponse = executeResponse;
     this.operation = operation;
+    this.metadata = metadata;
     this.poller = poller;
     this.execDir = execDir;
     this.action = action;
@@ -55,6 +59,7 @@ public final class OperationContext {
   public static class Builder {
     private ExecuteResponse.Builder executeResponse;
     private Operation operation;
+    private QueuedOperationMetadata.Builder metadata;
     private Poller poller;
     private Path execDir;
     private Action action;
@@ -65,6 +70,7 @@ public final class OperationContext {
     private Builder(
         ExecuteResponse.Builder executeResponse,
         Operation operation,
+        QueuedOperationMetadata.Builder metadata,
         Poller poller,
         Path execDir,
         Action action,
@@ -73,6 +79,7 @@ public final class OperationContext {
         QueueEntry queueEntry) {
       this.executeResponse = executeResponse;
       this.operation = operation;
+      this.metadata = metadata;
       this.poller = poller;
       this.execDir = execDir;
       this.action = action;
@@ -83,6 +90,11 @@ public final class OperationContext {
 
     public Builder setOperation(Operation operation) {
       this.operation = operation;
+      return this;
+    }
+
+    public Builder setMetadata(QueuedOperationMetadata.Builder metadata) {
+      this.metadata = metadata;
       return this;
     }
 
@@ -118,7 +130,7 @@ public final class OperationContext {
 
     public OperationContext build() {
       return new OperationContext(
-          executeResponse, operation, poller, execDir, action, command, tree, queueEntry);
+          executeResponse, operation, metadata, poller, execDir, action, command, tree, queueEntry);
     }
   }
 
@@ -126,6 +138,7 @@ public final class OperationContext {
     return new Builder(
         /* executeResponse= */ ExecuteResponse.newBuilder(),
         /* operation= */ null,
+        /* metadata= */ QueuedOperationMetadata.newBuilder(),
         /* poller= */ null,
         /* execDir= */ null,
         /* action= */ null,
@@ -136,6 +149,6 @@ public final class OperationContext {
 
   public Builder toBuilder() {
     return new Builder(
-        executeResponse, operation, poller, execDir, action, command, tree, queueEntry);
+        executeResponse, operation, metadata, poller, execDir, action, command, tree, queueEntry);
   }
 }

--- a/src/main/java/build/buildfarm/worker/PutOperationStage.java
+++ b/src/main/java/build/buildfarm/worker/PutOperationStage.java
@@ -47,7 +47,11 @@ public class PutOperationStage extends PipelineStage.NullStage {
       if (operationContext.operation.getDone()) {
         for (AverageTimeCostOfLastPeriod average : averagesWithinDifferentPeriods) {
           average.addOperation(
-              operationContext.executeResponse.build().getResult().getExecutionMetadata());
+              operationContext
+                  .metadata
+                  .build()
+                  .getExecuteOperationMetadata()
+                  .getPartialExecutionMetadata());
         }
       }
     }

--- a/src/test/java/build/buildfarm/worker/InputFetcherTest.java
+++ b/src/test/java/build/buildfarm/worker/InputFetcherTest.java
@@ -77,7 +77,10 @@ public class InputFetcherTest {
 
           @Override
           public boolean putOperation(Operation operation) {
-            return failedOperationRef.compareAndSet(null, operation);
+            if (operation.getDone()) {
+              return failedOperationRef.compareAndSet(null, operation);
+            }
+            return true;
           }
 
           @Override

--- a/src/test/java/build/buildfarm/worker/PipelineTest.java
+++ b/src/test/java/build/buildfarm/worker/PipelineTest.java
@@ -115,15 +115,27 @@ public class PipelineTest {
   }
 
   // Create a test stage that doesn't exit because of an a non-interrupt exception.
-  // This proves the stage is robust enough continue running when experiencing an exception.
+  // This proves the stage is robust enough to continue running when experiencing an exception.
   public class ContinueStage extends PipelineStage {
+    private static PipelineStage OPEN_STAGE =
+        new AbstractPipelineStage("open") {
+          @Override
+          public void run() {}
+        };
+
+    private boolean first = true;
+
     public ContinueStage(String name) {
-      super(name, null, null, null);
+      super(name, /* workerContext= */ null, /* output= */ OPEN_STAGE, /* error= */ null);
     }
 
     @Override
-    protected void runInterruptible() throws InterruptedException {
-      throw new RuntimeException("Exception");
+    protected void iterate() throws InterruptedException {
+      if (first) {
+        first = false;
+        throw new RuntimeException("Exception");
+      }
+      // avoid pouring errors into test log, a single exception is enough
     }
 
     @Override

--- a/src/test/java/build/buildfarm/worker/ReportResultStageTest.java
+++ b/src/test/java/build/buildfarm/worker/ReportResultStageTest.java
@@ -37,6 +37,7 @@ import build.buildfarm.common.Poller;
 import build.buildfarm.v1test.ExecuteEntry;
 import build.buildfarm.v1test.ExecutingOperationMetadata;
 import build.buildfarm.v1test.QueueEntry;
+import com.google.common.collect.Iterables;
 import com.google.longrunning.Operation;
 import com.google.protobuf.Any;
 import com.google.rpc.Code;
@@ -115,8 +116,8 @@ public class ReportResultStageTest {
     reportResultStage.run();
     verify(context, times(1)).destroyExecDir(reportedContext.execDir);
     ArgumentCaptor<Operation> operationCaptor = ArgumentCaptor.forClass(Operation.class);
-    verify(context, times(1)).putOperation(operationCaptor.capture());
-    Operation completeOperation = operationCaptor.getValue();
+    verify(context, times(2)).putOperation(operationCaptor.capture());
+    Operation completeOperation = Iterables.getLast(operationCaptor.getAllValues());
     assertThat(output.get().operation).isEqualTo(completeOperation);
   }
 
@@ -164,8 +165,8 @@ public class ReportResultStageTest {
     reportResultStage.run();
     verify(context, times(1)).destroyExecDir(erroringContext.execDir);
     ArgumentCaptor<Operation> operationCaptor = ArgumentCaptor.forClass(Operation.class);
-    verify(context, times(1)).putOperation(operationCaptor.capture());
-    Operation erroredOperation = operationCaptor.getValue();
+    verify(context, times(2)).putOperation(operationCaptor.capture());
+    Operation erroredOperation = Iterables.getLast(operationCaptor.getAllValues());
     assertThat(output.get().operation).isEqualTo(erroredOperation);
     verify(context, times(1))
         .uploadOutputs(


### PR DESCRIPTION
Deprecates Executing, Completed OperationMetadata definitions.
Cleaned up several adjacent tests that did not behave well with logs.

Fixes #402