### PR TITLE
chore: hide non-bazel files from ij project

### DIFF
--- a/ij.bazelproject
+++ b/ij.bazelproject
@@ -9,6 +9,10 @@ directories:
   -bazel-out
   -bazel-testlogs
   -tmp
+  -_site
+  -admin
+  -checkstyle
+
 
 targets:
   //...


### PR DESCRIPTION
Hide these folders from IntelliJ bazel plugin