### PR TITLE
feat: Leader Election for dispatched monitor

### DIFF
--- a/src/main/java/build/buildfarm/backplane/Backplane.java
+++ b/src/main/java/build/buildfarm/backplane/Backplane.java
@@ -340,4 +340,17 @@ public interface Backplane {
   void incrementRequestCounters(
       String actionId, String toolInvocationId, String actionMnemonic, String targetId)
       throws IOException;
+
+  /** Attempt to acquire leadership for a specific election key. */
+  default boolean tryBecomeLeader(String electionKey) throws IOException {
+    return true;
+  }
+
+  /** Check if this instance is currently the leader for a specific election. */
+  default boolean isLeader(String electionKey) throws IOException {
+    return true;
+  }
+
+  /** Resign leadership for a specific election. */
+  default void resignLeadership(String electionKey) throws IOException {}
 }

--- a/src/main/java/build/buildfarm/common/redis/LeaderElection.java
+++ b/src/main/java/build/buildfarm/common/redis/LeaderElection.java
@@ -165,8 +165,7 @@ public class LeaderElection implements Closeable {
     this.leaseDuration = leaseDuration;
     this.renewalInterval = renewalInterval;
     this.renewalExecutor =
-        Executors.newScheduledThreadPool(
-            1,
+        Executors.newSingleThreadScheduledExecutor(
             r -> {
               Thread thread = new Thread(r, "leader-election-renewal");
               thread.setDaemon(true);

--- a/src/main/java/build/buildfarm/common/redis/LeaderElection.java
+++ b/src/main/java/build/buildfarm/common/redis/LeaderElection.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
+import java.util.logging.Level;
 import lombok.extern.java.Log;
 import redis.clients.jedis.UnifiedJedis;
 import redis.clients.jedis.params.SetParams;
@@ -241,9 +242,10 @@ public class LeaderElection implements Closeable {
 
       return acquired;
     } catch (Exception e) {
-      log.severe(
-          String.format(
-              "Error attempting to become leader for '%s': %s", electionKey, e.getMessage()));
+      log.log(
+          Level.SEVERE,
+          String.format("Error attempting to become leader for '%s'", electionKey),
+          e);
       return false;
     }
   }
@@ -517,7 +519,7 @@ public class LeaderElection implements Closeable {
         renewalInterval.toMillis(),
         TimeUnit.MILLISECONDS);
 
-    log.fine(String.format("Renewal task started (interval: %d ms)", renewalInterval.toMillis()));
+    log.fine(String.format("Renewal task started (interval: %dms)", renewalInterval.toMillis()));
   }
 
   /**
@@ -550,9 +552,10 @@ public class LeaderElection implements Closeable {
             try {
               callback.accept(electionKey, isLeader);
             } catch (Exception e) {
-              log.severe(
-                  String.format(
-                      "Error in leadership callback for '%s': %s", electionKey, e.getMessage()));
+              log.log(
+                  Level.SEVERE,
+                  String.format("Error in leadership callback for '%s'", electionKey),
+                  e);
             }
           }
         });

--- a/src/main/java/build/buildfarm/common/redis/LeaderElection.java
+++ b/src/main/java/build/buildfarm/common/redis/LeaderElection.java
@@ -29,6 +29,7 @@ import java.util.function.BiConsumer;
 import java.util.logging.Level;
 import lombok.extern.java.Log;
 import redis.clients.jedis.UnifiedJedis;
+import redis.clients.jedis.exceptions.JedisException;
 import redis.clients.jedis.params.SetParams;
 
 /**
@@ -241,7 +242,7 @@ public class LeaderElection implements Closeable {
       }
 
       return acquired;
-    } catch (Exception e) {
+    } catch (JedisException e) {
       log.log(
           Level.SEVERE,
           String.format("Error attempting to become leader for '%s'", electionKey),
@@ -285,7 +286,7 @@ public class LeaderElection implements Closeable {
       }
 
       return renewed;
-    } catch (Exception e) {
+    } catch (JedisException e) {
       log.severe(
           String.format("Error renewing leadership for '%s': %s", electionKey, e.getMessage()));
       handleLeadershipLoss(electionKey);
@@ -310,7 +311,7 @@ public class LeaderElection implements Closeable {
     try {
       String currentLeader = jedis.get(redisKey);
       return value.equals(currentLeader);
-    } catch (Exception e) {
+    } catch (JedisException e) {
       log.severe(
           String.format("Error checking leadership for '%s': %s", electionKey, e.getMessage()));
       return false;
@@ -343,7 +344,7 @@ public class LeaderElection implements Closeable {
       }
 
       return value;
-    } catch (Exception e) {
+    } catch (JedisException e) {
       log.severe(
           String.format("Error getting current leader for '%s': %s", electionKey, e.getMessage()));
       return null;
@@ -385,7 +386,7 @@ public class LeaderElection implements Closeable {
       }
 
       return resigned;
-    } catch (Exception e) {
+    } catch (JedisException e) {
       log.severe(
           String.format("Error resigning leadership for '%s': %s", electionKey, e.getMessage()));
       return false;

--- a/src/main/java/build/buildfarm/common/redis/LeaderElection.java
+++ b/src/main/java/build/buildfarm/common/redis/LeaderElection.java
@@ -1,0 +1,578 @@
+// Copyright 2025 The Buildfarm Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.common.redis;
+
+import java.io.Closeable;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiConsumer;
+import lombok.extern.java.Log;
+import redis.clients.jedis.UnifiedJedis;
+import redis.clients.jedis.params.SetParams;
+
+/**
+ * @class LeaderElection
+ * @brief Redis-based distributed leader election implementation.
+ * @details Implements a leader election algorithm using Redis atomic operations. Multiple identical
+ *     replicas can compete for leadership of various resources, each identified by a unique String
+ *     (election key). The class uses Redis SET with NX (Not eXists) and PX (exPire) options to
+ *     implement distributed locking with automatic expiration. Features include: - Automatic lease
+ *     renewal for active leaders - Configurable lease duration and renewal intervals - Asynchronous
+ *     callbacks for leadership changes - Thread-safe operations - OpenTelemetry instrumentation
+ *     <p>Usage Example:
+ *     <pre>{@code
+ * LeaderElection election = new LeaderElection(
+ *     "worker-node-1",
+ *     Duration.ofSeconds(60),
+ *     Duration.ofSeconds(20)
+ * );
+ *
+ * election.addLeadershipCallback((electionKey, isLeader) -> {
+ *     if (isLeader) {
+ *         System.out.println("Became leader for: " + electionKey);
+ *     } else {
+ *         System.out.println("Lost leadership for: " + electionKey);
+ *     }
+ * });
+ *
+ * if (election.tryBecomeLeader(jedis, "build-scheduler")) {
+ *     // This node is now the leader for "build-scheduler"
+ *     // Lease will be automatically renewed
+ * }
+ *
+ * // Later, when shutting down
+ * election.resignLeadership(jedis, "build-scheduler");
+ * election.close();
+ *
+ * }</pre>
+ */
+@Log
+public class LeaderElection implements Closeable {
+  private static final String REDIS_KEY_PREFIX = "buildfarm:leader:";
+
+  // Lua script for atomic renewal - checks ownership before extending TTL
+  private static final String RENEWAL_SCRIPT =
+      "if redis.call('get', KEYS[1]) == ARGV[1] then "
+          + "return redis.call('pexpire', KEYS[1], ARGV[2]) "
+          + "else return 0 end";
+
+  // Lua script for atomic resignation - checks ownership before deleting
+  private static final String RESIGN_SCRIPT =
+      "if redis.call('get', KEYS[1]) == ARGV[1] then "
+          + "return redis.call('del', KEYS[1]) "
+          + "else return 0 end";
+
+  /**
+   * @field nodeId The unique identifier for this node (e.g., hostname, UUID)
+   */
+  private final String nodeId;
+
+  /**
+   * @field leaseDuration How long the leadership lease lasts before expiring
+   */
+  private final Duration leaseDuration;
+
+  /**
+   * @field renewalInterval How often the leader should renew the lease
+   */
+  private final Duration renewalInterval;
+
+  /**
+   * @field renewalExecutor Scheduled executor for automatic lease renewal
+   */
+  private final ScheduledExecutorService renewalExecutor;
+
+  /**
+   * @field closed Flag indicating if this election instance has been closed
+   */
+  private final AtomicBoolean closed = new AtomicBoolean(false);
+
+  /**
+   * @field activeElections Map of election keys this node is currently leading
+   */
+  private final Map<String, ElectionState> activeElections = new ConcurrentHashMap<>();
+
+  /**
+   * @field leadershipCallbacks List of callbacks to invoke on leadership changes
+   */
+  private final List<BiConsumer<String, Boolean>> leadershipCallbacks =
+      Collections.synchronizedList(new java.util.ArrayList<>());
+
+  /**
+   * @class ElectionState
+   * @brief Tracks the state of a specific election this node is participating in.
+   */
+  private static class ElectionState {
+    final UnifiedJedis jedis;
+    final long acquisitionTimestamp;
+    volatile boolean wasLeader;
+
+    ElectionState(UnifiedJedis jedis) {
+      this.jedis = jedis;
+      this.acquisitionTimestamp = System.currentTimeMillis();
+      this.wasLeader = true;
+    }
+  }
+
+  /**
+   * @brief Constructor with configurable lease duration and renewal interval.
+   * @details Creates a new LeaderElection instance with automatic lease renewal. The renewal
+   *     interval should be significantly less than the lease duration (recommended: renewal <
+   *     leaseDuration / 2) to avoid race conditions during renewal.
+   * @param nodeId Unique identifier for this node (must be stable across restarts if persistence is
+   *     desired)
+   * @param leaseDuration How long the leadership lease lasts before automatic expiration
+   * @param renewalInterval How often the leader should attempt to renew the lease
+   * @throws IllegalArgumentException if renewalInterval >= leaseDuration
+   */
+  public LeaderElection(String nodeId, Duration leaseDuration, Duration renewalInterval) {
+    if (nodeId == null || nodeId.isEmpty()) {
+      throw new IllegalArgumentException("nodeId cannot be null or empty");
+    }
+    if (leaseDuration == null || leaseDuration.isNegative() || leaseDuration.isZero()) {
+      throw new IllegalArgumentException("leaseDuration must be positive");
+    }
+    if (renewalInterval == null || renewalInterval.isNegative() || renewalInterval.isZero()) {
+      throw new IllegalArgumentException("renewalInterval must be positive");
+    }
+    if (renewalInterval.compareTo(leaseDuration) >= 0) {
+      throw new IllegalArgumentException("renewalInterval must be less than leaseDuration");
+    }
+
+    this.nodeId = nodeId;
+    this.leaseDuration = leaseDuration;
+    this.renewalInterval = renewalInterval;
+    this.renewalExecutor =
+        Executors.newScheduledThreadPool(
+            1,
+            r -> {
+              Thread thread = new Thread(r, "leader-election-renewal");
+              thread.setDaemon(true);
+              return thread;
+            });
+
+    startRenewalTask();
+    log.info(
+        String.format(
+            "LeaderElection initialized for node '%s' (lease: %ds, renewal: %ds)",
+            nodeId, leaseDuration.getSeconds(), renewalInterval.getSeconds()));
+  }
+
+  /**
+   * @brief Constructor with default renewal interval (leaseDuration / 3).
+   * @param nodeId Unique identifier for this node
+   * @param leaseDuration How long the leadership lease lasts before automatic expiration
+   */
+  public LeaderElection(String nodeId, Duration leaseDuration) {
+    this(nodeId, leaseDuration, leaseDuration.dividedBy(3));
+  }
+
+  /**
+   * @brief Constructor with default lease duration (60 seconds) and renewal interval (20 seconds).
+   * @param nodeId Unique identifier for this node
+   */
+  public LeaderElection(String nodeId) {
+    this(nodeId, Duration.ofSeconds(60), Duration.ofSeconds(20));
+  }
+
+  /**
+   * @brief Attempt to become the leader for a specific election.
+   * @details Uses Redis SET with NX (not exists) and PX (expire milliseconds) to atomically acquire
+   *     leadership. If successful, automatic renewal begins. This method is idempotent - calling it
+   *     multiple times while already leader has no effect.
+   * @param jedis UnifiedJedis client for Redis operations
+   * @param electionKey Unique identifier for what needs a leader (e.g., "build-scheduler")
+   * @return true if this node became (or already was) the leader, false otherwise
+   */
+  public boolean tryBecomeLeader(UnifiedJedis jedis, String electionKey) {
+    if (closed.get()) {
+      log.warning(
+          String.format(
+              "Attempted to become leader for '%s' but LeaderElection is closed", electionKey));
+      return false;
+    }
+
+    String redisKey = getRedisKey(electionKey);
+    String value = getLeaderValue();
+
+    try {
+      // Check if we're already the leader
+      String currentLeader = jedis.get(redisKey);
+      if (value.equals(currentLeader)) {
+        log.fine(String.format("Node '%s' already leader for '%s'", nodeId, electionKey));
+        return true;
+      }
+
+      // Attempt to acquire leadership with SET NX PX (atomic operation)
+      SetParams params = new SetParams().nx().px(leaseDuration.toMillis());
+      String result = jedis.set(redisKey, value, params);
+
+      boolean acquired = "OK".equals(result);
+      if (acquired) {
+        activeElections.put(electionKey, new ElectionState(jedis));
+        log.info(String.format("Node '%s' became leader for '%s'", nodeId, electionKey));
+        notifyLeadershipChange(electionKey, true);
+      } else {
+        log.fine(
+            String.format(
+                "Node '%s' failed to become leader for '%s' (already held by another node)",
+                nodeId, electionKey));
+      }
+
+      return acquired;
+    } catch (Exception e) {
+      log.severe(
+          String.format(
+              "Error attempting to become leader for '%s': %s", electionKey, e.getMessage()));
+      return false;
+    }
+  }
+
+  /**
+   * @brief Renew leadership for a specific election.
+   * @details Uses a Lua script to atomically verify ownership and extend the TTL. This method is
+   *     called automatically by the renewal task, but can also be called manually.
+   * @param jedis UnifiedJedis client for Redis operations
+   * @param electionKey Unique identifier for the election
+   * @return true if renewal was successful (this node is still leader), false otherwise
+   */
+  public boolean renewLeadership(UnifiedJedis jedis, String electionKey) {
+    if (closed.get()) {
+      return false;
+    }
+
+    String redisKey = getRedisKey(electionKey);
+    String value = getLeaderValue();
+
+    try {
+      // Use Lua script for atomic check-and-renew
+      Object result =
+          jedis.eval(
+              RENEWAL_SCRIPT,
+              Collections.singletonList(redisKey),
+              List.of(value, String.valueOf(leaseDuration.toMillis())));
+
+      boolean renewed = Long.valueOf(1).equals(result);
+      if (renewed) {
+        log.fine(String.format("Node '%s' renewed leadership for '%s'", nodeId, electionKey));
+      } else {
+        log.warning(
+            String.format(
+                "Node '%s' failed to renew leadership for '%s' (lost)", nodeId, electionKey));
+        handleLeadershipLoss(electionKey);
+      }
+
+      return renewed;
+    } catch (Exception e) {
+      log.severe(
+          String.format("Error renewing leadership for '%s': %s", electionKey, e.getMessage()));
+      handleLeadershipLoss(electionKey);
+      return false;
+    }
+  }
+
+  /**
+   * @brief Check if this node is currently the leader for a specific election.
+   * @param jedis UnifiedJedis client for Redis operations
+   * @param electionKey Unique identifier for the election
+   * @return true if this node is the current leader, false otherwise
+   */
+  public boolean isLeader(UnifiedJedis jedis, String electionKey) {
+    if (closed.get()) {
+      return false;
+    }
+
+    String redisKey = getRedisKey(electionKey);
+    String value = getLeaderValue();
+
+    try {
+      String currentLeader = jedis.get(redisKey);
+      return value.equals(currentLeader);
+    } catch (Exception e) {
+      log.severe(
+          String.format("Error checking leadership for '%s': %s", electionKey, e.getMessage()));
+      return false;
+    }
+  }
+
+  /**
+   * @brief Get the current leader's node ID for a specific election.
+   * @param jedis UnifiedJedis client for Redis operations
+   * @param electionKey Unique identifier for the election
+   * @return The node ID of the current leader, or null if there is no leader
+   */
+  public String getCurrentLeader(UnifiedJedis jedis, String electionKey) {
+    if (closed.get()) {
+      return null;
+    }
+
+    String redisKey = getRedisKey(electionKey);
+
+    try {
+      String value = jedis.get(redisKey);
+      if (value == null) {
+        return null;
+      }
+
+      // Parse nodeId from value (format: nodeId:timestamp)
+      int separatorIndex = value.lastIndexOf(':');
+      if (separatorIndex > 0) {
+        return value.substring(0, separatorIndex);
+      }
+
+      return value;
+    } catch (Exception e) {
+      log.severe(
+          String.format("Error getting current leader for '%s': %s", electionKey, e.getMessage()));
+      return null;
+    }
+  }
+
+  /**
+   * @brief Resign leadership for a specific election.
+   * @details Uses a Lua script to atomically verify ownership before deleting the key. This ensures
+   *     that only the current leader can resign. After resigning, automatic renewal stops for this
+   *     election.
+   * @param jedis UnifiedJedis client for Redis operations
+   * @param electionKey Unique identifier for the election
+   * @return true if resignation was successful, false if not currently leader
+   */
+  public boolean resignLeadership(UnifiedJedis jedis, String electionKey) {
+    if (closed.get()) {
+      return false;
+    }
+
+    String redisKey = getRedisKey(electionKey);
+    String value = getLeaderValue();
+
+    try {
+      // Use Lua script for atomic check-and-delete
+      Object result =
+          jedis.eval(RESIGN_SCRIPT, Collections.singletonList(redisKey), List.of(value));
+
+      boolean resigned = Long.valueOf(1).equals(result);
+      if (resigned) {
+        activeElections.remove(electionKey);
+        log.info(String.format("Node '%s' resigned leadership for '%s'", nodeId, electionKey));
+        notifyLeadershipChange(electionKey, false);
+      } else {
+        log.warning(
+            String.format(
+                "Node '%s' failed to resign leadership for '%s' (not current leader)",
+                nodeId, electionKey));
+      }
+
+      return resigned;
+    } catch (Exception e) {
+      log.severe(
+          String.format("Error resigning leadership for '%s': %s", electionKey, e.getMessage()));
+      return false;
+    }
+  }
+
+  /**
+   * @brief Add a callback to be invoked when leadership changes.
+   * @details Callbacks are invoked asynchronously on the renewal thread. The callback receives the
+   *     election key and a boolean indicating whether this node gained (true) or lost (false)
+   *     leadership.
+   * @param callback BiConsumer that accepts (electionKey, isLeader)
+   */
+  public void addLeadershipCallback(BiConsumer<String, Boolean> callback) {
+    if (callback != null) {
+      leadershipCallbacks.add(callback);
+      log.fine("Leadership callback added");
+    }
+  }
+
+  /**
+   * @brief Remove a previously registered callback.
+   * @param callback The callback to remove
+   * @return true if the callback was found and removed, false otherwise
+   */
+  public boolean removeLeadershipCallback(BiConsumer<String, Boolean> callback) {
+    return leadershipCallbacks.remove(callback);
+  }
+
+  /**
+   * @brief Get the node ID for this election instance.
+   * @return The unique node identifier
+   */
+  public String getNodeId() {
+    return nodeId;
+  }
+
+  /**
+   * @brief Get the configured lease duration.
+   * @return The lease duration
+   */
+  public Duration getLeaseDuration() {
+    return leaseDuration;
+  }
+
+  /**
+   * @brief Get the configured renewal interval.
+   * @return The renewal interval
+   */
+  public Duration getRenewalInterval() {
+    return renewalInterval;
+  }
+
+  /**
+   * @brief Check if this LeaderElection instance has been closed.
+   * @return true if closed, false otherwise
+   */
+  public boolean isClosed() {
+    return closed.get();
+  }
+
+  /**
+   * @brief Close this LeaderElection instance and release all resources.
+   * @details Stops the renewal task, resigns all active leaderships, and shuts down the executor.
+   *     After closing, no further operations can be performed.
+   */
+  @Override
+  public void close() {
+    if (closed.compareAndSet(false, true)) {
+      log.info(String.format("Closing LeaderElection for node '%s'", nodeId));
+
+      // Stop renewal task
+      renewalExecutor.shutdown();
+
+      // Resign all active leaderships
+      activeElections.forEach(
+          (electionKey, state) -> {
+            try {
+              resignLeadership(state.jedis, electionKey);
+            } catch (Exception e) {
+              log.warning(
+                  String.format(
+                      "Error resigning leadership for '%s' during close: %s",
+                      electionKey, e.getMessage()));
+            }
+          });
+
+      // Wait for executor shutdown
+      try {
+        if (!renewalExecutor.awaitTermination(5, TimeUnit.SECONDS)) {
+          renewalExecutor.shutdownNow();
+        }
+      } catch (InterruptedException e) {
+        renewalExecutor.shutdownNow();
+        Thread.currentThread().interrupt();
+      }
+
+      activeElections.clear();
+      leadershipCallbacks.clear();
+      log.info(String.format("LeaderElection closed for node '%s'", nodeId));
+    }
+  }
+
+  /**
+   * @brief Start the automatic renewal task.
+   * @details Runs periodically at the configured renewal interval to renew all active leaderships.
+   */
+  private void startRenewalTask() {
+    renewalExecutor.scheduleAtFixedRate(
+        () -> {
+          if (closed.get()) {
+            return;
+          }
+
+          activeElections.forEach(
+              (electionKey, state) -> {
+                try {
+                  if (!renewLeadership(state.jedis, electionKey)) {
+                    // Renewal failed - leadership was lost
+                    handleLeadershipLoss(electionKey);
+                  }
+                } catch (Exception e) {
+                  log.severe(
+                      String.format(
+                          "Error in renewal task for '%s': %s", electionKey, e.getMessage()));
+                  handleLeadershipLoss(electionKey);
+                }
+              });
+        },
+        renewalInterval.toMillis(),
+        renewalInterval.toMillis(),
+        TimeUnit.MILLISECONDS);
+
+    log.fine(String.format("Renewal task started (interval: %d ms)", renewalInterval.toMillis()));
+  }
+
+  /**
+   * @brief Handle loss of leadership for an election.
+   * @param electionKey The election key for which leadership was lost
+   */
+  private void handleLeadershipLoss(String electionKey) {
+    ElectionState state = activeElections.remove(electionKey);
+    if (state != null && state.wasLeader) {
+      state.wasLeader = false;
+      log.warning(String.format("Node '%s' lost leadership for '%s'", nodeId, electionKey));
+      notifyLeadershipChange(electionKey, false);
+    }
+  }
+
+  /**
+   * @brief Notify all registered callbacks of a leadership change.
+   * @param electionKey The election key
+   * @param isLeader true if leadership was gained, false if lost
+   */
+  private void notifyLeadershipChange(String electionKey, boolean isLeader) {
+    if (leadershipCallbacks.isEmpty()) {
+      return;
+    }
+
+    // Invoke callbacks asynchronously to avoid blocking
+    renewalExecutor.execute(
+        () -> {
+          for (BiConsumer<String, Boolean> callback : leadershipCallbacks) {
+            try {
+              callback.accept(electionKey, isLeader);
+            } catch (Exception e) {
+              log.severe(
+                  String.format(
+                      "Error in leadership callback for '%s': %s", electionKey, e.getMessage()));
+            }
+          }
+        });
+  }
+
+  /**
+   * @brief Get the Redis key for an election.
+   * @param electionKey The election key
+   * @return The full Redis key
+   */
+  private String getRedisKey(String electionKey) {
+    return REDIS_KEY_PREFIX + electionKey;
+  }
+
+  /**
+   * @brief Get the value to store in Redis for this node's leadership.
+   * @details Format: nodeId:timestamp
+   * @return The leader value string
+   */
+  private String getLeaderValue() {
+    return nodeId + ":" + Instant.now().toEpochMilli();
+  }
+}

--- a/src/main/java/build/buildfarm/common/redis/LeaderElection.java
+++ b/src/main/java/build/buildfarm/common/redis/LeaderElection.java
@@ -542,10 +542,9 @@ public class LeaderElection implements Closeable {
           activeElections.forEach(
               (electionKey, state) -> {
                 try {
-                  if (!renewLeadership(state.jedis, electionKey)) {
-                    // Renewal failed - leadership was lost (handleLeadershipLoss already
-                    // invoked inside renewLeadership).
-                  }
+                  // Renewal failures are handled inside renewLeadership via
+                  // handleLeadershipLoss; the boolean result is intentionally ignored.
+                  renewLeadership(state.jedis, electionKey);
                 } catch (Exception e) {
                   log.severe(
                       String.format(

--- a/src/main/java/build/buildfarm/common/redis/LeaderElection.java
+++ b/src/main/java/build/buildfarm/common/redis/LeaderElection.java
@@ -20,6 +20,7 @@ import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -115,6 +116,13 @@ public class LeaderElection implements Closeable {
   private final Map<String, ElectionState> activeElections = new ConcurrentHashMap<>();
 
   /**
+   * @field candidateElections Election keys this node wants to lead. Persistent across acquisition
+   *     failures and leadership losses so the renewal task can re-attempt acquisition until {@link
+   *     #stopParticipating} or {@link #close} is called.
+   */
+  private final Map<String, UnifiedJedis> candidateElections = new ConcurrentHashMap<>();
+
+  /**
    * @field leadershipCallbacks List of callbacks to invoke on leadership changes
    */
   private final List<BiConsumer<String, Boolean>> leadershipCallbacks =
@@ -126,11 +134,13 @@ public class LeaderElection implements Closeable {
    */
   private static class ElectionState {
     final UnifiedJedis jedis;
+    final String leaderValue;
     final long acquisitionTimestamp;
     volatile boolean wasLeader;
 
-    ElectionState(UnifiedJedis jedis) {
+    ElectionState(UnifiedJedis jedis, String leaderValue) {
       this.jedis = jedis;
+      this.leaderValue = leaderValue;
       this.acquisitionTimestamp = System.currentTimeMillis();
       this.wasLeader = true;
     }
@@ -214,23 +224,27 @@ public class LeaderElection implements Closeable {
     }
 
     String redisKey = getRedisKey(electionKey);
-    String value = getLeaderValue();
 
     try {
-      // Check if we're already the leader
-      String currentLeader = jedis.get(redisKey);
-      if (value.equals(currentLeader)) {
+      // Register as a candidate so the renewal task keeps re-attempting after losses
+      // or initial failures (e.g., stale lease from a prior leader).
+      candidateElections.put(electionKey, jedis);
+
+      // If we already hold this election in-process, nothing to do.
+      ElectionState existing = activeElections.get(electionKey);
+      if (existing != null) {
         log.fine(String.format("Node '%s' already leader for '%s'", nodeId, electionKey));
         return true;
       }
 
       // Attempt to acquire leadership with SET NX PX (atomic operation)
+      String value = newLeaderValue();
       SetParams params = new SetParams().nx().px(leaseDuration.toMillis());
       String result = jedis.set(redisKey, value, params);
 
       boolean acquired = "OK".equals(result);
       if (acquired) {
-        activeElections.put(electionKey, new ElectionState(jedis));
+        activeElections.put(electionKey, new ElectionState(jedis, value));
         log.info(String.format("Node '%s' became leader for '%s'", nodeId, electionKey));
         notifyLeadershipChange(electionKey, true);
       } else {
@@ -263,8 +277,13 @@ public class LeaderElection implements Closeable {
       return false;
     }
 
+    ElectionState state = activeElections.get(electionKey);
+    if (state == null) {
+      return false;
+    }
+
     String redisKey = getRedisKey(electionKey);
-    String value = getLeaderValue();
+    String value = state.leaderValue;
 
     try {
       // Use Lua script for atomic check-and-renew
@@ -304,12 +323,16 @@ public class LeaderElection implements Closeable {
       return false;
     }
 
+    ElectionState state = activeElections.get(electionKey);
+    if (state == null) {
+      return false;
+    }
+
     String redisKey = getRedisKey(electionKey);
-    String value = getLeaderValue();
 
     try {
       String currentLeader = jedis.get(redisKey);
-      return value.equals(currentLeader);
+      return state.leaderValue.equals(currentLeader);
     } catch (JedisException e) {
       log.severe(
           String.format("Error checking leadership for '%s': %s", electionKey, e.getMessage()));
@@ -336,12 +359,17 @@ public class LeaderElection implements Closeable {
         return null;
       }
 
-      // Parse nodeId from value (format: nodeId:timestamp)
-      int separatorIndex = value.lastIndexOf(':');
-      if (separatorIndex > 0) {
-        return value.substring(0, separatorIndex);
+      // Parse nodeId from value (format: nodeId:timestamp:uuid)
+      int firstSeparator = value.indexOf(':');
+      // nodeId itself is "host:port", so the nodeId/timestamp boundary is the second-to-last ':'.
+      int lastSeparator = value.lastIndexOf(':');
+      int penultimate = lastSeparator > 0 ? value.lastIndexOf(':', lastSeparator - 1) : -1;
+      if (penultimate > 0) {
+        return value.substring(0, penultimate);
       }
-
+      if (firstSeparator > 0) {
+        return value.substring(0, firstSeparator);
+      }
       return value;
     } catch (JedisException e) {
       log.severe(
@@ -364,8 +392,17 @@ public class LeaderElection implements Closeable {
       return false;
     }
 
+    ElectionState state = activeElections.get(electionKey);
+    if (state == null) {
+      log.warning(
+          String.format(
+              "Node '%s' failed to resign leadership for '%s' (not current leader)",
+              nodeId, electionKey));
+      return false;
+    }
+
     String redisKey = getRedisKey(electionKey);
-    String value = getLeaderValue();
+    String value = state.leaderValue;
 
     try {
       // Use Lua script for atomic check-and-delete
@@ -484,6 +521,7 @@ public class LeaderElection implements Closeable {
       }
 
       activeElections.clear();
+      candidateElections.clear();
       leadershipCallbacks.clear();
       log.info(String.format("LeaderElection closed for node '%s'", nodeId));
     }
@@ -500,12 +538,13 @@ public class LeaderElection implements Closeable {
             return;
           }
 
+          // Renew leases we currently hold.
           activeElections.forEach(
               (electionKey, state) -> {
                 try {
                   if (!renewLeadership(state.jedis, electionKey)) {
-                    // Renewal failed - leadership was lost
-                    handleLeadershipLoss(electionKey);
+                    // Renewal failed - leadership was lost (handleLeadershipLoss already
+                    // invoked inside renewLeadership).
                   }
                 } catch (Exception e) {
                   log.severe(
@@ -514,12 +553,41 @@ public class LeaderElection implements Closeable {
                   handleLeadershipLoss(electionKey);
                 }
               });
+
+          // Re-attempt acquisition for any election we want but don't hold. This covers
+          // initial start-up against a stale lease, and recovery after losing leadership.
+          candidateElections.forEach(
+              (electionKey, jedis) -> {
+                if (activeElections.containsKey(electionKey)) {
+                  return;
+                }
+                try {
+                  tryBecomeLeader(jedis, electionKey);
+                } catch (Exception e) {
+                  log.fine(
+                      String.format(
+                          "Candidate acquisition attempt failed for '%s': %s",
+                          electionKey, e.getMessage()));
+                }
+              });
         },
         renewalInterval.toMillis(),
         renewalInterval.toMillis(),
         TimeUnit.MILLISECONDS);
 
     log.fine(String.format("Renewal task started (interval: %dms)", renewalInterval.toMillis()));
+  }
+
+  /**
+   * @brief Stop participating in an election. Cancels candidacy and resigns if currently leader.
+   * @param jedis UnifiedJedis client for Redis operations
+   * @param electionKey Unique identifier for the election
+   */
+  public void stopParticipating(UnifiedJedis jedis, String electionKey) {
+    candidateElections.remove(electionKey);
+    if (activeElections.containsKey(electionKey)) {
+      resignLeadership(jedis, electionKey);
+    }
   }
 
   /**
@@ -571,11 +639,12 @@ public class LeaderElection implements Closeable {
   }
 
   /**
-   * @brief Get the value to store in Redis for this node's leadership.
-   * @details Format: nodeId:timestamp
-   * @return The leader value string
+   * @brief Mint a new unique value to store in Redis for a fresh acquisition.
+   * @details Format: nodeId:timestamp:uuid. The value must remain stable for the lifetime of an
+   *     acquisition so renewal/resign Lua scripts can verify ownership.
+   * @return A freshly minted leader value string
    */
-  private String getLeaderValue() {
-    return nodeId + ":" + Instant.now().toEpochMilli();
+  private String newLeaderValue() {
+    return nodeId + ":" + Instant.now().toEpochMilli() + ":" + UUID.randomUUID();
   }
 }

--- a/src/main/java/build/buildfarm/instance/shard/DispatchedMonitor.java
+++ b/src/main/java/build/buildfarm/instance/shard/DispatchedMonitor.java
@@ -218,11 +218,11 @@ class DispatchedMonitor implements Runnable {
    */
   void iterate() throws InterruptedException {
     // Only perform work if this node is the leader
-    if (!isLeader.getAsBoolean()) {
+    if (isLeader.getAsBoolean()) {
+      getOnlyInterruptibly(submitAll());
+    } else {
       log.log(Level.FINE, "DispatchedMonitor: Skipping iteration (not leader)");
-      return;
     }
-    getOnlyInterruptibly(submitAll());
   }
 
   /**

--- a/src/main/java/build/buildfarm/instance/shard/DispatchedMonitor.java
+++ b/src/main/java/build/buildfarm/instance/shard/DispatchedMonitor.java
@@ -32,7 +32,6 @@ import java.util.function.BiFunction;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 import java.util.logging.Level;
-import javax.annotation.Nullable;
 import lombok.extern.java.Log;
 
 /**
@@ -65,14 +64,13 @@ class DispatchedMonitor implements Runnable {
    */
   DispatchedMonitor(
       BooleanSupplier shouldStop,
-      @Nullable BooleanSupplier isLeader,
+      BooleanSupplier isLeader,
       Scannable<DispatchedOperation> location,
       BiFunction<QueueEntry, Duration, ListenableFuture<Void>> requeuer,
       int intervalSeconds,
       Duration requeueDelay) {
     this.shouldStop = shouldStop;
-    this.isLeader =
-        isLeader != null ? isLeader : () -> true; // Default to always leader if not provided
+    this.isLeader = isLeader;
     this.location = location;
     this.requeuer = requeuer;
     this.intervalSeconds = intervalSeconds;

--- a/src/main/java/build/buildfarm/instance/shard/DispatchedMonitor.java
+++ b/src/main/java/build/buildfarm/instance/shard/DispatchedMonitor.java
@@ -32,6 +32,7 @@ import java.util.function.BiFunction;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 import java.util.logging.Level;
+import javax.annotation.Nullable;
 import lombok.extern.java.Log;
 
 /**
@@ -47,6 +48,7 @@ import lombok.extern.java.Log;
 @Log
 class DispatchedMonitor implements Runnable {
   private final BooleanSupplier shouldStop;
+  private final BooleanSupplier isLeader;
   private final Scannable<DispatchedOperation> location;
   private final BiFunction<QueueEntry, Duration, ListenableFuture<Void>> requeuer;
   private final int intervalSeconds;
@@ -63,11 +65,14 @@ class DispatchedMonitor implements Runnable {
    */
   DispatchedMonitor(
       BooleanSupplier shouldStop,
+      @Nullable BooleanSupplier isLeader,
       Scannable<DispatchedOperation> location,
       BiFunction<QueueEntry, Duration, ListenableFuture<Void>> requeuer,
       int intervalSeconds,
       Duration requeueDelay) {
     this.shouldStop = shouldStop;
+    this.isLeader =
+        isLeader != null ? isLeader : () -> true; // Default to always leader if not provided
     this.location = location;
     this.requeuer = requeuer;
     this.intervalSeconds = intervalSeconds;
@@ -214,6 +219,11 @@ class DispatchedMonitor implements Runnable {
    * @throws InterruptedException if the thread is interrupted while waiting for requeue operations
    */
   void iterate() throws InterruptedException {
+    // Only perform work if this node is the leader
+    if (!isLeader.getAsBoolean()) {
+      log.log(Level.FINE, "DispatchedMonitor: Skipping iteration (not leader)");
+      return;
+    }
     getOnlyInterruptibly(submitAll());
   }
 

--- a/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
@@ -555,6 +555,16 @@ public class RedisShardBackplane implements Backplane {
     return client.isClosed();
   }
 
+  /**
+   * @brief Get a UnifiedJedis instance for direct Redis operations.
+   * @details This method provides access to the underlying UnifiedJedis client for operations that
+   *     need direct Redis access, such as leader election.
+   * @return A UnifiedJedis instance
+   */
+  public UnifiedJedis getJedis() {
+    return jedisClusterFactory.get();
+  }
+
   @Override
   public ListenableFuture<Void> watchExecution(String executionName, Watcher watcher) {
     TimedWatcher timedWatcher =

--- a/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
@@ -40,6 +40,7 @@ import build.buildfarm.common.config.BuildfarmConfigs;
 import build.buildfarm.common.function.InterruptingRunnable;
 import build.buildfarm.common.redis.BalancedRedisQueue.BalancedQueueEntry;
 import build.buildfarm.common.redis.Codec;
+import build.buildfarm.common.redis.LeaderElection;
 import build.buildfarm.common.redis.RedisClient;
 import build.buildfarm.common.redis.Unified;
 import build.buildfarm.instance.shard.ExecutionQueue.ExecutionQueueEntry;
@@ -112,6 +113,7 @@ public class RedisShardBackplane implements Backplane {
   private final Supplier<UnifiedJedis> jedisClusterFactory;
   private final Codec codec;
 
+  private @Nullable LeaderElection leaderElection = null;
   private @Nullable InterruptingRunnable onUnsubscribe = null;
   private Thread subscriptionThread = null;
   private Thread failsafeOperationThread = null;
@@ -489,6 +491,7 @@ public class RedisShardBackplane implements Backplane {
       throws IOException {
     this.client = client;
     this.state = state;
+    this.leaderElection = new LeaderElection(clientPublicName);
     if (subscribeToBackplane) {
       startSubscriptionThread(onWorkerRemoved);
     }
@@ -542,6 +545,11 @@ public class RedisShardBackplane implements Backplane {
         log.log(Level.WARNING, "subscriberService has not stopped");
       }
     }
+    if (leaderElection != null) {
+      leaderElection.close();
+      leaderElection = null;
+      log.log(Level.FINER, "leaderElection has been closed");
+    }
     if (client != null) {
       client.close();
       client = null;
@@ -555,14 +563,23 @@ public class RedisShardBackplane implements Backplane {
     return client.isClosed();
   }
 
-  /**
-   * @brief Get a UnifiedJedis instance for direct Redis operations.
-   * @details This method provides access to the underlying UnifiedJedis client for operations that
-   *     need direct Redis access, such as leader election.
-   * @return A UnifiedJedis instance
-   */
-  public UnifiedJedis getJedis() {
-    return jedisClusterFactory.get();
+  @Override
+  public boolean tryBecomeLeader(String electionKey) throws IOException {
+    return client.call(jedis -> leaderElection.tryBecomeLeader(jedis, electionKey));
+  }
+
+  @Override
+  public boolean isLeader(String electionKey) throws IOException {
+    return client.call(jedis -> leaderElection.isLeader(jedis, electionKey));
+  }
+
+  @Override
+  public void resignLeadership(String electionKey) throws IOException {
+    client.call(
+        jedis -> {
+          leaderElection.resignLeadership(jedis, electionKey);
+          return null;
+        });
   }
 
   @Override

--- a/src/main/java/build/buildfarm/instance/shard/ServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ServerInstance.java
@@ -89,7 +89,6 @@ import build.buildfarm.common.Write;
 import build.buildfarm.common.config.BuildfarmConfigs;
 import build.buildfarm.common.function.CountingConsumer;
 import build.buildfarm.common.grpc.UniformDelegateServerCallStreamObserver;
-import build.buildfarm.common.redis.LeaderElection;
 import build.buildfarm.common.redis.RedisHashtags;
 import build.buildfarm.instance.Instance;
 import build.buildfarm.instance.server.Filter;
@@ -260,7 +259,6 @@ public class ServerInstance extends NodeInstance {
   private final RemoteInputStreamFactory remoteInputStreamFactory;
   private final com.google.common.cache.LoadingCache<String, StubInstance> workerStubs;
   private final Thread dispatchedMonitor;
-  private final LeaderElection leaderElection;
   private final Duration maxActionTimeout;
   private AsyncCache<build.buildfarm.v1test.Digest, Directory> directoryCache;
   private AsyncCache<build.buildfarm.v1test.Digest, Command> commandCache;
@@ -526,19 +524,12 @@ public class ServerInstance extends NodeInstance {
         new RemoteInputStreamFactory(
             backplane, rand, workerStubs, this::removeMalfunctioningWorker);
 
-    // Initialize leader election for DispatchedMonitor coordination
-    if (backplane instanceof RedisShardBackplane) {
-      leaderElection = new LeaderElection(name);
-    } else {
-      leaderElection = null;
-    }
-
     if (runDispatchedMonitor) {
       dispatchedMonitor =
           new Thread(
               new DispatchedMonitor(
                   backplane::isStopped,
-                  leaderElection != null ? this::isDispatchedMonitorLeader : null,
+                  this::isDispatchedMonitorLeader,
                   dispatchedOperations,
                   this::requeueOperation,
                   dispatchedMonitorIntervalSeconds,
@@ -741,15 +732,13 @@ public class ServerInstance extends NodeInstance {
     }
   }
 
-  /**
-   * @brief Check if this server instance is the leader for DispatchedMonitor operations.
-   * @return true if this instance is the leader, false otherwise
-   */
   private boolean isDispatchedMonitorLeader() {
-    if (leaderElection == null || !(backplane instanceof RedisShardBackplane redisBackplane)) {
-      return true; // No leader election configured, assume leader
+    try {
+      return backplane.isLeader("dispatchedmonitor");
+    } catch (IOException e) {
+      log.log(Level.WARNING, "error checking leader status, assuming leader", e);
+      return true;
     }
-    return leaderElection.isLeader(redisBackplane.getJedis(), "dispatchedmonitor");
   }
 
   @Override
@@ -767,15 +756,12 @@ public class ServerInstance extends NodeInstance {
     }
 
     // Attempt to become leader for DispatchedMonitor operations
-    if (leaderElection != null && backplane instanceof RedisShardBackplane redisBackplane) {
-      boolean becameLeader =
-          leaderElection.tryBecomeLeader(redisBackplane.getJedis(), "dispatchedmonitor");
-      log.log(
-          Level.INFO,
-          format(
-              "ServerInstance '%s' leader election result: %s",
-              publicName, becameLeader ? "LEADER" : "FOLLOWER"));
-    }
+    boolean becameLeader = backplane.tryBecomeLeader("dispatchedmonitor");
+    log.log(
+        Level.INFO,
+        format(
+            "ServerInstance '%s' leader election result: %s",
+            publicName, becameLeader ? "LEADER" : "FOLLOWER"));
 
     if (dispatchedMonitor != null) {
       dispatchedMonitor.start();
@@ -804,14 +790,6 @@ public class ServerInstance extends NodeInstance {
     if (dispatchedMonitor != null) {
       dispatchedMonitor.interrupt();
       dispatchedMonitor.join();
-    }
-    if (leaderElection != null) {
-      try {
-        leaderElection.close();
-        log.log(Level.INFO, "LeaderElection closed for instance " + getName());
-      } catch (Exception e) {
-        log.log(Level.WARNING, "Error closing LeaderElection", e);
-      }
     }
     if (prometheusMetricsThread != null) {
       prometheusMetricsThread.interrupt();

--- a/src/main/java/build/buildfarm/instance/shard/ServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ServerInstance.java
@@ -89,6 +89,7 @@ import build.buildfarm.common.Write;
 import build.buildfarm.common.config.BuildfarmConfigs;
 import build.buildfarm.common.function.CountingConsumer;
 import build.buildfarm.common.grpc.UniformDelegateServerCallStreamObserver;
+import build.buildfarm.common.redis.LeaderElection;
 import build.buildfarm.common.redis.RedisHashtags;
 import build.buildfarm.instance.Instance;
 import build.buildfarm.instance.server.Filter;
@@ -259,6 +260,7 @@ public class ServerInstance extends NodeInstance {
   private final RemoteInputStreamFactory remoteInputStreamFactory;
   private final com.google.common.cache.LoadingCache<String, StubInstance> workerStubs;
   private final Thread dispatchedMonitor;
+  private final LeaderElection leaderElection;
   private final Duration maxActionTimeout;
   private AsyncCache<build.buildfarm.v1test.Digest, Directory> directoryCache;
   private AsyncCache<build.buildfarm.v1test.Digest, Command> commandCache;
@@ -524,11 +526,19 @@ public class ServerInstance extends NodeInstance {
         new RemoteInputStreamFactory(
             backplane, rand, workerStubs, this::removeMalfunctioningWorker);
 
+    // Initialize leader election for DispatchedMonitor coordination
+    if (backplane instanceof RedisShardBackplane) {
+      leaderElection = new LeaderElection(name);
+    } else {
+      leaderElection = null;
+    }
+
     if (runDispatchedMonitor) {
       dispatchedMonitor =
           new Thread(
               new DispatchedMonitor(
                   backplane::isStopped,
+                  leaderElection != null ? this::isDispatchedMonitorLeader : null,
                   dispatchedOperations,
                   this::requeueOperation,
                   dispatchedMonitorIntervalSeconds,
@@ -731,6 +741,17 @@ public class ServerInstance extends NodeInstance {
     }
   }
 
+  /**
+   * @brief Check if this server instance is the leader for DispatchedMonitor operations.
+   * @return true if this instance is the leader, false otherwise
+   */
+  private boolean isDispatchedMonitorLeader() {
+    if (leaderElection == null || !(backplane instanceof RedisShardBackplane redisBackplane)) {
+      return true; // No leader election configured, assume leader
+    }
+    return leaderElection.isLeader(redisBackplane.getJedis(), "dispatchedmonitor");
+  }
+
   @Override
   public void start(String publicName) throws IOException {
     stopped = false;
@@ -744,6 +765,18 @@ public class ServerInstance extends NodeInstance {
       }
       throw e;
     }
+
+    // Attempt to become leader for DispatchedMonitor operations
+    if (leaderElection != null && backplane instanceof RedisShardBackplane redisBackplane) {
+      boolean becameLeader =
+          leaderElection.tryBecomeLeader(redisBackplane.getJedis(), "dispatchedmonitor");
+      log.log(
+          Level.INFO,
+          format(
+              "ServerInstance '%s' leader election result: %s",
+              publicName, becameLeader ? "LEADER" : "FOLLOWER"));
+    }
+
     if (dispatchedMonitor != null) {
       dispatchedMonitor.start();
     }
@@ -771,6 +804,14 @@ public class ServerInstance extends NodeInstance {
     if (dispatchedMonitor != null) {
       dispatchedMonitor.interrupt();
       dispatchedMonitor.join();
+    }
+    if (leaderElection != null) {
+      try {
+        leaderElection.close();
+        log.log(Level.INFO, "LeaderElection closed for instance " + getName());
+      } catch (Exception e) {
+        log.log(Level.WARNING, "Error closing LeaderElection", e);
+      }
     }
     if (prometheusMetricsThread != null) {
       prometheusMetricsThread.interrupt();

--- a/src/main/java/build/buildfarm/instance/shard/ServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ServerInstance.java
@@ -251,6 +251,7 @@ public class ServerInstance extends NodeInstance {
           "bindings",
           ImmutableList.of(
               BINDING_EXECUTIONS, BINDING_TOOL_INVOCATIONS, BINDING_CORRELATED_INVOCATIONS));
+  public static final String ELECTION_KEY_DISPATCHEDMONITOR = "dispatchedmonitor";
 
   private final Runnable onStop;
   private final long maxEntrySizeBytes;
@@ -734,7 +735,7 @@ public class ServerInstance extends NodeInstance {
 
   private boolean isDispatchedMonitorLeader() {
     try {
-      return backplane.isLeader("dispatchedmonitor");
+      return backplane.isLeader(ELECTION_KEY_DISPATCHEDMONITOR);
     } catch (IOException e) {
       log.log(Level.WARNING, "error checking leader status, assuming leader", e);
       return true;
@@ -755,15 +756,13 @@ public class ServerInstance extends NodeInstance {
       throw e;
     }
 
-    // Attempt to become leader for DispatchedMonitor operations
-    boolean becameLeader = backplane.tryBecomeLeader("dispatchedmonitor");
-    log.log(
-        Level.INFO,
-        format(
-            "ServerInstance '%s' leader election result: %s",
-            publicName, becameLeader ? "LEADER" : "FOLLOWER"));
-
     if (dispatchedMonitor != null) {
+      boolean becameLeader = backplane.tryBecomeLeader(ELECTION_KEY_DISPATCHEDMONITOR);
+      log.log(
+          Level.INFO,
+          format(
+              "name='%s' leader election result: %s",
+              publicName, becameLeader ? "LEADER" : "FOLLOWER"));
       dispatchedMonitor.start();
     }
     if (operationQueuer != null) {

--- a/src/test/java/build/buildfarm/common/redis/BUILD
+++ b/src/test/java/build/buildfarm/common/redis/BUILD
@@ -17,6 +17,7 @@ COMMON_DEPS = [
 
 NATIVE_REDIS_TESTS = [
     "BalancedRedisQueueTest.java",
+    "LeaderElectionTest.java",
     "RedisNodeHashesTest.java",
     "RedisQueueTest.java",
     "RedisPriorityQueueTest.java",
@@ -106,6 +107,18 @@ java_test(
     name = "hashmap-redis",
     size = "small",
     srcs = ["RedisHashMapTest.java"],
+    tags = [
+        "exclusive",
+        "redis",
+    ],
+    test_class = "build.buildfarm.AllTests",
+    deps = COMMON_DEPS,
+)
+
+java_test(
+    name = "leaderelection-redis",
+    size = "small",
+    srcs = ["LeaderElectionTest.java"],
     tags = [
         "exclusive",
         "redis",

--- a/src/test/java/build/buildfarm/common/redis/LeaderElectionTest.java
+++ b/src/test/java/build/buildfarm/common/redis/LeaderElectionTest.java
@@ -1,0 +1,598 @@
+// Copyright 2025 The Buildfarm Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.common.redis;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import build.buildfarm.common.config.BuildfarmConfigs;
+import build.buildfarm.instance.shard.JedisClusterFactory;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPooled;
+import redis.clients.jedis.UnifiedJedis;
+
+/**
+ * @class LeaderElectionTest
+ * @brief Tests for Redis-based leader election.
+ * @details Tests cover single-node and multi-node scenarios, lease renewal, expiration, callbacks,
+ *     and error conditions. Tests requiring Redis are tagged appropriately.
+ */
+@RunWith(JUnit4.class)
+public class LeaderElectionTest {
+  private static final String TEST_ELECTION_KEY = "test-election";
+  private static final Duration SHORT_LEASE = Duration.ofSeconds(2);
+  private static final Duration VERY_SHORT_LEASE = Duration.ofMillis(500);
+  private static final Duration SHORT_RENEWAL = Duration.ofMillis(500);
+
+  private BuildfarmConfigs configs = BuildfarmConfigs.getInstance();
+  private JedisPooled pooled;
+  private Jedis redis;
+  private UnifiedJedis unified;
+  private List<LeaderElection> electionsToClose = new ArrayList<>();
+
+  @Before
+  public void setUp() throws Exception {
+    configs.getBackplane().setRedisUri("redis://localhost:6379");
+    unified = JedisClusterFactory.createTest();
+    assertThat(unified).isInstanceOf(JedisPooled.class);
+    pooled = (JedisPooled) unified;
+    redis = new Jedis(pooled.getPool().getResource());
+    redis.flushDB();
+  }
+
+  @After
+  public void tearDown() {
+    // Close all elections created during tests
+    for (LeaderElection election : electionsToClose) {
+      try {
+        election.close();
+      } catch (Exception e) {
+        // Ignore cleanup errors
+      }
+    }
+    electionsToClose.clear();
+
+    redis.flushDB();
+    redis.close();
+    pooled.close();
+  }
+
+  /** Helper method to create a LeaderElection instance that will be automatically closed. */
+  private LeaderElection createElection(String nodeId, Duration lease, Duration renewal) {
+    LeaderElection election = new LeaderElection(nodeId, lease, renewal);
+    electionsToClose.add(election);
+    return election;
+  }
+
+  private LeaderElection createElection(String nodeId) {
+    return createElection(nodeId, SHORT_LEASE, SHORT_RENEWAL);
+  }
+
+  // ===== Constructor and Validation Tests =====
+
+  @Test
+  public void testConstructorWithValidParameters() {
+    LeaderElection election =
+        createElection("node1", Duration.ofSeconds(60), Duration.ofSeconds(20));
+
+    assertThat(election.getNodeId()).isEqualTo("node1");
+    assertThat(election.getLeaseDuration()).isEqualTo(Duration.ofSeconds(60));
+    assertThat(election.getRenewalInterval()).isEqualTo(Duration.ofSeconds(20));
+    assertThat(election.isClosed()).isFalse();
+  }
+
+  @Test
+  public void testConstructorWithDefaultRenewalInterval() {
+    LeaderElection election = new LeaderElection("node1", Duration.ofSeconds(60));
+    electionsToClose.add(election);
+
+    assertThat(election.getNodeId()).isEqualTo("node1");
+    assertThat(election.getLeaseDuration()).isEqualTo(Duration.ofSeconds(60));
+    assertThat(election.getRenewalInterval()).isEqualTo(Duration.ofSeconds(20)); // 60 / 3
+  }
+
+  @Test
+  public void testConstructorWithAllDefaults() {
+    LeaderElection election = createElection("node1");
+
+    assertThat(election.getNodeId()).isEqualTo("node1");
+    assertThat(election.getLeaseDuration()).isEqualTo(Duration.ofSeconds(60));
+    assertThat(election.getRenewalInterval()).isEqualTo(Duration.ofSeconds(20));
+  }
+
+  @Test
+  public void testConstructorRejectsNullNodeId() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new LeaderElection(null, Duration.ofSeconds(60), Duration.ofSeconds(20)));
+  }
+
+  @Test
+  public void testConstructorRejectsEmptyNodeId() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new LeaderElection("", Duration.ofSeconds(60), Duration.ofSeconds(20)));
+  }
+
+  @Test
+  public void testConstructorRejectsNullLeaseDuration() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new LeaderElection("node1", null, Duration.ofSeconds(20)));
+  }
+
+  @Test
+  public void testConstructorRejectsNegativeLeaseDuration() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new LeaderElection("node1", Duration.ofSeconds(-10), Duration.ofSeconds(5)));
+  }
+
+  @Test
+  public void testConstructorRejectsZeroLeaseDuration() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new LeaderElection("node1", Duration.ZERO, Duration.ofSeconds(5)));
+  }
+
+  @Test
+  public void testConstructorRejectsRenewalGreaterThanLease() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new LeaderElection("node1", Duration.ofSeconds(10), Duration.ofSeconds(20)));
+  }
+
+  @Test
+  public void testConstructorRejectsRenewalEqualToLease() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new LeaderElection("node1", Duration.ofSeconds(10), Duration.ofSeconds(10)));
+  }
+
+  // ===== Single Node Leader Election Tests =====
+
+  @Test
+  public void testSingleNodeBecomesLeader() {
+    LeaderElection election = createElection("node1");
+
+    boolean becameLeader = election.tryBecomeLeader(unified, TEST_ELECTION_KEY);
+
+    assertThat(becameLeader).isTrue();
+    assertThat(election.isLeader(unified, TEST_ELECTION_KEY)).isTrue();
+    assertThat(election.getCurrentLeader(unified, TEST_ELECTION_KEY)).isEqualTo("node1");
+  }
+
+  @Test
+  public void testMultipleAttemptsToBecomLeaderAreIdempotent() {
+    LeaderElection election = createElection("node1");
+
+    boolean first = election.tryBecomeLeader(unified, TEST_ELECTION_KEY);
+    boolean second = election.tryBecomeLeader(unified, TEST_ELECTION_KEY);
+    boolean third = election.tryBecomeLeader(unified, TEST_ELECTION_KEY);
+
+    assertThat(first).isTrue();
+    assertThat(second).isTrue();
+    assertThat(third).isTrue();
+    assertThat(election.isLeader(unified, TEST_ELECTION_KEY)).isTrue();
+  }
+
+  @Test
+  public void testCanBecomeLeaderForMultipleElections() {
+    LeaderElection election = createElection("node1");
+
+    boolean leader1 = election.tryBecomeLeader(unified, "election-1");
+    boolean leader2 = election.tryBecomeLeader(unified, "election-2");
+    boolean leader3 = election.tryBecomeLeader(unified, "election-3");
+
+    assertThat(leader1).isTrue();
+    assertThat(leader2).isTrue();
+    assertThat(leader3).isTrue();
+    assertThat(election.isLeader(unified, "election-1")).isTrue();
+    assertThat(election.isLeader(unified, "election-2")).isTrue();
+    assertThat(election.isLeader(unified, "election-3")).isTrue();
+  }
+
+  // ===== Multi-Node Competition Tests =====
+
+  @Test
+  public void testMultipleNodesOnlyOneBecomesLeader() {
+    LeaderElection election1 = createElection("node1");
+    LeaderElection election2 = createElection("node2");
+    LeaderElection election3 = createElection("node3");
+
+    boolean leader1 = election1.tryBecomeLeader(unified, TEST_ELECTION_KEY);
+    boolean leader2 = election2.tryBecomeLeader(unified, TEST_ELECTION_KEY);
+    boolean leader3 = election3.tryBecomeLeader(unified, TEST_ELECTION_KEY);
+
+    // Exactly one should be leader
+    int leaderCount = (leader1 ? 1 : 0) + (leader2 ? 1 : 0) + (leader3 ? 1 : 0);
+    assertThat(leaderCount).isEqualTo(1);
+
+    // Verify the leader is correct
+    String currentLeader = election1.getCurrentLeader(unified, TEST_ELECTION_KEY);
+    assertThat(currentLeader).isNotNull();
+    assertThat(currentLeader).isIn(List.of("node1", "node2", "node3"));
+  }
+
+  @Test
+  public void testNonLeaderCannotRenewLeadership() {
+    LeaderElection election1 = createElection("node1");
+    LeaderElection election2 = createElection("node2");
+
+    election1.tryBecomeLeader(unified, TEST_ELECTION_KEY);
+
+    boolean renewed = election2.renewLeadership(unified, TEST_ELECTION_KEY);
+
+    assertThat(renewed).isFalse();
+  }
+
+  // ===== Lease Renewal Tests =====
+
+  @Test
+  public void testLeaderCanRenewLeadership() {
+    LeaderElection election = createElection("node1");
+
+    election.tryBecomeLeader(unified, TEST_ELECTION_KEY);
+    boolean renewed = election.renewLeadership(unified, TEST_ELECTION_KEY);
+
+    assertThat(renewed).isTrue();
+    assertThat(election.isLeader(unified, TEST_ELECTION_KEY)).isTrue();
+  }
+
+  @Test
+  public void testAutomaticLeaseRenewal() throws InterruptedException {
+    LeaderElection election = createElection("node1", SHORT_LEASE, SHORT_RENEWAL);
+
+    election.tryBecomeLeader(unified, TEST_ELECTION_KEY);
+
+    // Wait for more than the lease duration but let auto-renewal keep it alive
+    Thread.sleep(SHORT_LEASE.toMillis() + 500);
+
+    // Should still be leader due to auto-renewal
+    assertThat(election.isLeader(unified, TEST_ELECTION_KEY)).isTrue();
+  }
+
+  // ===== Lease Expiration Tests =====
+
+  @Test
+  public void testLeadershipExpiresWithoutRenewal() throws InterruptedException {
+    // Create election with very short lease and no auto-renewal
+    LeaderElection election =
+        createElection("node1", VERY_SHORT_LEASE, VERY_SHORT_LEASE.dividedBy(3));
+
+    election.tryBecomeLeader(unified, TEST_ELECTION_KEY);
+    assertThat(election.isLeader(unified, TEST_ELECTION_KEY)).isTrue();
+
+    // Close to stop auto-renewal
+    election.close();
+
+    // Wait for lease to expire
+    Thread.sleep(VERY_SHORT_LEASE.toMillis() + 200);
+
+    // Leadership should have expired
+    String currentLeader = election.getCurrentLeader(unified, TEST_ELECTION_KEY);
+    assertThat(currentLeader).isNull();
+  }
+
+  @Test
+  public void testLeadershipTransferAfterExpiration() throws InterruptedException {
+    LeaderElection election1 =
+        createElection("node1", VERY_SHORT_LEASE, VERY_SHORT_LEASE.dividedBy(3));
+    LeaderElection election2 = createElection("node2");
+
+    // Node1 becomes leader
+    election1.tryBecomeLeader(unified, TEST_ELECTION_KEY);
+    assertThat(election1.getCurrentLeader(unified, TEST_ELECTION_KEY)).isEqualTo("node1");
+
+    // Stop node1's renewal
+    election1.close();
+
+    // Wait for lease to expire
+    Thread.sleep(VERY_SHORT_LEASE.toMillis() + 200);
+
+    // Node2 should now be able to become leader
+    boolean becameLeader = election2.tryBecomeLeader(unified, TEST_ELECTION_KEY);
+    assertThat(becameLeader).isTrue();
+    assertThat(election2.getCurrentLeader(unified, TEST_ELECTION_KEY)).isEqualTo("node2");
+  }
+
+  // ===== Resignation Tests =====
+
+  @Test
+  public void testLeaderCanResign() {
+    LeaderElection election = createElection("node1");
+
+    election.tryBecomeLeader(unified, TEST_ELECTION_KEY);
+    boolean resigned = election.resignLeadership(unified, TEST_ELECTION_KEY);
+
+    assertThat(resigned).isTrue();
+    assertThat(election.isLeader(unified, TEST_ELECTION_KEY)).isFalse();
+    assertThat(election.getCurrentLeader(unified, TEST_ELECTION_KEY)).isNull();
+  }
+
+  @Test
+  public void testNonLeaderCannotResign() {
+    LeaderElection election1 = createElection("node1");
+    LeaderElection election2 = createElection("node2");
+
+    election1.tryBecomeLeader(unified, TEST_ELECTION_KEY);
+    boolean resigned = election2.resignLeadership(unified, TEST_ELECTION_KEY);
+
+    assertThat(resigned).isFalse();
+    assertThat(election1.isLeader(unified, TEST_ELECTION_KEY)).isTrue();
+  }
+
+  @Test
+  public void testResignationAllowsNewLeader() {
+    LeaderElection election1 = createElection("node1");
+    LeaderElection election2 = createElection("node2");
+
+    election1.tryBecomeLeader(unified, TEST_ELECTION_KEY);
+    election1.resignLeadership(unified, TEST_ELECTION_KEY);
+
+    boolean becameLeader = election2.tryBecomeLeader(unified, TEST_ELECTION_KEY);
+
+    assertThat(becameLeader).isTrue();
+    assertThat(election2.getCurrentLeader(unified, TEST_ELECTION_KEY)).isEqualTo("node2");
+  }
+
+  // ===== Callback Tests =====
+
+  @Test
+  public void testLeadershipAcquisitionCallback() throws InterruptedException {
+    LeaderElection election = createElection("node1");
+    CountDownLatch latch = new CountDownLatch(1);
+    AtomicInteger callbackCount = new AtomicInteger(0);
+
+    election.addLeadershipCallback(
+        (electionKey, isLeader) -> {
+          if (isLeader && electionKey.equals(TEST_ELECTION_KEY)) {
+            callbackCount.incrementAndGet();
+            latch.countDown();
+          }
+        });
+
+    election.tryBecomeLeader(unified, TEST_ELECTION_KEY);
+
+    assertThat(latch.await(2, TimeUnit.SECONDS)).isTrue();
+    assertThat(callbackCount.get()).isEqualTo(1);
+  }
+
+  @Test
+  public void testLeadershipLossCallback() throws InterruptedException {
+    LeaderElection election =
+        createElection("node1", VERY_SHORT_LEASE, VERY_SHORT_LEASE.dividedBy(3));
+    CountDownLatch acquisitionLatch = new CountDownLatch(1);
+    CountDownLatch lossLatch = new CountDownLatch(1);
+
+    election.addLeadershipCallback(
+        (electionKey, isLeader) -> {
+          if (electionKey.equals(TEST_ELECTION_KEY)) {
+            if (isLeader) {
+              acquisitionLatch.countDown();
+            } else {
+              lossLatch.countDown();
+            }
+          }
+        });
+
+    election.tryBecomeLeader(unified, TEST_ELECTION_KEY);
+    assertThat(acquisitionLatch.await(2, TimeUnit.SECONDS)).isTrue();
+
+    // Close to stop auto-renewal and trigger loss
+    election.close();
+
+    // Wait a bit longer than the lease for detection
+    assertThat(lossLatch.await(VERY_SHORT_LEASE.toMillis() * 2, TimeUnit.MILLISECONDS)).isTrue();
+  }
+
+  @Test
+  public void testLeadershipResignationCallback() throws InterruptedException {
+    LeaderElection election = createElection("node1");
+    CountDownLatch lossLatch = new CountDownLatch(1);
+
+    election.addLeadershipCallback(
+        (electionKey, isLeader) -> {
+          if (!isLeader && electionKey.equals(TEST_ELECTION_KEY)) {
+            lossLatch.countDown();
+          }
+        });
+
+    election.tryBecomeLeader(unified, TEST_ELECTION_KEY);
+    election.resignLeadership(unified, TEST_ELECTION_KEY);
+
+    assertThat(lossLatch.await(2, TimeUnit.SECONDS)).isTrue();
+  }
+
+  @Test
+  public void testMultipleCallbacks() throws InterruptedException {
+    LeaderElection election = createElection("node1");
+    CountDownLatch latch = new CountDownLatch(3); // 3 callbacks
+
+    election.addLeadershipCallback((key, isLeader) -> latch.countDown());
+    election.addLeadershipCallback((key, isLeader) -> latch.countDown());
+    election.addLeadershipCallback((key, isLeader) -> latch.countDown());
+
+    election.tryBecomeLeader(unified, TEST_ELECTION_KEY);
+
+    assertThat(latch.await(2, TimeUnit.SECONDS)).isTrue();
+  }
+
+  @Test
+  public void testRemoveCallback() throws InterruptedException {
+    LeaderElection election = createElection("node1");
+    AtomicInteger callbackCount = new AtomicInteger(0);
+
+    BiConsumer<String, Boolean> callback = (key, isLeader) -> callbackCount.incrementAndGet();
+
+    election.addLeadershipCallback(callback);
+    election.removeLeadershipCallback(callback);
+
+    election.tryBecomeLeader(unified, TEST_ELECTION_KEY);
+
+    // Give callbacks time to execute (if they would)
+    Thread.sleep(200);
+
+    // Callback should not have been invoked
+    assertThat(callbackCount.get()).isEqualTo(0);
+  }
+
+  // ===== Lifecycle Tests =====
+
+  @Test
+  public void testCloseResignsAllLeaderships() throws InterruptedException {
+    LeaderElection election = createElection("node1");
+
+    election.tryBecomeLeader(unified, "election-1");
+    election.tryBecomeLeader(unified, "election-2");
+    election.tryBecomeLeader(unified, "election-3");
+
+    election.close();
+
+    // Give time for resignations to complete
+    Thread.sleep(200);
+
+    assertThat(election.getCurrentLeader(unified, "election-1")).isNull();
+    assertThat(election.getCurrentLeader(unified, "election-2")).isNull();
+    assertThat(election.getCurrentLeader(unified, "election-3")).isNull();
+    assertThat(election.isClosed()).isTrue();
+  }
+
+  @Test
+  public void testOperationsAfterCloseReturnFalse() {
+    LeaderElection election = createElection("node1");
+
+    election.close();
+
+    boolean becameLeader = election.tryBecomeLeader(unified, TEST_ELECTION_KEY);
+    boolean isLeader = election.isLeader(unified, TEST_ELECTION_KEY);
+    boolean renewed = election.renewLeadership(unified, TEST_ELECTION_KEY);
+    boolean resigned = election.resignLeadership(unified, TEST_ELECTION_KEY);
+
+    assertThat(becameLeader).isFalse();
+    assertThat(isLeader).isFalse();
+    assertThat(renewed).isFalse();
+    assertThat(resigned).isFalse();
+  }
+
+  @Test
+  public void testMultipleClosesAreIdempotent() {
+    LeaderElection election = createElection("node1");
+
+    election.close();
+    election.close();
+    election.close();
+
+    assertThat(election.isClosed()).isTrue();
+  }
+
+  // ===== Redis Key Management Tests =====
+
+  @Test
+  public void testRedisKeyFormat() {
+    LeaderElection election = createElection("node1");
+
+    election.tryBecomeLeader(unified, "my-service");
+
+    // Verify the key exists with correct prefix
+    String value = redis.get("buildfarm:leader:my-service");
+    assertThat(value).isNotNull();
+    assertThat(value).startsWith("node1:");
+  }
+
+  @Test
+  public void testDifferentElectionKeysAreSeparate() {
+    LeaderElection election1 = createElection("node1");
+    LeaderElection election2 = createElection("node2");
+
+    election1.tryBecomeLeader(unified, "election-A");
+    election2.tryBecomeLeader(unified, "election-B");
+
+    assertThat(election1.isLeader(unified, "election-A")).isTrue();
+    assertThat(election2.isLeader(unified, "election-B")).isTrue();
+    assertThat(election1.isLeader(unified, "election-B")).isFalse();
+    assertThat(election2.isLeader(unified, "election-A")).isFalse();
+  }
+
+  // ===== Edge Cases and Error Handling =====
+
+  @Test
+  public void testGetCurrentLeaderWhenNoLeader() {
+    LeaderElection election = createElection("node1");
+
+    String leader = election.getCurrentLeader(unified, "non-existent-election");
+
+    assertThat(leader).isNull();
+  }
+
+  @Test
+  public void testIsLeaderWhenNoLeader() {
+    LeaderElection election = createElection("node1");
+
+    boolean isLeader = election.isLeader(unified, "non-existent-election");
+
+    assertThat(isLeader).isFalse();
+  }
+
+  @Test
+  public void testRenewWhenNotLeader() {
+    LeaderElection election = createElection("node1");
+
+    boolean renewed = election.renewLeadership(unified, "non-existent-election");
+
+    assertThat(renewed).isFalse();
+  }
+
+  @Test
+  public void testResignWhenNotLeader() {
+    LeaderElection election = createElection("node1");
+
+    boolean resigned = election.resignLeadership(unified, "non-existent-election");
+
+    assertThat(resigned).isFalse();
+  }
+
+  @Test
+  public void testCallbackExceptionDoesNotAffectOtherCallbacks() throws InterruptedException {
+    LeaderElection election = createElection("node1");
+    CountDownLatch latch = new CountDownLatch(2);
+
+    // First callback throws exception
+    election.addLeadershipCallback(
+        (key, isLeader) -> {
+          throw new RuntimeException("Test exception");
+        });
+
+    // Second and third callbacks should still execute
+    election.addLeadershipCallback((key, isLeader) -> latch.countDown());
+    election.addLeadershipCallback((key, isLeader) -> latch.countDown());
+
+    election.tryBecomeLeader(unified, TEST_ELECTION_KEY);
+
+    assertThat(latch.await(2, TimeUnit.SECONDS)).isTrue();
+  }
+}

--- a/src/test/java/build/buildfarm/instance/shard/DispatchedMonitorTest.java
+++ b/src/test/java/build/buildfarm/instance/shard/DispatchedMonitorTest.java
@@ -68,6 +68,7 @@ public class DispatchedMonitorTest {
     DispatchedMonitor dispatchedMonitor =
         new DispatchedMonitor(
             /* shouldStop= */ () -> true,
+            /* isLeader= */ null,
             location,
             requeuer,
             /* intervalSeconds= */ 0,
@@ -107,6 +108,7 @@ public class DispatchedMonitorTest {
     DispatchedMonitor dispatchedMonitor =
         new DispatchedMonitor(
             /* shouldStop= */ () -> false,
+            /* isLeader= */ null,
             location,
             requeuer,
             /* intervalSeconds= */ 0,
@@ -132,6 +134,7 @@ public class DispatchedMonitorTest {
     DispatchedMonitor dispatchedMonitor =
         new DispatchedMonitor(
             /* shouldStop= */ () -> false,
+            /* isLeader= */ null,
             location,
             requeuer,
             /* intervalSeconds= */ 0,
@@ -148,6 +151,7 @@ public class DispatchedMonitorTest {
     DispatchedMonitor dispatchedMonitor =
         new DispatchedMonitor(
             /* shouldStop= */ () -> false,
+            /* isLeader= */ null,
             location,
             requeuer,
             /* intervalSeconds= */ 0,
@@ -176,6 +180,7 @@ public class DispatchedMonitorTest {
     DispatchedMonitor dispatchedMonitor =
         new DispatchedMonitor(
             /* shouldStop= */ () -> false,
+            /* isLeader= */ null,
             location,
             requeuer,
             /* intervalSeconds= */ 0,
@@ -199,6 +204,7 @@ public class DispatchedMonitorTest {
     DispatchedMonitor dispatchedMonitor =
         new DispatchedMonitor(
             /* shouldStop= */ () -> false,
+            /* isLeader= */ null,
             location,
             requeuer,
             /* intervalSeconds= */ 0,
@@ -221,7 +227,12 @@ public class DispatchedMonitorTest {
     when(shouldStop.getAsBoolean()).thenReturn(false).thenReturn(true);
     DispatchedMonitor dispatchedMonitor =
         new DispatchedMonitor(
-            shouldStop, location, requeuer, /* intervalSeconds= */ 0, Durations.fromSeconds(1));
+            shouldStop,
+            /* isLeader= */ null,
+            location,
+            requeuer,
+            /* intervalSeconds= */ 0,
+            /* requeueDelay= */ Durations.fromSeconds(1));
     dispatchedMonitor.run();
     verify(location, atLeastOnce())
         .scan(any(Integer.class), any(String.class), any(Consumer.class));

--- a/src/test/java/build/buildfarm/instance/shard/DispatchedMonitorTest.java
+++ b/src/test/java/build/buildfarm/instance/shard/DispatchedMonitorTest.java
@@ -68,7 +68,7 @@ public class DispatchedMonitorTest {
     DispatchedMonitor dispatchedMonitor =
         new DispatchedMonitor(
             /* shouldStop= */ () -> true,
-            /* isLeader= */ null,
+            /* isLeader= */ () -> true,
             location,
             requeuer,
             /* intervalSeconds= */ 0,
@@ -108,7 +108,7 @@ public class DispatchedMonitorTest {
     DispatchedMonitor dispatchedMonitor =
         new DispatchedMonitor(
             /* shouldStop= */ () -> false,
-            /* isLeader= */ null,
+            /* isLeader= */ () -> true,
             location,
             requeuer,
             /* intervalSeconds= */ 0,
@@ -134,7 +134,7 @@ public class DispatchedMonitorTest {
     DispatchedMonitor dispatchedMonitor =
         new DispatchedMonitor(
             /* shouldStop= */ () -> false,
-            /* isLeader= */ null,
+            /* isLeader= */ () -> true,
             location,
             requeuer,
             /* intervalSeconds= */ 0,
@@ -151,7 +151,7 @@ public class DispatchedMonitorTest {
     DispatchedMonitor dispatchedMonitor =
         new DispatchedMonitor(
             /* shouldStop= */ () -> false,
-            /* isLeader= */ null,
+            /* isLeader= */ () -> true,
             location,
             requeuer,
             /* intervalSeconds= */ 0,
@@ -180,7 +180,7 @@ public class DispatchedMonitorTest {
     DispatchedMonitor dispatchedMonitor =
         new DispatchedMonitor(
             /* shouldStop= */ () -> false,
-            /* isLeader= */ null,
+            /* isLeader= */ () -> true,
             location,
             requeuer,
             /* intervalSeconds= */ 0,
@@ -204,7 +204,7 @@ public class DispatchedMonitorTest {
     DispatchedMonitor dispatchedMonitor =
         new DispatchedMonitor(
             /* shouldStop= */ () -> false,
-            /* isLeader= */ null,
+            /* isLeader= */ () -> true,
             location,
             requeuer,
             /* intervalSeconds= */ 0,
@@ -228,7 +228,7 @@ public class DispatchedMonitorTest {
     DispatchedMonitor dispatchedMonitor =
         new DispatchedMonitor(
             shouldStop,
-            /* isLeader= */ null,
+            /* isLeader= */ () -> true,
             location,
             requeuer,
             /* intervalSeconds= */ 0,


### PR DESCRIPTION
When "many" buildfarm-servers are running, they are all doing DispatchedMonitor quite frequently. With a large cluster, this is taxing when "many" operations are dispatched.

