### PR TITLE
fix: prefer Timestamps.now() to add nanosecond granularity

### DIFF
--- a/src/main/java/build/buildfarm/worker/Executor.java
+++ b/src/main/java/build/buildfarm/worker/Executor.java
@@ -118,7 +118,7 @@ class Executor {
 
   private long runInterruptible(Stopwatch stopwatch, ResourceLimits limits)
       throws InterruptedException {
-    Timestamp executionStartTimestamp = Timestamps.fromMillis(System.currentTimeMillis());
+    Timestamp executionStartTimestamp = Timestamps.now();
 
     operationContext
         .metadata

--- a/src/main/java/build/buildfarm/worker/InputFetcher.java
+++ b/src/main/java/build/buildfarm/worker/InputFetcher.java
@@ -190,7 +190,7 @@ public class InputFetcher implements Runnable {
 
   @VisibleForTesting
   long fetchPolled(Stopwatch stopwatch) throws InterruptedException {
-    Timestamp inputFetchStart = Timestamps.fromMillis(System.currentTimeMillis());
+    Timestamp inputFetchStart = Timestamps.now();
 
     String operationName = operationContext.queueEntry.getExecuteEntry().getOperationName();
     log.log(Level.FINER, format("fetching inputs: %s", operationName));

--- a/src/main/java/build/buildfarm/worker/MatchStage.java
+++ b/src/main/java/build/buildfarm/worker/MatchStage.java
@@ -170,7 +170,7 @@ public class MatchStage extends PipelineStage {
   }
 
   private OperationContext match(OperationContext operationContext) throws InterruptedException {
-    Timestamp workerStartTimestamp = Timestamps.fromMillis(System.currentTimeMillis());
+    Timestamp workerStartTimestamp = Timestamps.now();
 
     ExecuteEntry executeEntry = operationContext.queueEntry.getExecuteEntry();
     operationContext

--- a/src/main/java/build/buildfarm/worker/PutOperationStage.java
+++ b/src/main/java/build/buildfarm/worker/PutOperationStage.java
@@ -115,7 +115,7 @@ public class PutOperationStage extends PipelineStage.NullStage {
 
     OperationStageDurations getAverageOfLastPeriod() {
       // creating a Timestamp representing now to trigger stale data throwing away
-      Timestamp now = Timestamps.fromMillis(System.currentTimeMillis());
+      Timestamp now = Timestamps.now();
       removeStaleData(now);
 
       // compute unweighted average of all buckets

--- a/src/main/java/build/buildfarm/worker/ReportResultStage.java
+++ b/src/main/java/build/buildfarm/worker/ReportResultStage.java
@@ -147,7 +147,7 @@ public class ReportResultStage extends PipelineStage {
       return null;
     }
 
-    Timestamp completed = Timestamps.fromMillis(System.currentTimeMillis());
+    Timestamp completed = Timestamps.now();
     executedAction
         .setWorkerCompletedTimestamp(completed)
         .setOutputUploadCompletedTimestamp(completed);


### PR DESCRIPTION
`Timestamps.fromMillis(System.currentTimeMillis())` is missing nanosecond field for the Timestamp data structure. Prefer `Timestamps.now()` to add it.