### PR TITLE
fix: use UnifiedJedis instead of raw Jedis connections in queue layer

### DIFF
--- a/src/main/java/build/buildfarm/common/redis/BalancedRedisQueue.java
+++ b/src/main/java/build/buildfarm/common/redis/BalancedRedisQueue.java
@@ -37,13 +37,8 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import lombok.Getter;
 import redis.clients.jedis.AbstractPipeline;
-import redis.clients.jedis.Connection;
-import redis.clients.jedis.Jedis;
-import redis.clients.jedis.JedisCluster;
-import redis.clients.jedis.JedisPooled;
 import redis.clients.jedis.UnifiedJedis;
 import redis.clients.jedis.resps.ScanResult;
-import redis.clients.jedis.util.JedisClusterCRC16;
 
 /**
  * @class BalancedRedisQueue
@@ -165,9 +160,7 @@ public class BalancedRedisQueue<E> {
    */
   public boolean offer(UnifiedJedis unified, E e) {
     String queue = queues.get(roundRobinPushIndex());
-    try (Jedis jedis = getJedisFromKey(unified, queue)) {
-      return queueDecorator.decorate(jedis, queue).offer(e);
-    }
+    return queueDecorator.decorate(unified, queue).offer(e);
   }
 
   /**
@@ -177,9 +170,7 @@ public class BalancedRedisQueue<E> {
    */
   public boolean offer(UnifiedJedis unified, E e, double priority) {
     String queue = queues.get(roundRobinPushIndex());
-    try (Jedis jedis = getJedisFromKey(unified, queue)) {
-      return queueDecorator.decorate(jedis, queue).offer(e, priority);
-    }
+    return queueDecorator.decorate(unified, queue).offer(e, priority);
   }
 
   /**
@@ -191,12 +182,7 @@ public class BalancedRedisQueue<E> {
    */
   public boolean removeFromDequeue(UnifiedJedis unified, BalancedQueueEntry<E> balancedQueueEntry) {
     String queue = balancedQueueEntry.queue();
-    try (Jedis jedis = getJedisFromKey(unified, queue)) {
-      if (queueDecorator.decorate(jedis, queue).removeFromDequeue(balancedQueueEntry.value())) {
-        return true;
-      }
-    }
-    return false;
+    return queueDecorator.decorate(unified, queue).removeFromDequeue(balancedQueueEntry.value());
   }
 
   public void removeFromDequeue(
@@ -206,9 +192,9 @@ public class BalancedRedisQueue<E> {
         .removeFromDequeue(pipeline, balancedQueueEntry.value());
   }
 
-  private E take(Jedis jedis, Queue<E> queue, Duration timeout, ExecutorService service)
+  private E take(Queue<E> queue, Duration timeout, ExecutorService service)
       throws InterruptedException {
-    return interruptibleRequest(() -> queue.take(timeout), jedis::disconnect, service);
+    return interruptibleRequest(() -> queue.take(timeout), () -> {}, service);
   }
 
   private <T> T interruptibleRequest(
@@ -246,12 +232,10 @@ public class BalancedRedisQueue<E> {
     int currentIndex = roundRobinPopIndex();
     do {
       String queueName = queues.get(currentIndex);
-      try (Jedis jedis = getJedisFromKey(unified, queueName)) {
-        Queue<E> queue = queueDecorator.decorate(jedis, queueName);
-        E item = take(jedis, queue, queueTimeout, service);
-        if (item != null) {
-          return new BalancedQueueEntry<>(queueName, item);
-        }
+      Queue<E> queue = queueDecorator.decorate(unified, queueName);
+      E item = take(queue, queueTimeout, service);
+      if (item != null) {
+        return new BalancedQueueEntry<>(queueName, item);
       }
       currentIndex = roundRobinPopIndex();
     } while (currentIndex != startIndex);
@@ -293,13 +277,11 @@ public class BalancedRedisQueue<E> {
     while (true) {
       final E val;
       String queueName = queues.get(roundRobinPopIndex());
-      try (Jedis jedis = getJedisFromKey(unified, queueName)) {
-        Queue<E> queue = queueDecorator.decorate(jedis, queueName);
-        if (blocking) {
-          val = take(jedis, queue, currentTimeout, service);
-        } else {
-          val = queue.poll();
-        }
+      Queue<E> queue = queueDecorator.decorate(unified, queueName);
+      if (blocking) {
+        val = take(queue, currentTimeout, service);
+      } else {
+        val = queue.poll();
       }
       // return if found
       if (val != null) {
@@ -325,19 +307,6 @@ public class BalancedRedisQueue<E> {
     }
   }
 
-  private static Jedis getJedisFromKey(UnifiedJedis jedis, String name) {
-    Connection connection = null;
-    if (jedis instanceof JedisCluster cluster) {
-      connection = cluster.getConnectionFromSlot(JedisClusterCRC16.getSlot(name));
-    } else if (jedis instanceof JedisPooled pooled) {
-      connection = pooled.getPool().getResource();
-    }
-    if (connection == null) {
-      throw new IllegalArgumentException(jedis.toString());
-    }
-    return new Jedis(connection);
-  }
-
   // BalancedQueue -> BalancedRedisQueue
   // make into decorated pattern
   public @Nullable BalancedQueueEntry<E> pollAny(UnifiedJedis unified) throws InterruptedException {
@@ -345,11 +314,9 @@ public class BalancedRedisQueue<E> {
     int currentIndex = roundRobinPopIndex();
     do {
       String queueName = queues.get(currentIndex);
-      try (Jedis jedis = getJedisFromKey(unified, queueName)) {
-        E item = queueDecorator.decorate(jedis, queueName).poll();
-        if (item != null) {
-          return new BalancedQueueEntry<>(queueName, item);
-        }
+      E item = queueDecorator.decorate(unified, queueName).poll();
+      if (item != null) {
+        return new BalancedQueueEntry<>(queueName, item);
       }
       currentIndex = roundRobinPopIndex();
     } while (currentIndex != startIndex);
@@ -430,9 +397,7 @@ public class BalancedRedisQueue<E> {
   }
 
   private long size(UnifiedJedis unified, String queue) {
-    try (Jedis jedis = getJedisFromKey(unified, queue)) {
-      return queueDecorator.decorate(jedis, queue).size();
-    }
+    return queueDecorator.decorate(unified, queue).size();
   }
 
   private List<Supplier<Long>> sizes(AbstractPipeline pipeline) {
@@ -478,9 +443,7 @@ public class BalancedRedisQueue<E> {
    */
   public void visit(UnifiedJedis unified, Visitor<BalancedQueueEntry<E>> visitor) {
     for (String queue : fullIterationQueueOrder()) {
-      try (Jedis jedis = getJedisFromKey(unified, queue)) {
-        queueDecorator.decorate(jedis, queue).visit(createBalancedQueueVisitor(queue, visitor));
-      }
+      queueDecorator.decorate(unified, queue).visit(createBalancedQueueVisitor(queue, visitor));
     }
   }
 
@@ -491,11 +454,9 @@ public class BalancedRedisQueue<E> {
    */
   public void visitDequeue(UnifiedJedis unified, Visitor<BalancedQueueEntry<E>> visitor) {
     for (String queue : fullIterationQueueOrder()) {
-      try (Jedis jedis = getJedisFromKey(unified, queue)) {
-        queueDecorator
-            .decorate(jedis, queue)
-            .visitDequeue(createBalancedQueueVisitor(queue, visitor));
-      }
+      queueDecorator
+          .decorate(unified, queue)
+          .visitDequeue(createBalancedQueueVisitor(queue, visitor));
     }
   }
 
@@ -657,19 +618,16 @@ public class BalancedRedisQueue<E> {
         currentQueue = queueIter.next();
       }
       // should we put the source hash in the result set?
-      // should we be trying to use the same jedis connection for each cycle?
       final String entryQueue = currentQueue;
-      try (Jedis jedis = getJedisFromKey(unified, entryQueue)) {
-        ScanResult<E> scanResult =
-            queueDecorator
-                .decorate(jedis, currentQueue)
-                .scan(queueCursor, count - result.size(), match);
-        queueCursor = scanResult.getCursor();
-        result.addAll(
-            newArrayList(
-                transform(
-                    scanResult.getResult(), entry -> new BalancedQueueEntry<>(entryQueue, entry))));
-      }
+      ScanResult<E> scanResult =
+          queueDecorator
+              .decorate(unified, currentQueue)
+              .scan(queueCursor, count - result.size(), match);
+      queueCursor = scanResult.getCursor();
+      result.addAll(
+          newArrayList(
+              transform(
+                  scanResult.getResult(), entry -> new BalancedQueueEntry<>(entryQueue, entry))));
     }
 
     if (queueCursor.equals(SCAN_POINTER_START)) {

--- a/src/main/java/build/buildfarm/common/redis/QueueDecorator.java
+++ b/src/main/java/build/buildfarm/common/redis/QueueDecorator.java
@@ -1,8 +1,8 @@
 package build.buildfarm.common.redis;
 
 import build.buildfarm.common.Queue;
-import redis.clients.jedis.Jedis;
+import redis.clients.jedis.UnifiedJedis;
 
 public interface QueueDecorator<E> {
-  Queue<E> decorate(Jedis jedis, String name);
+  Queue<E> decorate(UnifiedJedis jedis, String name);
 }

--- a/src/main/java/build/buildfarm/common/redis/RedisPriorityQueue.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisPriorityQueue.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.function.Supplier;
 import lombok.Getter;
 import redis.clients.jedis.AbstractPipeline;
-import redis.clients.jedis.Jedis;
+import redis.clients.jedis.UnifiedJedis;
 import redis.clients.jedis.params.ScanParams;
 import redis.clients.jedis.resps.ScanResult;
 import redis.clients.jedis.resps.Tuple;
@@ -44,11 +44,11 @@ public class RedisPriorityQueue implements Queue<String> {
   private static final Clock defaultClock = Clock.systemUTC();
   private static final long defaultPollIntervalMillis = 100;
 
-  public static Queue<String> decorate(Jedis jedis, String name) {
+  public static Queue<String> decorate(UnifiedJedis jedis, String name) {
     return new RedisPriorityQueue(jedis, name);
   }
 
-  private final Jedis jedis;
+  private final UnifiedJedis jedis;
 
   /**
    * @field name
@@ -68,7 +68,7 @@ public class RedisPriorityQueue implements Queue<String> {
    * @details Construct a named redis queue with an established redis cluster.
    * @param name The global name of the queue.
    */
-  public RedisPriorityQueue(Jedis jedis, String name) {
+  public RedisPriorityQueue(UnifiedJedis jedis, String name) {
     this(jedis, name, defaultPollIntervalMillis);
   }
 
@@ -78,7 +78,7 @@ public class RedisPriorityQueue implements Queue<String> {
    *     testing of the order of the queued actions
    * @param name The global name of the queue.
    */
-  public RedisPriorityQueue(Jedis jedis, String name, Clock clock) {
+  public RedisPriorityQueue(UnifiedJedis jedis, String name, Clock clock) {
     this(jedis, name, clock, defaultPollIntervalMillis);
   }
 
@@ -89,7 +89,7 @@ public class RedisPriorityQueue implements Queue<String> {
    * @param name The global name of the queue.
    * @param pollIntervalMillis pollInterval to use when dqueuing from redis.
    */
-  public RedisPriorityQueue(Jedis jedis, String name, long pollIntervalMillis) {
+  public RedisPriorityQueue(UnifiedJedis jedis, String name, long pollIntervalMillis) {
     this(jedis, name, defaultClock, pollIntervalMillis);
   }
 
@@ -101,7 +101,7 @@ public class RedisPriorityQueue implements Queue<String> {
    * @param time Timestamp of the operation.
    * @param pollIntervalMillis pollInterval to use when dqueuing from redis.
    */
-  public RedisPriorityQueue(Jedis jedis, String name, Clock clock, long pollIntervalMillis) {
+  public RedisPriorityQueue(UnifiedJedis jedis, String name, Clock clock, long pollIntervalMillis) {
     this.jedis = jedis;
     this.name = name;
     this.clock = clock;

--- a/src/main/java/build/buildfarm/common/redis/RedisQueue.java
+++ b/src/main/java/build/buildfarm/common/redis/RedisQueue.java
@@ -25,7 +25,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.function.Supplier;
 import redis.clients.jedis.AbstractPipeline;
-import redis.clients.jedis.Jedis;
+import redis.clients.jedis.UnifiedJedis;
 import redis.clients.jedis.resps.ScanResult;
 
 /**
@@ -40,7 +40,7 @@ import redis.clients.jedis.resps.ScanResult;
 public class RedisQueue implements Queue<String> {
   private static final int defaultListPageSize = 10000;
 
-  public static Queue decorate(Jedis jedis, String name) {
+  public static Queue decorate(UnifiedJedis jedis, String name) {
     return new RedisQueue(jedis, name, defaultListPageSize);
   }
 
@@ -48,7 +48,7 @@ public class RedisQueue implements Queue<String> {
     return timeout.getSeconds() + timeout.getNano() / 1e9;
   }
 
-  private final Jedis jedis;
+  private final UnifiedJedis jedis;
 
   /**
    * @field name
@@ -65,11 +65,11 @@ public class RedisQueue implements Queue<String> {
    * @details Construct a named redis queue with an established redis cluster.
    * @param name The global name of the queue.
    */
-  public RedisQueue(Jedis jedis, String name) {
+  public RedisQueue(UnifiedJedis jedis, String name) {
     this(jedis, name, defaultListPageSize);
   }
 
-  public RedisQueue(Jedis jedis, String name, int listPageSize) {
+  public RedisQueue(UnifiedJedis jedis, String name, int listPageSize) {
     this.jedis = jedis;
     this.name = name;
     this.listPageSize = listPageSize;

--- a/src/main/java/build/buildfarm/common/redis/TranslatedQueueDecorator.java
+++ b/src/main/java/build/buildfarm/common/redis/TranslatedQueueDecorator.java
@@ -16,7 +16,7 @@ package build.buildfarm.common.redis;
 
 import build.buildfarm.common.Queue;
 import com.google.protobuf.Message;
-import redis.clients.jedis.Jedis;
+import redis.clients.jedis.UnifiedJedis;
 
 public class TranslatedQueueDecorator<T extends Message> implements QueueDecorator<T> {
   private final QueueDecorator<String> decorator;
@@ -29,7 +29,7 @@ public class TranslatedQueueDecorator<T extends Message> implements QueueDecorat
   }
 
   @Override
-  public Queue<T> decorate(Jedis jedis, String name) {
+  public Queue<T> decorate(UnifiedJedis jedis, String name) {
     return new TranslatedQueue<>(decorator.decorate(jedis, name), translator);
   }
 }

--- a/src/test/java/build/buildfarm/common/redis/BalancedRedisQueueMockTest.java
+++ b/src/test/java/build/buildfarm/common/redis/BalancedRedisQueueMockTest.java
@@ -38,9 +38,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import redis.clients.jedis.Connection;
-import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisCluster;
+import redis.clients.jedis.UnifiedJedis;
 
 /**
  * @class BalancedRedisQueueMockTest
@@ -54,18 +53,16 @@ import redis.clients.jedis.JedisCluster;
 @RunWith(JUnit4.class)
 public class BalancedRedisQueueMockTest {
   @Mock private JedisCluster redis;
-  @Mock private Connection connection;
   @Mock private Queue<String> subQueue;
 
   @SuppressWarnings("unused") // parameters are ignored
-  private Queue<String> subQueueDecorate(Jedis jedis, String name) {
+  private Queue<String> subQueueDecorate(UnifiedJedis jedis, String name) {
     return subQueue;
   }
 
   @Before
   public void setUp() {
     MockitoAnnotations.initMocks(this);
-    when(redis.getConnectionFromSlot(any(Integer.class))).thenReturn(connection);
   }
 
   // Function under test: removeFromDequeue

--- a/src/test/java/build/buildfarm/common/redis/RedisPriorityQueueMockTest.java
+++ b/src/test/java/build/buildfarm/common/redis/RedisPriorityQueueMockTest.java
@@ -35,7 +35,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import redis.clients.jedis.Jedis;
+import redis.clients.jedis.UnifiedJedis;
 
 /**
  * @class RedisPriorityQueueMockTest
@@ -48,7 +48,7 @@ import redis.clients.jedis.Jedis;
  */
 @RunWith(JUnit4.class)
 public class RedisPriorityQueueMockTest {
-  @Mock private Jedis redis;
+  @Mock private UnifiedJedis redis;
   @Mock private Clock clock;
 
   @Before

--- a/src/test/java/build/buildfarm/common/redis/RedisPriorityQueueTest.java
+++ b/src/test/java/build/buildfarm/common/redis/RedisPriorityQueueTest.java
@@ -73,7 +73,7 @@ public class RedisPriorityQueueTest {
   @Test
   public void redisPriorityQueueConstructsWithoutError() throws Exception {
     // ACT
-    new RedisPriorityQueue(redis, "test");
+    new RedisPriorityQueue(pooled, "test");
   }
 
   // Function under test: offer
@@ -82,7 +82,7 @@ public class RedisPriorityQueueTest {
   @Test
   public void offerWithoutError() throws Exception {
     // ARRANGE
-    RedisPriorityQueue queue = new RedisPriorityQueue(redis, "test");
+    RedisPriorityQueue queue = new RedisPriorityQueue(pooled, "test");
 
     // ACT
     queue.offer("foo");
@@ -94,7 +94,7 @@ public class RedisPriorityQueueTest {
   @Test
   public void offerDifferentWithoutError() throws Exception {
     // ARRANGE
-    RedisPriorityQueue queue = new RedisPriorityQueue(redis, "test");
+    RedisPriorityQueue queue = new RedisPriorityQueue(pooled, "test");
 
     // ACT
     queue.offer("foo");
@@ -107,7 +107,7 @@ public class RedisPriorityQueueTest {
   @Test
   public void pushPushSameWithoutError() throws Exception {
     // ARRANGE
-    RedisPriorityQueue queue = new RedisPriorityQueue(redis, "test");
+    RedisPriorityQueue queue = new RedisPriorityQueue(pooled, "test");
 
     // ACT
     queue.offer("foo");
@@ -120,7 +120,7 @@ public class RedisPriorityQueueTest {
   @Test
   public void pushPushMany() throws Exception {
     // ARRANGE
-    RedisPriorityQueue queue = new RedisPriorityQueue(redis, "test");
+    RedisPriorityQueue queue = new RedisPriorityQueue(pooled, "test");
 
     // ACT
     for (int i = 0; i < 1000; ++i) {
@@ -134,7 +134,7 @@ public class RedisPriorityQueueTest {
   @Test
   public void pushPushIncreasesSize() throws Exception {
     // ARRANGE
-    RedisPriorityQueue queue = new RedisPriorityQueue(redis, "test");
+    RedisPriorityQueue queue = new RedisPriorityQueue(pooled, "test");
 
     // ACT / ASSERT
     assertThat(queue.size()).isEqualTo(0);
@@ -166,7 +166,7 @@ public class RedisPriorityQueueTest {
   @Test
   public void getDequeueNameNameIsStored() throws Exception {
     // ARRANGE
-    RedisPriorityQueue queue = new RedisPriorityQueue(redis, "queue_name");
+    RedisPriorityQueue queue = new RedisPriorityQueue(pooled, "queue_name");
 
     // ACT
     String name = queue.getDequeueName();
@@ -181,7 +181,7 @@ public class RedisPriorityQueueTest {
   @Test
   public void sizeAdjustPushDequeue() throws Exception {
     // ARRANGE
-    RedisPriorityQueue queue = new RedisPriorityQueue(redis, "test");
+    RedisPriorityQueue queue = new RedisPriorityQueue(pooled, "test");
     ExecutorService service = mock(ExecutorService.class);
     Duration timeout = Duration.ofSeconds(1);
 
@@ -220,7 +220,7 @@ public class RedisPriorityQueueTest {
   @Test
   public void checkPriorityOnDequeue() throws Exception {
     // ARRANGE
-    RedisPriorityQueue queue = new RedisPriorityQueue(redis, "test");
+    RedisPriorityQueue queue = new RedisPriorityQueue(pooled, "test");
     ExecutorService service = mock(ExecutorService.class);
     Duration timeout = Duration.ofSeconds(1);
     // ACT / ASSERT
@@ -257,7 +257,7 @@ public class RedisPriorityQueueTest {
   @Test
   public void checkDequeueTimeout() throws Exception {
     // ARRANGE
-    RedisPriorityQueue queue = new RedisPriorityQueue(redis, "test");
+    RedisPriorityQueue queue = new RedisPriorityQueue(pooled, "test");
     ExecutorService service = mock(ExecutorService.class);
 
     Stopwatch stopwatch = Stopwatch.createStarted();
@@ -275,7 +275,7 @@ public class RedisPriorityQueueTest {
   @Test
   public void checkNegativesInPriority() throws Exception {
     // ARRANGE
-    RedisPriorityQueue queue = new RedisPriorityQueue(redis, "test");
+    RedisPriorityQueue queue = new RedisPriorityQueue(pooled, "test");
     ExecutorService service = mock(ExecutorService.class);
     Duration timeout = Duration.ofSeconds(1);
     String val;
@@ -315,7 +315,7 @@ public class RedisPriorityQueueTest {
   @Test
   public void visitCheckVisitOfEachElement() throws Exception {
     // ARRANGE
-    RedisPriorityQueue queue = new RedisPriorityQueue(redis, "test");
+    RedisPriorityQueue queue = new RedisPriorityQueue(pooled, "test");
     queue.offer("element 1");
     queue.offer("element 2");
     queue.offer("element 3");
@@ -353,7 +353,7 @@ public class RedisPriorityQueueTest {
   @Test
   public void visitVisitManyOverPageSize() throws Exception {
     // ARRANGE
-    RedisPriorityQueue queue = new RedisPriorityQueue(redis, "test");
+    RedisPriorityQueue queue = new RedisPriorityQueue(pooled, "test");
     for (int i = 0; i < 2500; ++i) {
       queue.offer("foo" + i);
     }

--- a/src/test/java/build/buildfarm/common/redis/RedisQueueMockTest.java
+++ b/src/test/java/build/buildfarm/common/redis/RedisQueueMockTest.java
@@ -32,11 +32,11 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import redis.clients.jedis.Jedis;
+import redis.clients.jedis.UnifiedJedis;
 
 @RunWith(JUnit4.class)
 public class RedisQueueMockTest {
-  @Mock private Jedis redis;
+  @Mock private UnifiedJedis redis;
 
   @Before
   public void setUp() {

--- a/src/test/java/build/buildfarm/common/redis/RedisQueueTest.java
+++ b/src/test/java/build/buildfarm/common/redis/RedisQueueTest.java
@@ -67,12 +67,12 @@ public class RedisQueueTest {
 
   @Test
   public void decorateSucceeds() {
-    RedisQueue.decorate(redis, "test");
+    RedisQueue.decorate(pooled, "test");
   }
 
   @Test
   public void offerShouldContain() {
-    RedisQueue queue = new RedisQueue(redis, "test");
+    RedisQueue queue = new RedisQueue(pooled, "test");
 
     queue.offer("foo");
 
@@ -81,7 +81,7 @@ public class RedisQueueTest {
 
   @Test
   public void removeFromDequeueShouldExclude() {
-    RedisQueue queue = new RedisQueue(redis, "test");
+    RedisQueue queue = new RedisQueue(pooled, "test");
     redis.lpush(queue.getDequeueName(), "foo", "bar", "foo");
 
     queue.removeFromDequeue("foo");
@@ -91,7 +91,7 @@ public class RedisQueueTest {
 
   @Test
   public void removeAllShouldExclude() {
-    RedisQueue queue = new RedisQueue(redis, "test");
+    RedisQueue queue = new RedisQueue(pooled, "test");
     redis.lpush("test", "foo", "bar", "foo");
 
     queue.removeAll("foo");
@@ -101,7 +101,7 @@ public class RedisQueueTest {
 
   @Test
   public void takeShouldPrependToDequeue() {
-    RedisQueue queue = new RedisQueue(redis, "test");
+    RedisQueue queue = new RedisQueue(pooled, "test");
     redis.lpush("test", "foo", "bar", "foo");
     redis.lpush(queue.getDequeueName(), "baz");
 
@@ -114,7 +114,7 @@ public class RedisQueueTest {
 
   @Test
   public void takeEmptyShouldReturnNullAfterTimeoutAndIgnoreDequeue() {
-    RedisQueue queue = new RedisQueue(redis, "test");
+    RedisQueue queue = new RedisQueue(pooled, "test");
     redis.lpush(queue.getDequeueName(), "foo");
 
     String value = queue.take(Duration.ofMillis(1));
@@ -126,7 +126,7 @@ public class RedisQueueTest {
 
   @Test
   public void pollShouldPrependToDequeue() {
-    RedisQueue queue = new RedisQueue(redis, "test");
+    RedisQueue queue = new RedisQueue(pooled, "test");
     redis.lpush("test", "foo", "bar", "foo");
     redis.lpush(queue.getDequeueName(), "baz");
 
@@ -139,7 +139,7 @@ public class RedisQueueTest {
 
   @Test
   public void pollEmptyShouldReturnNullAndIgnoreDequeue() {
-    RedisQueue queue = new RedisQueue(redis, "test");
+    RedisQueue queue = new RedisQueue(pooled, "test");
     redis.lpush(queue.getDequeueName(), "foo");
 
     String value = queue.poll();
@@ -151,7 +151,7 @@ public class RedisQueueTest {
 
   @Test
   public void sizeYieldsLengthAndIgnoresDequeue() {
-    RedisQueue queue = new RedisQueue(redis, "test");
+    RedisQueue queue = new RedisQueue(pooled, "test");
 
     redis.lpush(queue.getDequeueName(), "foo");
     assertThat(queue.size()).isEqualTo(0);
@@ -166,7 +166,7 @@ public class RedisQueueTest {
   @Test
   public void visitShouldEnumerateAndIgnoreDequeue() {
     int listPageSize = 3;
-    RedisQueue queue = new RedisQueue(redis, "test", listPageSize);
+    RedisQueue queue = new RedisQueue(pooled, "test", listPageSize);
     redis.lpush(queue.getDequeueName(), "processing");
     for (String entry : VISIT_ENTRIES) {
       redis.lpush("test", entry);
@@ -183,7 +183,7 @@ public class RedisQueueTest {
   @Test
   public void visitDequeueShouldEnumerateAndIgnoreQueue() {
     int listPageSize = 3;
-    RedisQueue queue = new RedisQueue(redis, "test", listPageSize);
+    RedisQueue queue = new RedisQueue(pooled, "test", listPageSize);
     redis.lpush("test", "processing");
     for (String entry : VISIT_ENTRIES) {
       redis.lpush(queue.getDequeueName(), entry);


### PR DESCRIPTION
When Redis Cluster topology changes (slot migrations, failovers), BalancedRedisQueue crashes with JedisMovedDataException because getJedisFromKey() extracts raw Connection objects from JedisCluster and wraps them in plain Jedis instances. Plain Jedis does not handle MOVED redirections — only JedisCluster (via UnifiedJedis) does this transparently with automatic retries.

This commit removes the raw connection extraction entirely and passes the UnifiedJedis client straight through to RedisQueue and RedisPriorityQueue. JedisCluster handles MOVED redirections, slot cache refresh, and retries internally.

Changes:
- QueueDecorator: decorate(Jedis, String) → decorate(UnifiedJedis, String)
- RedisQueue: field, constructors, and decorate() accept UnifiedJedis
- RedisPriorityQueue: same — field, all constructors, decorate()
- TranslatedQueueDecorator: decorate() parameter updated
- BalancedRedisQueue: deleted getJedisFromKey() method; removed all try-with-resource Jedis blocks from offer, removeFromDequeue, take, takeAny, pollAny, size, visit, visitDequeue, and scan methods; removed Connection/JedisCluster/JedisPooled/JedisClusterCRC16 imports
- Tests: mock tests use @Mock UnifiedJedis (Jedis does not extend UnifiedJedis in Jedis 7.x); integration tests pass JedisPooled (which does extend UnifiedJedis) to queue constructors while keeping a raw Jedis for test setup/teardown operations

Trade-off — blocking take interruption:
The old code used jedis::disconnect to immediately cancel blocking blmove calls during thread interruption (e.g. worker shutdown). With UnifiedJedis, the internal connection is not directly accessible for disconnect. Blocking blmove calls will now wait for their natural timeout (1–8 seconds via exponential backoff) instead of being cancelled instantly. This is acceptable because the timeout is bounded and worker shutdown already has grace periods — and is far better than crashing with unhandled JedisMovedDataException.