### PR TITLE
Update rules_cc because rules_cc 0.1.0 was pulled

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,7 +16,7 @@ bazel_dep(name = "grpc-proto", version = "0.0.0-20240627-ec30f58", repo_name = "
 bazel_dep(name = "hermetic_cc_toolchain", version = "3.1.1")
 bazel_dep(name = "platforms", version = "0.0.11")
 bazel_dep(name = "protobuf", version = "29.0-rc3")
-bazel_dep(name = "rules_cc", version = "0.1.0")
+bazel_dep(name = "rules_cc", version = "0.1.1")
 bazel_dep(name = "rules_go", version = "0.51.0")
 bazel_dep(name = "rules_java", version = "8.6.3")
 bazel_dep(name = "rules_jvm_external", version = "6.6")


### PR DESCRIPTION
Addresses this error;

```
Query command output: ERROR: Error computing the main repository mapping: Yanked version detected in your resolved dependency graph: rules_cc@0.1.0, for the reason: rules_cc 0.1.0 is yanked due to incompatible change (prematurely removing cc_proto_library from defs.bzl), please upgrade to 0.1.1.
```