### PR TITLE
fix(ExecutionService): scoping of Context.current()

### DIFF
--- a/src/main/java/build/buildfarm/server/services/ExecutionService.java
+++ b/src/main/java/build/buildfarm/server/services/ExecutionService.java
@@ -66,12 +66,13 @@ public class ExecutionService extends ExecutionGrpc.ExecutionImplBase {
 
   private void withCancellation(
       ServerCallStreamObserver<Operation> serverCallStreamObserver, ListenableFuture<Void> future) {
+    Context context = Context.current();
     addCallback(
         future,
         new FutureCallback<Void>() {
           boolean isCancelled() {
             return serverCallStreamObserver.isCancelled()
-                || Context.current().isCancelled()
+                || context.isCancelled()
                 || future.isCancelled();
           }
 
@@ -95,7 +96,7 @@ public class ExecutionService extends ExecutionGrpc.ExecutionImplBase {
             }
           }
         },
-        Context.current().fixedContextExecutor(directExecutor()));
+        context.fixedContextExecutor(directExecutor()));
     serverCallStreamObserver.setOnCancelHandler(() -> future.cancel(false));
   }
 


### PR DESCRIPTION
When running Buildfarm with opentelemetry-javaagent attached, occasionally remote exec gRPCs will get returned to remoteapi client (Bazel 8.4.1) with "Context cancelled without error" which halts the build.

This was only observable when opentelemetry-javaagent is attached. Without it, the issue is not reproducible.

It seems that there's some scoping/Context.current() issue when the javaagent has attached itself to grpc engine. This fix pins the context.

Co-Authored-by: Gemini 2.5 Pro