### PR TITLE
Fix #2502 Appending execroot/_main to execDir

### DIFF
--- a/src/main/java/build/buildfarm/worker/CFCExecFileSystem.java
+++ b/src/main/java/build/buildfarm/worker/CFCExecFileSystem.java
@@ -348,7 +348,8 @@ public class CFCExecFileSystem implements ExecFileSystem {
       throws IOException, InterruptedException {
     OutputDirectory outputDirectory = createOutputDirectory(command);
 
-    Path execDir = root.resolve(operationName);
+    Path opDir = root().resolve(operationName);
+    Path execDir = opDir.resolve("execroot/_main"); // See https://github.com/bazelbuild/bazel/issues/19733
     checkState(!Files.exists(execDir));
 
     log.log(Level.FINER, operationName + " walking execTree");

--- a/src/main/java/build/buildfarm/worker/CFCLinkExecFileSystem.java
+++ b/src/main/java/build/buildfarm/worker/CFCLinkExecFileSystem.java
@@ -367,7 +367,8 @@ public class CFCLinkExecFileSystem extends CFCExecFileSystem {
     Digest inputRootDigest = DigestUtil.fromDigest(action.getInputRootDigest(), digestFunction);
     OutputDirectory outputDirectory = createOutputDirectory(command);
 
-    Path execDir = root().resolve(operationName);
+    Path opDir = root().resolve(operationName);
+    Path execDir = opDir.resolve("execroot/_main"); // See https://github.com/bazelbuild/bazel/issues/19733
     if (Files.exists(execDir)) {
       Directories.remove(execDir, fileStore);
     }


### PR DESCRIPTION
Adds workaround for https://github.com/bazelbuild/bazel/issues/19733.

This resolves my problem, #2502, using a windows worker and a msvc toolchain.