### PR TITLE
fix(helm): fix statefulset port for worker grpc

### DIFF
--- a/kubernetes/helm-charts/buildfarm/templates/shard-worker/statefulsets.yaml
+++ b/kubernetes/helm-charts/buildfarm/templates/shard-worker/statefulsets.yaml
@@ -52,7 +52,7 @@ spec:
             {{- toYaml .Values.shardWorker.extraEnv | nindent 12 }}
             {{- end }}
           ports:
-            - containerPort: 8981
+            - containerPort: 8982
               name: "worker-comm"
             - containerPort: 9090
               name: "metrics"


### PR DESCRIPTION
We pass `--public_name=$(POD_IP):8982` as an arg to the worker, so this should be 8982. There's also reference to 8982 in the configmap.

Fixes: #1796