### PR TITLE
Clear partial metadata on completion

### DIFF
--- a/src/main/java/build/buildfarm/instance/shard/ServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ServerInstance.java
@@ -287,8 +287,7 @@ public class ServerInstance extends NodeInstance {
           identifier,
           /* subscribeToBackplane= */ true,
           configs.getServer().isRunFailsafeOperation(),
-          ServerInstance::stripOperation,
-          ServerInstance::stripQueuedOperation);
+          ServerInstance::stripOperation);
     } else {
       throw new IllegalArgumentException("Shard Backplane not set in config");
     }
@@ -2715,16 +2714,6 @@ public class ServerInstance extends NodeInstance {
       metadata = ExecuteOperationMetadata.getDefaultInstance();
     }
     return operation.toBuilder().setMetadata(Any.pack(metadata)).build();
-  }
-
-  private static Operation stripQueuedOperation(Operation operation) {
-    if (operation.getMetadata().is(QueuedOperationMetadata.class)) {
-      operation =
-          operation.toBuilder()
-              .setMetadata(Any.pack(expectExecuteOperationMetadata(operation)))
-              .build();
-    }
-    return operation;
   }
 
   @Override

--- a/src/main/java/build/buildfarm/worker/ReportResultStage.java
+++ b/src/main/java/build/buildfarm/worker/ReportResultStage.java
@@ -153,6 +153,8 @@ public class ReportResultStage extends PipelineStage {
         .setOutputUploadCompletedTimestamp(completed);
 
     executionContext.executeResponse.getResultBuilder().setExecutionMetadata(executedAction);
+    // remove partial metadata in favor of result
+    executionContext.metadata.getExecuteOperationMetadataBuilder().clearPartialExecutionMetadata();
     ExecuteResponse executeResponse = executionContext.executeResponse.build();
 
     if (blacklist

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -194,10 +194,6 @@ public final class Worker extends LoggingMain {
     return instance.stripOperation(operation);
   }
 
-  private Operation stripQueuedOperation(Operation operation) {
-    return instance.stripQueuedOperation(operation);
-  }
-
   private Server createServer(
       ServerBuilder<?> serverBuilder,
       @Nullable CASFileCache storage,
@@ -564,8 +560,7 @@ public final class Worker extends LoggingMain {
               identifier,
               /* subscribeToBackplane= */ false,
               /* runFailsafeOperation= */ false,
-              this::stripOperation,
-              this::stripQueuedOperation);
+              this::stripOperation);
       backplane.start(configs.getWorker().getPublicName());
     } else {
       throw new IllegalArgumentException("Shard Backplane not set in config");

--- a/src/main/java/build/buildfarm/worker/shard/WorkerInstance.java
+++ b/src/main/java/build/buildfarm/worker/shard/WorkerInstance.java
@@ -299,16 +299,6 @@ public class WorkerInstance extends NodeInstance {
         .build();
   }
 
-  public Operation stripQueuedOperation(Operation operation) {
-    if (operation.getMetadata().is(QueuedOperationMetadata.class)) {
-      operation =
-          operation.toBuilder()
-              .setMetadata(Any.pack(expectExecuteOperationMetadata(operation)))
-              .build();
-    }
-    return operation;
-  }
-
   @Override
   protected Logger getLogger() {
     return log;

--- a/src/test/java/build/buildfarm/instance/shard/RedisShardBackplaneTest.java
+++ b/src/test/java/build/buildfarm/instance/shard/RedisShardBackplaneTest.java
@@ -80,7 +80,6 @@ public class RedisShardBackplaneTest {
         /* subscribeToBackplane= */ false,
         /* runFailsafeOperation= */ false,
         o -> o,
-        o -> o,
         mockJedisClusterFactory);
   }
 


### PR DESCRIPTION
ExecutedActionMetadata is redundant in complete
ExecuteOperationMetadata.