### PR TITLE
fix(cas): make `hexBucketLevels` work with BLAKE3 digests

### DIFF
--- a/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
+++ b/src/main/java/build/buildfarm/cas/cfc/CASFileCache.java
@@ -406,7 +406,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
     Entry entry = getEntry(key);
     if (entry != null && entry.referenceCount < 0) {
       try {
-        entry = new Entry(key, Files.size(getPath(key)), null);
+        entry = new Entry(key, Files.size(getPath(digest, key)), null);
       } catch (IOException e) {
         return false;
       }
@@ -475,7 +475,8 @@ public abstract class CASFileCache implements ContentAddressableStorage {
       return true;
     }
 
-    if (Files.exists(getPath(e.key))) {
+    Digest digest = entryDigest(e.key, e.size);
+    if (digest != null && Files.exists(getPath(digest, e.key))) {
       e.existsDeadline = Deadline.after(10, SECONDS);
       return true;
     }
@@ -572,7 +573,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
       if (e != null) {
         InputStream input = null;
         try {
-          input = compressorInputStream(compressor, Files.newInputStream(getPath(key)));
+          input = compressorInputStream(compressor, Files.newInputStream(getPath(digest, key)));
           input.skip(offset);
         } catch (IOException ioEx) {
           if (!(ioEx instanceof NoSuchFileException)) {
@@ -587,7 +588,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
             boolean removed = false;
             synchronized (this) {
               invalidateWrite(digest);
-              Entry removedEntry = safeStorageRemoval(key);
+              Entry removedEntry = safeStorageRemoval(digest, key);
               if (removedEntry == e) { // Intentional reference comparison
                 unlinkEntry(removedEntry);
                 removed = true;
@@ -994,7 +995,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
               if (fileCommittedSize < 0) {
                 // we need to cache this from disk until an out stream is acquired
                 String blobKey = getKey(key.getDigest(), false);
-                Path blobKeyPath = getPath(blobKey);
+                Path blobKeyPath = getPath(key.getDigest(), blobKey);
                 try {
                   fileCommittedSize =
                       Files.size(blobKeyPath.resolveSibling(blobKey + "." + key.getIdentifier()));
@@ -1460,7 +1461,12 @@ public abstract class CASFileCache implements ContentAddressableStorage {
     try (BufferedReader br = Files.newBufferedReader(lru)) {
       for (SizeEntry entry : db.entries(br)) {
         // ignore files in the lru that are not present in the directories
-        Path path = entryPathStrategy.getPath(entry.key());
+        Digest digest = entryDigest(entry.key(), entry.size());
+        if (digest == null) {
+          // unparseable lru entry: no managed file can correspond to it, skip
+          continue;
+        }
+        Path path = entryPathStrategy.getPath(digest, entry.key());
         if (files.remove(path)) {
           processRootFile(onStartPut, path, entry, computeDirsBuilder, deleteFilesBuilder);
         }
@@ -1617,12 +1623,34 @@ public abstract class CASFileCache implements ContentAddressableStorage {
     return entriesDereferenced;
   }
 
-  public Path getPath(String filename) {
-    return entryPathStrategy.getPath(filename);
+  public Path getPath(Digest digest, String filename) {
+    return entryPathStrategy.getPath(digest, filename);
   }
 
-  protected Path getRemovingPath(String filename) {
-    return entryPathStrategy.getPath(filename + "_removed");
+  protected Path getRemovingPath(Digest digest, String filename) {
+    return entryPathStrategy.getPath(digest, filename + "_removed");
+  }
+
+  /**
+   * Recovers the digest a stored key was computed from, for the bookkeeping paths that only carry
+   * the key string (LRU reconciliation, existence checks, removal). Handles blob keys (bare hex or
+   * {@code <digestfn>_} prefixed, with an optional {@code _exec} suffix) and {@code _dir} keys.
+   * Returns null if the key is unparseable.
+   */
+  protected static @Nullable Digest entryDigest(String key, long size) {
+    if (key.endsWith("_dir")) {
+      DigestUtil digestUtil = parseDirectoryDigestUtil(key);
+      if (digestUtil == null) {
+        return null;
+      }
+      try {
+        return keyToDigest(key, size, digestUtil);
+      } catch (NumberFormatException e) {
+        return null;
+      }
+    }
+    FileEntryKey fileEntryKey = parseFileEntryKey(key, size);
+    return fileEntryKey == null ? null : fileEntryKey.digest();
   }
 
   private synchronized void dischargeAndNotify(String key, long size) {
@@ -1653,7 +1681,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
 
   @VisibleForTesting
   public Path getDirectoryPath(Digest digest) {
-    return getPath(getDirectoryKey(digest));
+    return getPath(digest, getDirectoryKey(digest));
   }
 
   @GuardedBy("this")
@@ -1813,9 +1841,9 @@ public abstract class CASFileCache implements ContentAddressableStorage {
     }
   }
 
-  private Entry safeStorageRemoval(String key) throws IOException {
-    Path path = getPath(key);
-    Path expiredPath = getRemovingPath(key);
+  private Entry safeStorageRemoval(Digest digest, String key) throws IOException {
+    Path path = getPath(digest, key);
+    Path expiredPath = getRemovingPath(digest, key);
     boolean deleteExpiredPath = false;
 
     Lock lock;
@@ -1873,8 +1901,9 @@ public abstract class CASFileCache implements ContentAddressableStorage {
                 + " references");
       }
       boolean interrupted = false;
+      FileEntryKey fileEntryKey = null;
       if (!e.key.endsWith("_dir")) {
-        FileEntryKey fileEntryKey = parseFileEntryKey(e.key, e.size);
+        fileEntryKey = parseFileEntryKey(e.key, e.size);
         if (fileEntryKey == null) {
           log.log(Level.SEVERE, format("error parsing expired key %s", e.key));
         } else {
@@ -1886,7 +1915,9 @@ public abstract class CASFileCache implements ContentAddressableStorage {
           invalidateWrite(fileEntryKey.digest());
         }
       }
-      Entry removedEntry = safeStorageRemoval(e.key);
+      // Reuse the parsed blob digest where we have one; recover it from a `_dir` key otherwise.
+      Digest digest = fileEntryKey != null ? fileEntryKey.digest() : entryDigest(e.key, e.size);
+      Entry removedEntry = safeStorageRemoval(digest, e.key);
       // reference compare on purpose
       if (removedEntry == e) {
         ListenableFuture<Entry> entryFuture = dischargeEntryFuture(e, service);
@@ -2123,7 +2154,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
         }
       }
     }
-    return new PathResult(getPath(key), downloadComplete);
+    return new PathResult(getPath(digest, key), downloadComplete);
   }
 
   private void copyExternalInputProgressive(Digest digest, CancellableOutputStream out)
@@ -2347,8 +2378,8 @@ public abstract class CASFileCache implements ContentAddressableStorage {
     }
   }
 
-  protected void deleteExpiredKey(String key) throws IOException {
-    Path path = getRemovingPath(key);
+  protected void deleteExpiredKey(Digest digest, String key) throws IOException {
+    Path path = getRemovingPath(digest, key);
     long createdTimeMs = Files.getLastModifiedTime(path).to(MILLISECONDS);
 
     Files.delete(path);
@@ -2386,8 +2417,9 @@ public abstract class CASFileCache implements ContentAddressableStorage {
                     expiredFuture,
                     (expiredEntry) -> {
                       String expiredKey = expiredEntry.key;
+                      Digest expiredDigest = entryDigest(expiredKey, expiredEntry.size);
                       try {
-                        deleteExpiredKey(expiredKey);
+                        deleteExpiredKey(expiredDigest, expiredKey);
                       } catch (NoSuchFileException eNoEnt) {
                         log.log(
                             Level.SEVERE,
@@ -2456,8 +2488,9 @@ public abstract class CASFileCache implements ContentAddressableStorage {
     }
 
     DigestUtil digestUtil = new DigestUtil(HashFunction.get(digestFunction));
+    Digest digest = keyToDigest(key, blobSizeInBytes, digestUtil);
     String writeKey = key + "." + writeId;
-    Path writePath = getPath(key).resolveSibling(writeKey);
+    Path writePath = getPath(digest, key).resolveSibling(writeKey);
     final long committedSize;
     HashingOutputStream hashOut;
     if (!isReset && Files.exists(writePath)) {
@@ -2481,7 +2514,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
     CountingOutputStream countingOut = new CountingOutputStream(committedSize, hashOut);
     return new CancellableOutputStream(countingOut) {
       long written = committedSize;
-      final Digest expectedDigest = keyToDigest(key, blobSizeInBytes, digestUtil);
+      final Digest expectedDigest = digest;
 
       @Override
       public long getWritten() {
@@ -2588,7 +2621,7 @@ public abstract class CASFileCache implements ContentAddressableStorage {
         boolean inserted = false;
         try {
           // acquire the key lock
-          Files.createLink(CASFileCache.this.getPath(key), writePath);
+          Files.createLink(CASFileCache.this.getPath(actual, key), writePath);
           existingEntry = safeStorageInsertion(key, entry);
           inserted = existingEntry == null;
         } catch (FileAlreadyExistsException e) {
@@ -2795,14 +2828,14 @@ public abstract class CASFileCache implements ContentAddressableStorage {
               UUID.randomUUID(),
               RequestMetadata.getDefaultInstance());
       if (write != null) {
-        performCopy(write, fileEntryKey.key());
+        performCopy(write, fileEntryKey.digest(), fileEntryKey.key());
       }
     }
   }
 
-  private void performCopy(Write write, String key) throws IOException {
+  private void performCopy(Write write, Digest digest, String key) throws IOException {
     try (OutputStream out = write.getOutput(1, MINUTES, () -> {});
-        InputStream in = Files.newInputStream(getPath(key))) {
+        InputStream in = Files.newInputStream(getPath(digest, key))) {
       ByteStreams.copy(in, out);
     } catch (IOException ioEx) {
       boolean interrupted = causedByInterrupted(ioEx);

--- a/src/main/java/build/buildfarm/cas/cfc/DirectoryEntryCFC.java
+++ b/src/main/java/build/buildfarm/cas/cfc/DirectoryEntryCFC.java
@@ -156,13 +156,13 @@ public class DirectoryEntryCFC extends CASFileCache {
   }
 
   @Override
-  protected void deleteExpiredKey(String expiredKey) throws IOException {
+  protected void deleteExpiredKey(Digest digest, String expiredKey) throws IOException {
     if (expiredKey.endsWith("_dir")) {
-      Path path = getRemovingPath(expiredKey);
+      Path path = getRemovingPath(digest, expiredKey);
       Directories.remove(path, fileStore);
       // accounting for expiration metric?
     } else {
-      super.deleteExpiredKey(expiredKey);
+      super.deleteExpiredKey(digest, expiredKey);
     }
   }
 

--- a/src/main/java/build/buildfarm/cas/cfc/EntryPathStrategy.java
+++ b/src/main/java/build/buildfarm/cas/cfc/EntryPathStrategy.java
@@ -14,11 +14,13 @@
 
 package build.buildfarm.cas.cfc;
 
+import build.buildfarm.v1test.Digest;
 import java.nio.file.Path;
 
 interface EntryPathStrategy extends Iterable<Path> {
-  // key must begin with a hexdigest
-  Path getPath(String key);
+  // Resolves the on-disk path for an entry. The leaf is fileName; any hash bucketing is derived
+  // from digest.getHash(), the bare hex hash the fileName was computed from.
+  Path getPath(Digest digest, String fileName);
 
   // BFS of all directories involved from a root
   Iterable<Path> branchDirectories();

--- a/src/main/java/build/buildfarm/cas/cfc/FileDirectoriesIndex.java
+++ b/src/main/java/build/buildfarm/cas/cfc/FileDirectoriesIndex.java
@@ -28,7 +28,7 @@ abstract class FileDirectoriesIndex implements DirectoriesIndex {
   }
 
   Path path(Digest digest) {
-    return entryPathStrategy.getPath(digest.getHash() + "_dir_inputs");
+    return entryPathStrategy.getPath(digest, digest.getHash() + "_dir_inputs");
   }
 
   @Override

--- a/src/main/java/build/buildfarm/cas/cfc/HexBucketEntryPathStrategy.java
+++ b/src/main/java/build/buildfarm/cas/cfc/HexBucketEntryPathStrategy.java
@@ -6,14 +6,11 @@ import static java.lang.String.format;
 import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 class HexBucketEntryPathStrategy implements EntryPathStrategy {
   private static final int MAX_LEVEL = 4;
   private final Path path;
   private final int levels;
-  private final Pattern pattern;
 
   private static long depthMaxCounter(int depth) {
     return (1L << (depth * 8)) - 1;
@@ -23,29 +20,68 @@ class HexBucketEntryPathStrategy implements EntryPathStrategy {
     checkState(levels <= MAX_LEVEL);
     this.path = path;
     this.levels = levels;
-    // Match a key as an optional `<digestfn>_` prefix (e.g. `blake3_`)
-    // followed by the hex hash. Group 1 captures the hex hash so bucketing
-    // works for non-omitted digest functions (BLAKE3) the same way it does
-    // for the omitted ones (SHA*, MD5), whose keys are bare hex hashes.
-    String match = format("(?:[a-z0-9]+_)?([0-9a-f]{%d}.*)", levels * 2);
-    pattern = Pattern.compile(match);
   }
 
   @Override
   public Path getPath(String key) {
-    Matcher matcher = pattern.matcher(key);
-    checkState(levels == 0 || matcher.matches());
     // Bucket on the hex hash, skipping any `<digestfn>_` prefix. Without
     // this, a BLAKE3 key like `blake3_220fcb...` would shard on `bl/ak/`,
     // which aren't hex bucket directories, and every read/write would land
     // in a non-existent path.
-    int hashStart = levels == 0 ? 0 : matcher.start(1);
+    int hashStart = levels == 0 ? 0 : hexHashStart(key);
+    checkState(levels == 0 || hashStart >= 0);
     Path keyPath = path;
     for (int i = 0; i < levels; i++) {
       int from = hashStart + i * 2;
       keyPath = keyPath.resolve(key.substring(from, from + 2));
     }
     return keyPath.resolve(key);
+  }
+
+  /**
+   * Returns the offset of the hex hash within {@code key}, skipping an optional {@code <digestfn>_}
+   * prefix (e.g. {@code blake3_}), or {@code -1} if no hex hash of at least {@code levels * 2}
+   * digits sits at a bucketable position.
+   *
+   * <p>This is the allocation-free, backtracking-free equivalent of matching {@code
+   * (?:[a-z0-9]+_)?([0-9a-f]{levels*2}.*)} and reading the start of group 1: an optional prefix is
+   * a maximal run of {@code [a-z0-9]} terminated by {@code _}, preferred over no prefix when both
+   * leave a hex hash. The hash captures bare keys from the omitted digest functions (SHA*, MD5) as
+   * well as prefixed ones (BLAKE3), and a trailing {@code _exec}/{@code _dir} suffix stays part of
+   * the leaf filename rather than being mistaken for a prefix.
+   */
+  private int hexHashStart(String key) {
+    int width = levels * 2;
+    // Optional `<digestfn>_` prefix: a non-empty run of [a-z0-9] then '_'.
+    int prefixEnd = 0;
+    while (prefixEnd < key.length() && isLowerAlnum(key.charAt(prefixEnd))) {
+      prefixEnd++;
+    }
+    if (prefixEnd > 0
+        && prefixEnd < key.length()
+        && key.charAt(prefixEnd) == '_'
+        && isHexRun(key, prefixEnd + 1, width)) {
+      return prefixEnd + 1;
+    }
+    // No prefix: a bare hex hash, as written by the omitted digest functions.
+    return isHexRun(key, 0, width) ? 0 : -1;
+  }
+
+  private static boolean isHexRun(String s, int from, int length) {
+    if (from + length > s.length()) {
+      return false;
+    }
+    for (int i = from; i < from + length; i++) {
+      char c = s.charAt(i);
+      if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static boolean isLowerAlnum(char c) {
+    return (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9');
   }
 
   @Override

--- a/src/main/java/build/buildfarm/cas/cfc/HexBucketEntryPathStrategy.java
+++ b/src/main/java/build/buildfarm/cas/cfc/HexBucketEntryPathStrategy.java
@@ -6,6 +6,7 @@ import static java.lang.String.format;
 import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 class HexBucketEntryPathStrategy implements EntryPathStrategy {
@@ -22,16 +23,27 @@ class HexBucketEntryPathStrategy implements EntryPathStrategy {
     checkState(levels <= MAX_LEVEL);
     this.path = path;
     this.levels = levels;
-    String match = format("[0-9a-f]{%d}.*", levels * 2);
+    // Match a key as an optional `<digestfn>_` prefix (e.g. `blake3_`)
+    // followed by the hex hash. Group 1 captures the hex hash so bucketing
+    // works for non-omitted digest functions (BLAKE3) the same way it does
+    // for the omitted ones (SHA*, MD5), whose keys are bare hex hashes.
+    String match = format("(?:[a-z0-9]+_)?([0-9a-f]{%d}.*)", levels * 2);
     pattern = Pattern.compile(match);
   }
 
   @Override
   public Path getPath(String key) {
-    checkState(levels == 0 || pattern.matcher(key).matches());
+    Matcher matcher = pattern.matcher(key);
+    checkState(levels == 0 || matcher.matches());
+    // Bucket on the hex hash, skipping any `<digestfn>_` prefix. Without
+    // this, a BLAKE3 key like `blake3_220fcb...` would shard on `bl/ak/`,
+    // which aren't hex bucket directories, and every read/write would land
+    // in a non-existent path.
+    int hashStart = levels == 0 ? 0 : matcher.start(1);
     Path keyPath = path;
     for (int i = 0; i < levels; i++) {
-      keyPath = keyPath.resolve(key.substring(i * 2, i * 2 + 2));
+      int from = hashStart + i * 2;
+      keyPath = keyPath.resolve(key.substring(from, from + 2));
     }
     return keyPath.resolve(key);
   }

--- a/src/main/java/build/buildfarm/cas/cfc/HexBucketEntryPathStrategy.java
+++ b/src/main/java/build/buildfarm/cas/cfc/HexBucketEntryPathStrategy.java
@@ -3,6 +3,7 @@ package build.buildfarm.cas.cfc;
 import static com.google.common.base.Preconditions.checkState;
 import static java.lang.String.format;
 
+import build.buildfarm.v1test.Digest;
 import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
@@ -23,65 +24,18 @@ class HexBucketEntryPathStrategy implements EntryPathStrategy {
   }
 
   @Override
-  public Path getPath(String key) {
-    // Bucket on the hex hash, skipping any `<digestfn>_` prefix. Without
-    // this, a BLAKE3 key like `blake3_220fcb...` would shard on `bl/ak/`,
-    // which aren't hex bucket directories, and every read/write would land
-    // in a non-existent path.
-    int hashStart = levels == 0 ? 0 : hexHashStart(key);
-    checkState(levels == 0 || hashStart >= 0);
+  public Path getPath(Digest digest, String fileName) {
+    // Bucket on the digest's hash, which is always the bare hex the fileName was computed from.
+    // Taking it from the digest rather than parsing fileName keeps bucketing oblivious to the
+    // `<digestfn>_` prefix (e.g. `blake3_`) and the `_exec`/`_dir` suffixes a fileName may carry.
     Path keyPath = path;
-    for (int i = 0; i < levels; i++) {
-      int from = hashStart + i * 2;
-      keyPath = keyPath.resolve(key.substring(from, from + 2));
-    }
-    return keyPath.resolve(key);
-  }
-
-  /**
-   * Returns the offset of the hex hash within {@code key}, skipping an optional {@code <digestfn>_}
-   * prefix (e.g. {@code blake3_}), or {@code -1} if no hex hash of at least {@code levels * 2}
-   * digits sits at a bucketable position.
-   *
-   * <p>This is the allocation-free, backtracking-free equivalent of matching {@code
-   * (?:[a-z0-9]+_)?([0-9a-f]{levels*2}.*)} and reading the start of group 1: an optional prefix is
-   * a maximal run of {@code [a-z0-9]} terminated by {@code _}, preferred over no prefix when both
-   * leave a hex hash. The hash captures bare keys from the omitted digest functions (SHA*, MD5) as
-   * well as prefixed ones (BLAKE3), and a trailing {@code _exec}/{@code _dir} suffix stays part of
-   * the leaf filename rather than being mistaken for a prefix.
-   */
-  private int hexHashStart(String key) {
-    int width = levels * 2;
-    // Optional `<digestfn>_` prefix: a non-empty run of [a-z0-9] then '_'.
-    int prefixEnd = 0;
-    while (prefixEnd < key.length() && isLowerAlnum(key.charAt(prefixEnd))) {
-      prefixEnd++;
-    }
-    if (prefixEnd > 0
-        && prefixEnd < key.length()
-        && key.charAt(prefixEnd) == '_'
-        && isHexRun(key, prefixEnd + 1, width)) {
-      return prefixEnd + 1;
-    }
-    // No prefix: a bare hex hash, as written by the omitted digest functions.
-    return isHexRun(key, 0, width) ? 0 : -1;
-  }
-
-  private static boolean isHexRun(String s, int from, int length) {
-    if (from + length > s.length()) {
-      return false;
-    }
-    for (int i = from; i < from + length; i++) {
-      char c = s.charAt(i);
-      if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'))) {
-        return false;
+    if (levels > 0) {
+      String hash = digest.getHash();
+      for (int i = 0; i < levels; i++) {
+        keyPath = keyPath.resolve(hash.substring(i * 2, i * 2 + 2));
       }
     }
-    return true;
-  }
-
-  private static boolean isLowerAlnum(char c) {
-    return (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9');
+    return keyPath.resolve(fileName);
   }
 
   @Override

--- a/src/test/java/build/buildfarm/cas/cfc/CASFileCacheTest.java
+++ b/src/test/java/build/buildfarm/cas/cfc/CASFileCacheTest.java
@@ -344,8 +344,8 @@ class CASFileCacheTest {
     FileStore fileStore = Files.getFileStore(root);
     ByteString blob = ByteString.copyFromUtf8("blob");
     Digest blobDigest = DIGEST_UTIL.compute(blob);
-    Path path = fileCache.getPath(fileCache.getKey(blobDigest, false));
-    Path execPath = fileCache.getPath(fileCache.getKey(blobDigest, true));
+    Path path = fileCache.getPath(blobDigest, fileCache.getKey(blobDigest, false));
+    Path execPath = fileCache.getPath(blobDigest, fileCache.getKey(blobDigest, true));
     Files.write(path, blob.toByteArray());
     EvenMoreFiles.setReadOnlyPerms(path, false, fileStore);
     Files.write(execPath, blob.toByteArray());
@@ -367,8 +367,8 @@ class CASFileCacheTest {
     FileStore fileStore = Files.getFileStore(root);
     ByteString blob = ByteString.copyFromUtf8("blob");
     Digest blobDigest = DIGEST_UTIL.compute(blob);
-    Path path = fileCache.getPath(fileCache.getKey(blobDigest, false));
-    Path execPath = fileCache.getPath(fileCache.getKey(blobDigest, true));
+    Path path = fileCache.getPath(blobDigest, fileCache.getKey(blobDigest, false));
+    Path execPath = fileCache.getPath(blobDigest, fileCache.getKey(blobDigest, true));
     Files.write(path, blob.toByteArray());
     EvenMoreFiles.setReadOnlyPerms(path, false, fileStore);
     Files.write(execPath, blob.toByteArray());
@@ -389,7 +389,8 @@ class CASFileCacheTest {
     Path invalidDigest = root.resolve("00").resolve("digest");
     ByteString validBlob = ByteString.copyFromUtf8("valid");
     Digest validDigest = DIGEST_UTIL.compute(ByteString.copyFromUtf8("valid"));
-    Path invalidExec = fileCache.getPath(CASFileCache.getKey(validDigest, false) + "_regular");
+    Path invalidExec =
+        fileCache.getPath(validDigest, CASFileCache.getKey(validDigest, false) + "_regular");
 
     Files.write(tooFewComponents, ImmutableList.of("Too Few Components"), StandardCharsets.UTF_8);
     Files.write(tooManyComponents, ImmutableList.of("Too Many Components"), StandardCharsets.UTF_8);
@@ -544,7 +545,7 @@ class CASFileCacheTest {
     assertThat(notified.get()).isTrue();
     String key = fileCache.getKey(digest, false);
     assertThat(storage.get(key)).isNotNull();
-    try (InputStream in = Files.newInputStream(fileCache.getPath(key))) {
+    try (InputStream in = Files.newInputStream(fileCache.getPath(digest, key))) {
       assertThat(ByteString.readFrom(in)).isEqualTo(content);
     }
   }
@@ -624,7 +625,7 @@ class CASFileCacheTest {
 
     UUID writeId = UUID.randomUUID();
     String key = fileCache.getKey(digest, false);
-    Path writePath = fileCache.getPath(key).resolveSibling(key + "." + writeId);
+    Path writePath = fileCache.getPath(digest, key).resolveSibling(key + "." + writeId);
     try (OutputStream out = Files.newOutputStream(writePath)) {
       content.substring(0, 6).writeTo(out);
     }
@@ -710,7 +711,7 @@ class CASFileCacheTest {
     fileCache.put(blob);
     String key = fileCache.getKey(blob.getDigest(), /* isExecutable= */ false);
     // putCreatesFile verifies this
-    Files.delete(fileCache.getPath(key));
+    Files.delete(fileCache.getPath(blob.getDigest(), key));
     // update entry with expired deadline
     storage.get(key).existsDeadline = Deadline.after(0, SECONDS);
 
@@ -903,7 +904,7 @@ class CASFileCacheTest {
     // assert expiration of non-executable digest
     String expiringKey = fileCache.getKey(expiringBlob.getDigest(), /* isExecutable= */ false);
     assertThat(storage.containsKey(expiringKey)).isFalse();
-    assertThat(Files.exists(fileCache.getPath(expiringKey))).isFalse();
+    assertThat(Files.exists(fileCache.getPath(expiringBlob.getDigest(), expiringKey))).isFalse();
   }
 
   @SuppressWarnings("unchecked")

--- a/src/test/java/build/buildfarm/cas/cfc/HexBucketEntryPathStrategyTest.java
+++ b/src/test/java/build/buildfarm/cas/cfc/HexBucketEntryPathStrategyTest.java
@@ -73,4 +73,29 @@ public class HexBucketEntryPathStrategyTest {
     assertThat(blobPath.toString())
         .isEqualTo(path.resolve("aa").resolve("55").resolve(key).toString());
   }
+
+  @Test
+  public void getPathStripsDigestFunctionPrefix() {
+    Path path = Path.of("cache");
+    EntryPathStrategy entryPathStrategy = new HexBucketEntryPathStrategy(path, 2);
+
+    // The hash starts with `aa`, but the prefix `blake3` ends in `3` (hex)
+    // and starts with `b` (also hex) — so detection cannot rely on the
+    // first character of the key being non-hex.
+    String key = "blake3_aa55bb1100bb";
+    Path blobPath = entryPathStrategy.getPath(key);
+    assertThat(blobPath.toString())
+        .isEqualTo(path.resolve("aa").resolve("55").resolve(key).toString());
+  }
+
+  @Test
+  public void getPathTreatsExecSuffixAsPartOfHash() {
+    Path path = Path.of("cache");
+    EntryPathStrategy entryPathStrategy = new HexBucketEntryPathStrategy(path, 2);
+
+    String key = "aa55bb1100bb_exec";
+    Path blobPath = entryPathStrategy.getPath(key);
+    assertThat(blobPath.toString())
+        .isEqualTo(path.resolve("aa").resolve("55").resolve(key).toString());
+  }
 }

--- a/src/test/java/build/buildfarm/cas/cfc/HexBucketEntryPathStrategyTest.java
+++ b/src/test/java/build/buildfarm/cas/cfc/HexBucketEntryPathStrategyTest.java
@@ -17,6 +17,7 @@ package build.buildfarm.cas.cfc;
 import static com.google.common.truth.Truth.assertThat;
 import static java.lang.String.format;
 
+import build.buildfarm.v1test.Digest;
 import java.nio.file.Path;
 import java.util.Iterator;
 import org.junit.Test;
@@ -25,6 +26,11 @@ import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class HexBucketEntryPathStrategyTest {
+  // The strategy buckets purely on the digest's hash, so only setHash matters here.
+  private static Digest digest(String hash) {
+    return Digest.newBuilder().setHash(hash).build();
+  }
+
   @Test
   public void branchDirectoriesNoLevelsIsEmpty() {
     Path path = Path.of("cache");
@@ -69,32 +75,32 @@ public class HexBucketEntryPathStrategyTest {
     EntryPathStrategy entryPathStrategy = new HexBucketEntryPathStrategy(path, 2);
 
     String key = "aa55bb1100bb";
-    Path blobPath = entryPathStrategy.getPath(key);
+    Path blobPath = entryPathStrategy.getPath(digest("aa55bb1100bb"), key);
     assertThat(blobPath.toString())
         .isEqualTo(path.resolve("aa").resolve("55").resolve(key).toString());
   }
 
   @Test
-  public void getPathStripsDigestFunctionPrefix() {
+  public void getPathBucketsOnHashNotDigestFunctionPrefix() {
     Path path = Path.of("cache");
     EntryPathStrategy entryPathStrategy = new HexBucketEntryPathStrategy(path, 2);
 
-    // The hash starts with `aa`, but the prefix `blake3` ends in `3` (hex)
-    // and starts with `b` (also hex) — so detection cannot rely on the
-    // first character of the key being non-hex.
+    // The fileName carries a `blake3_` prefix, but bucketing is driven by the digest's hash, so
+    // the path shards on `aa/55` (the hash) rather than `bl/ak` (the prefixed fileName).
     String key = "blake3_aa55bb1100bb";
-    Path blobPath = entryPathStrategy.getPath(key);
+    Path blobPath = entryPathStrategy.getPath(digest("aa55bb1100bb"), key);
     assertThat(blobPath.toString())
         .isEqualTo(path.resolve("aa").resolve("55").resolve(key).toString());
   }
 
   @Test
-  public void getPathTreatsExecSuffixAsPartOfHash() {
+  public void getPathBucketsOnHashNotExecSuffix() {
     Path path = Path.of("cache");
     EntryPathStrategy entryPathStrategy = new HexBucketEntryPathStrategy(path, 2);
 
+    // The `_exec` suffix is part of the leaf fileName only; it does not affect bucketing.
     String key = "aa55bb1100bb_exec";
-    Path blobPath = entryPathStrategy.getPath(key);
+    Path blobPath = entryPathStrategy.getPath(digest("aa55bb1100bb"), key);
     assertThat(blobPath.toString())
         .isEqualTo(path.resolve("aa").resolve("55").resolve(key).toString());
   }


### PR DESCRIPTION
`HexBucketEntryPathStrategy.getPath` rejected every CAS key whose hex hash didn't sit at offset 0, throwing `IllegalStateException` from the `checkState` on line 31. The pattern matched the start of the *whole* key against `[0-9a-f]{levels*2}`, which works for the digest functions in `OMITTED_DIGEST_FUNCTIONS` (MD5, SHA1, SHA-2 family) — those keys are bare hex hashes — but not for BLAKE3, whose keys are prefixed with `blake3_` per `digestFilename`.

Result: `hexBucketLevels > 0` was unusable with BLAKE3 clients; every read or write failed before reaching disk.

Allow the pattern to match an optional `<digestfn>_` prefix, capture the hex portion in group 1, and bucket on `Matcher.start(1)`. Group capture is correct where character-level heuristics aren't: testing `isHexChar(key.charAt(0))` is fooled by `blake3_…`, since `b` is in `[a-f]`, and silently routes BLAKE3 writes to nonexistent `<root>/bl/ak/…` directories.

The full key remains the leaf filename, so blobs of identical hex hash but different digest functions don't collide.

Adds tests for the BLAKE3 prefix (chosen so its first character is also hex, to guard against the heuristic regression) and the trailing `_exec` suffix on SHA-family keys.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>