### PR TITLE
Allow prioritized execution policies to be applied before built-in policies

### DIFF
--- a/_site/docs/configuration/configuration.md
+++ b/_site/docs/configuration/configuration.md
@@ -459,6 +459,7 @@ worker:
 | Configuration    | Accepted and _Default_ Values                              | Description                                                         |
 |------------------|------------------------------------------------------------|---------------------------------------------------------------------|
 | name             | String                                                     | Execution policy name                                               |
+| prioritized      | Boolean, _false_                                           | If true, policy will run before built-in policies                   |
 | executionWrapper | Execution wrapper, containing a path and list of arguments | Execution wrapper, its path and a list of arguments for the wrapper |
 
 Example:
@@ -467,6 +468,7 @@ Example:
 worker:
   executionPolicies:
     - name: as-nobody
+      prioritized: true
       executionWrapper:
         path: /app/build_buildfarm/as-nobody
         arguments:

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -157,6 +157,7 @@ worker:
   zstdBufferPoolSize: 2048
   executionPolicies:
   - name: test
+    prioritized: false
     executionWrapper:
       path: /
       arguments:

--- a/src/main/java/build/buildfarm/common/config/ExecutionPolicy.java
+++ b/src/main/java/build/buildfarm/common/config/ExecutionPolicy.java
@@ -5,6 +5,7 @@ import lombok.Data;
 @Data
 public class ExecutionPolicy {
   private String name;
+  private boolean prioritized;
   private ExecutionWrapper executionWrapper;
 
   /** Required for snakeyaml to parse correctly */


### PR DESCRIPTION
Since https://github.com/buildfarm/buildfarm/pull/2297, which fixed cgroupsv2 for non-sandbox usage, the cgroupsv1 with sandbox has stopped working as well. To allow both cgroup versions to work under v1 w/sandbox and v2 without sandbox, allow falling back on prevous behavior by enabling prioritized execution policies, which can run BEFORE built-in policies until cgroupsv2 can work with linux-sandbox.