### PR TITLE
Bug: Check WriteComplete Before Write

### DIFF
--- a/src/main/java/build/buildfarm/common/services/WriteStreamObserver.java
+++ b/src/main/java/build/buildfarm/common/services/WriteStreamObserver.java
@@ -365,7 +365,7 @@ public class WriteStreamObserver implements StreamObserver<WriteRequest> {
                       "request resource_name %s does not match previous resource_name %s",
                       resourceName, name))
               .asException());
-    } else {
+    } else if (!write.isComplete()) {
       if (earliestOffset < 0 || offset < earliestOffset) {
         earliestOffset = offset;
       }


### PR DESCRIPTION
### Issue:
The current flow allows, under specific circumstances, the write method to be called on a blob that has already been written. This leads to a failure later in the stack, resulting in a [WriteCompleteException](https://github.com/bazelbuild/bazel-buildfarm/blob/635d9fed03bedc076d019dcf4f430f20744eafe8/src/main/java/build/buildfarm/common/grpc/StubWriteOutputStream.java#L267).

```
build.buildfarm.common.Write$WriteCompleteException
	at build.buildfarm.common.grpc.StubWriteOutputStream.write(StubWriteOutputStream.java:267)
	at java.base/java.io.OutputStream.write(OutputStream.java:127)
	at com.google.protobuf.ByteString$LiteralByteString.writeTo(ByteString.java:1457)
	at build.buildfarm.common.services.WriteStreamObserver.writeData(WriteStreamObserver.java:419)
	at build.buildfarm.common.services.WriteStreamObserver.handleWrite(WriteStreamObserver.java:391)
	at build.buildfarm.common.services.WriteStreamObserver.handleRequest(WriteStreamObserver.java:323)
	at build.buildfarm.common.services.WriteStreamObserver.initialize(WriteStreamObserver.java:238)
	at build.buildfarm.common.services.WriteStreamObserver.onUncommittedNext(WriteStreamObserver.java:127)
	at build.buildfarm.common.services.WriteStreamObserver.onNext(WriteStreamObserver.java:106)
	at build.buildfarm.common.services.WriteStreamObserver.onNext(WriteStreamObserver.java:54)
```

### Fix:
Ensure that the write method is not called on a blob that has already been written.

### When:
When compression is enabled, the write-completion check does not function properly based on size. The current [logic](https://github.com/bazelbuild/bazel-buildfarm/blob/635d9fed03bedc076d019dcf4f430f20744eafe8/src/main/java/build/buildfarm/common/grpc/StubWriteOutputStream.java#L337) compares committed_size with expected_size. However, when compression is enabled, expected_size is set to [∞](https://github.com/bazelbuild/bazel-buildfarm/blob/635d9fed03bedc076d019dcf4f430f20744eafe8/src/main/java/build/buildfarm/instance/stub/StubInstance.java#L754), causing the check to fail.