### PR TITLE
ci: GitHub action permissions

### DIFF
--- a/.github/workflows/buildfarm-helm-chart-publish.yml
+++ b/.github/workflows/buildfarm-helm-chart-publish.yml
@@ -11,10 +11,15 @@ env:
   CHART_ROOT: ${{ github.workspace }}/kubernetes/helm-charts/buildfarm
   GHCR_REPO: ghcr.io/${{ github.repository_owner }}
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Lint, Package, and Release BuildFarm Helm Chart
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/buildfarm-images-build-and-deploy.yml
+++ b/.github/workflows/buildfarm-images-build-and-deploy.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     if: github.repository == 'bazelbuild/bazel-buildfarm'

--- a/.github/workflows/buildfarm-release-build-and-deploy.yml
+++ b/.github/workflows/buildfarm-release-build-and-deploy.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     if: github.repository == 'bazelbuild/bazel-buildfarm'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,11 +4,15 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: read
 
 jobs:
   build_and_deploy:
     if: github.repository == 'bazelbuild/bazel-buildfarm'
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
- helm chart publish gains `packages: write`
- github pages gains `pages: write`
- docker build & deploy are now limited to read-only actions

This brings BuildFarm from 0/10 → 10/10 for the [Token-Permissions](https://github.com/ossf/scorecard/blob/9ff40de429d0c7710076070387c8755494a9f187/docs/checks.md#token-permissions) check.