### PR TITLE
chore(protobuf): remove/deprecate unused fields

### DIFF
--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -452,8 +452,8 @@ message BackplaneStatus {
 
   DispatchedOperationsStatus dispatched_operations = 9;
 
-  // Maintained for backward compatibility.
-  repeated string active_workers = 4;
+  // Maintained for backward compatibility. Union of active_storage_workers and active_execute_workers
+  repeated string active_workers = 4 [deprecated = true];
 
   repeated string active_storage_workers = 12;
 
@@ -461,17 +461,11 @@ message BackplaneStatus {
 
   repeated string active_execute_workers = 13;
 
-  int64 cas_lookup_size = 5;
-
-  int64 action_cache_size = 6;
-
-  int64 blocked_actions_size = 7;
-
-  int64 blocked_invocations_size = 8;
-
-  int64 fetch_time_ms = 10;
-
+  // Count of dispatched operations (non-negative)
   int64 dispatched_size = 11;
+
+  reserved 5 to 8; // cas_lookup_size, action_cache_size, blocked_actions_size, blocked_invocations_size
+  reserved 10; // fetch_time_ms
 }
 
 message QueuedOperationMetadata {


### PR DESCRIPTION
- added `[deprecated = true]` for `BackplaneStatus.active_workers`
- removed unused fields that were never set.