### PR TITLE
Handle missing operations in execution scan results

### DIFF
--- a/src/main/java/build/buildfarm/instance/shard/Executions.java
+++ b/src/main/java/build/buildfarm/instance/shard/Executions.java
@@ -87,6 +87,11 @@ public class Executions {
     return executions.get(jedis, name);
   }
 
+  private Iterable<Map.Entry<String, Operation>> getOrName(
+      UnifiedJedis jedis, Iterable<String> names) {
+    return executions.get(jedis, names, key -> Operation.newBuilder().setName(key).build());
+  }
+
   /**
    * @brief Get the executions by executionNames.
    * @details If the execution does not exist, null is returned.
@@ -97,14 +102,13 @@ public class Executions {
    * @note Suggested return identifier: operations.
    */
   public Iterable<Operation> get(UnifiedJedis jedis, Iterable<String> names) {
-    return transform(executions.get(jedis, names), Map.Entry::getValue);
+    return transform(getOrName(jedis, names), Map.Entry::getValue);
   }
 
   private ScanResult<Operation> parseScanResult(UnifiedJedis jedis, ScanResult<String> scanResult) {
     return new ScanResult<>(
         scanResult.getCursor(),
-        newArrayList(
-            transform(executions.get(jedis, scanResult.getResult()), Map.Entry::getValue)));
+        newArrayList(transform(getOrName(jedis, scanResult.getResult()), Map.Entry::getValue)));
   }
 
   public ScanResult<Operation> scan(UnifiedJedis jedis, String cursor, int count) {

--- a/src/test/java/build/buildfarm/instance/shard/BUILD
+++ b/src/test/java/build/buildfarm/instance/shard/BUILD
@@ -40,6 +40,7 @@ java_test(
     name = "RedisShardBackplaneTest",
     size = "small",
     srcs = [
+        "ExecutionsTest.java",
         "RedisShardBackplaneTest.java",
         "UnobservableWatcher.java",
     ],

--- a/src/test/java/build/buildfarm/instance/shard/ExecutionsTest.java
+++ b/src/test/java/build/buildfarm/instance/shard/ExecutionsTest.java
@@ -1,0 +1,60 @@
+// Copyright 2025 The Buildfarm Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.instance.shard;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import build.buildfarm.common.redis.StringTranslator;
+import com.google.common.collect.ImmutableList;
+import com.google.longrunning.Operation;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import redis.clients.jedis.PipelineBase;
+import redis.clients.jedis.Response;
+import redis.clients.jedis.UnifiedJedis;
+
+@RunWith(JUnit4.class)
+public class ExecutionsTest {
+  @Test
+  public void missingOperationsInScanAreNotNull() {
+    StringTranslator<Operation> translator = mock(StringTranslator.class);
+    when(translator.parse(anyString())).thenReturn(null);
+
+    Executions executions =
+        new Executions(
+            /* toolInvocations= */ null,
+            translator,
+            /* name= */ null,
+            /* actionsName= */ null,
+            /* timeout_s= */ -1,
+            /* action_timeout_s= */ -1);
+
+    Response<String> value = mock(Response.class);
+    PipelineBase pipeline = mock(PipelineBase.class);
+    when(pipeline.get(anyString())).thenReturn(value);
+
+    UnifiedJedis jedis = mock(UnifiedJedis.class);
+    when(jedis.pipelined()).thenReturn(pipeline);
+
+    Operation operation =
+        getOnlyElement(executions.get(jedis, ImmutableList.of("missing-operation")));
+    assertThat(operation).isNotNull();
+  }
+}


### PR DESCRIPTION
Convert RedisMap scan results via a user specified translator to eliminate NPE for nonexistent operations in listOperations responses