### PR TITLE
Null-out Android env for non-Android macos builds

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -74,6 +74,9 @@ tasks:
     - '...'
   macos:
     name: Unit Tests
+    environment:
+      ANDROID_HOME: ""
+      ANDROID_NDK_HOME: ""
     build_flags:
     - --cxxopt=-std=c++14
     - --build_tag_filters=-container


### PR DESCRIPTION
The Intel `macos` deployment in BazelCI does not have the latest Android build tools installed. By default, BazelCI adds `ANDROID*` environment variables to builds, which registers an Android toolchain for any transitively-loaded Android deps, which causes a repo rule-level error.

To prevent this, this PR nulls out the `ANDROID*` environment variables.