### PR TITLE
Remove InterruptedException from instance execute

### DIFF
--- a/src/main/java/build/buildfarm/instance/Instance.java
+++ b/src/main/java/build/buildfarm/instance/Instance.java
@@ -131,8 +131,7 @@ public interface Instance {
       ExecutionPolicy executionPolicy,
       ResultsCachePolicy resultsCachePolicy,
       RequestMetadata requestMetadata,
-      Watcher operationObserver)
-      throws InterruptedException;
+      Watcher operationObserver);
 
   BackplaneStatus backplaneStatus();
 

--- a/src/main/java/build/buildfarm/server/services/ExecutionService.java
+++ b/src/main/java/build/buildfarm/server/services/ExecutionService.java
@@ -204,20 +204,16 @@ public class ExecutionService extends ExecutionGrpc.ExecutionImplBase {
     }
     ServerCallStreamObserver<Operation> serverCallStreamObserver =
         (ServerCallStreamObserver<Operation>) responseObserver;
-    try {
-      RequestMetadata requestMetadata = TracingMetadataUtils.fromCurrentContext();
-      withCancellation(
-          serverCallStreamObserver,
-          instance.execute(
-              actionDigest,
-              request.getSkipCacheLookup(),
-              request.getExecutionPolicy(),
-              request.getResultsCachePolicy(),
-              requestMetadata,
-              createWatcher(serverCallStreamObserver, requestMetadata)));
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-    }
+    RequestMetadata requestMetadata = TracingMetadataUtils.fromCurrentContext();
+    withCancellation(
+        serverCallStreamObserver,
+        instance.execute(
+            actionDigest,
+            request.getSkipCacheLookup(),
+            request.getExecutionPolicy(),
+            request.getResultsCachePolicy(),
+            requestMetadata,
+            createWatcher(serverCallStreamObserver, requestMetadata)));
   }
 
   private static MetricsPublisher getMetricsPublisher() {


### PR DESCRIPTION
Interrupted should not take place within the context of the execute call, it should only be deliverable within the future.