### PR TITLE
fix(worker): NPE on worker shutdown

### DIFF
--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -518,7 +518,7 @@ public final class Worker extends LoggingMain {
               @Override
               public void run() {
                 try {
-                  while (!server.isShutdown()) {
+                  while (server != null && !server.isShutdown()) {
                     registerIfExpired();
                     SECONDS.sleep(1);
                   }


### PR DESCRIPTION
Fixes a small NullPointerException while server is shutting down.

```
Exception in thread "Worker.failsafeRegistration"
java.lang.NullPointerException: Cannot invoke "io.grpc.Server.isShutdown()" because "this.this$0.server" is null
     at build.buildfarm.worker.shard.Worker$1.run(Worker.java:521)
     at java.base/java.lang.Thread.run(Thread.java:1583)
```