### PR TITLE
Respond with ActionCacheUpdateCapabilities matching config

### DIFF
--- a/src/main/java/build/buildfarm/instance/shard/ServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ServerInstance.java
@@ -48,6 +48,7 @@ import static net.javacrumbs.futureconverter.java8guava.FutureConverter.toComple
 import static net.javacrumbs.futureconverter.java8guava.FutureConverter.toListenableFuture;
 
 import build.bazel.remote.execution.v2.Action;
+import build.bazel.remote.execution.v2.ActionCacheUpdateCapabilities;
 import build.bazel.remote.execution.v2.ActionResult;
 import build.bazel.remote.execution.v2.BatchReadBlobsResponse.Response;
 import build.bazel.remote.execution.v2.CacheCapabilities;
@@ -3374,6 +3375,9 @@ public class ServerInstance extends NodeInstance {
             ? SymlinkAbsolutePathStrategy.Value.ALLOWED
             : SymlinkAbsolutePathStrategy.Value.DISALLOWED;
     return super.getCacheCapabilities().toBuilder()
+        .setActionCacheUpdateCapabilities(
+            ActionCacheUpdateCapabilities.newBuilder()
+                .setUpdateEnabled(!configs.getServer().isActionCacheReadOnly()))
         .setSymlinkAbsolutePathStrategy(symlinkAbsolutePathStrategy)
         .build();
   }


### PR DESCRIPTION
Populate the AC Update Capabilities with the config setting for a server. This should prevent bazel clients from attempting to upload to endpoints that have the feature disabled, without a client flag requesting to do so.