### PR TITLE
Interrupt claim-waits when poller failures occur

### DIFF
--- a/src/main/java/build/buildfarm/worker/Executor.java
+++ b/src/main/java/build/buildfarm/worker/Executor.java
@@ -271,7 +271,7 @@ class Executor {
         "Executor(claim)",
         operationContext.queueEntry,
         ExecutionStage.Value.EXECUTING,
-        () -> {},
+        Thread.currentThread()::interrupt,
         Deadline.after(10, DAYS));
 
     long executeUSecs = stopwatch.elapsed(MICROSECONDS);

--- a/src/main/java/build/buildfarm/worker/InputFetcher.java
+++ b/src/main/java/build/buildfarm/worker/InputFetcher.java
@@ -97,13 +97,12 @@ public class InputFetcher implements Runnable {
   }
 
   private long runInterruptibly(Stopwatch stopwatch) throws InterruptedException {
-    final Thread fetcherThread = Thread.currentThread();
     workerContext.resumePoller(
         operationContext.poller,
         "InputFetcher",
         operationContext.queueEntry,
         QUEUED,
-        fetcherThread::interrupt,
+        Thread.currentThread()::interrupt,
         Deadline.after(workerContext.getInputFetchDeadline(), SECONDS));
     try {
       return fetchPolled(stopwatch);
@@ -284,7 +283,7 @@ public class InputFetcher implements Runnable {
         "InputFetcher(claim)",
         operationContext.queueEntry,
         QUEUED,
-        () -> {},
+        Thread.currentThread()::interrupt,
         Deadline.after(10, DAYS));
 
     OperationContext fetchedOperationContext =


### PR DESCRIPTION
This can happen if the execution is cancelled, or if unrelated state causes an operation state to be unacceptable on the current worker.

Use standard interrupt callback lambda reference.