### PR TITLE
Leave toplevel directory writable for rename

### DIFF
--- a/src/main/java/build/buildfarm/cas/cfc/DirectoryEntryCFC.java
+++ b/src/main/java/build/buildfarm/cas/cfc/DirectoryEntryCFC.java
@@ -15,6 +15,7 @@
 package build.buildfarm.cas.cfc;
 
 import static build.buildfarm.common.io.Directories.disableAllWriteAccess;
+import static build.buildfarm.common.io.Directories.makeWritable;
 import static build.buildfarm.common.io.EvenMoreFiles.setReadOnlyPerms;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.util.concurrent.Futures.catchingAsync;
@@ -205,7 +206,7 @@ public class DirectoryEntryCFC extends CASFileCache {
         transformAsync(
             fetched,
             weight -> {
-              disableAllWriteAccess(tmpPath, fileStore);
+              disableAllWriteAccess(tmpPath, fileStore, /* excludeTopLevel= */ true);
               return immediateFuture(null);
             },
             service);
@@ -214,6 +215,7 @@ public class DirectoryEntryCFC extends CASFileCache {
             limited,
             result -> {
               Files.move(tmpPath, path);
+              makeWritable(path, /* writable= */ false, fileStore);
               return immediateFuture(result);
             },
             service);

--- a/src/main/java/build/buildfarm/common/io/Directories.java
+++ b/src/main/java/build/buildfarm/common/io/Directories.java
@@ -81,7 +81,7 @@ public final class Directories {
     }
   }
 
-  private static void makeWritable(Path dir, boolean writable, FileStore fileStore)
+  public static void makeWritable(Path dir, boolean writable, FileStore fileStore)
       throws IOException {
     if (fileStore.supportsFileAttributeView("posix")) {
       if (writable) {
@@ -203,8 +203,19 @@ public final class Directories {
         });
   }
 
+  public static void disableAllWriteAccess(
+      Path directory, FileStore fileStore, boolean excludeTopLevel) throws IOException {
+    forAllPostDirs(
+        directory,
+        dir -> {
+          if (!excludeTopLevel || !dir.equals(directory)) {
+            makeWritable(dir, false, fileStore);
+          }
+        });
+  }
+
   public static void disableAllWriteAccess(Path directory, FileStore fileStore) throws IOException {
-    forAllPostDirs(directory, dir -> makeWritable(dir, false, fileStore));
+    disableAllWriteAccess(directory, fileStore, /* excludeTopLevel= */ false);
   }
 
   public static void disableAllFileWriteAccess(Path directory, FileStore fileStore)


### PR DESCRIPTION
Java will refuse to move a read-only directory. Splitting hairs, but avoiding the final iop and trading it for one after rename. Should instead be:
ensuring mode on file create exit
ensuring mode on directory complete
But otherwise this is at least consistent.