### PR TITLE
Present buildfarm Digests in ExecTree fileKeys

### DIFF
--- a/src/main/java/build/buildfarm/worker/ExecFileSystem.java
+++ b/src/main/java/build/buildfarm/worker/ExecFileSystem.java
@@ -110,9 +110,9 @@ public interface ExecFileSystem extends InputStreamFactory {
   }
 
   class ExecDigestAttributes extends ExecBaseAttributes {
-    private final build.bazel.remote.execution.v2.Digest digest;
+    private final Digest digest;
 
-    ExecDigestAttributes(build.bazel.remote.execution.v2.Digest digest, ExecFileType type) {
+    ExecDigestAttributes(Digest digest, ExecFileType type) {
       super(type);
       this.digest = digest;
     }
@@ -124,14 +124,14 @@ public interface ExecFileSystem extends InputStreamFactory {
 
     @Override
     public long size() {
-      return digest.getSizeBytes();
+      return digest.getSize();
     }
   }
 
   class ExecFileAttributes extends ExecDigestAttributes {
     private final boolean isExecutable;
 
-    ExecFileAttributes(build.bazel.remote.execution.v2.Digest digest, boolean isExecutable) {
+    ExecFileAttributes(Digest digest, boolean isExecutable) {
       super(digest, ExecFileType.FILE);
       this.isExecutable = isExecutable;
     }
@@ -165,7 +165,7 @@ public interface ExecFileSystem extends InputStreamFactory {
   }
 
   class ExecDirectoryAttributes extends ExecDigestAttributes {
-    ExecDirectoryAttributes(build.bazel.remote.execution.v2.Digest digest) {
+    ExecDirectoryAttributes(Digest digest) {
       super(digest, ExecFileType.DIRECTORY);
     }
   }


### PR DESCRIPTION
Prevents a failure during exec tree walking resulting in a ClassCastException in CFCExecFileSystem.