### PR TITLE
fix: use user’s preferred `bash`

### DIFF
--- a/.bazelci/format.sh
+++ b/.bazelci/format.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Run from the root of repository.
 # This script will format all of the java source files.
 # Use the flag --check if you want the script to fail when formatting is not correct.

--- a/_site/docs/execution/execution_policies.md
+++ b/_site/docs/execution/execution_policies.md
@@ -52,7 +52,7 @@ This addresses two problems in regards to an action's dependence on time.  The 1
 ### Issue 1 (slow test)
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 echo -n "testing... "
@@ -81,7 +81,7 @@ Now the test is 10x faster.  If skipping sleep makes an action perform significa
 ### Issue 2 (future failing test)
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 CURRENT_YEAR=$(date +"%Y")

--- a/_site/docs/execution/execution_properties.md
+++ b/_site/docs/execution/execution_properties.md
@@ -78,7 +78,7 @@ Despite being given 1 core, they see all of the cpus and decide to spawn that ma
 This test will succeed when env var TESTVAR is foobar, and fail otherwise.
 
 ```shell
-#!/bin/bash
+#!/usr/bin/env bash
 [ "$TESTVAR" = "foobar" ]
 ```
 
@@ -99,7 +99,7 @@ PASS
 **Template Example:**
 If you give a range of cores, buildfarm has the authority to decide how many your operation actually claims.  You can let buildfarm resolve this value for you (via [mustache](https://mustache.github.io/)).
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 [ "$MKL_NUM_THREADS" = "1" ]
 ```
 

--- a/delay.sh
+++ b/delay.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Delay running a program by sleeping.
 # If you are also skipping sleep syscalls, this will result in timeshifting you into the future.
 # This can help catch problems by tricking the program into thinking its future time.

--- a/examples/bf-run
+++ b/examples/bf-run
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/examples/development-redis-cluster.sh
+++ b/examples/development-redis-cluster.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # First, start six Redis instances using this script:
 #   ./development-redis-cluster.sh 0

--- a/generate_coverage.sh
+++ b/generate_coverage.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Run on specifc test targets via: ./generate_coverage.sh <target>
 # Script can be run without <target> to get coverage on all tests.
 

--- a/macos-wrapper.sh
+++ b/macos-wrapper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # An Apple specific Apple execution wrapper - mainly to set SDKROOT and
 # DEVELOPER_DIR.
 # There is no enforcement of where Xcode.app is installed locally or remote so


### PR DESCRIPTION
Especially important on macOS where `/bin/bash` is antiquated.

@jasonschroeder-sfdc Please review.