### PR TITLE
refactor: replace FileInputStream/FileOutputStream with Files.newInpu…

### DIFF
--- a/.bazelci/static_analysis_checks.xml
+++ b/.bazelci/static_analysis_checks.xml
@@ -130,7 +130,6 @@
 </rule>
 
 <rule ref="category/java/performance.xml">
-    <exclude name="AvoidFileStream"/>
     <exclude name="AvoidInstantiatingObjectsInLoops"/>
     <exclude name="RedundantFieldInitializer"/>
     <exclude name="UseStringBufferForStringAppends"/>

--- a/src/main/java/build/buildfarm/common/blake3/JniLoader.java
+++ b/src/main/java/build/buildfarm/common/blake3/JniLoader.java
@@ -19,7 +19,6 @@ import static build.buildfarm.common.base.System.isWindows;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.io.ByteStreams;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -77,7 +76,7 @@ public final class JniLoader {
         if (resource == null) {
           throw new UnsatisfiedLinkError("Resource " + resourceName + " not in JAR");
         }
-        try (OutputStream diskFile = new FileOutputStream(tempFile.toString())) {
+        try (OutputStream diskFile = Files.newOutputStream(tempFile)) {
           ByteStreams.copy(resource, diskFile);
         }
       }

--- a/src/main/java/build/buildfarm/common/config/BuildfarmConfigs.java
+++ b/src/main/java/build/buildfarm/common/config/BuildfarmConfigs.java
@@ -54,6 +54,8 @@ public final class BuildfarmConfigs {
         return yaml.load(input);
       } catch (NoSuchFileException ex) {
         throw new RuntimeException("Could not find config file: " + value);
+      } catch (IOException ex) {
+        throw new RuntimeException("Could not read config file: " + value, ex);
       }
     }
   }

--- a/src/main/java/build/buildfarm/common/config/BuildfarmConfigs.java
+++ b/src/main/java/build/buildfarm/common/config/BuildfarmConfigs.java
@@ -7,13 +7,11 @@ import build.buildfarm.common.SystemProcessors;
 import com.google.common.base.Strings;
 import com.google.devtools.common.options.OptionsParser;
 import com.google.devtools.common.options.OptionsParsingException;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetAddress;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -51,10 +49,10 @@ public final class BuildfarmConfigs {
       final ScalarNode scalarNode = (ScalarNode) node;
       final String value = scalarNode.getValue();
       try {
-        final InputStream input = new FileInputStream(new File(configsBasePath + "/" + value));
+        final InputStream input = Files.newInputStream(Path.of(configsBasePath + "/" + value));
         final Yaml yaml = new Yaml(constructor);
         return yaml.load(input);
-      } catch (FileNotFoundException ex) {
+      } catch (NoSuchFileException ex) {
         throw new RuntimeException("Could not find config file: " + value);
       }
     }

