### PR TITLE
Backoff execution dequeues

### DIFF
--- a/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
@@ -462,7 +462,6 @@ public class RedisShardBackplane implements Backplane {
         Multimaps.synchronizedListMultimap(
             MultimapBuilder.linkedHashKeys().arrayListValues().build());
     subscriberService = BuildfarmExecutors.getSubscriberPool();
-    dequeueService = BuildfarmExecutors.getDequeuePool();
     subscriber =
         new RedisShardSubscriber(
             watchers,
@@ -533,6 +532,7 @@ public class RedisShardBackplane implements Backplane {
     if (subscribeToBackplane) {
       startSubscriptionThread();
     }
+    dequeueService = BuildfarmExecutors.getDequeuePool();
     if (runFailsafeOperation) {
       startFailsafeOperationThread();
     }
@@ -1158,7 +1158,7 @@ public class RedisShardBackplane implements Backplane {
 
   private @Nullable QueueEntry dispatchOperation(
       UnifiedJedis jedis, List<Platform.Property> provisions) throws InterruptedException {
-    String queueEntryJson = state.executionQueue.dequeue(jedis, provisions);
+    String queueEntryJson = state.executionQueue.dequeue(jedis, provisions, dequeueService);
     if (queueEntryJson == null) {
       return null;
     }

--- a/src/test/java/build/buildfarm/instance/shard/RedisShardBackplaneTest.java
+++ b/src/test/java/build/buildfarm/instance/shard/RedisShardBackplaneTest.java
@@ -50,6 +50,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
 import java.util.function.Supplier;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -216,7 +217,8 @@ public class RedisShardBackplaneTest {
             .setRequeueAttempts(STARTING_REQUEUE_AMOUNT)
             .build();
     String queueEntryJson = JsonFormat.printer().print(queueEntry);
-    when(state.executionQueue.dequeue(eq(jedis), any(List.class))).thenReturn(queueEntryJson);
+    when(state.executionQueue.dequeue(eq(jedis), any(List.class), any(ExecutorService.class)))
+        .thenReturn(queueEntryJson);
     when(state.executionQueue.removeFromDequeue(jedis, queueEntryJson)).thenReturn(true);
     // PRE-ASSERT
     when(state.dispatchedExecutions.insertIfMissing(eq(jedis), eq(opName), any(String.class)))
@@ -242,7 +244,8 @@ public class RedisShardBackplaneTest {
     // ASSERT
     assertThat(readyForRequeue.getRequeueAttempts())
         .isEqualTo(REQUEUE_AMOUNT_WHEN_READY_TO_REQUEUE);
-    verify(state.executionQueue, times(1)).dequeue(eq(jedis), any(List.class));
+    verify(state.executionQueue, times(1))
+        .dequeue(eq(jedis), any(List.class), any(ExecutorService.class));
     verify(state.executionQueue, times(1)).removeFromDequeue(jedis, queueEntryJson);
     verifyNoMoreInteractions(state.executionQueue);
     verify(state.dispatchedExecutions, times(1))
@@ -283,7 +286,8 @@ public class RedisShardBackplaneTest {
             .setRequeueAttempts(STARTING_REQUEUE_AMOUNT)
             .build();
     String queueEntryJson = JsonFormat.printer().print(queueEntry);
-    when(state.executionQueue.dequeue(eq(jedis), any(List.class))).thenReturn(queueEntryJson);
+    when(state.executionQueue.dequeue(eq(jedis), any(List.class), any(ExecutorService.class)))
+        .thenReturn(queueEntryJson);
     when(state.executionQueue.removeFromDequeue(jedis, queueEntryJson)).thenReturn(true);
     // PRE-ASSERT
     when(state.dispatchedExecutions.insertIfMissing(eq(jedis), eq(opName), any(String.class)))
@@ -309,7 +313,8 @@ public class RedisShardBackplaneTest {
     // ASSERT
     assertThat(readyForRequeue.getRequeueAttempts())
         .isEqualTo(REQUEUE_AMOUNT_WHEN_READY_TO_REQUEUE);
-    verify(state.executionQueue, times(1)).dequeue(eq(jedis), any(List.class));
+    verify(state.executionQueue, times(1))
+        .dequeue(eq(jedis), any(List.class), any(ExecutorService.class));
     verify(state.executionQueue, times(1)).removeFromDequeue(jedis, queueEntryJson);
     verifyNoMoreInteractions(state.executionQueue);
     verify(state.dispatchedExecutions, times(1))


### PR DESCRIPTION
With the new layer of checking multiple queues, we must avoid excessive calls into redis for what can be done more efficiently with blocking commands for non-priority queues, and the periodic checks of priority queues. We reuse the dequeueService here, assign for all backplane users, and should never have more than a single thread in the cache pool due to MatchStage singularity.

The getBlockingReply of BalancedRedisQueue also was incapable of handling an actual interrupt during call. Now all interrupts result in real exception delivery and shut down match stage appropriately.

Fixes #1844 