### PR TITLE
Perform automatitc worker queue registration

### DIFF
--- a/examples/config.yml
+++ b/examples/config.yml
@@ -52,6 +52,10 @@ server:
   correlatedInvocationsIndexScopes: !!set
     ? host
     ? username
+  # Queue auto-discovery: when enabled, the server will periodically discover
+  # worker-published queues from Redis and update its execution queues live.
+  enableQueueAutoDiscovery: false
+  queueDiscoveryIntervalSeconds: 30
 backplane:
   type: SHARD
   redisUri: redis://localhost:6379
@@ -102,6 +106,10 @@ backplane:
       value: '*'
     - name: max-cores
       value: '*'
+  # Prefix for worker-published queue keys in Redis
+  workerQueuePrefix: WorkerQueue
+  # TTL in seconds for worker-published queue keys (workers refresh this periodically)
+  workerQueueExpireSeconds: 60
 worker:
   port: 8981
   publicName: localhost:8981

--- a/src/main/java/build/buildfarm/backplane/BUILD
+++ b/src/main/java/build/buildfarm/backplane/BUILD
@@ -7,6 +7,7 @@ java_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/main/java/build/buildfarm/common",
+        "//src/main/java/build/buildfarm/common/config",
         "//src/main/java/build/buildfarm/worker/resources",
         "//src/main/protobuf/build/buildfarm/v1test:buildfarm_java_proto",
         "@buildfarm_maven//:com_google_code_findbugs_jsr305",

--- a/src/main/java/build/buildfarm/backplane/Backplane.java
+++ b/src/main/java/build/buildfarm/backplane/Backplane.java
@@ -22,6 +22,7 @@ import build.bazel.remote.execution.v2.ToolDetails;
 import build.buildfarm.common.CasIndexResults;
 import build.buildfarm.common.DigestUtil.ActionKey;
 import build.buildfarm.common.Watcher;
+import build.buildfarm.common.config.Queue;
 import build.buildfarm.common.function.InterruptingRunnable;
 import build.buildfarm.v1test.BackplaneStatus;
 import build.buildfarm.v1test.Digest;
@@ -340,4 +341,23 @@ public interface Backplane {
   void incrementRequestCounters(
       String actionId, String toolInvocationId, String actionMnemonic, String targetId)
       throws IOException;
+
+  /**
+   * Publish a worker's queue configuration to the backplane so that the server can auto-discover
+   * it. The queue key is set with an expiration so it is automatically removed when the worker
+   * stops refreshing it.
+   */
+  void publishWorkerQueue(Queue queue) throws IOException;
+
+  /**
+   * Discover all worker-published queue configurations currently in the backplane. Returns the list
+   * of Queue configs whose Redis keys have not yet expired.
+   */
+  List<Queue> discoverWorkerQueues() throws IOException;
+
+  /**
+   * Rebuild the execution queue with the given queue configurations. This allows the server to
+   * dynamically adopt new queues discovered from workers without a restart.
+   */
+  void updateExecutionQueues(Queue[] queues) throws IOException;
 }