--- a/src/main/java/build/buildfarm/common/config/BuildfarmConfigs.java
+++ b/src/main/java/build/buildfarm/common/config/BuildfarmConfigs.java
@@ -48,8 +48,7 @@ public final class BuildfarmConfigs {
     public Object construct(Node node) {
       final ScalarNode scalarNode = (ScalarNode) node;
       final String value = scalarNode.getValue();
-      try {
-        final InputStream input = Files.newInputStream(Path.of(configsBasePath + "/" + value));
+      try (InputStream input = Files.newInputStream(Path.of(configsBasePath + "/" + value))) {
         final Yaml yaml = new Yaml(constructor);
         return yaml.load(input);
       } catch (NoSuchFileException ex) {

--- a/src/main/java/build/buildfarm/common/io/Utils.java
+++ b/src/main/java/build/buildfarm/common/io/Utils.java
@@ -22,8 +22,8 @@ import com.google.common.base.Suppliers;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.lang.reflect.Field;
 import java.nio.file.DirectoryStream;
 import java.nio.file.FileStore;
@@ -508,7 +508,7 @@ public final class Utils {
 
       // Copy tar files to the destination path
       else {
-        try (FileOutputStream fos = new FileOutputStream(destinationPath)) {
+        try (OutputStream fos = Files.newOutputStream(destinationPath.toPath())) {
           IOUtils.copy(tis, fos);
         }
       }

--- a/src/main/java/build/buildfarm/common/io/Utils.java
+++ b/src/main/java/build/buildfarm/common/io/Utils.java
@@ -498,17 +498,17 @@ public final class Utils {
    *     execution is performed in the docker container, it will return ta stream object so that
    *     files can be extracted.
    */
-  public static void unTar(TarArchiveInputStream tis, File destinationPath) throws IOException {
+  public static void unTar(TarArchiveInputStream tis, Path destinationPath) throws IOException {
     TarArchiveEntry tarEntry;
     while ((tarEntry = tis.getNextTarEntry()) != null) {
       // Directories don't need copied over. We ensure the destination path exists.
       if (tarEntry.isDirectory()) {
-        destinationPath.mkdirs();
+        Files.createDirectories(destinationPath);
       }
 
       // Copy tar files to the destination path
       else {
-        try (OutputStream fos = Files.newOutputStream(destinationPath.toPath())) {
+        try (OutputStream fos = Files.newOutputStream(destinationPath)) {
           IOUtils.copy(tis, fos);
         }
       }

--- a/src/main/java/build/buildfarm/common/s3/S3Bucket.java
+++ b/src/main/java/build/buildfarm/common/s3/S3Bucket.java
@@ -31,6 +31,8 @@ import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
 import com.amazonaws.services.secretsmanager.model.GetSecretValueRequest;
 import com.amazonaws.services.secretsmanager.model.GetSecretValueResult;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;

--- a/src/main/java/build/buildfarm/common/s3/S3Bucket.java
+++ b/src/main/java/build/buildfarm/common/s3/S3Bucket.java
@@ -31,10 +31,10 @@ import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
 import com.amazonaws.services.secretsmanager.model.GetSecretValueRequest;
 import com.amazonaws.services.secretsmanager.model.GetSecretValueResult;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.logging.Level;
@@ -109,14 +109,14 @@ public class S3Bucket {
     try {
       S3Object o = s3.getObject(bucket.getName(), keyName);
       S3ObjectInputStream s3is = o.getObjectContent();
-      FileOutputStream fos = new FileOutputStream(new File(filePath));
-      byte[] read_buf = new byte[1024];
-      int read_len;
-      while ((read_len = s3is.read(read_buf)) > 0) {
-        fos.write(read_buf, 0, read_len);
+      try (OutputStream fos = Files.newOutputStream(Path.of(filePath))) {
+        byte[] read_buf = new byte[1024];
+        int read_len;
+        while ((read_len = s3is.read(read_buf)) > 0) {
+          fos.write(read_buf, 0, read_len);
+        }
       }
       s3is.close();
-      fos.close();
     } catch (AmazonServiceException e) {
       log.log(
           Level.SEVERE,

--- a/src/main/java/build/buildfarm/proxy/http/GoogleAuthUtils.java
+++ b/src/main/java/build/buildfarm/proxy/http/GoogleAuthUtils.java
@@ -26,11 +26,12 @@ import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
 import io.netty.handler.ssl.SslContext;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
 import java.util.List;
 import org.jspecify.annotations.Nullable;
 
@@ -125,9 +126,9 @@ public final class GoogleAuthUtils {
       return null;
     } else if (options.googleCredentials != null) {
       // Credentials from file
-      try (InputStream authFile = new FileInputStream(options.googleCredentials)) {
+      try (InputStream authFile = Files.newInputStream(Path.of(options.googleCredentials))) {
         return newCredentials(authFile, options.googleAuthScopes);
-      } catch (FileNotFoundException e) {
+      } catch (NoSuchFileException | FileNotFoundException e) {
         String message =
             String.format(
                 "Could not open auth credentials file '%s': %s",

--- a/src/main/java/build/buildfarm/proxy/http/GoogleAuthUtils.java
+++ b/src/main/java/build/buildfarm/proxy/http/GoogleAuthUtils.java
@@ -26,6 +26,7 @@ import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
 import io.netty.handler.ssl.SslContext;
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/main/java/build/buildfarm/worker/DockerExecutor.java
+++ b/src/main/java/build/buildfarm/worker/DockerExecutor.java
@@ -37,7 +37,6 @@ import com.google.protobuf.Duration;
 import com.google.protobuf.util.Durations;
 import com.google.rpc.Code;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -381,7 +380,7 @@ public class DockerExecutor {
       cmd.withResource(path.toString());
 
       try (TarArchiveInputStream tarStream = new TarArchiveInputStream(cmd.exec())) {
-        Utils.unTar(tarStream, new File(path.toString()));
+        Utils.unTar(tarStream, path);
       }
     } catch (Exception e) {
       log.log(Level.WARNING, "Could not extract file from container: ", e);

--- a/src/main/java/build/buildfarm/worker/Executor.java
+++ b/src/main/java/build/buildfarm/worker/Executor.java
@@ -59,7 +59,6 @@ import com.google.protobuf.util.Durations;
 import com.google.protobuf.util.Timestamps;
 import com.google.rpc.Code;
 import io.grpc.Deadline;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -663,8 +662,7 @@ class Executor {
       if (limits.useLinuxSandbox) {
         executionStatistics =
             ExecutionStatistics.newBuilder()
-                .mergeFrom(
-                    new FileInputStream(execDir.resolve("action_execution_statistics").toString()))
+                .mergeFrom(Files.newInputStream(execDir.resolve("action_execution_statistics")))
                 .build();
       }
 

--- a/src/test/java/build/buildfarm/common/io/UtilsTest.java
+++ b/src/test/java/build/buildfarm/common/io/UtilsTest.java
@@ -18,7 +18,6 @@ import static build.buildfarm.common.base.System.isWindows;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.protobuf.ByteString;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileStore;
 import java.nio.file.Files;
@@ -87,13 +86,13 @@ public class UtilsTest {
   public void unTarTisEmpty() throws IOException {
     // ARRANGE
     TarArchiveInputStream tis = Mockito.mock(TarArchiveInputStream.class);
-    File dst = Mockito.mock(File.class);
+    Path dst = root.resolve("untar-empty");
 
     // ACT
     Utils.unTar(tis, dst);
 
     // ASSERT
-    Mockito.verify(dst, Mockito.times(0)).mkdirs();
+    assertThat(Files.exists(dst)).isFalse();
   }
 
   @Test
@@ -101,7 +100,7 @@ public class UtilsTest {
     // ARRANGE
     TarArchiveInputStream tis = Mockito.mock(TarArchiveInputStream.class);
     TarArchiveEntry entry = Mockito.mock(TarArchiveEntry.class);
-    File dst = Mockito.mock(File.class);
+    Path dst = root.resolve("untar-dir");
 
     Mockito.when(tis.getNextTarEntry()).thenReturn(entry).thenReturn(null);
     Mockito.when(entry.isDirectory()).thenReturn(true);
@@ -110,7 +109,7 @@ public class UtilsTest {
     Utils.unTar(tis, dst);
 
     // ASSERT
-    Mockito.verify(dst, Mockito.times(1)).mkdirs();
+    assertThat(Files.isDirectory(dst)).isTrue();
   }
 
   @Test
@@ -118,7 +117,7 @@ public class UtilsTest {
     // ARRANGE
     TarArchiveInputStream tis = Mockito.mock(TarArchiveInputStream.class);
     TarArchiveEntry entry = Mockito.mock(TarArchiveEntry.class);
-    File dst = Mockito.mock(File.class);
+    Path dst = root.resolve("untar-dir-repeated");
 
     Mockito.when(tis.getNextTarEntry())
         .thenReturn(entry)
@@ -131,6 +130,6 @@ public class UtilsTest {
     Utils.unTar(tis, dst);
 
     // ASSERT
-    Mockito.verify(dst, Mockito.times(3)).mkdirs();
+    assertThat(Files.isDirectory(dst)).isTrue();
   }
 }


### PR DESCRIPTION
…tStream/newOutputStream

Enables the PMD AvoidFileStream rule and fixes all 6 violations. The legacy File stream classes have a finalizer that adds GC overhead; the NIO alternatives avoid this.