### PR TITLE
fix(RedisShardBackplane): Don't return execute-only workers in getStorageWorkers

### DIFF
--- a/src/main/java/build/buildfarm/instance/shard/RedisShardSubscriber.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardSubscriber.java
@@ -62,19 +62,19 @@ class RedisShardSubscriber extends JedisPubSub {
 
   private final ListMultimap<String, TimedWatchFuture> watchers;
   private final Map<String, ShardWorker> workers;
-  private final int workerType;
+  private final int workerChangeTypeMask;
   private final String workerChannel;
   private final Executor executor;
 
   RedisShardSubscriber(
       ListMultimap<String, TimedWatchFuture> watchers,
       Map<String, ShardWorker> workers,
-      int workerType,
+      int workerChangeTypeMask,
       String workerChannel,
       Executor executor) {
     this.watchers = watchers;
     this.workers = workers;
-    this.workerType = workerType;
+    this.workerChangeTypeMask = workerChangeTypeMask;
     this.workerChannel = workerChannel;
     this.executor = executor;
   }
@@ -235,7 +235,7 @@ class RedisShardSubscriber extends JedisPubSub {
   }
 
   void addWorker(WorkerChange workerChange) {
-    if ((workerChange.getAdd().getWorkerType() & workerType) > 0) {
+    if ((workerChange.getAdd().getWorkerType() & workerChangeTypeMask) != 0) {
       synchronized (workers) {
         workers.put(
             workerChange.getName(),

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -281,6 +281,8 @@ message ShardWorker {
 message WorkerChange {
   message Add {
     google.protobuf.Timestamp effectiveAt = 1;
+
+    int32 worker_type = 2;
   }
 
   message Remove {

--- a/src/test/java/build/buildfarm/instance/shard/RedisShardSubscriberTest.java
+++ b/src/test/java/build/buildfarm/instance/shard/RedisShardSubscriberTest.java
@@ -185,7 +185,7 @@ public class RedisShardSubscriberTest {
 
   RedisShardSubscriber createSubscriber(
       ListMultimap<String, TimedWatchFuture> watchers, Executor executor) {
-    return new RedisShardSubscriber(watchers, /* workers= */ null, /*WorkerType.NONE*/ 0, "worker-channel", executor);
+    return new RedisShardSubscriber(watchers, /* workers= */ null, WorkerType.NONE.getNumber(), "worker-channel", executor);
   }
 
   RedisShardSubscriber createSubscriber(ListMultimap<String, TimedWatchFuture> watchers) {


### PR DESCRIPTION
BuildFarm now registers all workers in RedisBackplane. When an execute-only worker is registered, RedisShardSubscriber will add it to RedisBackplane's storageWorkers. Then it's possible for getStorageWorkers() to reurn execute-only workers.

To fix this bug, We add a field worker_type to the proto message WorkerChange.Add so that RedisShardSubscriber can tell if the worker type matches the expected value.