### PR TITLE
Use gRPC health check instead

### DIFF
--- a/kubernetes/helm-charts/buildfarm/templates/server/deployment.yaml
+++ b/kubernetes/helm-charts/buildfarm/templates/server/deployment.yaml
@@ -48,7 +48,7 @@ spec:
             initialDelaySeconds: 10
           readinessProbe:
             grpc:
-              port: server-comm
+              port: 8980
             initialDelaySeconds: 10
           resources:
             {{- toYaml .Values.server.resources | nindent 12 }}

--- a/kubernetes/helm-charts/buildfarm/templates/server/deployment.yaml
+++ b/kubernetes/helm-charts/buildfarm/templates/server/deployment.yaml
@@ -44,7 +44,7 @@ spec:
               name: "metrics"
           livenessProbe:
             grpc:
-              port: server-comm
+              port: 8980
             initialDelaySeconds: 10
           readinessProbe:
             grpc:

--- a/kubernetes/helm-charts/buildfarm/templates/server/deployment.yaml
+++ b/kubernetes/helm-charts/buildfarm/templates/server/deployment.yaml
@@ -43,13 +43,13 @@ spec:
             - containerPort: 9090
               name: "metrics"
           livenessProbe:
-            httpGet:
-              path: /
-              port: metrics
+            grpc:
+              port: server-comm
+            initialDelaySeconds: 10
           readinessProbe:
-            httpGet:
-              path: /
-              port: metrics
+            grpc:
+              port: server-comm
+            initialDelaySeconds: 10
           resources:
             {{- toYaml .Values.server.resources | nindent 12 }}
           volumeMounts:

--- a/kubernetes/helm-charts/buildfarm/templates/shard-worker/statefulsets.yaml
+++ b/kubernetes/helm-charts/buildfarm/templates/shard-worker/statefulsets.yaml
@@ -58,7 +58,7 @@ spec:
               name: "metrics"
           livenessProbe:
             grpc:
-              port: worker-comm
+              port: 8981
             initialDelaySeconds: 10
           readinessProbe:
             grpc:

--- a/kubernetes/helm-charts/buildfarm/templates/shard-worker/statefulsets.yaml
+++ b/kubernetes/helm-charts/buildfarm/templates/shard-worker/statefulsets.yaml
@@ -62,7 +62,7 @@ spec:
             initialDelaySeconds: 10
           readinessProbe:
             grpc:
-              port: worker-comm
+              port: 8981
             initialDelaySeconds: 10
           resources:
             {{- toYaml .Values.shardWorker.resources | nindent 12 }}

--- a/kubernetes/helm-charts/buildfarm/templates/shard-worker/statefulsets.yaml
+++ b/kubernetes/helm-charts/buildfarm/templates/shard-worker/statefulsets.yaml
@@ -57,13 +57,13 @@ spec:
             - containerPort: 9090
               name: "metrics"
           livenessProbe:
-            httpGet:
-              path: /
-              port: metrics
+            grpc:
+              port: worker-comm
+            initialDelaySeconds: 10
           readinessProbe:
-            httpGet:
-              path: /
-              port: metrics
+            grpc:
+              port: worker-comm
+            initialDelaySeconds: 10
           resources:
             {{- toYaml .Values.shardWorker.resources | nindent 12 }}
           volumeMounts:


### PR DESCRIPTION
The gRPC end point is the one that's used by Bazel client side, since
 checking /metrics here.