### PR TITLE
Make `logging.properties` configurable via ConfigMap

### DIFF
--- a/kubernetes/helm-charts/buildfarm/templates/configmap.yaml
+++ b/kubernetes/helm-charts/buildfarm/templates/configmap.yaml
@@ -26,3 +26,23 @@ data:
     worker:
       {{- toYaml . | nindent 6 }}
     {{- end }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "buildfarm.fullname" . }}-server-log-props
+data:
+  logging.properties: |-
+    {{- range $key, $value := .Values.server.loggingProperties }}
+    {{ $key }}={{ $value }}
+    {{- end }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "buildfarm.fullname" . }}-shard-worker-log-props
+data:
+  logging.properties: |-
+    {{- range $key, $value := .Values.shardWorker.loggingProperties }}
+    {{ $key }}={{ $value }}
+    {{- end }}

--- a/kubernetes/helm-charts/buildfarm/templates/server/deployment.yaml
+++ b/kubernetes/helm-charts/buildfarm/templates/server/deployment.yaml
@@ -34,6 +34,8 @@ spec:
           env:
             - name: CONFIG_PATH
               value: /config/config.yml
+            - name: JAVA_TOOL_OPTIONS
+              value: -XX:+UseContainerSupport -XX:MaxRAMPercentage=80.0 -XX:+UseStringDeduplication -XX:+UseCompressedOops -XX:+HeapDumpOnOutOfMemoryError -Djava.util.logging.config.file=/server-log-props/logging.properties
             {{- if .Values.server.extraEnv }}
             {{- toYaml .Values.server.extraEnv | nindent 12 }}
             {{- end }}
@@ -56,6 +58,9 @@ spec:
             - mountPath: /config
               name: config
               readOnly: true
+            - mountPath: /server-log-props
+              name: server-log-props
+              readOnly: true
       {{- with .Values.server.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -73,3 +78,7 @@ spec:
             defaultMode: 420
             name: {{ include "buildfarm.fullname" . }}-config
           name: config
+        - configMap:
+            defaultMode: 420
+            name: {{ include "buildfarm.fullname" . }}-server-log-props
+          name: server-log-props

--- a/kubernetes/helm-charts/buildfarm/templates/shard-worker/statefulsets.yaml
+++ b/kubernetes/helm-charts/buildfarm/templates/shard-worker/statefulsets.yaml
@@ -43,6 +43,8 @@ spec:
           env:
             - name: CONFIG_PATH
               value: /config/config.yml
+            - name: JAVA_TOOL_OPTIONS
+              value: -XX:+UseContainerSupport -XX:MaxRAMPercentage=80.0 -XX:+UseStringDeduplication -XX:+UseCompressedOops -XX:+HeapDumpOnOutOfMemoryError -Djava.util.logging.config.file=/shard-worker-log-props/logging.properties
             - name: POD_IP
               valueFrom:
                 fieldRef:
@@ -70,8 +72,8 @@ spec:
             - mountPath: /config
               name: config
               readOnly: true
-            - mountPath: /tmp/worker
-              name: {{ include "buildfarm.fullname" . }}-shard-worker-data
+            - mountPath: /shard-worker-log-props
+              name: shard-worker-log-props
             {{- with .Values.shardWorker.extraVolumeMounts }}
             {{- tpl (toYaml .) $ | nindent 12 -}}
             {{- end }}
@@ -95,6 +97,10 @@ spec:
             defaultMode: 420
             name: {{ include "buildfarm.fullname" . }}-config
           name: config
+        - configMap:
+            defaultMode: 420
+            name: {{ include "buildfarm.fullname" . }}-shard-worker-log-props
+          name: shard-worker-log-props
         {{- with .Values.shardWorker.extraVolumes }}
         {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}

--- a/kubernetes/helm-charts/buildfarm/templates/shard-worker/statefulsets.yaml
+++ b/kubernetes/helm-charts/buildfarm/templates/shard-worker/statefulsets.yaml
@@ -72,6 +72,8 @@ spec:
             - mountPath: /config
               name: config
               readOnly: true
+            - mountPath: /tmp/worker
+              name: {{ include "buildfarm.fullname" . }}-shard-worker-data
             - mountPath: /shard-worker-log-props
               name: shard-worker-log-props
             {{- with .Values.shardWorker.extraVolumeMounts }}

--- a/kubernetes/helm-charts/buildfarm/templates/shard-worker/statefulsets.yaml
+++ b/kubernetes/helm-charts/buildfarm/templates/shard-worker/statefulsets.yaml
@@ -76,6 +76,7 @@ spec:
               name: {{ include "buildfarm.fullname" . }}-shard-worker-data
             - mountPath: /shard-worker-log-props
               name: shard-worker-log-props
+              readOnly: true
             {{- with .Values.shardWorker.extraVolumeMounts }}
             {{- tpl (toYaml .) $ | nindent 12 -}}
             {{- end }}

--- a/kubernetes/helm-charts/buildfarm/values.yaml
+++ b/kubernetes/helm-charts/buildfarm/values.yaml
@@ -98,6 +98,12 @@ server:
     relabelings: []
     targetLabels: []
 
+  loggingProperties:
+    handlers: java.util.logging.ConsoleHandler
+    java.util.logging.ConsoleHandler.level: INFO
+    java.util.logging.ConsoleHandler.formatter: java.util.logging.SimpleFormatter
+    java.util.logging.SimpleFormatter.format: '[%4$-7s] %2$s - %5$s %6$s %n'
+
 shardWorker:
   image:
     repository: bazelbuild/buildfarm-worker
@@ -172,6 +178,12 @@ shardWorker:
     scrapeTimeout: 30s
     relabelings: []
     targetLabels: []
+
+  loggingProperties:
+    handlers: java.util.logging.ConsoleHandler
+    java.util.logging.ConsoleHandler.level: INFO
+    java.util.logging.ConsoleHandler.formatter: java.util.logging.SimpleFormatter
+    java.util.logging.SimpleFormatter.format: '[%4$-7s] %2$s - %5$s %6$s %n'
 
 ###################################
 ## DATABASE | Embedded Redis


### PR DESCRIPTION
Resolves #1794

## What

- Manage `logging.properties` as ConfigMap and configured it to be mounted by Pod.
- Configure `JAVA_TOOL_OPTIONS` to be managed in Pod's environment variables.

## Why

> Manage `logging.properties` as ConfigMap and configured it to be mounted by Pod.

This allows `logging.properties` to be modified externally.

> Configure `JAVA_TOOL_OPTIONS` to be managed in Pod's environment variables.

This is to specify the value of `-Djava.util.logging.config.file` property representing the path of file mounted from ConfigMap.