### PR TITLE
fix(helm): fix statefulset {ready,live}ness probe port for worker grpc

### DIFF
--- a/kubernetes/helm-charts/buildfarm/templates/shard-worker/statefulsets.yaml
+++ b/kubernetes/helm-charts/buildfarm/templates/shard-worker/statefulsets.yaml
@@ -58,11 +58,11 @@ spec:
               name: "metrics"
           livenessProbe:
             grpc:
-              port: 8981
+              port: 8982
             initialDelaySeconds: 10
           readinessProbe:
             grpc:
-              port: 8981
+              port: 8982
             initialDelaySeconds: 10
           resources:
             {{- toYaml .Values.shardWorker.resources | nindent 12 }}


### PR DESCRIPTION
Commit
https://github.com/bazelbuild/bazel-buildfarm/commit/ba057003761cbe7a21a505ddad2e694a0c6d5c6b introduced a change to move the named "worker-comm" to port 8982. However, both the livenessProbe and the readinessProbe for that container were still pointing to 8981, which prevented the container to start.

Fixes #1820 