### PR TITLE
fix: action deduplication bypass in mergeOrSchedule loop

### DIFF
--- a/src/main/java/build/buildfarm/instance/shard/ServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ServerInstance.java
@@ -2427,7 +2427,7 @@ public class ServerInstance extends NodeInstance {
           return immediateFailedFuture(
               Status.RESOURCE_EXHAUSTED.withDescription("Too many jobs pending").asException());
         }
-        ignoreMerge = ignoreMerge || lookupAttempts != 0;
+        ignoreMerge = ignoreMerge || lookupAttempts == 0;
         execution =
             schedule(
                 actionDigest,

--- a/src/test/java/build/buildfarm/instance/shard/ServerInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/shard/ServerInstanceTest.java
@@ -862,7 +862,8 @@ public class ServerInstanceTest {
         .prequeue(any(ExecuteEntry.class), any(Operation.class), eq(true));
     // Verify the second iteration merged onto the winner's execution.
     verify(mockBackplane, times(2)).mergeExecution(actionKey);
-    verify(mockBackplane, times(1)).watchExecution(eq(winnerExecution.getName()), any(Watcher.class));
+    verify(mockBackplane, times(1))
+        .watchExecution(eq(winnerExecution.getName()), any(Watcher.class));
   }
 
   @Test

--- a/src/test/java/build/buildfarm/instance/shard/ServerInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/shard/ServerInstanceTest.java
@@ -825,6 +825,47 @@ public class ServerInstanceTest {
   }
 
   @Test
+  public void executeRetriesMergeWhenPrequeueLosesRace() throws Exception {
+    when(mockBackplane.canPrequeue()).thenReturn(true);
+
+    build.buildfarm.v1test.Digest actionDigest =
+        build.buildfarm.v1test.Digest.newBuilder().setHash("raced-action").setSize(10).build();
+    ActionKey actionKey = DigestUtil.asActionKey(actionDigest);
+
+    // First mergeExecution returns null (no existing execution yet — both servers see empty state).
+    // Second mergeExecution returns the winner's operation (the other server won the NX race).
+    Operation winnerExecution = Operation.newBuilder().setName("winner-execution").build();
+    when(mockBackplane.mergeExecution(actionKey)).thenReturn(null).thenReturn(winnerExecution);
+
+    // prequeue returns false on the first attempt, simulating losing the SET NX race.
+    when(mockBackplane.prequeue(any(ExecuteEntry.class), any(Operation.class), eq(false)))
+        .thenReturn(false);
+
+    SettableFuture<Void> future = SettableFuture.create();
+    when(mockBackplane.watchExecution(eq(winnerExecution.getName()), any(Watcher.class)))
+        .thenReturn(future);
+
+    Watcher mockWatcher = mock(Watcher.class);
+    instance.execute(
+        actionDigest,
+        /* skipCacheLookup= */ false,
+        ExecutionPolicy.getDefaultInstance(),
+        ResultsCachePolicy.getDefaultInstance(),
+        RequestMetadata.getDefaultInstance(),
+        /* watcher= */ mockWatcher);
+
+    // Verify prequeue was called exactly once with ignoreMerge=false (not forced through).
+    verify(mockBackplane, times(1))
+        .prequeue(any(ExecuteEntry.class), any(Operation.class), eq(false));
+    // Verify prequeue was never called with ignoreMerge=true (the bug would cause this).
+    verify(mockBackplane, never())
+        .prequeue(any(ExecuteEntry.class), any(Operation.class), eq(true));
+    // Verify the second iteration merged onto the winner's execution.
+    verify(mockBackplane, times(2)).mergeExecution(actionKey);
+    verify(mockBackplane, times(1)).watchExecution(eq(winnerExecution.getName()), any(Watcher.class));
+  }
+
+  @Test
   public void requeueFailsOnMissingDirectory() throws Exception {
     String operationName = "missing-directory-operation";
 


### PR DESCRIPTION
Fix a bug in ServerInstance.mergeOrSchedule() where the `ignoreMerge` flag was incorrectly set to `true` on the very first scheduling attempt, effectively disabling action deduplication for concurrent Execute requests. We regularly saw identical action digest hashes be scheduled and executed.

Full disclosure: This issue was found and fixed by claude code. I have not yet tested it in our buildfarm deployment, but the logic seems pretty straight forward to follow, so I figured I'd open this PR now. I'll update this PR as we test and evaluate in our deployment.

## Root cause

Line 2431 had:

    ignoreMerge = ignoreMerge || lookupAttempts != 0;

The while loop condition `lookupAttempts-- != 0` decrements *before* the loop body runs, so on the first iteration `lookupAttempts` is already 4 (decremented from 5). Since `4 != 0` is true, `ignoreMerge` was set to `true` immediately.

When `ignoreMerge=true` is passed to `schedule()` -> `prequeue()`, the clause in RedisShardBackplane.prequeue():

    if (state.executions.create(...) || ignoreMerge) { ... }

allows the operation onto the prequeue even when `create()` returns false (i.e., another server already claimed this action key via SET NX). This defeats the atomic Redis SET NX dedup protection.

## How duplicates occur with multiple server replicas

With N server replicas behind a gRPC load balancer, two Execute RPCs for the same action digest can hit different servers nearly simultaneously:

    Server A (replica 1)                    Server B (replica 7)
    ─────────────────                       ─────────────────
    Execute(action=abc123)                  Execute(action=abc123)
      │                                       │
      ├─ mergeExecution() → null              ├─ mergeExecution() → null
      │  (nothing in Redis yet)               │  (nothing in Redis yet)
      │                                       │
      ├─ ignoreMerge = true  (BUG)            ├─ ignoreMerge = true  (BUG)
      │                                       │
      ├─ schedule(ignoreMerge=true)           ├─ schedule(ignoreMerge=true)
      │  ├─ SET NX Action:abc123 → OK         │  ├─ SET NX Action:abc123 → FAIL
      │  ├─ prequeue.offer() → queued         │  ├─ || ignoreMerge → TRUE
      │                                       │  ├─ prequeue.offer() → DUPLICATE
      │                                       │
      ▼                                       ▼
      Worker X executes action                Worker Y executes SAME action

The correct behavior (after fix) is: Server B's prequeue() returns false because create() fails and ignoreMerge is false, schedule() returns null, and the retry loop calls mergeExecution() again — which now finds Server A's operation and merges onto it.

## Fix

Change `!= 0` to `== 0` so that `ignoreMerge` is only forced to `true` on the *last* retry attempt (when lookupAttempts has been exhausted), as a fallback to avoid returning RESOURCE_EXHAUSTED. The first 4 iterations now properly rely on the SET NX atomic check for deduplication.

## Test

Add `executeRetriesMergeWhenPrequeueLosesRace` to ServerInstanceTest which simulates the race: mergeExecution returns null, prequeue returns false (NX race lost), then verifies the retry merges onto the winner's operation instead of forcing through with ignoreMerge=true.