### PR TITLE
Support missing content-length and checksum.sri

### DIFF
--- a/src/main/java/build/buildfarm/server/services/FetchService.java
+++ b/src/main/java/build/buildfarm/server/services/FetchService.java
@@ -90,18 +90,12 @@ public class FetchService extends FetchImplBase {
     FetchQualifiers qualifiers = parseQualifiers(request.getQualifiersList());
 
     expectedDigest = qualifiers.getDigest();
-    if (expectedDigest.equals(Digest.getDefaultInstance())) {
-      responseObserver.onError(
-          Status.INVALID_ARGUMENT
-              .withDescription(format("Missing qualifier '%s'", QUALIFIER_CHECKSUM_SRI))
-              .asException());
-      return;
-    }
 
     // TODO consider doing something with QUALIFIER_CANONICAL_ID
 
     Digest.Builder result = Digest.newBuilder();
-    if (instance.containsBlob(expectedDigest, result, requestMetadata)) {
+    if (!expectedDigest.equals(Digest.getDefaultInstance())
+        && instance.containsBlob(expectedDigest, result, requestMetadata)) {
       responseObserver.onNext(FetchBlobResponse.newBuilder().setBlobDigest(result.build()).build());
       responseObserver.onCompleted();
       return;


### PR DESCRIPTION
Load fetch url targets in when either content-length is missing or the checksum was not provided.
Will fail for exceedingly large contents and require additional solutions to page contents/stream and refetch.

Fixes #1779 