### PR TITLE
Reduce log spam from killAllProcs

### DIFF
--- a/src/main/java/build/buildfarm/worker/cgroup/BUILD
+++ b/src/main/java/build/buildfarm/worker/cgroup/BUILD
@@ -5,6 +5,8 @@ java_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/main/java/build/buildfarm/worker",
+        "@maven//:com_github_jnr_jnr_constants",
+        "@maven//:com_github_jnr_jnr_posix",
         "@maven//:com_google_code_findbugs_jsr305",
         "@maven//:com_google_guava_guava",
         "@maven//:io_grpc_grpc_api",

--- a/src/main/java/build/buildfarm/worker/cgroup/BUILD
+++ b/src/main/java/build/buildfarm/worker/cgroup/BUILD
@@ -7,6 +7,7 @@ java_library(
         "//src/main/java/build/buildfarm/worker",
         "@maven//:com_google_code_findbugs_jsr305",
         "@maven//:com_google_guava_guava",
+        "@maven//:io_grpc_grpc_api",
         "@maven//:org_projectlombok_lombok",
     ],
 )


### PR DESCRIPTION
Only emit log messages once a second while killing, or when the pid list changes contents.