### PR TITLE
refactor: remove extra builders

### DIFF
--- a/src/main/java/build/buildfarm/instance/shard/ServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ServerInstance.java
@@ -324,22 +324,18 @@ public class ServerInstance extends NodeInstance {
   void initializeCaches() {
     directoryCache =
         Caffeine.newBuilder()
-            .newBuilder()
             .maximumSize(configs.getServer().getCaches().getDirectoryCacheMaxEntries())
             .buildAsync();
     commandCache =
         Caffeine.newBuilder()
-            .newBuilder()
             .maximumSize(configs.getServer().getCaches().getCommandCacheMaxEntries())
             .buildAsync();
     digestToActionCache =
         Caffeine.newBuilder()
-            .newBuilder()
             .maximumSize(configs.getServer().getCaches().getDigestToActionCacheMaxEntries())
             .buildAsync();
     recentCacheServedExecutions =
         Caffeine.newBuilder()
-            .newBuilder()
             .maximumSize(configs.getServer().getCaches().getRecentServedExecutionsCacheMaxEntries())
             .build();
   }


### PR DESCRIPTION
`Caffeine.newBuilder().newBuilder()` -> `Caffeine.newBuilder()`