### PR TITLE
Remove lock contention from CFC state

### DIFF
--- a/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
+++ b/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
@@ -224,15 +224,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
   protected final transient Entry header = new SentinelEntry();
   protected volatile long unreferencedEntryCount = 0;
 
-  enum State {
-    STOPPED,
-    STARTING, // files are checked for existence/read
-    WRITING, // only writable state
-    READ_ONLY,
-  }
-
-  @GuardedBy("this")
-  private State state = State.STOPPED;
+  private State state = new State();
 
   @GuardedBy("this")
   private long removedEntrySize = 0;
@@ -516,11 +508,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
         builder.add(result.build());
       }
     }
-    boolean recordAccess;
-    synchronized (this) {
-      recordAccess = state == State.WRITING || state == State.READ_ONLY;
-    }
-    if (recordAccess) {
+    if (state.shouldRecordAccess()) {
       List<String> foundDigests = found.build();
       if (!foundDigests.isEmpty()) {
         accessed(foundDigests);
@@ -566,10 +554,8 @@ public abstract class CASFileCache implements ContentAddressableStorage {
     if (entry != null) {
       return entry;
     }
-    synchronized (this) {
-      if (state != State.WRITING && state != State.READ_ONLY) {
-        return new Entry();
-      }
+    if (!state.shouldRecordAccess()) {
+      return new Entry();
     }
     return null;
   }
@@ -833,26 +819,19 @@ public abstract class CASFileCache implements ContentAddressableStorage {
   }
 
   @Override
-  public synchronized boolean isReadOnly() {
-    return state != State.WRITING;
+  public boolean isReadOnly() {
+    return !state.isWritable();
   }
 
-  public synchronized boolean setReadOnly(boolean value) {
-    if (value && state == State.WRITING) {
-      state = State.READ_ONLY;
-      return true;
-    }
-    if (!value && state == State.READ_ONLY) {
-      state = State.WRITING;
-      notifyAll(); // ensure that we wake up any waits for this state
-      return true;
-    }
-    return false;
+  public boolean setReadOnly(boolean value) {
+    return state.setReadOnly(value);
   }
 
   @Override
-  public synchronized void waitForWritable(Duration timeout) throws InterruptedException {
-    wait(timeout.toMillis(), (int) (timeout.toNanos() % 1000000));
+  public void waitForWritable(Duration timeout) throws InterruptedException {
+    synchronized (state) {
+      state.wait(timeout.toMillis(), (int) (timeout.toNanos() % 1000000));
+    }
   }
 
   @Override
@@ -1320,7 +1299,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
     // lock ordering, [this] -> [lru]
     // path used as lock due to isolation by filename
     saveLRU();
-    state = State.STOPPED;
+    state.stop();
   }
 
   public ListenableFuture<Void> start(boolean skipLoad) {
@@ -1337,10 +1316,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
       ExecutorService removeDirectoryService,
       boolean skipLoad,
       boolean writable) {
-    synchronized (this) {
-      checkState(state == State.STOPPED);
-      state = State.STARTING;
-    }
+    state.start();
     CasFallbackDelegate.start(
         delegate, onStartPut, removeDirectoryService, delegateSkipLoad, writable);
 
@@ -1350,10 +1326,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
               startRoutine(onStartPut, removeDirectoryService, skipLoad);
               synchronized (this) {
                 saveLRUAfter = Deadline.after(10, MINUTES);
-                state = writable ? State.WRITING : State.READ_ONLY;
-                if (writable) {
-                  notifyAll();
-                }
+                checkState(state.setReadOnly(!writable));
               }
               return null;
             });

--- a/src/main/java/build/buildfarm/cas/cfc/State.java
+++ b/src/main/java/build/buildfarm/cas/cfc/State.java
@@ -1,0 +1,62 @@
+// Copyright 2026 The Buildfarm Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.cas.cfc;
+
+import static com.google.common.base.Preconditions.checkState;
+
+class State {
+  enum Value {
+    STOPPED,
+    STARTING, // files are checked for existence/read
+    WRITING, // only writable state
+    READ_ONLY
+  }
+
+  private Value value;
+
+  State() {
+    value = Value.STOPPED;
+  }
+
+  synchronized boolean isWritable() {
+    return value == Value.WRITING;
+  }
+
+  synchronized boolean shouldRecordAccess() {
+    return value == Value.WRITING || value == Value.READ_ONLY;
+  }
+
+  synchronized boolean setReadOnly(boolean readOnly) {
+    if (readOnly && (value == Value.WRITING || value == Value.STARTING)) {
+      value = Value.READ_ONLY;
+      return true;
+    }
+    if (!readOnly && (value == Value.READ_ONLY || value == Value.STARTING)) {
+      value = Value.WRITING;
+      notifyAll(); // ensure that we wake up any waits for this state
+      return true;
+    }
+    return false;
+  }
+
+  synchronized void start() {
+    checkState(value == Value.STOPPED);
+    value = Value.STARTING;
+  }
+
+  synchronized void stop() {
+    value = Value.STOPPED;
+  }
+}

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -409,11 +409,9 @@ class ShardWorkerContext implements WorkerContext {
   /** wait until matching should occur, false return indicates that we are shutting down */
   private boolean waitToMatch() throws InterruptedException {
     ContentAddressableStorage storage = execFileSystem.getStorage();
-    synchronized (storage) {
-      // we may want to get interrupted when match is paused
-      while (!inGracefulShutdown && storage.isReadOnly()) {
-        storage.waitForWritable(java.time.Duration.ofSeconds(1));
-      }
+    // we may want to get interrupted when match is paused
+    while (!inGracefulShutdown && storage.isReadOnly()) {
+      storage.waitForWritable(java.time.Duration.ofSeconds(1));
     }
     return !inGracefulShutdown;
   }


### PR DESCRIPTION
Make CFC State into its own class to manage states without direct manipulation, and limiting the lock scope to its behavior.