### PR TITLE
Make action cache size configurable and set default equal to other server caches

### DIFF
--- a/_site/docs/configuration/configuration.md
+++ b/_site/docs/configuration/configuration.md
@@ -127,6 +127,7 @@ server:
 | commandCacheMaxEntries                | Long, _64 * 1024_             | The max number of entries that the command cache will hold.          |
 | digestToActionCacheMaxEntries         | Long, _64 * 1024_             | The max number of entries that the digest-to-action cache will hold. |
 | recentServedExecutionsCacheMaxEntries | Long, _64 * 1024_             | The max number of entries that the executions cache will hold.       |
+| actionCacheMaxEntries                 | Long, _1000000_               | The max number of entries that the action cache will hold.           |
 
 Example:
 
@@ -137,6 +138,7 @@ server:
     commandCacheMaxEntries: 10000
     digestToActionCacheMaxEntries: 10000
     recentServedExecutionsCacheMaxEntries: 10000
+    actionCacheMaxEntries: 10000
 ```
 
 ### Admin

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -42,6 +42,7 @@ server:
     commandCacheMaxEntries: 10000
     digestToActionCacheMaxEntries: 10000
     recentServedExecutionsCacheMaxEntries: 10000
+    actionCacheMaxEntries: 10000
   admin:
     deploymentEnvironment: AWS
     clusterEndpoint: grpc://localhost

--- a/src/main/java/build/buildfarm/actioncache/ShardActionCache.java
+++ b/src/main/java/build/buildfarm/actioncache/ShardActionCache.java
@@ -37,7 +37,7 @@ public class ShardActionCache implements ActionCache {
   private final AsyncLoadingCache<ActionKey, ActionResult> actionResultCache;
 
   public ShardActionCache(
-      int maxLocalCacheSize, Backplane backplane, ListeningExecutorService service) {
+      long maxLocalCacheSize, Backplane backplane, ListeningExecutorService service) {
     this.backplane = backplane;
 
     AsyncCacheLoader<ActionKey, ActionResult> loader =

--- a/src/main/java/build/buildfarm/common/config/ServerCacheConfigs.java
+++ b/src/main/java/build/buildfarm/common/config/ServerCacheConfigs.java
@@ -52,4 +52,11 @@ public class ServerCacheConfigs {
    * @details This will not dictate the max memory used.
    */
   private long recentServedExecutionsCacheMaxEntries = 64 * 1024;
+
+  /**
+   * @field actionCacheMaxEntries
+   * @brief The max number of entries that the action cache will hold.
+   * @details This will not dictate the max memory used.
+   */
+  private long actionCacheMaxEntries = 1_000_000;
 }

--- a/src/main/java/build/buildfarm/instance/shard/ServerInstance.java
+++ b/src/main/java/build/buildfarm/instance/shard/ServerInstance.java
@@ -191,8 +191,6 @@ public class ServerInstance extends NodeInstance {
   private static final String TIMEOUT_OUT_OF_BOUNDS =
       "A timeout specified is out of bounds with a configured range";
 
-  private static final int DEFAULT_MAX_LOCAL_ACTION_CACHE_SIZE = 1000000;
-
   private static final int TRANSFORM_TOKENS = 256;
 
   // Prometheus metrics
@@ -329,7 +327,9 @@ public class ServerInstance extends NodeInstance {
         name,
         backplane,
         new ShardActionCache(
-            DEFAULT_MAX_LOCAL_ACTION_CACHE_SIZE, backplane, actionCacheFetchService),
+            configs.getServer().getCaches().getActionCacheMaxEntries(),
+            backplane,
+            actionCacheFetchService),
         configs.getServer().isRunDispatchedMonitor(),
         configs.getServer().getDispatchedMonitorIntervalSeconds(),
         configs.getServer().isRunOperationQueuer(),

--- a/src/test/java/build/buildfarm/actioncache/BUILD
+++ b/src/test/java/build/buildfarm/actioncache/BUILD
@@ -1,0 +1,19 @@
+load("@rules_java//java:java_test.bzl", "java_test")
+
+java_test(
+    name = "ShardActionCacheTest",
+    size = "small",
+    srcs = ["ShardActionCacheTest.java"],
+    test_class = "build.buildfarm.AllTests",
+    deps = [
+        "//src/main/java/build/buildfarm/actioncache",
+        "//src/main/java/build/buildfarm/backplane",
+        "//src/main/java/build/buildfarm/common",
+        "//src/main/protobuf/build/buildfarm/v1test:buildfarm_java_proto",
+        "//src/test/java/build/buildfarm:test_runner",
+        "@buildfarm_maven//:com_google_guava_guava",
+        "@buildfarm_maven//:com_google_truth_truth",
+        "@buildfarm_maven//:org_mockito_mockito_core",
+        "@remoteapis//build/bazel/remote/execution/v2:remote_execution_java_proto",
+    ],
+)

--- a/src/test/java/build/buildfarm/actioncache/ShardActionCacheTest.java
+++ b/src/test/java/build/buildfarm/actioncache/ShardActionCacheTest.java
@@ -1,0 +1,117 @@
+// Copyright 2026 The Buildfarm Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.actioncache;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import build.bazel.remote.execution.v2.ActionResult;
+import build.bazel.remote.execution.v2.OutputFile;
+import build.buildfarm.backplane.Backplane;
+import build.buildfarm.common.DigestUtil;
+import build.buildfarm.common.DigestUtil.ActionKey;
+import build.buildfarm.v1test.Digest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+@RunWith(JUnit4.class)
+public class ShardActionCacheTest {
+  private static final ActionKey KEY_A = key("a");
+  private static final ActionResult RESULT_A = result("a");
+
+  @Mock private Backplane backplane;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test
+  public void getShouldLoadFromBackplaneAndCacheResultWhenCacheMisses() throws Exception {
+    when(backplane.getActionResult(KEY_A)).thenReturn(RESULT_A);
+    ShardActionCache cache = newCache(/* maxEntries= */ 10L);
+
+    // First get reaches the backplane and caches; second get for the same key uses the cache.
+    assertThat(cache.get(KEY_A).get()).isEqualTo(RESULT_A);
+    assertThat(cache.get(KEY_A).get()).isEqualTo(RESULT_A);
+
+    verify(backplane, times(1)).getActionResult(KEY_A);
+  }
+
+  @Test
+  public void invalidateShouldRemoveEntryAndForceReloadFromBackplane() throws Exception {
+    when(backplane.getActionResult(KEY_A)).thenReturn(RESULT_A);
+    ShardActionCache cache = newCache(/* maxEntries= */ 10L);
+
+    // First get reaches backplane, then invalidate, then get again reaches backplane again.
+    cache.get(KEY_A).get();
+    cache.invalidate(KEY_A);
+    cache.get(KEY_A).get();
+
+    verify(backplane, times(2)).getActionResult(KEY_A);
+  }
+
+  @Test
+  public void readThroughShouldWriteLocalCacheOnlyAndNeverCallBackplane() throws Exception {
+    ShardActionCache cache = newCache(/* maxEntries= */ 10L);
+
+    // Puts the key in the cache and doesn't contact the backplane.
+    cache.readThrough(KEY_A, RESULT_A);
+    assertThat(cache.get(KEY_A).get()).isEqualTo(RESULT_A);
+
+    verify(backplane, never()).putActionResult(any(), any());
+    verify(backplane, never()).getActionResult(any());
+  }
+
+  @Test
+  public void readThroughShouldEvictOldEntriesAndReloadFromBackplaneWhenCapExceeded()
+      throws Exception {
+    when(backplane.getActionResult(KEY_A)).thenReturn(RESULT_A);
+    ShardActionCache cache = newCache(/* maxEntries= */ 10L);
+
+    cache.readThrough(KEY_A, RESULT_A);
+    for (int i = 0; i < 100; i++) {
+      cache.readThrough(key("filler-" + i), result("filler-" + i));
+    }
+
+    cache.get(KEY_A).get();
+
+    // Make sure the key is fetched from the backplane after being evicted due to cache size.
+    verify(backplane, times(1)).getActionResult(KEY_A);
+  }
+
+  private ShardActionCache newCache(long maxEntries) {
+    return new ShardActionCache(maxEntries, backplane, newDirectExecutorService());
+  }
+
+  private static ActionKey key(String hash) {
+    return DigestUtil.asActionKey(Digest.newBuilder().setHash(hash).setSize(1).build());
+  }
+
+  private static ActionResult result(String tag) {
+    return ActionResult.newBuilder()
+        .addOutputFiles(OutputFile.newBuilder().setPath(tag).build())
+        .build();
+  }
+}

--- a/src/test/java/build/buildfarm/instance/shard/ServerInstanceTest.java
+++ b/src/test/java/build/buildfarm/instance/shard/ServerInstanceTest.java
@@ -152,7 +152,7 @@ public class ServerInstanceTest {
   public void setUp() throws IOException, InterruptedException {
     MockitoAnnotations.initMocks(this);
     blobDigests = Maps.newHashMap();
-    ActionCache actionCache = new ShardActionCache(10, mockBackplane, newDirectExecutorService());
+    ActionCache actionCache = new ShardActionCache(10L, mockBackplane, newDirectExecutorService());
     instance =
         new ServerInstance(
             "shard",


### PR DESCRIPTION
After the action merging fix from #2556 was applied to our Buildfarm cluster we started running into OOMs on our Buildfarm servers. We were seeing a heap usage pattern akin to a memory leak. A heap dump showed that the `ShardActionCache` was using roughly 18 GB of heap with ~921k entries. The cache never hit its max entries of 1,000,000, so memory usage kept climbing.

Best I can tell when an action merge occurs a cache invalidation for the action cache doesn't occur because `schedule()` isn't called. Looking at heap usage from before the action merging fix it looks like we were seeing a similar problem. However, it was happening much more slowly because action merging was happening far less often.

This change makes the `ShardActionCache` size configurable and sets its default to the same size as the other server caches.

This change also adds a handful of `ShardActionCache` tests.

We've deployed this change to our Buildfarm cluster and it resolved our issue. Action merging has continued working with this change applied.

Here's JVM heap usage on our servers before this change with the problematic heap usage:
<img width="2516" height="1035" alt="image" src="https://github.com/user-attachments/assets/533d6a45-fd4d-4fe7-9401-144c769dd513" />

Here's JVM heap usage with this change deployed to one server. The yellow line has the change applied and its heap looks healthy:
<img width="2516" height="1058" alt="image" src="https://github.com/user-attachments/assets/dd5b32e1-e94e-46f4-bca9-4c0c700949d9" />

Here's the JVM heap usage on our servers with this change deployed to all servers. The heap usage no longer is problematic:
<img width="2516" height="1058" alt="image" src="https://github.com/user-attachments/assets/457cd0e8-3f2b-4e0a-ae6d-da5f4f65d3c4" />