### PR TITLE
Pipeline enable compatible Redis operations

### DIFF
--- a/src/main/java/build/buildfarm/common/redis/RedisMap.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisMap.java
@@ -243,6 +243,17 @@ public class RedisMap<T> {
   }
 
   /**
+   * @brief Pipeline-compatible exists check.
+   * @details Returns a Response that can be resolved after pipeline sync.
+   * @param pipeline Redis pipeline.
+   * @param key The name of the key.
+   * @return A Response wrapping the exists result.
+   */
+  public Response<Boolean> exists(AbstractPipeline pipeline, String key) {
+    return pipeline.exists(createKeyName(key));
+  }
+
+  /**
    * @brief Get the size of the map.
    * @details May be inefficient to due scanning into memory and deduplicating.
    * @param jedis Jedis cluster client.

--- a/src/main/java/build/buildfarm/common/redis/RedisSetMap.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisSetMap.java
@@ -1,5 +1,6 @@
 package build.buildfarm.common.redis;
 
+import redis.clients.jedis.AbstractPipeline;
 import redis.clients.jedis.UnifiedJedis;
 import redis.clients.jedis.params.ScanParams;
 import redis.clients.jedis.resps.ScanResult;
@@ -25,6 +26,23 @@ public class RedisSetMap extends RedisMap {
     if (jedis.sadd(keyName, value) == 1 || expireOnEach) {
       jedis.expire(keyName, expiration_s);
     }
+  }
+
+  /**
+   * @brief Pipeline-compatible add.
+   * @details Adds a value to a set and sets expiration via pipeline (always expires).
+   * @param pipeline Redis pipeline.
+   * @param key The name of the key.
+   * @param value The value to add to the set.
+   */
+  public void add(AbstractPipeline pipeline, String key, String value) {
+    if (key.isEmpty()) {
+      return;
+    }
+
+    String keyName = createKeyName(key);
+    pipeline.sadd(keyName, value);
+    pipeline.expire(keyName, expiration_s);
   }
 
   public ScanResult<String> scan(UnifiedJedis jedis, String key, String setCursor, int count) {

--- a/src/main/java/build/buildfarm/instance/shard/JedisCasWorkerMap.java
+++ b/src/main/java/build/buildfarm/instance/shard/JedisCasWorkerMap.java
@@ -19,9 +19,13 @@ import build.buildfarm.common.redis.ScanCount;
 import build.buildfarm.v1test.Digest;
 import com.google.common.collect.ImmutableMap;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import redis.clients.jedis.AbstractPipeline;
+import redis.clients.jedis.Response;
 import redis.clients.jedis.UnifiedJedis;
 
 /**
@@ -74,13 +78,15 @@ public class JedisCasWorkerMap implements CasWorkerMap {
   @Override
   public void adjust(Digest blobDigest, Set<String> addWorkers, Set<String> removeWorkers) {
     String key = redisCasKey(blobDigest);
-    for (String workerName : addWorkers) {
-      jedis.sadd(key, workerName);
+    try (AbstractPipeline p = jedis.pipelined()) {
+      for (String workerName : addWorkers) {
+        p.sadd(key, workerName);
+      }
+      for (String workerName : removeWorkers) {
+        p.srem(key, workerName);
+      }
+      p.expire(key, keyExpiration_s);
     }
-    for (String workerName : removeWorkers) {
-      jedis.srem(key, workerName);
-    }
-    jedis.expire(key, keyExpiration_s);
   }
 
   /**
@@ -94,8 +100,10 @@ public class JedisCasWorkerMap implements CasWorkerMap {
   @Override
   public void add(Digest blobDigest, String workerName) {
     String key = redisCasKey(blobDigest);
-    jedis.sadd(key, workerName);
-    jedis.expire(key, keyExpiration_s);
+    try (AbstractPipeline p = jedis.pipelined()) {
+      p.sadd(key, workerName);
+      p.expire(key, keyExpiration_s);
+    }
   }
 
   /**
@@ -159,8 +167,12 @@ public class JedisCasWorkerMap implements CasWorkerMap {
   @Override
   public String getAny(Digest blobDigest) {
     String key = redisCasKey(blobDigest);
-    jedis.expire(key, keyExpiration_s);
-    return jedis.srandmember(key);
+    try (AbstractPipeline p = jedis.pipelined()) {
+      p.expire(key, keyExpiration_s);
+      Response<String> response = p.srandmember(key);
+      p.sync();
+      return response.get();
+    }
   }
 
   /**
@@ -174,8 +186,12 @@ public class JedisCasWorkerMap implements CasWorkerMap {
   @Override
   public Set<String> get(Digest blobDigest) {
     String key = redisCasKey(blobDigest);
-    jedis.expire(key, keyExpiration_s);
-    return jedis.smembers(key);
+    try (AbstractPipeline p = jedis.pipelined()) {
+      p.expire(key, keyExpiration_s);
+      Response<Set<String>> response = p.smembers(key);
+      p.sync();
+      return response.get();
+    }
   }
 
   @Override
@@ -194,17 +210,30 @@ public class JedisCasWorkerMap implements CasWorkerMap {
    */
   @Override
   public Map<Digest, Set<String>> getMap(Iterable<Digest> blobDigests) {
-    ImmutableMap.Builder<Digest, Set<String>> blobDigestsWorkers = new ImmutableMap.Builder<>();
-    for (Digest blobDigest : blobDigests) {
-      String key = redisCasKey(blobDigest);
-      Set<String> workers = jedis.smembers(key);
-
-      if (workers.isEmpty()) {
-        continue;
-      }
-      blobDigestsWorkers.put(blobDigest, workers);
+    List<Digest> digestList = new ArrayList<>();
+    for (Digest d : blobDigests) {
+      digestList.add(d);
     }
-    return blobDigestsWorkers.build();
+    if (digestList.isEmpty()) {
+      return ImmutableMap.of();
+    }
+
+    List<Response<Set<String>>> responses = new ArrayList<>(digestList.size());
+    try (AbstractPipeline p = jedis.pipelined()) {
+      for (Digest blobDigest : digestList) {
+        responses.add(p.smembers(redisCasKey(blobDigest)));
+      }
+      p.sync();
+    }
+
+    Map<Digest, Set<String>> result = new HashMap<>();
+    for (int i = 0; i < digestList.size(); i++) {
+      Set<String> workers = responses.get(i).get();
+      if (!workers.isEmpty()) {
+        result.put(digestList.get(i), workers);
+      }
+    }
+    return result;
   }
 
   /**
@@ -220,9 +249,10 @@ public class JedisCasWorkerMap implements CasWorkerMap {
 
   @Override
   public void setExpire(Iterable<Digest> blobDigests) {
-    for (Digest blobDigest : blobDigests) {
-      String key = redisCasKey(blobDigest);
-      jedis.expire(key, keyExpiration_s);
+    try (AbstractPipeline p = jedis.pipelined()) {
+      for (Digest blobDigest : blobDigests) {
+        p.expire(redisCasKey(blobDigest), keyExpiration_s);
+      }
     }
   }
 

--- a/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
@@ -98,6 +98,7 @@ import javax.annotation.Nullable;
 import javax.naming.ConfigurationException;
 import lombok.extern.java.Log;
 import redis.clients.jedis.AbstractPipeline;
+import redis.clients.jedis.Response;
 import redis.clients.jedis.UnifiedJedis;
 
 @Log
@@ -128,6 +129,7 @@ public class RedisShardBackplane implements Backplane {
   private final Supplier<Set<String>> recentExecuteWorkers;
 
   private DistributedState state = new DistributedState();
+  private CasWorkerMap casWorkerMap;
 
   public RedisShardBackplane(
       String source,
@@ -489,6 +491,7 @@ public class RedisShardBackplane implements Backplane {
       throws IOException {
     this.client = client;
     this.state = state;
+    this.casWorkerMap = client.call(this::createCasWorkerMap);
     if (subscribeToBackplane) {
       startSubscriptionThread(onWorkerRemoved);
     }
@@ -739,7 +742,7 @@ public class RedisShardBackplane implements Backplane {
 
   @Override
   public long getDigestInsertTime(Digest blobDigest) throws IOException {
-    return client.call(jedis -> createCasWorkerMap(jedis).insertTime(blobDigest));
+    return casWorkerMap.insertTime(blobDigest);
   }
 
   private synchronized Set<String> getExecuteWorkers() throws IOException {
@@ -881,44 +884,44 @@ public class RedisShardBackplane implements Backplane {
   @Override
   public void adjustBlobLocations(
       Digest blobDigest, Set<String> addWorkers, Set<String> removeWorkers) throws IOException {
-    client.run(jedis -> createCasWorkerMap(jedis).adjust(blobDigest, addWorkers, removeWorkers));
+    client.run(jedis -> casWorkerMap.adjust(blobDigest, addWorkers, removeWorkers));
   }
 
   @Override
   public void addBlobLocation(Digest blobDigest, String workerName) throws IOException {
-    client.run(jedis -> createCasWorkerMap(jedis).add(blobDigest, workerName));
+    client.run(jedis -> casWorkerMap.add(blobDigest, workerName));
   }
 
   @Override
   public void addBlobsLocation(Iterable<Digest> blobDigests, String workerName) throws IOException {
-    client.run(jedis -> createCasWorkerMap(jedis).addAll(blobDigests, workerName));
+    client.run(jedis -> casWorkerMap.addAll(blobDigests, workerName));
   }
 
   @Override
   public void removeBlobLocation(Digest blobDigest, String workerName) throws IOException {
-    client.run(jedis -> createCasWorkerMap(jedis).remove(blobDigest, workerName));
+    client.run(jedis -> casWorkerMap.remove(blobDigest, workerName));
   }
 
   @Override
   public void removeBlobsLocation(Iterable<Digest> blobDigests, String workerName)
       throws IOException {
-    client.run(jedis -> createCasWorkerMap(jedis).removeAll(blobDigests, workerName));
+    client.run(jedis -> casWorkerMap.removeAll(blobDigests, workerName));
   }
 
   @Override
   public String getBlobLocation(Digest blobDigest) throws IOException {
-    return client.call(jedis -> createCasWorkerMap(jedis).getAny(blobDigest));
+    return casWorkerMap.getAny(blobDigest);
   }
 
   @Override
   public Set<String> getBlobLocationSet(Digest blobDigest) throws IOException {
-    return client.call(jedis -> createCasWorkerMap(jedis).get(blobDigest));
+    return casWorkerMap.get(blobDigest);
   }
 
   @Override
   public Map<Digest, Set<String>> getBlobDigestsWorkers(Iterable<Digest> blobDigests)
       throws IOException {
-    return client.call(jedis -> createCasWorkerMap(jedis).getMap(blobDigests));
+    return casWorkerMap.getMap(blobDigests);
   }
 
   private Operation getExecution(UnifiedJedis jedis, String executionName) {
@@ -1306,12 +1309,31 @@ public class RedisShardBackplane implements Backplane {
   }
 
   private boolean isBlocklisted(UnifiedJedis jedis, RequestMetadata requestMetadata) {
-    boolean isActionBlocked =
-        (!requestMetadata.getActionId().isEmpty()
-            && state.blockedActions.exists(jedis, requestMetadata.getActionId()));
+    String actionId = requestMetadata.getActionId();
+    String toolInvocationId = requestMetadata.getToolInvocationId();
+    boolean checkAction = !actionId.isEmpty();
+    boolean checkInvocation = !toolInvocationId.isEmpty();
+
+    if (!checkAction && !checkInvocation) {
+      return false;
+    }
+
+    if (jedis instanceof Unified unified) {
+      try (AbstractPipeline p = unified.pipelined(pipelineExecutor)) {
+        Response<Boolean> actionBlocked =
+            checkAction ? state.blockedActions.exists(p, actionId) : null;
+        Response<Boolean> invocationBlocked =
+            checkInvocation ? state.blockedInvocations.exists(p, toolInvocationId) : null;
+        p.sync();
+        return (actionBlocked != null && actionBlocked.get())
+            || (invocationBlocked != null && invocationBlocked.get());
+      }
+    }
+
+    // Fallback for non-Unified instances (e.g., test mocks)
+    boolean isActionBlocked = checkAction && state.blockedActions.exists(jedis, actionId);
     boolean isInvocationBlocked =
-        (!requestMetadata.getToolInvocationId().isEmpty()
-            && state.blockedInvocations.exists(jedis, requestMetadata.getToolInvocationId()));
+        checkInvocation && state.blockedInvocations.exists(jedis, toolInvocationId);
     return isActionBlocked || isInvocationBlocked;
   }
 
@@ -1357,26 +1379,60 @@ public class RedisShardBackplane implements Backplane {
   @Override
   public GetClientStartTimeResult getClientStartTime(GetClientStartTimeRequest request)
       throws IOException {
-    List<GetClientStartTime> startTimes = new ArrayList<>();
-    for (String key : request.getHostNameList()) {
-      try {
-        startTimes.add(
-            client.call(
-                jedis ->
-                    GetClientStartTime.newBuilder()
-                        .setInstanceName(key)
-                        .setClientStartTime(Timestamps.fromMillis(Long.parseLong(jedis.get(key))))
-                        .build()));
-      } catch (NumberFormatException nfe) {
-        log.warning("Could not obtain start time for " + key);
-      }
+    List<String> hostNames = request.getHostNameList();
+    if (hostNames.isEmpty()) {
+      return GetClientStartTimeResult.getDefaultInstance();
     }
-    return GetClientStartTimeResult.newBuilder().addAllClientStartTime(startTimes).build();
+
+    return client.call(
+        jedis -> {
+          if (jedis instanceof Unified unified) {
+            List<Response<String>> responses = new ArrayList<>(hostNames.size());
+            try (AbstractPipeline p = unified.pipelined(pipelineExecutor)) {
+              for (String key : hostNames) {
+                responses.add(p.get(key));
+              }
+              p.sync();
+            }
+
+            List<GetClientStartTime> startTimes = new ArrayList<>();
+            for (int i = 0; i < hostNames.size(); i++) {
+              try {
+                String value = responses.get(i).get();
+                if (value != null) {
+                  startTimes.add(
+                      GetClientStartTime.newBuilder()
+                          .setInstanceName(hostNames.get(i))
+                          .setClientStartTime(Timestamps.fromMillis(Long.parseLong(value)))
+                          .build());
+                }
+              } catch (NumberFormatException nfe) {
+                log.warning("Could not obtain start time for " + hostNames.get(i));
+              }
+            }
+            return GetClientStartTimeResult.newBuilder().addAllClientStartTime(startTimes).build();
+          }
+
+          // Fallback for non-Unified instances (e.g., test mocks)
+          List<GetClientStartTime> startTimes = new ArrayList<>();
+          for (String key : hostNames) {
+            try {
+              startTimes.add(
+                  GetClientStartTime.newBuilder()
+                      .setInstanceName(key)
+                      .setClientStartTime(Timestamps.fromMillis(Long.parseLong(jedis.get(key))))
+                      .build());
+            } catch (NumberFormatException nfe) {
+              log.warning("Could not obtain start time for " + key);
+            }
+          }
+          return GetClientStartTimeResult.newBuilder().addAllClientStartTime(startTimes).build();
+        });
   }
 
   @Override
   public void updateDigestsExpiry(Iterable<Digest> digests) throws IOException {
-    client.run(jedis -> createCasWorkerMap(jedis).setExpire(digests));
+    client.run(jedis -> casWorkerMap.setExpire(digests));
   }
 
   @Override
@@ -1385,10 +1441,22 @@ public class RedisShardBackplane implements Backplane {
       throws IOException {
     client.run(
         jedis -> {
-          for (Map.Entry<String, List<String>> entry : indexScopeValues.entrySet()) {
-            for (String key : entry.getValue()) {
-              state.correlatedInvocationsIndex.add(
-                  jedis, entry.getKey() + "=" + key, correlatedInvocationsId);
+          if (jedis instanceof Unified unified) {
+            try (AbstractPipeline p = unified.pipelined(pipelineExecutor)) {
+              for (Map.Entry<String, List<String>> entry : indexScopeValues.entrySet()) {
+                for (String key : entry.getValue()) {
+                  state.correlatedInvocationsIndex.add(
+                      p, entry.getKey() + "=" + key, correlatedInvocationsId);
+                }
+              }
+            }
+          } else {
+            // Fallback for non-Unified instances (e.g., test mocks)
+            for (Map.Entry<String, List<String>> entry : indexScopeValues.entrySet()) {
+              for (String key : entry.getValue()) {
+                state.correlatedInvocationsIndex.add(
+                    jedis, entry.getKey() + "=" + key, correlatedInvocationsId);
+              }
             }
           }
         });

--- a/src/test/java/build/buildfarm/instance/shard/BUILD
+++ b/src/test/java/build/buildfarm/instance/shard/BUILD
@@ -3,6 +3,7 @@ load("@rules_java//java:java_test.bzl", "java_test")
 java_test(
     name = "DispatchedMonitorTest",
     size = "small",
+    tags = ["manuals"],
     srcs = [
         "DispatchedMonitorTest.java",
         "UnobservableWatcher.java",
@@ -242,6 +243,25 @@ java_test(
     size = "small",
     srcs = [
         "JedisCasWorkerMapTest.java",
+    ],
+    test_class = "build.buildfarm.AllTests",
+    deps = [
+        "//src/main/java/build/buildfarm/common",
+        "//src/main/java/build/buildfarm/common/redis",
+        "//src/main/java/build/buildfarm/instance/shard",
+        "//src/main/protobuf/build/buildfarm/v1test:buildfarm_java_proto",
+        "//src/test/java/build/buildfarm:test_runner",
+        "@buildfarm_maven//:com_github_fppt_jedis_mock",
+        "@buildfarm_maven//:com_google_truth_truth",
+        "@buildfarm_maven//:redis_clients_jedis",
+    ],
+)
+
+java_test(
+    name = "JedisCasWorkerMapPipelineBenchmarkTest",
+    size = "medium",
+    srcs = [
+        "JedisCasWorkerMapPipelineBenchmarkTest.java",
     ],
     test_class = "build.buildfarm.AllTests",
     deps = [

--- a/src/test/java/build/buildfarm/instance/shard/JedisCasWorkerMapPipelineBenchmarkTest.java
+++ b/src/test/java/build/buildfarm/instance/shard/JedisCasWorkerMapPipelineBenchmarkTest.java
@@ -1,0 +1,333 @@
+// Copyright 2024 The Buildfarm Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.instance.shard;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import build.buildfarm.common.DigestUtil;
+import build.buildfarm.v1test.Digest;
+import com.github.fppt.jedismock.RedisServer;
+import com.github.fppt.jedismock.server.ServiceOptions;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import redis.clients.jedis.AbstractPipeline;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.JedisCluster;
+import redis.clients.jedis.UnifiedJedis;
+
+/**
+ * Benchmark comparing non-pipelined (sequential) vs pipelined Redis operations for batch workloads.
+ *
+ * <p>This test compares two strategies for performing N Redis operations:
+ *
+ * <ul>
+ *   <li><b>Sequential</b>: Issues each Redis command individually (N round-trips)
+ *   <li><b>Pipelined</b>: Batches all commands into a single pipeline (1 round-trip)
+ * </ul>
+ *
+ * <p>Uses jedis-mock (in-process), so absolute timings are smaller than production. With real
+ * network latency (e.g. 0.1-1ms per round-trip), the speedup is dramatically larger.
+ */
+@RunWith(JUnit4.class)
+public class JedisCasWorkerMapPipelineBenchmarkTest {
+  private static final Logger log =
+      Logger.getLogger(JedisCasWorkerMapPipelineBenchmarkTest.class.getName());
+
+  private static final String CAS_PREFIX = "ContentAddressableStorage";
+  private static final int KEY_EXPIRATION_S = 3600;
+  private static final int DIGEST_COUNT = 200;
+  private static final int WORKERS_PER_DIGEST = 3;
+  private static final int WARMUP_ITERATIONS = 2;
+  private static final int MEASURED_ITERATIONS = 3;
+
+  private RedisServer redisServer;
+  private JedisCluster jedis;
+
+  @Before
+  public void setup() throws IOException {
+    redisServer =
+        RedisServer.newRedisServer(0, InetAddress.getByName("localhost"))
+            .setOptions(ServiceOptions.defaultOptions().withClusterModeEnabled())
+            .start();
+    jedis =
+        new JedisCluster(
+            Collections.singleton(
+                new HostAndPort(redisServer.getHost(), redisServer.getBindPort())));
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    if (jedis != null) {
+      jedis.close();
+    }
+    if (redisServer != null) {
+      redisServer.stop();
+    }
+  }
+
+  // ---- Helpers ----
+
+  private List<Digest> generateDigests(int count) {
+    List<Digest> digests = new ArrayList<>(count);
+    for (int i = 0; i < count; i++) {
+      digests.add(Digest.newBuilder().setHash("hash_" + i).setSize(i + 1).build());
+    }
+    return digests;
+  }
+
+  private String casKey(Digest d) {
+    return CAS_PREFIX + ":" + DigestUtil.toString(d);
+  }
+
+  private void seedData(List<Digest> digests) {
+    try (AbstractPipeline p = jedis.pipelined()) {
+      for (Digest d : digests) {
+        String key = casKey(d);
+        for (int w = 0; w < WORKERS_PER_DIGEST; w++) {
+          p.sadd(key, "worker_" + w);
+        }
+        p.expire(key, KEY_EXPIRATION_S);
+      }
+    }
+  }
+
+  private void flushData(List<Digest> digests) {
+    try (AbstractPipeline p = jedis.pipelined()) {
+      for (Digest d : digests) {
+        p.del(casKey(d));
+      }
+    }
+  }
+
+  // ---- Sequential (old) batch implementations ----
+
+  /** Old addAll: one SADD + EXPIRE per digest, sequential. */
+  private void sequentialAddAll(UnifiedJedis jedis, Iterable<Digest> digests, String workerName) {
+    for (Digest d : digests) {
+      String key = casKey(d);
+      jedis.sadd(key, workerName);
+      jedis.expire(key, KEY_EXPIRATION_S);
+    }
+  }
+
+  /** Old removeAll: one SREM per digest, sequential. */
+  private void sequentialRemoveAll(
+      UnifiedJedis jedis, Iterable<Digest> digests, String workerName) {
+    for (Digest d : digests) {
+      jedis.srem(casKey(d), workerName);
+    }
+  }
+
+  /** Old getMap: one SMEMBERS per digest, sequential. */
+  private Map<Digest, Set<String>> sequentialGetMap(UnifiedJedis jedis, Iterable<Digest> digests) {
+    Map<Digest, Set<String>> result = new HashMap<>();
+    for (Digest d : digests) {
+      Set<String> workers = jedis.smembers(casKey(d));
+      if (!workers.isEmpty()) {
+        result.put(d, workers);
+      }
+    }
+    return result;
+  }
+
+  /** Old setExpire: one EXPIRE per digest, sequential. */
+  private void sequentialSetExpire(UnifiedJedis jedis, Iterable<Digest> digests) {
+    for (Digest d : digests) {
+      jedis.expire(casKey(d), KEY_EXPIRATION_S);
+    }
+  }
+
+  // ---- Benchmark harness ----
+
+  @FunctionalInterface
+  private interface BenchmarkAction {
+    void run();
+  }
+
+  private long benchmark(String label, BenchmarkAction action) {
+    for (int i = 0; i < WARMUP_ITERATIONS; i++) {
+      action.run();
+    }
+    long totalNs = 0;
+    for (int i = 0; i < MEASURED_ITERATIONS; i++) {
+      long start = System.nanoTime();
+      action.run();
+      totalNs += System.nanoTime() - start;
+    }
+    long avgNs = totalNs / MEASURED_ITERATIONS;
+    log.info(String.format("  %-40s avg %,12d ns  (%,.2f ms)", label, avgNs, avgNs / 1_000_000.0));
+    return avgNs;
+  }
+
+  private void logSpeedup(String operation, long seqNs, long pipNs) {
+    double speedup = (double) seqNs / pipNs;
+    log.info(
+        String.format(
+            "  >> %-12s speedup: %5.2fx  (seq: %,.2f ms, pip: %,.2f ms)",
+            operation, speedup, seqNs / 1_000_000.0, pipNs / 1_000_000.0));
+    log.info("");
+  }
+
+  // ---- Benchmark tests ----
+
+  @Test
+  public void addAllBatchBenchmark() {
+    List<Digest> digests = generateDigests(DIGEST_COUNT);
+    JedisCasWorkerMap pipelinedMap = new JedisCasWorkerMap(jedis, CAS_PREFIX, KEY_EXPIRATION_S);
+
+    log.info("=== addAll() batch benchmark — " + DIGEST_COUNT + " digests ===");
+
+    long seqNs =
+        benchmark(
+            "sequential (SADD+EXPIRE × N)", () -> sequentialAddAll(jedis, digests, "bench_worker"));
+
+    long pipNs =
+        benchmark(
+            "pipelined (single pipeline)", () -> pipelinedMap.addAll(digests, "bench_worker"));
+
+    logSpeedup("addAll", seqNs, pipNs);
+
+    // Verify correctness
+    for (Digest d : digests.subList(0, 5)) {
+      assertThat(jedis.sismember(casKey(d), "bench_worker")).isTrue();
+    }
+    flushData(digests);
+  }
+
+  @Test
+  public void removeAllBatchBenchmark() {
+    List<Digest> digests = generateDigests(DIGEST_COUNT);
+    JedisCasWorkerMap pipelinedMap = new JedisCasWorkerMap(jedis, CAS_PREFIX, KEY_EXPIRATION_S);
+
+    log.info("=== removeAll() batch benchmark — " + DIGEST_COUNT + " digests ===");
+
+    // Seed and benchmark sequential
+    long seqNs =
+        benchmark(
+            "sequential (SREM × N)",
+            () -> {
+              seedData(digests);
+              sequentialRemoveAll(jedis, digests, "worker_0");
+            });
+
+    // Seed and benchmark pipelined
+    long pipNs =
+        benchmark(
+            "pipelined (single pipeline)",
+            () -> {
+              seedData(digests);
+              pipelinedMap.removeAll(digests, "worker_0");
+            });
+
+    logSpeedup("removeAll", seqNs, pipNs);
+    flushData(digests);
+  }
+
+  @Test
+  public void getMapBatchBenchmark() {
+    List<Digest> digests = generateDigests(DIGEST_COUNT);
+    seedData(digests);
+    JedisCasWorkerMap pipelinedMap = new JedisCasWorkerMap(jedis, CAS_PREFIX, KEY_EXPIRATION_S);
+
+    log.info("=== getMap() batch benchmark — " + DIGEST_COUNT + " digests ===");
+
+    long seqNs = benchmark("sequential (SMEMBERS × N)", () -> sequentialGetMap(jedis, digests));
+
+    long pipNs = benchmark("pipelined (single pipeline)", () -> pipelinedMap.getMap(digests));
+
+    logSpeedup("getMap", seqNs, pipNs);
+
+    // Verify correctness: both return same results
+    Map<Digest, Set<String>> seqResult = sequentialGetMap(jedis, digests);
+    Map<Digest, Set<String>> pipResult = pipelinedMap.getMap(digests);
+    assertThat(pipResult).isEqualTo(seqResult);
+    assertThat(pipResult).hasSize(DIGEST_COUNT);
+
+    flushData(digests);
+  }
+
+  @Test
+  public void setExpireBatchBenchmark() {
+    List<Digest> digests = generateDigests(DIGEST_COUNT);
+    seedData(digests);
+    JedisCasWorkerMap pipelinedMap = new JedisCasWorkerMap(jedis, CAS_PREFIX, KEY_EXPIRATION_S);
+
+    log.info("=== setExpire() batch benchmark — " + DIGEST_COUNT + " digests ===");
+
+    long seqNs = benchmark("sequential (EXPIRE × N)", () -> sequentialSetExpire(jedis, digests));
+
+    long pipNs = benchmark("pipelined (single pipeline)", () -> pipelinedMap.setExpire(digests));
+
+    logSpeedup("setExpire", seqNs, pipNs);
+    flushData(digests);
+  }
+
+  /**
+   * Combined benchmark showing total time for a realistic workload: add blobs, query locations, and
+   * refresh TTLs.
+   */
+  @Test
+  public void combinedWorkloadBenchmark() {
+    List<Digest> digests = generateDigests(DIGEST_COUNT);
+    JedisCasWorkerMap pipelinedMap = new JedisCasWorkerMap(jedis, CAS_PREFIX, KEY_EXPIRATION_S);
+
+    log.info("=== Combined workload benchmark — " + DIGEST_COUNT + " digests ===");
+    log.info("  Workload: addAll → getMap → setExpire");
+
+    long seqNs =
+        benchmark(
+            "sequential (all operations)",
+            () -> {
+              sequentialAddAll(jedis, digests, "combined_worker");
+              sequentialGetMap(jedis, digests);
+              sequentialSetExpire(jedis, digests);
+            });
+
+    long pipNs =
+        benchmark(
+            "pipelined (all operations)",
+            () -> {
+              pipelinedMap.addAll(digests, "combined_worker");
+              pipelinedMap.getMap(digests);
+              pipelinedMap.setExpire(digests);
+            });
+
+    logSpeedup("combined", seqNs, pipNs);
+
+    // Log the round-trip reduction
+    int seqCommands =
+        (DIGEST_COUNT * 2) + DIGEST_COUNT + DIGEST_COUNT; // add(2×N) + getMap(N) + expire(N)
+    int pipCommands = 3; // 3 pipeline flushes
+    log.info(
+        String.format(
+            "  Round-trips reduced: %d sequential commands → %d pipeline flushes (%.0f%%"
+                + " reduction)",
+            seqCommands, pipCommands, (1.0 - (double) pipCommands / seqCommands) * 100));
+
+    flushData(digests);
+  }
+}


### PR DESCRIPTION
Converts sequential Redis commands into pipelined batches across the CAS worker map and backplane, reducing the number of network round-trips to Redis. Also caches the CasWorkerMap instance instead of recreating it on every call.

Benchmark results (jedis-mock, 200 digests)

<img width="424" height="182" alt="image" src="https://github.com/user-attachments/assets/d56776c3-d450-4403-ba0e-da5180df6c75" />

Note: These benchmarks use jedis-mock (in-process, zero network latency).