### PR TITLE
Ignore output_paths specified as linkable input dirs

### DIFF
--- a/src/main/java/build/buildfarm/worker/CFCExecFileSystem.java
+++ b/src/main/java/build/buildfarm/worker/CFCExecFileSystem.java
@@ -27,15 +27,12 @@ import static com.google.common.util.concurrent.MoreExecutors.listeningDecorator
 import static com.google.common.util.concurrent.MoreExecutors.shutdownAndAwaitTermination;
 import static java.util.concurrent.TimeUnit.MINUTES;
 
-import build.bazel.remote.execution.v2.Action;
 import build.bazel.remote.execution.v2.Command;
 import build.bazel.remote.execution.v2.Compressor;
-import build.bazel.remote.execution.v2.DigestFunction;
 import build.bazel.remote.execution.v2.Directory;
 import build.buildfarm.cas.ContentAddressableStorage;
 import build.buildfarm.cas.cfc.CASFileCache;
 import build.buildfarm.cas.cfc.CASFileCache.PathResult;
-import build.buildfarm.common.DigestUtil;
 import build.buildfarm.common.io.Directories;
 import build.buildfarm.common.io.Dirent;
 import build.buildfarm.v1test.Digest;
@@ -340,8 +337,7 @@ public class CFCExecFileSystem implements ExecFileSystem {
   public Path createExecDir(
       String operationName,
       Map<build.bazel.remote.execution.v2.Digest, Directory> directoriesIndex,
-      DigestFunction.Value digestFunction,
-      Action action,
+      Digest inputRootDigest,
       Command command,
       @Nullable UserPrincipal owner,
       WorkerExecutedMetadata.Builder workerExecutedMetadata)
@@ -354,8 +350,7 @@ public class CFCExecFileSystem implements ExecFileSystem {
     log.log(Level.FINER, operationName + " walking execTree");
     ExecTree execTree = new ExecTree(directoriesIndex);
     ExecFileVisitor visitor = new ExecFileVisitor(workerExecutedMetadata);
-    execTree.walk(
-        execDir, DigestUtil.fromDigest(action.getInputRootDigest(), digestFunction), visitor);
+    execTree.walk(execDir, inputRootDigest, visitor);
 
     // TODO refactor into single future that produces all exceptions in a list
     Iterable<ListenableFuture<Void>> fetchedFutures = visitor.futures();

--- a/src/main/java/build/buildfarm/worker/CFCLinkExecFileSystem.java
+++ b/src/main/java/build/buildfarm/worker/CFCLinkExecFileSystem.java
@@ -22,7 +22,6 @@ import static com.google.common.util.concurrent.Futures.transformAsync;
 import static com.google.common.util.concurrent.MoreExecutors.listeningDecorator;
 import static java.util.Collections.synchronizedList;
 
-import build.bazel.remote.execution.v2.Action;
 import build.bazel.remote.execution.v2.Command;
 import build.bazel.remote.execution.v2.DigestFunction;
 import build.bazel.remote.execution.v2.Directory;
@@ -162,53 +161,79 @@ public class CFCLinkExecFileSystem extends CFCExecFileSystem {
     }
   }
 
-  private static Iterator<String> directoriesIterator(
-      build.bazel.remote.execution.v2.Digest digest,
-      Map<build.bazel.remote.execution.v2.Digest, Directory> directoriesIndex) {
-    Directory root = directoriesIndex.get(digest);
-    return new Iterator<>() {
-      boolean atEnd = root.getDirectoriesCount() == 0;
-      Stack<String> path = new Stack<>();
-      Stack<Iterator<DirectoryNode>> route = new Stack<>();
-      Iterator<DirectoryNode> current = root.getDirectoriesList().iterator();
+  private static final class DirectoryIterator implements Iterator<String> {
+    private final Map<build.bazel.remote.execution.v2.Digest, Directory> directoriesIndex;
+    private final Set<String> ignorePaths;
+    private Iterator<DirectoryNode> current;
+    private Stack<Iterator<DirectoryNode>> route = new Stack<>();
+    private Stack<String> path = new Stack<>();
+    private DirectoryNode next;
 
-      @Override
-      public boolean hasNext() {
-        return !atEnd;
-      }
+    DirectoryIterator(
+        Directory root,
+        Map<build.bazel.remote.execution.v2.Digest, Directory> directoriesIndex,
+        Set<String> ignorePaths) {
+      this.directoriesIndex = directoriesIndex;
+      this.ignorePaths = ignorePaths;
+      current = root.getDirectoriesList().iterator();
+      advance("");
+    }
 
-      @Override
-      public String next() {
-        String nextPath;
+    @Override
+    public boolean hasNext() {
+      return next != null;
+    }
+
+    private void advance(String prefix) {
+      next = null;
+      while (current.hasNext()) {
         DirectoryNode next = current.next();
-        String name = next.getName();
-        path.push(name);
-        nextPath = String.join("/", path);
-        build.bazel.remote.execution.v2.Digest digest = next.getDigest();
-        if (digest.getSizeBytes() != 0) {
-          route.push(current);
-          current = directoriesIndex.get(digest).getDirectoriesList().iterator();
-        } else {
-          path.pop();
+        if (!ignorePaths.contains(prefix + next.getName())) {
+          this.next = next;
+          return;
         }
-        while (!current.hasNext() && !route.isEmpty()) {
+      }
+    }
+
+    @Override
+    public String next() {
+      String nextPath;
+      String name = next.getName();
+      path.push(name);
+      nextPath = String.join("/", path);
+      build.bazel.remote.execution.v2.Digest digest = next.getDigest();
+      if (digest.getSizeBytes() != 0) {
+        route.push(current);
+        current = directoriesIndex.get(digest).getDirectoriesList().iterator();
+        // nextPath guaranteed to be non-empty
+        advance(nextPath + "/");
+        if (!current.hasNext()) {
           current = route.pop();
           path.pop();
         }
-        atEnd = !current.hasNext();
-        return nextPath;
+      } else {
+        path.pop();
       }
-    };
+      while (!current.hasNext() && !route.isEmpty()) {
+        current = route.pop();
+        path.pop();
+        String prefix = path.isEmpty() ? "" : (String.join("/", path) + "/");
+        advance(prefix);
+      }
+      return nextPath;
+    }
   }
 
   private Set<String> linkedDirectories(
       Map<build.bazel.remote.execution.v2.Digest, Directory> directoriesIndex,
-      build.bazel.remote.execution.v2.Digest rootDigest) {
+      build.bazel.remote.execution.v2.Digest rootDigest,
+      Set<String> ignorePaths) {
     // skip this search if all the directories are real
     if (linkInputDirectories) {
       ImmutableSet.Builder<String> builder = ImmutableSet.builder();
 
-      Iterator<String> dirs = directoriesIterator(rootDigest, directoriesIndex);
+      Directory root = directoriesIndex.get(rootDigest);
+      Iterator<String> dirs = new DirectoryIterator(root, directoriesIndex, ignorePaths);
       while (dirs.hasNext()) {
         String dir = dirs.next();
         for (Pattern pattern : linkedInputDirectories) {
@@ -358,13 +383,11 @@ public class CFCLinkExecFileSystem extends CFCExecFileSystem {
   public Path createExecDir(
       String operationName,
       Map<build.bazel.remote.execution.v2.Digest, Directory> directoriesIndex,
-      DigestFunction.Value digestFunction,
-      Action action,
+      Digest inputRootDigest,
       Command command,
       @Nullable UserPrincipal owner,
       WorkerExecutedMetadata.Builder workerExecutedMetadata)
       throws IOException, InterruptedException {
-    Digest inputRootDigest = DigestUtil.fromDigest(action.getInputRootDigest(), digestFunction);
     OutputDirectory outputDirectory = createOutputDirectory(command);
 
     Path execDir = root().resolve(operationName);
@@ -373,11 +396,15 @@ public class CFCLinkExecFileSystem extends CFCExecFileSystem {
     }
     Files.createDirectories(execDir);
 
+    // output_paths should never be linked themselves, and their output path chain
+    // will terminate at their parent, making them appear valid for some selections
+    Set<String> ignorePaths = ImmutableSet.copyOf(command.getOutputPathsList());
     Set<Path> linkedInputDirectories =
         linkInputDirectories
             ? ImmutableSet.copyOf(
                 Iterables.transform(
-                    linkedDirectories(directoriesIndex, DigestUtil.toDigest(inputRootDigest)),
+                    linkedDirectories(
+                        directoriesIndex, DigestUtil.toDigest(inputRootDigest), ignorePaths),
                     execDir::resolve))
             : ImmutableSet.of(); // does this work on windows with / separators?
 
@@ -430,12 +457,12 @@ public class CFCLinkExecFileSystem extends CFCExecFileSystem {
     } finally {
       if (!success) {
         fileCache.decrementReferences(
-            visitor.inputFiles(), visitor.inputDirectories(), digestFunction);
+            visitor.inputFiles(), visitor.inputDirectories(), inputRootDigest.getDigestFunction());
         Directories.remove(execDir, fileStore);
       }
     }
 
-    rootInputDigestFunction.put(execDir, digestFunction);
+    rootInputDigestFunction.put(execDir, inputRootDigest.getDigestFunction());
     rootInputFiles.put(execDir, visitor.inputFiles());
     rootInputDirectories.put(execDir, visitor.inputDirectories());
 

--- a/src/main/java/build/buildfarm/worker/ExecFileSystem.java
+++ b/src/main/java/build/buildfarm/worker/ExecFileSystem.java
@@ -14,9 +14,7 @@
 
 package build.buildfarm.worker;
 
-import build.bazel.remote.execution.v2.Action;
 import build.bazel.remote.execution.v2.Command;
-import build.bazel.remote.execution.v2.DigestFunction;
 import build.bazel.remote.execution.v2.Directory;
 import build.buildfarm.cas.ContentAddressableStorage;
 import build.buildfarm.common.InputStreamFactory;
@@ -49,8 +47,7 @@ public interface ExecFileSystem extends InputStreamFactory {
   Path createExecDir(
       String operationName,
       Map<build.bazel.remote.execution.v2.Digest, Directory> directoriesIndex,
-      DigestFunction.Value digestFunction,
-      Action action,
+      Digest inputRootDigest,
       Command command,
       @Nullable UserPrincipal owner,
       WorkerExecutedMetadata.Builder workerExecutedMetadata)

--- a/src/main/java/build/buildfarm/worker/InputFetcher.java
+++ b/src/main/java/build/buildfarm/worker/InputFetcher.java
@@ -23,6 +23,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import build.bazel.remote.execution.v2.Action;
 import build.bazel.remote.execution.v2.Command;
 import build.bazel.remote.execution.v2.Digest;
+import build.bazel.remote.execution.v2.DigestFunction;
 import build.bazel.remote.execution.v2.Directory;
 import build.bazel.remote.execution.v2.DirectoryNode;
 import build.bazel.remote.execution.v2.ExecutedActionMetadata;
@@ -242,12 +243,15 @@ public class InputFetcher implements Runnable {
 
       directoriesIndex = new ProxyDirectoriesIndex(queuedOperation.getTree().getDirectoriesMap());
 
+      DigestFunction.Value digestFunction =
+          executionContext.queueEntry.getExecuteEntry().getActionDigest().getDigestFunction();
+      build.buildfarm.v1test.Digest inputRootDigest =
+          DigestUtil.fromDigest(queuedOperation.getAction().getInputRootDigest(), digestFunction);
       execDir =
           workerContext.createExecDir(
               executionName,
               directoriesIndex,
-              executionContext.queueEntry.getExecuteEntry().getActionDigest().getDigestFunction(),
-              queuedOperation.getAction(),
+              inputRootDigest,
               queuedOperation.getCommand(),
               executionContext.claim.owner(),
               executionContext.workerExecutedMetadata);

--- a/src/main/java/build/buildfarm/worker/WorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/WorkerContext.java
@@ -14,11 +14,9 @@
 
 package build.buildfarm.worker;
 
-import build.bazel.remote.execution.v2.Action;
 import build.bazel.remote.execution.v2.ActionResult;
 import build.bazel.remote.execution.v2.Command;
 import build.bazel.remote.execution.v2.Digest;
-import build.bazel.remote.execution.v2.DigestFunction;
 import build.bazel.remote.execution.v2.Directory;
 import build.bazel.remote.execution.v2.ExecutionStage;
 import build.buildfarm.common.DigestUtil.ActionKey;
@@ -100,8 +98,7 @@ public interface WorkerContext {
   Path createExecDir(
       String operationName,
       Map<Digest, Directory> directoriesIndex,
-      DigestFunction.Value digestFunction,
-      Action action,
+      build.buildfarm.v1test.Digest inputRootDigest,
       Command command,
       @Nullable UserPrincipal owner,
       WorkerExecutedMetadata.Builder workerExecutedMetadata)

--- a/src/main/java/build/buildfarm/worker/shard/FuseExecFileSystem.java
+++ b/src/main/java/build/buildfarm/worker/shard/FuseExecFileSystem.java
@@ -16,13 +16,10 @@ package build.buildfarm.worker.shard;
 
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 
-import build.bazel.remote.execution.v2.Action;
 import build.bazel.remote.execution.v2.Command;
 import build.bazel.remote.execution.v2.Compressor;
-import build.bazel.remote.execution.v2.DigestFunction;
 import build.bazel.remote.execution.v2.Directory;
 import build.buildfarm.cas.ContentAddressableStorage;
-import build.buildfarm.common.DigestUtil;
 import build.buildfarm.v1test.Digest;
 import build.buildfarm.v1test.WorkerExecutedMetadata;
 import build.buildfarm.worker.ExecFileSystem;
@@ -84,15 +81,13 @@ class FuseExecFileSystem implements ExecFileSystem {
   public Path createExecDir(
       String operationName,
       Map<build.bazel.remote.execution.v2.Digest, Directory> directoriesIndex,
-      DigestFunction.Value digestFunction,
-      Action action,
+      Digest inputRootDigest,
       Command command,
       UserPrincipal owner,
       WorkerExecutedMetadata.Builder workerExecutedMetadata)
       throws IOException, InterruptedException {
     // FIXME insist that the FUSE perform permission checks against the owner
-    fuseCAS.createInputRoot(
-        operationName, DigestUtil.fromDigest(action.getInputRootDigest(), digestFunction));
+    fuseCAS.createInputRoot(operationName, inputRootDigest);
     return root.resolve(operationName);
   }
 

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -21,11 +21,9 @@ import static build.buildfarm.common.Errors.VIOLATION_TYPE_MISSING;
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.DAYS;
 
-import build.bazel.remote.execution.v2.Action;
 import build.bazel.remote.execution.v2.ActionResult;
 import build.bazel.remote.execution.v2.Command;
 import build.bazel.remote.execution.v2.Compressor;
-import build.bazel.remote.execution.v2.DigestFunction;
 import build.bazel.remote.execution.v2.Directory;
 import build.bazel.remote.execution.v2.ExecutionStage;
 import build.bazel.remote.execution.v2.Platform;
@@ -822,20 +820,13 @@ class ShardWorkerContext implements WorkerContext {
   public Path createExecDir(
       String operationName,
       Map<build.bazel.remote.execution.v2.Digest, Directory> directoriesIndex,
-      DigestFunction.Value digestFunction,
-      Action action,
+      Digest inputRootDigest,
       Command command,
       @Nullable UserPrincipal owner,
       WorkerExecutedMetadata.Builder workerExecutedMetadata)
       throws IOException, InterruptedException {
     return execFileSystem.createExecDir(
-        operationName,
-        directoriesIndex,
-        digestFunction,
-        action,
-        command,
-        owner,
-        workerExecutedMetadata);
+        operationName, directoriesIndex, inputRootDigest, command, owner, workerExecutedMetadata);
   }
 
   // might want to split for removeDirectory and decrement references to avoid removing for streamed

--- a/src/test/java/build/buildfarm/worker/CFCLinkExecFileSystemTest.java
+++ b/src/test/java/build/buildfarm/worker/CFCLinkExecFileSystemTest.java
@@ -1,0 +1,182 @@
+// Copyright 2026 The Buildfarm Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.worker;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import build.bazel.remote.execution.v2.Command;
+import build.bazel.remote.execution.v2.Directory;
+import build.bazel.remote.execution.v2.DirectoryNode;
+import build.bazel.remote.execution.v2.FileNode;
+import build.buildfarm.cas.cfc.CASFileCache;
+import build.buildfarm.cas.cfc.CASFileCache.PathResult;
+import build.buildfarm.common.DigestUtil;
+import build.buildfarm.common.DigestUtil.HashFunction;
+import build.buildfarm.v1test.Digest;
+import build.buildfarm.v1test.WorkerExecutedMetadata;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class CFCLinkExecFileSystemTest {
+  private static final DigestUtil DIGEST_UTIL = new DigestUtil(HashFunction.SHA256);
+
+  @Test
+  public void createExecDirDoesNotLinkOutputPath() throws Exception {
+    // larger scale test:
+    //   validates that linkedDirectories ignores as requested
+    //   ensures no symlink is created for a matching input directory (regardless of content) for
+    //      an output_path
+    String inputOutputPath = "path/to/input";
+    Command command = Command.newBuilder().addOutputPaths(inputOutputPath).build();
+    // path
+    // |_ to
+    //    |_ input <-- output_path
+    //       |_ sub <-- should also be real
+    //          |_ *file
+    Digest fileDigest =
+        DIGEST_UTIL.toDigest(
+            build.bazel.remote.execution.v2.Digest.newBuilder()
+                .setHash("file-hash")
+                .setSizeBytes(1)
+                .build());
+    Directory subDirectory =
+        Directory.newBuilder()
+            .addFiles(
+                FileNode.newBuilder()
+                    .setName("file")
+                    .setIsExecutable(true)
+                    .setDigest(DigestUtil.toDigest(fileDigest))
+                    .build())
+            .build();
+    Digest subDigest = DIGEST_UTIL.compute(subDirectory);
+    Directory inputDirectory =
+        Directory.newBuilder()
+            .addDirectories(
+                DirectoryNode.newBuilder()
+                    .setName("sub")
+                    .setDigest(DigestUtil.toDigest(subDigest))
+                    .build())
+            .build();
+    Digest inputDigest = DIGEST_UTIL.compute(inputDirectory);
+    Directory toDirectory =
+        Directory.newBuilder()
+            .addDirectories(
+                DirectoryNode.newBuilder()
+                    .setName("input")
+                    .setDigest(DigestUtil.toDigest(inputDigest))
+                    .build())
+            .build();
+    Digest toDigest = DIGEST_UTIL.compute(toDirectory);
+    Directory pathDirectory =
+        Directory.newBuilder()
+            .addDirectories(
+                DirectoryNode.newBuilder()
+                    .setName("to")
+                    .setDigest(DigestUtil.toDigest(toDigest))
+                    .build())
+            .build();
+    Digest pathDigest = DIGEST_UTIL.compute(pathDirectory);
+    Directory inputRootDirectory =
+        Directory.newBuilder()
+            .addDirectories(
+                DirectoryNode.newBuilder()
+                    .setName("path")
+                    .setDigest(DigestUtil.toDigest(pathDigest))
+                    .build())
+            .build();
+    Digest inputRootDigest = DIGEST_UTIL.compute(inputRootDirectory);
+    Map<build.bazel.remote.execution.v2.Digest, Directory> directoriesIndex =
+        ImmutableMap.of(
+            DigestUtil.toDigest(inputRootDigest), inputRootDirectory,
+            DigestUtil.toDigest(pathDigest), pathDirectory,
+            DigestUtil.toDigest(toDigest), toDirectory,
+            DigestUtil.toDigest(inputDigest), inputDirectory,
+            DigestUtil.toDigest(subDigest), subDirectory);
+    Path root =
+        Iterables.getFirst(
+            Jimfs.newFileSystem(
+                    Configuration.unix().toBuilder()
+                        .setAttributeViews("basic", "owner", "posix", "unix")
+                        .build())
+                .getRootDirectories(),
+            null);
+    Path fileEntryPath = root.resolve("cfc-entry-file");
+    byte[] data = new byte[1];
+    data[0] = 'f';
+    Files.write(fileEntryPath, data);
+    CASFileCache cfc = mock(CASFileCache.class);
+    ExecutorService fetchService = newDirectExecutorService();
+    when(cfc.put(fileDigest, true, fetchService))
+        .thenReturn(
+            immediateFuture(new PathResult(root.resolve("cfc-entry-file"), /* isMissed= */ false)));
+    // should not be called, but supply a dir if we do so that we see the unexpected behavior below
+    // in the symlink creation
+    when(cfc.putDirectory(inputDigest, directoriesIndex, fetchService))
+        .thenReturn(
+            immediateFuture(
+                new PathResult(root.resolve("cfc-entry-input"), /* isMissed= */ false)));
+    when(cfc.putDirectory(subDigest, directoriesIndex, fetchService))
+        .thenReturn(
+            immediateFuture(new PathResult(root.resolve("cfc-entry-sub"), /* isMissed= */ false)));
+    CFCLinkExecFileSystem efs =
+        new CFCLinkExecFileSystem(
+            root,
+            cfc,
+            ImmutableMap.of(),
+            /* linkInputDirectories= */ true,
+            ImmutableList.of(".*"),
+            /* allowSymlinkTargetAbsolute= */ false,
+            /* removeDirectoryService= */ null,
+            /* accessRecorder= */ null,
+            fetchService);
+    Path execDir =
+        efs.createExecDir(
+            "outputPathDirOp",
+            directoriesIndex,
+            inputRootDigest,
+            command,
+            /* owner= */ null,
+            WorkerExecutedMetadata.newBuilder());
+
+    // first check: did we create "execDir/path/to/input" as a real dir?
+    assertThat(Files.isDirectory(execDir.resolve(inputOutputPath))).isTrue();
+    // second check: input/sub should also be a real dir
+    assertThat(Files.isDirectory(execDir.resolve(inputOutputPath).resolve("sub"))).isTrue();
+    // no symlinks up the chain
+    assertThat(Files.isDirectory(execDir.resolve("path"))).isTrue();
+    assertThat(Files.isDirectory(execDir.resolve("path/to"))).isTrue();
+    // mock completionism
+    verify(cfc, times(1)).put(fileDigest, true, fetchService);
+    verifyNoMoreInteractions(cfc);
+  }
+}

--- a/src/test/java/build/buildfarm/worker/CFCLinkExecFileSystemTest.java
+++ b/src/test/java/build/buildfarm/worker/CFCLinkExecFileSystemTest.java
@@ -179,4 +179,117 @@ public class CFCLinkExecFileSystemTest {
     verify(cfc, times(1)).put(fileDigest, true, fetchService);
     verifyNoMoreInteractions(cfc);
   }
+
+  // DirectoryIterator constructor calls advance("") and then
+  // unconditionally re-advances `current` in a trailing while loop, so the first
+  // non-ignored root child gets skipped whenever there are >= 2 root children.
+  // Concretely: the linked-directories pattern matches only the second root child,
+  // not the first. If the first child were skipped, putDirectory would never be
+  // requested for the second.
+  @Test
+  public void directoryIteratorDoesNotSkipFirstRootChild() throws Exception {
+    // Two root children "a" and "b". Pattern matches only "b".
+    // No output_paths, so ignorePaths is empty.
+    Command command = Command.newBuilder().build();
+    Digest aFileDigest =
+        DIGEST_UTIL.toDigest(
+            build.bazel.remote.execution.v2.Digest.newBuilder()
+                .setHash("a-file-hash")
+                .setSizeBytes(1)
+                .build());
+    Digest bFileDigest =
+        DIGEST_UTIL.toDigest(
+            build.bazel.remote.execution.v2.Digest.newBuilder()
+                .setHash("b-file-hash")
+                .setSizeBytes(1)
+                .build());
+    Directory aDirectory =
+        Directory.newBuilder()
+            .addFiles(
+                FileNode.newBuilder()
+                    .setName("af")
+                    .setIsExecutable(false)
+                    .setDigest(DigestUtil.toDigest(aFileDigest))
+                    .build())
+            .build();
+    Digest aDigest = DIGEST_UTIL.compute(aDirectory);
+    Directory bDirectory =
+        Directory.newBuilder()
+            .addFiles(
+                FileNode.newBuilder()
+                    .setName("bf")
+                    .setIsExecutable(false)
+                    .setDigest(DigestUtil.toDigest(bFileDigest))
+                    .build())
+            .build();
+    Digest bDigest = DIGEST_UTIL.compute(bDirectory);
+    Directory inputRootDirectory =
+        Directory.newBuilder()
+            .addDirectories(
+                DirectoryNode.newBuilder()
+                    .setName("a")
+                    .setDigest(DigestUtil.toDigest(aDigest))
+                    .build())
+            .addDirectories(
+                DirectoryNode.newBuilder()
+                    .setName("b")
+                    .setDigest(DigestUtil.toDigest(bDigest))
+                    .build())
+            .build();
+    Digest inputRootDigest = DIGEST_UTIL.compute(inputRootDirectory);
+    Map<build.bazel.remote.execution.v2.Digest, Directory> directoriesIndex =
+        ImmutableMap.of(
+            DigestUtil.toDigest(inputRootDigest), inputRootDirectory,
+            DigestUtil.toDigest(aDigest), aDirectory,
+            DigestUtil.toDigest(bDigest), bDirectory);
+    Path root =
+        Iterables.getFirst(
+            Jimfs.newFileSystem(
+                    Configuration.unix().toBuilder()
+                        .setAttributeViews("basic", "owner", "posix", "unix")
+                        .build())
+                .getRootDirectories(),
+            null);
+    Path afEntry = root.resolve("cfc-entry-af");
+    Files.write(afEntry, new byte[] {'a'});
+    Path bfEntry = root.resolve("cfc-entry-bf");
+    Files.write(bfEntry, new byte[] {'b'});
+    CASFileCache cfc = mock(CASFileCache.class);
+    ExecutorService fetchService = newDirectExecutorService();
+    when(cfc.put(aFileDigest, false, fetchService))
+        .thenReturn(immediateFuture(new PathResult(afEntry, /* isMissed= */ false)));
+    when(cfc.put(bFileDigest, false, fetchService))
+        .thenReturn(immediateFuture(new PathResult(bfEntry, /* isMissed= */ false)));
+    when(cfc.putDirectory(aDigest, directoriesIndex, fetchService))
+        .thenReturn(
+            immediateFuture(new PathResult(root.resolve("cfc-entry-a"), /* isMissed= */ false)));
+    when(cfc.putDirectory(bDigest, directoriesIndex, fetchService))
+        .thenReturn(
+            immediateFuture(new PathResult(root.resolve("cfc-entry-b"), /* isMissed= */ false)));
+    CFCLinkExecFileSystem efs =
+        new CFCLinkExecFileSystem(
+            root,
+            cfc,
+            ImmutableMap.of(),
+            /* linkInputDirectories= */ true,
+            // Match only "a" (the first root child). If the iterator skips "a", the
+            // linkedDirectories set will be empty and "a" will be created as a real dir
+            // instead of a symlink.
+            ImmutableList.of("a"),
+            /* allowSymlinkTargetAbsolute= */ false,
+            /* removeDirectoryService= */ null,
+            /* accessRecorder= */ null,
+            fetchService);
+    efs.createExecDir(
+        "iteratorSkipOp",
+        directoriesIndex,
+        inputRootDigest,
+        command,
+        /* owner= */ null,
+        WorkerExecutedMetadata.newBuilder());
+
+    // "a" matched the linked-directories pattern; it should have been linked via
+    // putDirectory. If the constructor double-advance bug skipped "a", this fails.
+    verify(cfc, times(1)).putDirectory(aDigest, directoriesIndex, fetchService);
+  }
 }

--- a/src/test/java/build/buildfarm/worker/InputFetcherTest.java
+++ b/src/test/java/build/buildfarm/worker/InputFetcherTest.java
@@ -23,9 +23,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-import build.bazel.remote.execution.v2.Action;
 import build.bazel.remote.execution.v2.Command;
-import build.bazel.remote.execution.v2.DigestFunction;
 import build.bazel.remote.execution.v2.Directory;
 import build.bazel.remote.execution.v2.ExecuteResponse;
 import build.buildfarm.cas.cfc.PutDirectoryException;
@@ -96,15 +94,14 @@ public class InputFetcherTest {
           public Path createExecDir(
               String operationName,
               Map<build.bazel.remote.execution.v2.Digest, Directory> directoriesIndex,
-              DigestFunction.Value digestFunction,
-              Action action,
+              Digest inputRootDigest,
               Command command,
               UserPrincipal owner,
               WorkerExecutedMetadata.Builder workerExecutedMetadata)
               throws IOException {
             Path root = Path.of(operationName);
             throw new ExecDirException(
-                Path.of(operationName),
+                root,
                 ImmutableList.of(
                     new ViolationException(
                         Digest.getDefaultInstance(),

--- a/src/test/java/build/buildfarm/worker/StubWorkerContext.java
+++ b/src/test/java/build/buildfarm/worker/StubWorkerContext.java
@@ -14,11 +14,9 @@
 
 package build.buildfarm.worker;
 
-import build.bazel.remote.execution.v2.Action;
 import build.bazel.remote.execution.v2.ActionResult;
 import build.bazel.remote.execution.v2.Command;
 import build.bazel.remote.execution.v2.Digest;
-import build.bazel.remote.execution.v2.DigestFunction;
 import build.bazel.remote.execution.v2.Directory;
 import build.bazel.remote.execution.v2.ExecutionStage;
 import build.buildfarm.common.DigestUtil.ActionKey;
@@ -143,8 +141,7 @@ class StubWorkerContext implements WorkerContext {
   public Path createExecDir(
       String operationName,
       Map<Digest, Directory> directoriesIndex,
-      DigestFunction.Value digestFunction,
-      Action action,
+      build.buildfarm.v1test.Digest inputRootDigest,
       Command command,
       UserPrincipal owner,
       WorkerExecutedMetadata.Builder workerExecutedMetadata)


### PR DESCRIPTION
Filtering on linkedDirectory iteration for output_paths
Ignores output_paths and all subdirectories
Simplify createExecDir signature - no action

Fixes #2562 