### PR TITLE
Handle CancellationException from input fetch

### DIFF
--- a/src/main/java/build/buildfarm/worker/CFCLinkExecFileSystem.java
+++ b/src/main/java/build/buildfarm/worker/CFCLinkExecFileSystem.java
@@ -53,6 +53,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.Stack;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -402,6 +403,8 @@ public class CFCLinkExecFileSystem extends CFCExecFileSystem {
         } else {
           try {
             fetchedFuture.get();
+          } catch (CancellationException e) {
+            exceptions.add(e);
           } catch (ExecutionException e) {
             // just to ensure that no other code can react to interrupt status
             exceptions.add(e.getCause());


### PR DESCRIPTION
A CancellationException thrown during the fetch will result in a failure to wait for all subsequent fetch completions. Enumerate this exception in the list and continue to ensure that the finally recovery which decrements references in the CAS runs without possibility of concurrent modification, detected or oblivious, crashing the recovery or leaking references, respectively.

Fixes #2411