--- a/src/main/java/build/buildfarm/common/config/Backplane.java
+++ b/src/main/java/build/buildfarm/common/config/Backplane.java
@@ -54,6 +54,9 @@ public class Backplane {
   private int maxPreQueueDepth = 1000000;
   private boolean priorityQueue = false;
   private Queue[] queues = {};
+  private String workerQueuePrefix = "WorkerQueue";
+  private int workerQueueExpireSeconds =
+      604800; // Worker queue keys expire after 1 week if not refreshed
   private String redisCredentialFile;
   private String redisUsername;
   @ToString.Exclude // Do not log the password on start-up.

--- a/src/main/java/build/buildfarm/common/config/DequeueMatchSettings.java
+++ b/src/main/java/build/buildfarm/common/config/DequeueMatchSettings.java
@@ -7,7 +7,6 @@ import lombok.Data;
 
 @Data
 public class DequeueMatchSettings {
-
   private boolean allowUnmatched = false;
   private List<Property> properties = new ArrayList<>();
 

--- a/src/main/java/build/buildfarm/common/config/Server.java
+++ b/src/main/java/build/buildfarm/common/config/Server.java
@@ -53,6 +53,8 @@ public class Server {
   private boolean findMissingBlobsViaBackplane = false;
   private int gracefulShutdownSeconds = 0;
   private Set<String> correlatedInvocationsIndexScopes = ImmutableSet.of("host", "username");
+  private boolean enableQueueAutoDiscovery = false;
+  private int queueDiscoveryIntervalSeconds = 60;
 
   public String getSession() {
     return String.format("buildfarm-server-%s-%s", getPublicName(), sessionGuid);

--- a/src/main/java/build/buildfarm/instance/shard/DistributedStateCreator.java
+++ b/src/main/java/build/buildfarm/instance/shard/DistributedStateCreator.java
@@ -111,6 +111,15 @@ public class DistributedStateCreator {
 
   private static ExecutionQueue createExecutionQueue(
       UnifiedJedis jedis, StringTranslator<QueueEntry> translator) {
+    return createExecutionQueue(jedis, translator, configs.getBackplane().getQueues());
+  }
+
+  /**
+   * Create an execution queue from an explicit list of queue configurations. This overload is used
+   * for dynamic queue rebuilding when workers register new queues.
+   */
+  static ExecutionQueue createExecutionQueue(
+      UnifiedJedis jedis, StringTranslator<QueueEntry> translator, Queue[] queueConfigs) {
     // Construct an operation queue based on configuration.
     // An operation queue consists of multiple provisioned queues in which the order dictates the
     // eligibility and placement of operations.
@@ -118,7 +127,7 @@ public class DistributedStateCreator {
     // requirements.  This will ensure that all operations are eligible for the final queue.
     ImmutableList.Builder<ProvisionedRedisQueue<QueueEntry>> provisionedQueues =
         new ImmutableList.Builder<>();
-    for (Queue queueConfig : configs.getBackplane().getQueues()) {
+    for (Queue queueConfig : queueConfigs) {
       ProvisionedRedisQueue<QueueEntry> provisionedQueue =
           new ProvisionedRedisQueue<QueueEntry>(
               getQueueName(queueConfig),
@@ -135,7 +144,7 @@ public class DistributedStateCreator {
     // all operations.
     // This will ensure the expected behavior for the paradigm in which all work is put on the same
     // queue.
-    if (configs.getBackplane().getQueues().length == 0) {
+    if (queueConfigs.length == 0) {
       SetMultimap defaultProvisions = LinkedHashMultimap.create();
       defaultProvisions.put(
           ProvisionedRedisQueue.WILDCARD_VALUE, ProvisionedRedisQueue.WILDCARD_VALUE);

--- a/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
+++ b/src/main/java/build/buildfarm/instance/shard/RedisShardBackplane.java
@@ -36,6 +36,8 @@ import build.buildfarm.common.Visitor;
 import build.buildfarm.common.Watcher;
 import build.buildfarm.common.WorkerIndexer;
 import build.buildfarm.common.config.BuildfarmConfigs;
+import build.buildfarm.common.config.Property;
+import build.buildfarm.common.config.Queue;
 import build.buildfarm.common.function.InterruptingRunnable;
 import build.buildfarm.common.redis.BalancedRedisQueue.BalancedQueueEntry;
 import build.buildfarm.common.redis.Codec;
@@ -56,6 +58,7 @@ import build.buildfarm.v1test.QueueEntry;
 import build.buildfarm.v1test.QueueStatus;
 import build.buildfarm.v1test.ShardWorker;
 import build.buildfarm.v1test.WorkerChange;
+import build.buildfarm.v1test.WorkerQueueConfig;
 import build.buildfarm.v1test.WorkerType;
 import build.buildfarm.worker.resources.LocalResourceSet;
 import com.google.common.annotations.VisibleForTesting;
@@ -70,6 +73,7 @@ import com.google.common.collect.Multimaps;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.longrunning.Operation;
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Timestamps;
 import com.google.rpc.Code;
@@ -1409,5 +1413,91 @@ public class RedisShardBackplane implements Backplane {
   public void incrementRequestCounters(
       String actionId, String toolInvocationId, String actionMnemonic, String targetId) {
     // TODO count for each of these fields
+  }
+
+  @SuppressWarnings("ConstantConditions")
+  @Override
+  public void publishWorkerQueue(Queue queue) throws IOException {
+    String prefix = configs.getBackplane().getWorkerQueuePrefix();
+    int expireSeconds = configs.getBackplane().getWorkerQueueExpireSeconds();
+    byte[] key = (prefix + ":" + queue.getName()).getBytes();
+
+    WorkerQueueConfig.Builder builder =
+        WorkerQueueConfig.newBuilder()
+            .setName(queue.getName())
+            .setAllowUnmatched(queue.isAllowUnmatched());
+    for (Property prop : queue.getProperties()) {
+      builder.addProperties(
+          Platform.Property.newBuilder().setName(prop.getName()).setValue(prop.getValue()).build());
+    }
+    byte[] value = builder.build().toByteArray();
+
+    client.run(
+        jedis -> {
+          jedis.setex(key, expireSeconds, value);
+        });
+    log.log(
+        Level.INFO,
+        format(
+            "Published worker queue '%s' to Redis with %ds TTL", queue.getName(), expireSeconds));
+  }
+
+  @SuppressWarnings("ConstantConditions")
+  @Override
+  public List<Queue> discoverWorkerQueues() throws IOException {
+    String prefix = configs.getBackplane().getWorkerQueuePrefix();
+    byte[] pattern = (prefix + ":*").getBytes();
+
+    return client.call(
+        jedis -> {
+          List<Queue> discoveredQueues = new ArrayList<>();
+          Set<byte[]> keys = jedis.keys(pattern);
+          for (byte[] key : keys) {
+            byte[] value = jedis.get(key);
+            if (value == null) {
+              continue; // key expired between keys() and get()
+            }
+            Queue queue = fromProto(value);
+            if (queue != null) {
+              discoveredQueues.add(queue);
+            }
+          }
+          return discoveredQueues;
+        });
+  }
+
+  private static Queue fromProto(byte[] data) {
+    try {
+      WorkerQueueConfig proto = WorkerQueueConfig.parseFrom(data);
+      Queue queue = new Queue();
+      queue.setName(proto.getName());
+      queue.setAllowUnmatched(proto.getAllowUnmatched());
+      List<Property> properties = new ArrayList<>();
+      for (Platform.Property pp : proto.getPropertiesList()) {
+        Property prop = new Property();
+        prop.setName(pp.getName());
+        prop.setValue(pp.getValue());
+        properties.add(prop);
+      }
+      queue.setProperties(properties);
+      return queue;
+    } catch (InvalidProtocolBufferException e) {
+      log.log(Level.WARNING, "Failed to parse WorkerQueueConfig proto from Redis", e);
+      return null;
+    }
+  }
+
+  @SuppressWarnings("ConstantConditions")
+  @Override
+  public void updateExecutionQueues(Queue[] queues) throws IOException {
+    client.run(
+        jedis -> {
+          ExecutionQueue newExecutionQueue =
+              DistributedStateCreator.createExecutionQueue(jedis, codec.queueEntry(), queues);
+          state.executionQueue = newExecutionQueue;
+          log.log(
+              Level.INFO,
+              format("Execution queue rebuilt with %d provisioned queue(s)", queues.length));
+        });
   }
 }

--- a/src/main/java/build/buildfarm/instance/shard/ServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ServerInstance.java
@@ -291,6 +291,7 @@ public class ServerInstance extends NodeInstance {
   private final Scannable<String> correlatedInvocations;
   private final Scannable<String> toolInvocations;
   private Thread operationQueuer;
+  private Thread queueDiscoveryThread;
   private boolean stopping = false;
   private boolean stopped = true;
   private final Thread prometheusMetricsThread;
@@ -711,6 +712,116 @@ public class ServerInstance extends NodeInstance {
               }
             },
             "Prometheus Metrics Collector");
+
+    // Initialize queue auto-discovery thread if enabled
+    if (configs.getServer().isEnableQueueAutoDiscovery()) {
+      int discoveryIntervalSeconds = configs.getServer().getQueueDiscoveryIntervalSeconds();
+      Set<String> knownQueueNames = new HashSet<>();
+      // Seed with statically configured queues
+      for (build.buildfarm.common.config.Queue q : configs.getBackplane().getQueues()) {
+        knownQueueNames.add(q.getName());
+      }
+      queueDiscoveryThread =
+          new Thread(
+              () -> {
+                while (!Thread.currentThread().isInterrupted()) {
+                  try {
+                    TimeUnit.SECONDS.sleep(discoveryIntervalSeconds);
+                    List<build.buildfarm.common.config.Queue> discoveredQueues =
+                        backplane.discoverWorkerQueues();
+                    boolean hasNewQueues = false;
+                    for (build.buildfarm.common.config.Queue q : discoveredQueues) {
+                      if (!knownQueueNames.contains(q.getName())) {
+                        hasNewQueues = true;
+                        log.log(
+                            Level.INFO, format("Discovered new worker queue: '%s'", q.getName()));
+                      }
+                    }
+
+                    // Build the merged set: discovered queues override, plus keep any
+                    // statically-configured queues that are still relevant
+                    Set<String> discoveredNames = new HashSet<>();
+                    for (build.buildfarm.common.config.Queue q : discoveredQueues) {
+                      discoveredNames.add(q.getName());
+                    }
+
+                    // Check if any previously known queues have expired (were in discovered
+                    // but are no longer)
+                    boolean hasExpiredQueues = false;
+                    for (String queueName : knownQueueNames) {
+                      if (!discoveredNames.contains(queueName)) {
+                        // Check if this was a statically-configured queue
+                        boolean isStatic = false;
+                        for (build.buildfarm.common.config.Queue sq :
+                            configs.getBackplane().getQueues()) {
+                          if (sq.getName().equals(queueName)) {
+                            isStatic = true;
+                            break;
+                          }
+                        }
+                        if (!isStatic) {
+                          hasExpiredQueues = true;
+                          log.log(
+                              Level.INFO,
+                              format(
+                                  "Worker queue '%s' has expired and will be removed", queueName));
+                        }
+                      }
+                    }
+
+                    if (hasNewQueues || hasExpiredQueues) {
+                      // Build merged queue list: static queues + discovered queues
+                      // Discovered queues take precedence over static ones with the same name
+                      Map<String, build.buildfarm.common.config.Queue> mergedQueues =
+                          new HashMap<>();
+                      for (build.buildfarm.common.config.Queue sq :
+                          configs.getBackplane().getQueues()) {
+                        mergedQueues.put(sq.getName(), sq);
+                      }
+                      for (build.buildfarm.common.config.Queue dq : discoveredQueues) {
+                        mergedQueues.put(dq.getName(), dq);
+                      }
+                      // Remove expired non-static queues
+                      for (String queueName : new HashSet<>(mergedQueues.keySet())) {
+                        if (!discoveredNames.contains(queueName)) {
+                          boolean isStatic = false;
+                          for (build.buildfarm.common.config.Queue sq :
+                              configs.getBackplane().getQueues()) {
+                            if (sq.getName().equals(queueName)) {
+                              isStatic = true;
+                              break;
+                            }
+                          }
+                          if (!isStatic) {
+                            mergedQueues.remove(queueName);
+                          }
+                        }
+                      }
+
+                      build.buildfarm.common.config.Queue[] queueArray =
+                          mergedQueues.values().toArray(new build.buildfarm.common.config.Queue[0]);
+                      backplane.updateExecutionQueues(queueArray);
+
+                      // Update known queues
+                      knownQueueNames.clear();
+                      knownQueueNames.addAll(mergedQueues.keySet());
+
+                      log.log(
+                          Level.INFO,
+                          format("Execution queues updated. Active queues: %s", knownQueueNames));
+                    }
+                  } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                  } catch (Exception e) {
+                    log.log(Level.SEVERE, "Error during queue auto-discovery", e);
+                  }
+                }
+              },
+              "Queue Auto-Discovery");
+    } else {
+      queueDiscoveryThread = null;
+    }
   }
 
   private void updateQueueSizes(List<QueueStatus> queues) {
@@ -754,6 +865,10 @@ public class ServerInstance extends NodeInstance {
     if (prometheusMetricsThread != null) {
       prometheusMetricsThread.start();
     }
+
+    if (queueDiscoveryThread != null) {
+      queueDiscoveryThread.start();
+    }
   }
 
   @Override
@@ -774,6 +889,10 @@ public class ServerInstance extends NodeInstance {
     }
     if (prometheusMetricsThread != null) {
       prometheusMetricsThread.interrupt();
+    }
+    if (queueDiscoveryThread != null) {
+      queueDiscoveryThread.interrupt();
+      queueDiscoveryThread.join();
     }
     contextDeadlineScheduler.shutdown();
     operationDeletionService.shutdown();

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -601,6 +601,20 @@ public final class Worker extends LoggingMain {
                 return isPaused;
               }
 
+              void publishQueues() {
+                for (build.buildfarm.common.config.Queue queue :
+                    configs.getBackplane().getQueues()) {
+                  try {
+                    backplane.publishWorkerQueue(queue);
+                  } catch (IOException e) {
+                    log.log(
+                        Level.WARNING,
+                        String.format("Failed to publish queue '%s' to backplane", queue.getName()),
+                        e);
+                  }
+                }
+              }
+
               void registerIfExpired() {
                 long now = System.currentTimeMillis();
                 if (now >= workerRegistrationExpiresAt
@@ -608,6 +622,8 @@ public final class Worker extends LoggingMain {
                     && !isWorkerPausedFromNewWork()) {
                   // worker must be registered to match
                   addWorker(nextRegistration(now));
+                  // publish queue configurations to Redis for server auto-discovery
+                  publishQueues();
                   // update every 10 seconds
                   workerRegistrationExpiresAt = nextInterval(now);
                 }

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -278,6 +278,20 @@ message ShardWorker {
   int64 first_registered_at = 4;
 }
 
+// Configuration for a worker-published execution queue, stored in Redis
+// so that servers can auto-discover queues registered by workers.
+message WorkerQueueConfig {
+  // The name of the queue (e.g. "cpu", "gpu").
+  string name = 1;
+
+  // Whether the queue accepts operations with properties not listed
+  // in the queue's platform requirements.
+  bool allow_unmatched = 2;
+
+  // Platform properties that define the queue's provisioning requirements.
+  repeated build.bazel.remote.execution.v2.Platform.Property properties = 3;
+}
+
 message WorkerChange {
   message Add {
     google.protobuf.Timestamp effectiveAt = 1;

--- a/src/test/java/build/buildfarm/instance/shard/RedisShardBackplaneTest.java
+++ b/src/test/java/build/buildfarm/instance/shard/RedisShardBackplaneTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import build.bazel.remote.execution.v2.Platform;
 import build.bazel.remote.execution.v2.RequestMetadata;
 import build.buildfarm.common.DigestUtil;
 import build.buildfarm.common.DigestUtil.HashFunction;
@@ -45,6 +46,7 @@ import build.buildfarm.v1test.OperationChange;
 import build.buildfarm.v1test.QueueEntry;
 import build.buildfarm.v1test.ShardWorker;
 import build.buildfarm.v1test.WorkerChange;
+import build.buildfarm.v1test.WorkerQueueConfig;
 import build.buildfarm.worker.resources.LocalResourceSet;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -495,5 +497,109 @@ public class RedisShardBackplaneTest {
             "",
             JsonCodec.CODEC.worker().print(shardWorker));
     verify(jedis, times(1)).publish(anyString(), anyString());
+  }
+
+  @Test
+  public void publishWorkerQueueSetsKeyWithExpiry() throws IOException {
+    UnifiedJedis jedis = mock(UnifiedJedis.class);
+    when(mockJedisClusterFactory.get()).thenReturn(jedis);
+    configs.getBackplane().setWorkerQueuePrefix("WorkerQueue");
+    configs.getBackplane().setWorkerQueueExpireSeconds(60);
+
+    RedisShardBackplane backplane = createBackplane("publish-worker-queue-test");
+    backplane.start("publishQueue/test:0000", name -> {});
+    Queue queue = new Queue();
+    queue.setName("gpu");
+    queue.setAllowUnmatched(false);
+    build.buildfarm.common.config.Property prop1 = new build.buildfarm.common.config.Property();
+    prop1.setName("gpu");
+    prop1.setValue("1");
+    build.buildfarm.common.config.Property prop2 = new build.buildfarm.common.config.Property();
+    prop2.setName("min-cores");
+    prop2.setValue("4");
+    queue.setProperties(List.of(prop1, prop2));
+
+    backplane.publishWorkerQueue(queue);
+
+    // Verify that the proto-serialized bytes are stored with the correct key and TTL
+    WorkerQueueConfig expectedProto =
+        WorkerQueueConfig.newBuilder()
+            .setName("gpu")
+            .setAllowUnmatched(false)
+            .addProperties(Platform.Property.newBuilder().setName("gpu").setValue("1").build())
+            .addProperties(
+                Platform.Property.newBuilder().setName("min-cores").setValue("4").build())
+            .build();
+    verify(jedis, times(1)).setex("WorkerQueue:gpu".getBytes(), 60, expectedProto.toByteArray());
+  }
+
+  @Test
+  public void discoverWorkerQueuesReturnsPublishedQueues() throws IOException {
+    UnifiedJedis jedis = mock(UnifiedJedis.class);
+    when(mockJedisClusterFactory.get()).thenReturn(jedis);
+    configs.getBackplane().setWorkerQueuePrefix("WorkerQueue");
+    configs.getBackplane().setWorkerQueueExpireSeconds(60);
+
+    WorkerQueueConfig cpuProto =
+        WorkerQueueConfig.newBuilder()
+            .setName("cpu")
+            .setAllowUnmatched(true)
+            .addProperties(
+                Platform.Property.newBuilder().setName("min-cores").setValue("*").build())
+            .addProperties(
+                Platform.Property.newBuilder().setName("max-cores").setValue("*").build())
+            .build();
+    WorkerQueueConfig gpuProto =
+        WorkerQueueConfig.newBuilder()
+            .setName("gpu")
+            .setAllowUnmatched(false)
+            .addProperties(Platform.Property.newBuilder().setName("gpu").setValue("1").build())
+            .build();
+
+    when(jedis.keys("WorkerQueue:*".getBytes()))
+        .thenReturn(Set.of("WorkerQueue:cpu".getBytes(), "WorkerQueue:gpu".getBytes()));
+    when(jedis.get("WorkerQueue:cpu".getBytes())).thenReturn(cpuProto.toByteArray());
+    when(jedis.get("WorkerQueue:gpu".getBytes())).thenReturn(gpuProto.toByteArray());
+
+    RedisShardBackplane backplane = createBackplane("discover-worker-queues-test");
+    backplane.start("discoverQueues/test:0000", name -> {});
+    List<Queue> queues = backplane.discoverWorkerQueues();
+
+    assertThat(queues).hasSize(2);
+
+    // Find the queues by name (order is not guaranteed from Set)
+    Queue cpuQueue =
+        queues.stream().filter(q -> q.getName().equals("cpu")).findFirst().orElse(null);
+    Queue gpuQueue =
+        queues.stream().filter(q -> q.getName().equals("gpu")).findFirst().orElse(null);
+
+    assertThat(cpuQueue).isNotNull();
+    assertThat(cpuQueue.isAllowUnmatched()).isTrue();
+    assertThat(cpuQueue.getProperties()).hasSize(2);
+    assertThat(cpuQueue.getProperties().get(0).getName()).isEqualTo("min-cores");
+    assertThat(cpuQueue.getProperties().get(0).getValue()).isEqualTo("*");
+
+    assertThat(gpuQueue).isNotNull();
+    assertThat(gpuQueue.isAllowUnmatched()).isFalse();
+    assertThat(gpuQueue.getProperties()).hasSize(1);
+    assertThat(gpuQueue.getProperties().get(0).getName()).isEqualTo("gpu");
+    assertThat(gpuQueue.getProperties().get(0).getValue()).isEqualTo("1");
+  }
+
+  @Test
+  public void discoverWorkerQueuesHandlesExpiredKeys() throws IOException {
+    UnifiedJedis jedis = mock(UnifiedJedis.class);
+    when(mockJedisClusterFactory.get()).thenReturn(jedis);
+    configs.getBackplane().setWorkerQueuePrefix("WorkerQueue");
+
+    // Key exists in scan but expired before GET
+    when(jedis.keys("WorkerQueue:*".getBytes()))
+        .thenReturn(Set.of("WorkerQueue:expired".getBytes()));
+    when(jedis.get("WorkerQueue:expired".getBytes())).thenReturn((byte[]) null);
+
+    RedisShardBackplane backplane = createBackplane("discover-expired-queue-test");
+    backplane.start("discoverExpired/test:0000", name -> {});
+    List<Queue> queues = backplane.discoverWorkerQueues();
+    assertThat(queues).isEmpty();
   }
 }


### PR DESCRIPTION
If enabled, workers will automatically publish their queue configurations to Redis, enabling the server to dynamically discover and adopt new execution queues without requiring a restart or a shared queues.yml configuration.

Motivation

Previously, execution queue definitions had to be statically configured on the server side in queues.yml config YAML. This meant that:
- Adding a new worker pool (e.g. GPU workers) required updating the server config and restarting
- Server and worker queue configs had to be kept in sync manually
- There was no mechanism for queues to be cleaned up when a worker pool was decommissioned

How It Works

Worker side: During its periodic registration heartbeat (every 10s), each worker publishes its queue configuration(s) to Redis as protobuf-serialized keys with a configurable TTL. When all workers in a queue stop, its queue keys naturally expire after a configured period (default is 7 days).

Server side: A background thread periodically discovers worker-published queues from Redis, merges them with any statically-configured queues, and live-rebuilds the execution queue. New queues are adopted automatically; expired (non-static) queues are removed.

The feature is fully opt-in. When enableQueueAutoDiscovery is false (default), behavior is completely unchanged. Static queues from the server config are never removed by the discovery process.

