### PR TITLE
ci: un-pin the bazel version for macOS

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -59,8 +59,6 @@ tasks:
     - "..."
   macos:
     name: "Unit Tests"
-    environment:
-      USE_BAZEL_VERSION: 17be878292730359c9c90efdceabed26126df7ae
     build_flags:
     - "--cxxopt=-std=c++14"
     - "--build_tag_filters=-container"


### PR DESCRIPTION
It was pinned in https://github.com/bazelbuild/bazel-buildfarm/pull/1539

to a [Bazel version 10months ago](https://github.com/bazelbuild/bazel/commit/17be878292730359c9c90efdceabed26126df7ae). Time to move forward...