### PR TITLE
Initial CPU Farmer's Market

### DIFF
--- a/src/main/java/build/buildfarm/common/Claim.java
+++ b/src/main/java/build/buildfarm/common/Claim.java
@@ -14,6 +14,7 @@
 
 package build.buildfarm.common;
 
+import build.buildfarm.v1test.Resource;
 import java.util.List;
 import java.util.Map.Entry;
 
@@ -23,9 +24,27 @@ public interface Claim {
     REPORT_RESULT_STAGE,
   }
 
+  interface Lease {
+    String name();
+
+    int amount();
+
+    Stage stage();
+
+    static Resource toResource(Lease lease) {
+      return Resource.newBuilder().setName(lease.name()).setAmount(lease.amount()).build();
+    }
+  }
+
   void release(Stage stage);
 
   void release();
 
   Iterable<Entry<String, List<Object>>> getPools();
+
+  void add(Lease lease);
+
+  Lease get(String name);
+
+  Iterable<Resource> resources();
 }

--- a/src/main/java/build/buildfarm/common/ExecutionProperties.java
+++ b/src/main/java/build/buildfarm/common/ExecutionProperties.java
@@ -297,4 +297,44 @@ public class ExecutionProperties {
    * @details See https://github.com/bazelbuild/bazel/issues/10091
    */
   public static final String PERSISTENT_WORKER_COMMAND = "persistentWorkerCommand";
+
+  /**
+   * @field CPU_SHARE_FLOOR
+   * @brief minimum number of cpu shares an execution must own
+   * @details Prevent available cpu from being reduced beyond this amount Must not be <= 0 for
+   *     market interactions
+   */
+  public static final String CPU_SHARE_FLOOR = "cpuShareFloor";
+
+  /**
+   * @field PCT_MIN_UNUSED
+   * @brief Percentage of owned shares that must be unused before sale
+   * @details Headroom for per-sample volatility of use before its cpu may be sold Must not be <= 0.
+   *     Values should be between <code>0 < x < 1</code> for market interactions
+   */
+  public static final String PCT_MIN_UNUSED = "pctMinUnused";
+
+  /**
+   * @field PCT_MIN_THROTTLE
+   * @brief Percentage of throttle that must be observed before buying cpu shares
+   * @details Headroom for per-sample volatility of throttle before cpu may be bought Must not be <=
+   *     0 for market interactions
+   */
+  public static final String PCT_MIN_THROTTLED = "pctMinThrottled";
+
+  /**
+   * @field MIN_SHARES_SOLD
+   * @brief CPU Shares minimum threshold sold
+   * @details Headroom for per-sample volatility of use before its cpu may be sold Must not be <= 0
+   *     for market interactions
+   */
+  public static final String MIN_SHARES_SOLD = "minSharesSold";
+
+  /**
+   * @field MAX_SHARES_SOLD
+   * @brief CPU Shares maximum sold clamp
+   * @details Headroom for per-sample volatility of unuse that may be sold Must not be <= 0 for
+   *     market interactions
+   */
+  public static final String MAX_SHARES_SOLD = "maxSharesSold";
 }

--- a/src/main/java/build/buildfarm/common/Resource.java
+++ b/src/main/java/build/buildfarm/common/Resource.java
@@ -1,0 +1,25 @@
+// Copyright 2026 The Buildfarm Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.common;
+
+public interface Resource {
+  void release(int amount);
+
+  int availablePermits();
+
+  boolean tryAcquire(int amount);
+
+  Claim.Stage stage();
+}

--- a/src/main/java/build/buildfarm/common/config/Worker.java
+++ b/src/main/java/build/buildfarm/common/config/Worker.java
@@ -64,6 +64,7 @@ public class Worker {
   private int zstdBufferPoolSize = 2048; /* * ZSTD_DStreamInSize (current is 128k) == 256MiB */
   private boolean compressedBlobTransfer = false;
   private Set<String> persistentWorkerActionMnemonicAllowlist = Set.of("*");
+  private Set<String> ignoreMarketExecutionMnemonics = Set.of("TestRunner");
   // These limited resources are only for the individual worker.
   // An example would be hardware resources such as GPUs.
   // If you want GPU actions to run exclusively, define a single GPU resource.
@@ -72,6 +73,7 @@ public class Worker {
   private boolean errorOperationOutputSizeExceeded = false;
   private boolean legacyDirectoryFileCache = false;
   private boolean absolutizeCommandProgram = isWindows();
+  private boolean executionMarket = false;
 
   public List<ExecutionPolicy> getExecutionPolicies() {
     return executionPolicies;

--- a/src/main/java/build/buildfarm/tools/Cat.java
+++ b/src/main/java/build/buildfarm/tools/Cat.java
@@ -292,6 +292,11 @@ class Cat implements Callable<Integer> {
         out.push().println(linkedInputDirectory);
       }
     }
+    if (metadata.getUsageCount() > 0) {
+      for (Map.Entry<String, Long> usage : metadata.getUsageMap().entrySet()) {
+        out.push().format("%s: %d", usage.getKey(), usage.getValue());
+      }
+    }
   }
 
   private static void printExecutedActionMetadata(

--- a/src/main/java/build/buildfarm/worker/CPULease.java
+++ b/src/main/java/build/buildfarm/worker/CPULease.java
@@ -1,0 +1,66 @@
+// Copyright 2026 The Buildfarm Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.worker;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import build.buildfarm.common.Claim.Lease;
+import build.buildfarm.common.Claim.Stage;
+
+public class CPULease implements Lease {
+  public static final String RESOURCE_NAME = "cpu.shares";
+  private int balance = 0;
+
+  CPULease(int amount, Market market) throws InterruptedException {
+    Order order = market.buy(amount, this::accumulate);
+    try {
+      synchronized (this) {
+        while (balance != amount) {
+          wait();
+        }
+      }
+    } catch (InterruptedException e) {
+      order.cancel();
+      // objectively finally, but we could still be interrupted while waiting for the last item
+      market.sell(balance);
+      throw e;
+    }
+  }
+
+  public synchronized void accumulate(int n) {
+    checkArgument(n >= 0);
+    balance += n;
+    notifyAll();
+  }
+
+  public synchronized void deplete(int n) {
+    checkArgument(n >= 0);
+    balance -= n;
+  }
+
+  @Override
+  public String name() {
+    return RESOURCE_NAME;
+  }
+
+  @Override
+  public synchronized int amount() {
+    return balance;
+  }
+
+  public Stage stage() {
+    return Stage.EXECUTE_ACTION_STAGE;
+  }
+}

--- a/src/main/java/build/buildfarm/worker/ExecuteActionStage.java
+++ b/src/main/java/build/buildfarm/worker/ExecuteActionStage.java
@@ -15,6 +15,7 @@
 package build.buildfarm.worker;
 
 import build.buildfarm.worker.resources.ResourceLimits;
+import io.prometheus.client.Histogram;
 import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -29,6 +30,13 @@ import lombok.extern.java.Log;
 
 @Log
 public class ExecuteActionStage extends PipelineStage {
+  private static final Histogram executionTime =
+      Histogram.build().name("execution_time_ms").help("Execution time in ms.").register();
+  private static final Histogram executionStallTime =
+      Histogram.build()
+          .name("execution_stall_time_ms")
+          .help("Execution stall time in ms.")
+          .register();
   private static final int IDLE_STAGE_CLOSED_MS = 10;
   private static final TimeUnit IDLE_STAGE_CLOSED_UNIT = TimeUnit.MILLISECONDS;
 
@@ -237,6 +245,8 @@ public class ExecuteActionStage extends PipelineStage {
   }
 
   void releaseExecutor(String executionName, long usecs, long stallUSecs, int exitCode) {
+    executionTime.observe(usecs / 1000.0);
+    executionStallTime.observe(stallUSecs / 1000.0);
     complete(executionName, usecs, stallUSecs, String.format("exit code: %d", exitCode));
   }
 }

--- a/src/main/java/build/buildfarm/worker/ExecuteActionStage.java
+++ b/src/main/java/build/buildfarm/worker/ExecuteActionStage.java
@@ -15,45 +15,30 @@
 package build.buildfarm.worker;
 
 import build.buildfarm.worker.resources.ResourceLimits;
-import io.prometheus.client.Gauge;
-import io.prometheus.client.Histogram;
 import java.io.IOException;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import lombok.extern.java.Log;
 
 @Log
-public class ExecuteActionStage extends SuperscalarPipelineStage {
-  private static final Gauge executionSlotUsage =
-      Gauge.build().name("execution_slot_usage").help("Execution slot Usage.").register();
-  private static final Histogram executionTime =
-      Histogram.build().name("execution_time_ms").help("Execution time in ms.").register();
-  private static final Histogram executionStallTime =
-      Histogram.build()
-          .name("execution_stall_time_ms")
-          .help("Execution stall time in ms.")
-          .register();
+public class ExecuteActionStage extends PipelineStage {
+  private static final int IDLE_STAGE_CLOSED_MS = 10;
+  private static final TimeUnit IDLE_STAGE_CLOSED_UNIT = TimeUnit.MILLISECONDS;
 
-  private final AtomicInteger executorClaims = new AtomicInteger(0);
+  public static final int SHARES_PER_SLOT = 1000;
 
-  public ExecuteActionStage(
-      WorkerContext workerContext, PipelineStage output, PipelineStage error) {
-    this(workerContext, output, error, workerContext.getExecuteStageWidth());
-  }
+  private final BlockingQueue<ExecutionContext> queue = new ArrayBlockingQueue<>(1);
+  private final ExecutorService executor = Executors.newCachedThreadPool();
+  private final Map<String, Executor> executions = new ConcurrentHashMap<>();
 
-  public ExecuteActionStage(
-      WorkerContext workerContext, PipelineStage output, PipelineStage error, int width) {
-    super(
-        "ExecuteActionStage",
-        "executor",
-        workerContext,
-        output,
-        createDestroyExecDirStage(workerContext, error),
-        width);
-  }
-
-  static PipelineStage createDestroyExecDirStage(
+  private static PipelineStage createDestroyExecDirStage(
       WorkerContext workerContext, PipelineStage nextStage) {
     return new PipelineStage.NullStage(workerContext, nextStage) {
       @Override
@@ -70,38 +55,68 @@ public class ExecuteActionStage extends SuperscalarPipelineStage {
     };
   }
 
+  public ExecuteActionStage(
+      WorkerContext workerContext, PipelineStage output, PipelineStage error) {
+    super(
+        "ExecuteActionStage",
+        workerContext,
+        output,
+        createDestroyExecDirStage(workerContext, error));
+  }
+
   @Override
-  protected Logger getLogger() {
+  Logger getLogger() {
     return log;
   }
 
-  synchronized int removeAndRelease(String operationName, int claims) {
-    releaseClaim(operationName, claims);
-    int slotUsage = executorClaims.addAndGet(-claims);
-    executionSlotUsage.set(slotUsage);
-    return slotUsage;
-  }
-
-  public void releaseExecutor(
-      String operationName, int claims, long usecs, long stallUSecs, int exitCode) {
-    int slotUsage = removeAndRelease(operationName, claims);
-    executionTime.observe(usecs / 1000.0);
-    executionStallTime.observe(stallUSecs / 1000.0);
-    complete(
-        operationName,
-        usecs,
-        stallUSecs,
-        String.format("exit code: %d, %s", exitCode, getUsage(slotUsage)));
+  @Override
+  ExecutionContext take() throws InterruptedException {
+    boolean interrupted = false;
+    InterruptedException exception;
+    try {
+      while (!isClosed() && !output.isClosed()) {
+        ExecutionContext context = queue.poll(IDLE_STAGE_CLOSED_MS, IDLE_STAGE_CLOSED_UNIT);
+        if (context != null) {
+          return context;
+        }
+      }
+      exception = new InterruptedException();
+    } catch (InterruptedException e) {
+      // only possible way to be terminated
+      exception = e;
+      // clear interrupted flag
+      interrupted = Thread.interrupted();
+    }
+    waitForRelease(queue);
+    if (interrupted) {
+      Thread.currentThread().interrupt();
+    }
+    throw exception;
   }
 
   @Override
   public int getSlotUsage() {
-    return executorClaims.get();
+    return executions.size();
   }
 
   @Override
-  protected int claimsRequired(ExecutionContext executionContext) {
-    return workerContext.commandExecutionClaims(executionContext.command);
+  public Iterable<String> getOperationNames() {
+    return executions.keySet();
+  }
+
+  public Iterable<Executor> getExecutions() {
+    return executions.values();
+  }
+
+  private void start(String operationName, Executor executor) {
+    executions.put(operationName, executor);
+    super.start(operationName, "Starting");
+  }
+
+  @Override
+  protected void complete(String operationName, long usecs, long stallUSecs, String status) {
+    super.complete(operationName, usecs, stallUSecs, status);
+    executions.remove(operationName);
   }
 
   @Override
@@ -111,26 +126,117 @@ public class ExecuteActionStage extends SuperscalarPipelineStage {
     }
     ExecutionContext executionContext = take();
     ResourceLimits limits = workerContext.commandExecutionSettings(executionContext.command);
-    Executor actionExecutor = new Executor(workerContext, executionContext, this, pollerExecutor);
+    Executor actionExecutor =
+        new Executor(
+            workerContext,
+            executionContext,
+            /* owner= */ this,
+            limits.cpuShareFloor,
+            limits.pctMinUnused,
+            limits.pctMinThrottled,
+            limits.minSharesSold,
+            limits.maxSharesSold,
+            executor);
 
     synchronized (this) {
-      int slotUsage = executorClaims.addAndGet(limits.cpu.claimed);
-      executionSlotUsage.set(slotUsage);
-      start(executionContext.operation.getName(), getUsage(slotUsage));
+      start(executionContext.operation.getName(), actionExecutor);
       executor.execute(() -> actionExecutor.run(limits));
     }
+  }
+
+  @Override
+  void put(ExecutionContext executionContext) throws InterruptedException {
+    while (!isClosed() && !output.isClosed()) {
+      if (queue.offer(executionContext, IDLE_STAGE_CLOSED_MS, IDLE_STAGE_CLOSED_UNIT)) {
+        return;
+      }
+    }
+    throw new InterruptedException("stage closed");
   }
 
   @Override
   public void close() {
     super.close();
     // might want to move this to actual teardown of the stage
+    executor.shutdown();
+    boolean interrupted = false;
+    try {
+      if (!executor.awaitTermination(1, TimeUnit.MINUTES)) {
+        getLogger().severe("executor did not terminate");
+      }
+    } catch (InterruptedException e) {
+      getLogger().severe("executor await shutdown interrupted");
+      interrupted = Thread.interrupted() || true;
+    }
     workerContext.destroyExecutionLimits();
+    if (interrupted) {
+      Thread.currentThread().interrupt();
+    }
   }
 
   @Override
   public void run() {
     workerContext.createExecutionLimits(); // TODO: if this throws, we should shutdown the worker.
     super.run();
+  }
+
+  public int getSharesConfigured() {
+    return workerContext.getExecuteStageWidth() * SHARES_PER_SLOT;
+  }
+
+  public int getSharesUsed() {
+    return getSharesConfigured() - getCpuStock();
+  }
+
+  private int getCpuStock() {
+    return workerContext.market().balance();
+  }
+
+  public synchronized boolean claim(ExecutionContext executionContext) throws InterruptedException {
+    // issue blocking buy order for SHARES_PER_SLOT * claims
+    int slots =
+        executionContext.marketExecution
+            ? 1
+            : workerContext.commandExecutionClaims(executionContext.command);
+    int sharesToBuy = SHARES_PER_SLOT * slots;
+
+    CPULease lease = new CPULease(sharesToBuy, workerContext.market());
+    executionContext.claim.add(lease);
+
+    return true;
+  }
+
+  @Override
+  protected boolean isClaimed() {
+    return !executions.isEmpty() || workerContext.market().balance() != getSharesConfigured();
+  }
+
+  synchronized void waitForRelease(BlockingQueue<ExecutionContext> queue) {
+    boolean interrupted = false;
+    while (isClaimed()) {
+      if (output.isClosed()) {
+        // interrupt the currently running threads, because they have nowhere to go
+        executor.shutdownNow();
+      }
+      ExecutionContext executionContext = queue.poll();
+      if (executionContext != null) {
+        // we need to sell the cpu this process has bought
+        executionContext.claim.release();
+      } else {
+        try {
+          wait(/* timeout= */ IDLE_STAGE_CLOSED_MS);
+        } catch (InterruptedException e) {
+          interrupted = Thread.interrupted() || interrupted;
+          // ignore, we will throw it eventually
+        }
+      }
+    }
+    if (interrupted) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  void releaseExecutor(String executionName, long usecs, long stallUSecs, int exitCode) {
+    complete(executionName, usecs, stallUSecs, String.format("exit code: %d", exitCode));
   }
 }

--- a/src/main/java/build/buildfarm/worker/ExecutionContext.java
+++ b/src/main/java/build/buildfarm/worker/ExecutionContext.java
@@ -38,6 +38,7 @@ public final class ExecutionContext {
   final QueueEntry queueEntry;
   public final Claim claim;
   final WorkerExecutedMetadata.Builder workerExecutedMetadata;
+  final boolean marketExecution;
 
   private ExecutionContext(
       ExecuteResponse.Builder executeResponse,
@@ -50,7 +51,8 @@ public final class ExecutionContext {
       Tree tree,
       QueueEntry queueEntry,
       Claim claim,
-      WorkerExecutedMetadata.Builder workerExecutedMetadata) {
+      WorkerExecutedMetadata.Builder workerExecutedMetadata,
+      boolean marketExecution) {
     this.executeResponse = executeResponse;
     this.operation = operation;
     this.metadata = metadata;
@@ -62,6 +64,7 @@ public final class ExecutionContext {
     this.queueEntry = queueEntry;
     this.claim = claim;
     this.workerExecutedMetadata = workerExecutedMetadata;
+    this.marketExecution = marketExecution;
   }
 
   public static final class Builder {
@@ -76,6 +79,7 @@ public final class ExecutionContext {
     private QueueEntry queueEntry;
     private Claim claim;
     private WorkerExecutedMetadata.Builder workerExecutedMetadata;
+    private boolean marketExecution;
 
     private Builder(
         ExecuteResponse.Builder executeResponse,
@@ -88,7 +92,8 @@ public final class ExecutionContext {
         Tree tree,
         QueueEntry queueEntry,
         Claim claim,
-        WorkerExecutedMetadata.Builder workerExecutedMetadata) {
+        WorkerExecutedMetadata.Builder workerExecutedMetadata,
+        boolean marketExecution) {
       this.executeResponse = executeResponse;
       this.operation = operation;
       this.metadata = metadata;
@@ -100,6 +105,7 @@ public final class ExecutionContext {
       this.queueEntry = queueEntry;
       this.claim = claim;
       this.workerExecutedMetadata = workerExecutedMetadata;
+      this.marketExecution = marketExecution;
     }
 
     public Builder setOperation(Operation operation) {
@@ -147,6 +153,11 @@ public final class ExecutionContext {
       return this;
     }
 
+    public Builder setMarketExecution(boolean marketExecution) {
+      this.marketExecution = marketExecution;
+      return this;
+    }
+
     public ExecutionContext build() {
       return new ExecutionContext(
           executeResponse,
@@ -159,7 +170,8 @@ public final class ExecutionContext {
           tree,
           queueEntry,
           claim,
-          workerExecutedMetadata);
+          workerExecutedMetadata,
+          marketExecution);
     }
   }
 
@@ -175,7 +187,8 @@ public final class ExecutionContext {
         /* tree= */ null,
         /* queueEntry= */ null,
         /* claim= */ null,
-        /* workerExecutedMetadata= */ WorkerExecutedMetadata.newBuilder());
+        /* workerExecutedMetadata= */ WorkerExecutedMetadata.newBuilder(),
+        /* marketExecution= */ false);
   }
 
   public Builder toBuilder() {
@@ -190,6 +203,7 @@ public final class ExecutionContext {
         tree,
         queueEntry,
         claim,
-        workerExecutedMetadata);
+        workerExecutedMetadata,
+        marketExecution);
   }
 }

--- a/src/main/java/build/buildfarm/worker/Executor.java
+++ b/src/main/java/build/buildfarm/worker/Executor.java
@@ -38,6 +38,7 @@ import build.buildfarm.common.Write.NullWrite;
 import build.buildfarm.common.config.BuildfarmConfigs;
 import build.buildfarm.common.config.ExecutionPolicy;
 import build.buildfarm.common.config.ExecutionWrapper;
+import build.buildfarm.v1test.Resource;
 import build.buildfarm.v1test.Tree;
 import build.buildfarm.worker.WorkerContext.IOResource;
 import build.buildfarm.worker.persistent.PersistentExecutor;
@@ -60,6 +61,7 @@ import com.google.protobuf.util.Timestamps;
 import com.google.rpc.Code;
 import io.grpc.Deadline;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.UserPrincipal;
@@ -75,26 +77,53 @@ import java.util.logging.Level;
 import lombok.extern.java.Log;
 
 @Log
-class Executor {
+public class Executor {
   private static final int INCOMPLETE_EXIT_CODE = -1;
+  private static final long SAMPLE_NANOS = 100_000_000;
+  private static final String SAMPLE_CPU_USAGE_USEC = "cpu.usage_usec";
+  private static final String SAMPLE_CPU_THROTTLED_USEC = "cpu.throttled_usec";
+  private static final String SAMPLE_CPU_NR_PERIODS = "cpu.nr_periods";
+  private static final String SAMPLE_CPU_PERIOD_USEC = "cpu.period_usec";
 
   private final WorkerContext workerContext;
   private final ExecutionContext executionContext;
   private final ExecuteActionStage owner;
   private final java.util.concurrent.Executor pollerExecutor;
+  private final int shareFloor; // minimum number of cpu shares a process must have
+  private final int pctMinUnused; // percentage difference required to sell
+  private final int pctMinThrottled; // percentage difference required to buy
+  private final int minSharesSold;
+  private final int maxSharesSold;
   private int exitCode = INCOMPLETE_EXIT_CODE;
   private boolean wasErrored = false;
   private boolean polling = false;
+  private int shareLimit = 0;
+  private volatile int shares = 0;
+  private Order order = Order.COMPLETE;
 
   Executor(
       WorkerContext workerContext,
       ExecutionContext executionContext,
       ExecuteActionStage owner,
+      int shareFloor,
+      int pctMinUnused,
+      int pctMinThrottled,
+      int minSharesSold,
+      int maxSharesSold,
       java.util.concurrent.Executor pollerExecutor) {
     this.workerContext = workerContext;
     this.executionContext = executionContext;
     this.owner = owner;
     this.pollerExecutor = pollerExecutor;
+    this.shareFloor = shareFloor;
+    this.pctMinUnused = pctMinUnused;
+    this.pctMinThrottled = pctMinThrottled;
+    this.minSharesSold = minSharesSold;
+    this.maxSharesSold = maxSharesSold;
+  }
+
+  public String name() {
+    return executionContext.operation.getName();
   }
 
   // ensure that only one error put attempt occurs
@@ -152,7 +181,12 @@ class Executor {
 
     // decide timeout and begin deadline
     Duration timeout = decideTimeout(timeoutSettings, executionContext.action);
-    Deadline pollDeadline = Time.toDeadline(timeout).offset(30, TimeUnit.SECONDS);
+    Duration pollTimeout = timeout;
+    if (executionContext.marketExecution) {
+      // permit double timeout interrupt if sell cpu
+      pollTimeout = add(pollTimeout, timeout);
+    }
+    Deadline pollDeadline = Time.toDeadline(pollTimeout).offset(30, TimeUnit.SECONDS);
 
     workerContext.resumePoller(
         executionContext.poller,
@@ -286,7 +320,7 @@ class Executor {
       throws InterruptedException {
     /* execute command */
     String executionName = executionContext.operation.getName();
-    log.log(Level.FINER, "Executor: Operation " + executionName + " Executing command");
+    log.log(Level.FINER, format("Executor: Operation %s Executing command", executionName));
 
     Command command = executionContext.command;
     Path workingDirectory = executionContext.execDir;
@@ -346,6 +380,7 @@ class Executor {
               arguments.build(),
               command.getEnvironmentVariablesList(),
               limits,
+              resource,
               timeout,
               // executingMetadata.getStdoutStreamName(),
               // executingMetadata.getStderrStreamName(),
@@ -371,7 +406,7 @@ class Executor {
             .setMessage("command resources were referenced after execution completed");
       }
     } catch (IOException e) {
-      log.log(Level.SEVERE, format("error executing operation %s", executionName), e);
+      log.log(Level.SEVERE, format("error executing %s", executionName), e);
       executionContext.poller.pause();
       putError();
       return 0;
@@ -414,7 +449,7 @@ class Executor {
         throw e;
       }
     } else {
-      log.log(Level.FINER, "Executor: Operation " + executionName + " Failed to claim output");
+      log.log(Level.FINER, format("Executor: Execution %s Failed to claim output", executionName));
       boolean wasInterrupted = Thread.interrupted();
       try {
         putError();
@@ -429,6 +464,7 @@ class Executor {
   }
 
   public void run(ResourceLimits limits) {
+    shareLimit = limits.cpu.claimed * ExecuteActionStage.SHARES_PER_SLOT;
     long stallUSecs = 0;
     Stopwatch stopwatch = Stopwatch.createStarted();
     String executionName = executionContext.operation.getName();
@@ -468,12 +504,7 @@ class Executor {
         // Now that the execution has finished we can return any of the claims against local
         // resources.
         executionContext.claim.release(EXECUTE_ACTION_STAGE);
-        owner.releaseExecutor(
-            executionName,
-            limits.cpu.claimed,
-            stopwatch.elapsed(MICROSECONDS),
-            stallUSecs,
-            exitCode);
+        owner.releaseExecutor(executionName, stopwatch.elapsed(MICROSECONDS), stallUSecs, exitCode);
       } finally {
         if (wasInterrupted) {
           Thread.currentThread().interrupt();
@@ -511,6 +542,7 @@ class Executor {
       List<String> arguments,
       List<EnvironmentVariable> environmentVariables,
       ResourceLimits limits,
+      IOResource resource,
       Duration timeout,
       ActionResult.Builder resultBuilder)
       throws IOException, InterruptedException {
@@ -524,16 +556,30 @@ class Executor {
     }
     environment.putAll(limits.extraEnvironmentVariables);
 
+    return executeProcess(
+        executionName, execDir, processBuilder, limits, resource, timeout, resultBuilder);
+  }
+
+  private Code executeProcess(
+      String executionName,
+      Path execDir,
+      ProcessBuilder processBuilder,
+      ResourceLimits limits,
+      IOResource resource,
+      Duration timeout,
+      ActionResult.Builder resultBuilder)
+      throws IOException, InterruptedException {
     // allow debugging before an execution
     if (limits.debugBeforeExecution) {
       return ExecutionDebugger.performBeforeExecutionDebug(processBuilder, limits, resultBuilder);
     }
+
     if (shouldRunOnPersistentWorker(limits)) {
       // RBE Client suggests to run this Action as persistent...
       log.fine(
-          "usePersistentWorker (mnemonic="
-              + executionContext.metadata.getRequestMetadata().getActionMnemonic()
-              + ")");
+          format(
+              "usePersistentWorker (mnemonic=%s)",
+              executionContext.metadata.getRequestMetadata().getActionMnemonic()));
 
       Tree execTree = executionContext.tree;
 
@@ -543,8 +589,8 @@ class Executor {
       return PersistentExecutor.runOnPersistentWorker(
           filesContext,
           executionName,
-          ImmutableList.copyOf(arguments),
-          ImmutableMap.copyOf(environment),
+          ImmutableList.copyOf(processBuilder.command()),
+          ImmutableMap.copyOf(processBuilder.environment()),
           limits,
           timeout,
           PersistentExecutor.defaultWorkRootsDir,
@@ -561,13 +607,214 @@ class Executor {
       settings.executionContext = executionContext;
       settings.execDir = execDir;
       settings.limits = limits;
-      settings.envVars = environment;
+      settings.envVars = processBuilder.environment();
       settings.timeout = timeout;
-      settings.arguments = arguments;
+      settings.arguments = processBuilder.command();
 
       return DockerExecutor.runActionWithDocker(dockerClient, settings, resultBuilder);
     }
-    long startNanoTime = System.nanoTime();
+
+    return executeNativeProcessAndDebug(
+        executionName, execDir, processBuilder, limits, resource, timeout, resultBuilder);
+  }
+
+  private Code executeNativeProcessAndDebug(
+      String executionName,
+      Path execDir,
+      ProcessBuilder processBuilder,
+      ResourceLimits limits,
+      IOResource resource,
+      Duration timeout,
+      ActionResult.Builder resultBuilder)
+      throws IOException, InterruptedException {
+    Code code =
+        executeNativeProcess(executionName, processBuilder, resource, timeout, resultBuilder);
+
+    // allow debugging after an execution
+    if (limits.debugAfterExecution) {
+      // Obtain execution statistics recorded while the action executed.
+      // Currently we can only source this data when using the sandbox.
+      ExecutionStatistics executionStatistics = ExecutionStatistics.getDefaultInstance();
+      if (limits.useLinuxSandbox) {
+        try (InputStream in =
+            Files.newInputStream(execDir.resolve("action_execution_statistics"))) {
+          executionStatistics = ExecutionStatistics.newBuilder().mergeFrom(in).build();
+        }
+      }
+
+      code =
+          ExecutionDebugger.performAfterExecutionDebug(
+              processBuilder, exitCode, limits, executionStatistics, resultBuilder);
+    }
+
+    return code;
+  }
+
+  private int getAdjustment(
+      int currentShares,
+      int effectiveShares,
+      long nsPeriod,
+      long nsDeltaUsed,
+      long nsDeltaThrottled) {
+    // our budget - the available shares we could buy based on limits
+    int pctUnused = 100 - (int) (nsDeltaUsed * 100 / (currentShares * nsPeriod));
+    int shareDifference = (int) (((effectiveShares * nsPeriod) - nsDeltaUsed) / nsPeriod);
+    long pctThrottle = nsDeltaThrottled * 100 / nsPeriod;
+    // System.out.println(String.format("pctUnused: %d, shareDifference %d, pctThrottle %d",
+    // pctUnused, shareDifference, pctThrottle));
+    shareDifference = Math.min(shareDifference, currentShares - shareFloor);
+    if (pctUnused >= pctMinUnused
+        && shareDifference > minSharesSold
+        && shareDifference < currentShares
+        && maxSharesSold != 0) {
+      int sharesToSell =
+          maxSharesSold < 0 ? shareDifference : Math.min(shareDifference, maxSharesSold);
+      return -sharesToSell;
+    }
+    if (pctThrottle >= pctMinThrottled) {
+      return shareLimit - currentShares;
+    }
+    return 0;
+  }
+
+  public Iterable<Resource> resources() {
+    return executionContext.claim.resources();
+  }
+
+  private record CPUUsageState(
+      long nsSampleElapsed, long nrPeriods, long usCpuUsed, long usCpuThrottled) {}
+
+  private int engageMarket(
+      int shares, IOResource resource, CPULease cpuLease, CPUUsageState now, CPUUsageState last)
+      throws IOException {
+    long nsPeriod = now.nsSampleElapsed() - last.nsSampleElapsed();
+    long nsDeltaUsed =
+        (now.usCpuUsed() - last.usCpuUsed())
+            * 1000 /* us -> ns */
+            * ExecuteActionStage.SHARES_PER_SLOT /* shares per cpu */;
+    long nsDeltaThrottled = (now.usCpuThrottled() - last.usCpuThrottled()) * 1000 /* us -> ns */;
+
+    // we can't miss samples in this process
+    // use the previous share count to ensure we don't think we've bought when we just
+    // bumped
+    int adjustment = getAdjustment(shares, shares, nsPeriod, nsDeltaUsed, nsDeltaThrottled);
+    if (adjustment > 0 && order.balance() == 0) {
+      // might recommend a different value, but we're already buying...
+      order = workerContext.market().buy(adjustment, cpuLease::accumulate);
+      return shares;
+    }
+    order.cancel();
+    if (adjustment < 0) {
+      shares += adjustment;
+      resource.setCpu(shares * 100);
+      int sale = -adjustment;
+      workerContext.market().sell(sale);
+      cpuLease.deplete(sale);
+    }
+    return shares;
+  }
+
+  private void recordUsage(long periodShares, long lastNrPeriods, Map<String, Long> sample) {
+    executionContext.workerExecutedMetadata.putAllUsage(sample);
+    // will cover any condition of marketExecution if present
+    if (sample.containsKey(SAMPLE_CPU_NR_PERIODS)) {
+      long nrPeriods = sample.get(SAMPLE_CPU_NR_PERIODS);
+      if (lastNrPeriods < nrPeriods) {
+        periodShares += shares * (nrPeriods - lastNrPeriods);
+      }
+      executionContext.workerExecutedMetadata.putUsage(SAMPLE_CPU_PERIOD_USEC, periodShares * 100);
+    }
+  }
+
+  private Code pollingExecution(
+      String executionName,
+      Process process,
+      Duration timeout,
+      IOResource resource,
+      boolean marketExecution,
+      CPULease cpuLease)
+      throws IOException, InterruptedException {
+    long nsStart = System.nanoTime();
+    long periodShares = 0;
+    CPUUsageState lastUsage = new CPUUsageState(0, 0, 0, 0);
+    long nsTimeout = Durations.toNanos(timeout);
+    for (; ; ) {
+      long nsElapsed = System.nanoTime() - nsStart;
+      long nsWait = nsTimeout - nsElapsed;
+      if (marketExecution || order.balance() != 0) {
+        nsWait = Math.min(nsWait, SAMPLE_NANOS);
+      }
+      if (process.waitFor(nsWait, TimeUnit.NANOSECONDS)) {
+        recordUsage(periodShares, lastUsage.nrPeriods(), resource.sample());
+        exitCode = process.exitValue();
+        return Code.OK;
+      }
+
+      // after wait, recompute time
+      nsElapsed = System.nanoTime() - nsStart;
+      if (nsElapsed > nsTimeout) {
+        if (!marketExecution) {
+          recordUsage(periodShares, lastUsage.nrPeriods(), resource.sample());
+          log.log(
+              Level.INFO,
+              format(
+                  "process timed out for %s after %ds",
+                  executionName, Durations.toSeconds(timeout)));
+          return Code.DEADLINE_EXCEEDED;
+        }
+
+        // we may want to consider whether anything was ever sold, or if any throttle was
+        // actually experienced
+
+        // the process could have been throttled throughout
+        // extend the timeout to the original time from now
+        nsTimeout += nsElapsed;
+        // turn off throttles and fail after next timeout elapsed
+        marketExecution = false;
+        // and issue a buy order for the current limit
+        order.cancel();
+        order = workerContext.market().buy(shareLimit - shares, cpuLease::accumulate);
+      }
+
+      int effectiveShares = shares;
+      int currentShares = cpuLease.amount();
+      if (effectiveShares != currentShares) {
+        // a buy occurred in the last sample
+        shares = currentShares;
+        resource.setCpu(shares * 100);
+      }
+
+      if (marketExecution) {
+        Map<String, Long> sample = resource.sample();
+        long nrPeriods = sample.get(SAMPLE_CPU_NR_PERIODS);
+        long usCpuUsed = sample.get(SAMPLE_CPU_USAGE_USEC);
+        long usCpuThrottled = sample.get(SAMPLE_CPU_THROTTLED_USEC);
+        CPUUsageState usage = new CPUUsageState(nsElapsed, nrPeriods, usCpuUsed, usCpuThrottled);
+
+        shares = engageMarket(effectiveShares, resource, cpuLease, usage, lastUsage);
+
+        long deltaNrPeriods = usage.nrPeriods() - lastUsage.nrPeriods();
+        if (deltaNrPeriods > 0) {
+          periodShares += effectiveShares * deltaNrPeriods;
+        }
+
+        lastUsage = usage;
+      }
+    }
+  }
+
+  private Code executeNativeProcess(
+      String executionName,
+      ProcessBuilder processBuilder,
+      IOResource resource,
+      Duration timeout,
+      ActionResult.Builder resultBuilder)
+      throws IOException, InterruptedException {
+    // consider necessity here...
+    CPULease cpuLease = (CPULease) executionContext.claim.get(CPULease.RESOURCE_NAME);
+    shares = cpuLease.amount();
+    resource.setCpu(shares * 100);
+
     Process process;
     try {
       process = ProcessUtils.threadSafeStart(processBuilder);
@@ -609,26 +856,19 @@ class Executor {
 
     Code statusCode = Code.OK;
     boolean processCompleted = false;
+
+    boolean marketExecution = executionContext.marketExecution;
     try {
-      if (timeout == null) {
+      if (timeout == null && !marketExecution) {
         exitCode = process.waitFor();
-        processCompleted = true;
+        executionContext.workerExecutedMetadata.putAllUsage(resource.sample());
       } else {
-        long timeoutNanos = Durations.toNanos(timeout);
-        long remainingNanoTime = timeoutNanos - (System.nanoTime() - startNanoTime);
-        if (process.waitFor(remainingNanoTime, TimeUnit.NANOSECONDS)) {
-          exitCode = process.exitValue();
-          processCompleted = true;
-        } else {
-          log.log(
-              Level.INFO,
-              format(
-                  "process timed out for %s after %ds",
-                  executionName, Durations.toSeconds(timeout)));
-          statusCode = Code.DEADLINE_EXCEEDED;
-        }
+        statusCode =
+            pollingExecution(executionName, process, timeout, resource, marketExecution, cpuLease);
       }
+      processCompleted = true;
     } finally {
+      order.cancel();
       if (!processCompleted) {
         process.destroy();
         int waitMillis = 1000;
@@ -639,8 +879,14 @@ class Executor {
           process.destroyForcibly();
           waitMillis = 100;
         }
+        executionContext.workerExecutedMetadata.putAllUsage(resource.sample());
       }
     }
+
+    // ensure resource release on process completion or timeout
+    // some resource conditions at this point may warrant triggering
+    // failure and/or content in output
+    resource.close();
 
     // Now that the process is completed, extract the final stdout/stderr.
     ByteString stdout = ByteString.EMPTY;
@@ -650,28 +896,11 @@ class Executor {
       stderrReaderThread.join();
       stdout = stdoutReader.getData();
       stderr = stderrReader.getData();
-
     } catch (Exception e) {
       log.log(Level.SEVERE, format("error extracting stdout/stderr for %s", executionName), e);
     }
 
     resultBuilder.setExitCode(exitCode).setStdoutRaw(stdout).setStderrRaw(stderr);
-
-    // allow debugging after an execution
-    if (limits.debugAfterExecution) {
-      // Obtain execution statistics recorded while the action executed.
-      // Currently we can only source this data when using the sandbox.
-      ExecutionStatistics executionStatistics = ExecutionStatistics.newBuilder().build();
-      if (limits.useLinuxSandbox) {
-        executionStatistics =
-            ExecutionStatistics.newBuilder()
-                .mergeFrom(Files.newInputStream(execDir.resolve("action_execution_statistics")))
-                .build();
-      }
-
-      return ExecutionDebugger.performAfterExecutionDebug(
-          processBuilder, exitCode, limits, executionStatistics, resultBuilder);
-    }
 
     return statusCode;
   }

--- a/src/main/java/build/buildfarm/worker/Executor.java
+++ b/src/main/java/build/buildfarm/worker/Executor.java
@@ -62,6 +62,7 @@ import io.grpc.Deadline;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.UserPrincipal;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -307,14 +308,16 @@ class Executor {
       }
     }
 
+    UserPrincipal execOwner = null;
+    if (executionContext.claim.get(UserPrincipalLease.RESOURCE_NAME)
+        instanceof UserPrincipalLease ownerLease) {
+      execOwner = ownerLease.owner();
+    }
+
     Code statusCode;
     try (IOResource resource =
         workerContext.limitExecution(
-            executionName,
-            executionContext.claim.owner(),
-            arguments,
-            executionContext.command,
-            workingDirectory)) {
+            executionName, execOwner, arguments, executionContext.command, workingDirectory)) {
       // Apply all other custom execution policies AFTER built-in wrappers
       for (ExecutionPolicy policy : policies) {
         if (!policy.isPrioritized() && policy.getExecutionWrapper() != null) {

--- a/src/main/java/build/buildfarm/worker/InputFetcher.java
+++ b/src/main/java/build/buildfarm/worker/InputFetcher.java
@@ -48,6 +48,7 @@ import com.google.rpc.Status;
 import io.grpc.Deadline;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.attribute.UserPrincipal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -247,13 +248,20 @@ public class InputFetcher implements Runnable {
           executionContext.queueEntry.getExecuteEntry().getActionDigest().getDigestFunction();
       build.buildfarm.v1test.Digest inputRootDigest =
           DigestUtil.fromDigest(queuedOperation.getAction().getInputRootDigest(), digestFunction);
+
+      UserPrincipal owner = null;
+      if (executionContext.claim.get(UserPrincipalLease.RESOURCE_NAME)
+          instanceof UserPrincipalLease ownerLease) {
+        owner = ownerLease.owner();
+      }
+
       execDir =
           workerContext.createExecDir(
               executionName,
               directoriesIndex,
               inputRootDigest,
               queuedOperation.getCommand(),
-              executionContext.claim.owner(),
+              owner,
               executionContext.workerExecutedMetadata);
     } catch (IOException e) {
       Status.Builder status = Status.newBuilder().setMessage("Error creating exec dir");

--- a/src/main/java/build/buildfarm/worker/InputFetcher.java
+++ b/src/main/java/build/buildfarm/worker/InputFetcher.java
@@ -28,6 +28,7 @@ import build.bazel.remote.execution.v2.Directory;
 import build.bazel.remote.execution.v2.DirectoryNode;
 import build.bazel.remote.execution.v2.ExecutedActionMetadata;
 import build.bazel.remote.execution.v2.FileNode;
+import build.bazel.remote.execution.v2.RequestMetadata;
 import build.buildfarm.common.DigestUtil;
 import build.buildfarm.common.OperationFailer;
 import build.buildfarm.common.ProxyDirectoriesIndex;
@@ -331,12 +332,15 @@ public class InputFetcher implements Runnable {
         Thread.currentThread()::interrupt,
         Deadline.after(10, DAYS),
         pollerExecutor);
+    RequestMetadata requestMetadata =
+        executionContext.queueEntry.getExecuteEntry().getRequestMetadata();
     ExecutionContext fetchedExecutionContext =
         executionContext.toBuilder()
             .setExecDir(execDir)
             .setAction(action)
             .setCommand(command)
             .setTree(tree)
+            .setMarketExecution(workerContext.shouldMarketExecution(requestMetadata))
             .build();
     boolean claimed;
     // PMD exemption false positive: unused variable

--- a/src/main/java/build/buildfarm/worker/Market.java
+++ b/src/main/java/build/buildfarm/worker/Market.java
@@ -1,0 +1,160 @@
+// Copyright 2026 The Buildfarm Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.worker;
+
+import static java.util.logging.Level.SEVERE;
+
+import build.buildfarm.common.Claim;
+import build.buildfarm.common.Resource;
+import java.util.Iterator;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.function.Consumer;
+import javax.annotation.concurrent.GuardedBy;
+import lombok.extern.java.Log;
+
+@Log
+public class Market implements Runnable, Resource {
+  private static final long CYCLE_WAIT_S = 1;
+  private static final int CYCLE_WAIT_NS = 0;
+
+  private final BlockingQueue<Order> orders = new LinkedBlockingQueue<>(); // buys
+  private final Thread broker = new Thread(this);
+  private int balance = 0;
+
+  synchronized int balance() {
+    return balance;
+  }
+
+  Order buy(int amount, Consumer<Integer> onBuy) {
+    Order order = new Order(amount, onBuy);
+    synchronized (this) {
+      orders.add(order);
+      notifyAll();
+    }
+    return order;
+  }
+
+  private boolean clearCancelledOrders() {
+    Iterator<Order> iter = orders.iterator();
+    boolean removed = false;
+    while (iter.hasNext()) {
+      Order o = iter.next();
+      if (o.balance() == 0) {
+        iter.remove();
+        removed = true;
+      }
+    }
+    return removed;
+  }
+
+  @GuardedBy("this")
+  private void waitCycle() throws InterruptedException {
+    wait(CYCLE_WAIT_S, CYCLE_WAIT_NS);
+  }
+
+  @Override
+  public void run() {
+    try {
+      int totalBought = 0;
+      for (; ; ) {
+        int available = balance();
+        while (available > totalBought) {
+          Order order;
+          if (totalBought == 0) {
+            order = orders.take();
+          } else {
+            order = orders.poll();
+            if (order == null) {
+              synchronized (this) {
+                balance = available = balance - totalBought;
+                totalBought = 0;
+              }
+              continue;
+            }
+          }
+          int bought = order.buy(available - totalBought);
+          totalBought += bought;
+          if (bought != 0) {
+            if (available == totalBought) {
+              synchronized (this) {
+                balance = available = balance - totalBought;
+              }
+              totalBought = 0;
+            }
+            // replace order if we bought something for it
+            // 0 balances will release themselves after the next iteration
+            orders.add(order);
+          }
+        }
+        // out of buy orders or at 0 balance
+        synchronized (this) {
+          balance -= totalBought;
+          while (orders.isEmpty() || balance == 0) {
+            // purge the rolls of cancelled orders, cycling until none are reported
+            if (balance != 0 || !clearCancelledOrders()) {
+              waitCycle();
+            }
+          }
+        }
+      }
+    } catch (InterruptedException e) {
+      // ignore
+    } catch (RuntimeException e) {
+      log.log(SEVERE, "Market run threw exception", e);
+    }
+  }
+
+  public void start() {
+    broker.start();
+  }
+
+  public void stop() throws InterruptedException {
+    broker.interrupt();
+    broker.join();
+  }
+
+  public void sell(int amount) {
+    if (amount != 0) {
+      // checkState(amount > 0);
+      sellSyncPositive(amount);
+    }
+  }
+
+  synchronized void sellSyncPositive(int amount) {
+    balance += amount;
+    notifyAll();
+  }
+
+  @Override
+  public Claim.Stage stage() {
+    return Claim.Stage.EXECUTE_ACTION_STAGE;
+  }
+
+  @Override
+  public boolean tryAcquire(int amount) {
+    return false;
+  }
+
+  @Override
+  public int availablePermits() {
+    return 0;
+  }
+
+  @Override
+  public void release(int amount) {
+    sell(amount);
+  }
+}

--- a/src/main/java/build/buildfarm/worker/Market.java
+++ b/src/main/java/build/buildfarm/worker/Market.java
@@ -33,9 +33,15 @@ public class Market implements Runnable, Resource {
   private final BlockingQueue<Order> orders = new LinkedBlockingQueue<>(); // buys
   private final Thread broker = new Thread(this);
   private int balance = 0;
+  private Consumer<Integer> onChangeBalance = balance -> {};
 
-  synchronized int balance() {
+  public synchronized int balance() {
     return balance;
+  }
+
+  // set this once, avoid reset
+  public void onChangeBalance(Consumer<Integer> onChangeBalance) {
+    this.onChangeBalance = onChangeBalance;
   }
 
   Order buy(int amount, Consumer<Integer> onBuy) {
@@ -82,6 +88,7 @@ public class Market implements Runnable, Resource {
                 balance = available = balance - totalBought;
                 totalBought = 0;
               }
+              onChangeBalance.accept(available);
               continue;
             }
           }
@@ -92,6 +99,7 @@ public class Market implements Runnable, Resource {
               synchronized (this) {
                 balance = available = balance - totalBought;
               }
+              onChangeBalance.accept(available);
               totalBought = 0;
             }
             // replace order if we bought something for it
@@ -128,14 +136,15 @@ public class Market implements Runnable, Resource {
 
   public void sell(int amount) {
     if (amount != 0) {
-      // checkState(amount > 0);
-      sellSyncPositive(amount);
+      int available = sellSyncPositive(amount);
+      onChangeBalance.accept(available);
     }
   }
 
-  synchronized void sellSyncPositive(int amount) {
+  synchronized int sellSyncPositive(int amount) {
     balance += amount;
     notifyAll();
+    return balance;
   }
 
   @Override

--- a/src/main/java/build/buildfarm/worker/Order.java
+++ b/src/main/java/build/buildfarm/worker/Order.java
@@ -1,0 +1,50 @@
+// Copyright 2026 The Buildfarm Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.worker;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.function.Consumer;
+
+class Order {
+  static final Order COMPLETE = new Order(0, available -> {});
+  private final Consumer<Integer> onBuy;
+  private int balance;
+
+  Order(int balance, Consumer<Integer> onBuy) {
+    this.onBuy = onBuy;
+    this.balance = balance;
+  }
+
+  synchronized void cancel() {
+    balance = 0;
+  }
+
+  // returns the number of shares bought from the available pool
+  synchronized int buy(int available) {
+    if (balance == 0 || available == 0) {
+      return 0;
+    }
+    checkArgument(available > 0);
+    int sharesToBuy = Math.min(available, balance);
+    balance -= sharesToBuy;
+    onBuy.accept(sharesToBuy);
+    return sharesToBuy;
+  }
+
+  synchronized int balance() {
+    return balance;
+  }
+}

--- a/src/main/java/build/buildfarm/worker/Pipeline.java
+++ b/src/main/java/build/buildfarm/worker/Pipeline.java
@@ -80,26 +80,8 @@ public class Pipeline implements Iterable<PipelineStage> {
    */
   public boolean isEmpty() {
     for (PipelineStage stage : stageClosePriorities.keySet()) {
-      // InputFetchStage
-      if (stage instanceof InputFetchStage) {
-        int slotUsage = ((InputFetchStage) stage).getSlotUsage();
-        if (slotUsage != 0) {
-          log.log(
-              Level.INFO,
-              String.format("InputFetchStage is not empty with slot usage: %d!", slotUsage));
-          return false;
-        }
-      } else if (stage instanceof ExecuteActionStage) { // ExecuteActionStage
-        int slotUsage = ((ExecuteActionStage) stage).getSlotUsage();
-        if (slotUsage != 0) {
-          log.log(Level.INFO, String.format("ExecuteActionStage slot usage: %d!", slotUsage));
-          return false;
-        }
-      } else { // not SuperScalar stage
-        if (stage.claimed) {
-          log.log(Level.INFO, "NonSuperScalarPipelineStage is not empty yet!");
-          return false;
-        }
+      if (!stage.isEmpty()) {
+        return false;
       }
     }
     return true;

--- a/src/main/java/build/buildfarm/worker/PipelineStage.java
+++ b/src/main/java/build/buildfarm/worker/PipelineStage.java
@@ -18,6 +18,7 @@ import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
 
 import com.google.common.base.Stopwatch;
+import com.google.common.collect.ImmutableList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import lombok.Getter;
@@ -49,6 +50,10 @@ public abstract class PipelineStage implements Runnable {
     return false;
   }
 
+  public boolean isEmpty() {
+    return !claimed;
+  }
+
   protected void runInterruptible() throws InterruptedException {
     while (!output.isClosed() || isClaimed()) {
       iterate();
@@ -57,6 +62,17 @@ public abstract class PipelineStage implements Runnable {
 
   public @Nullable String getOperationName() {
     return operationName;
+  }
+
+  public Iterable<String> getOperationNames() {
+    if (operationName != null) {
+      return ImmutableList.of(operationName);
+    }
+    return ImmutableList.of();
+  }
+
+  public int getSlotUsage() {
+    return operationName != null ? 1 : 0;
   }
 
   @Override

--- a/src/main/java/build/buildfarm/worker/SuperscalarPipelineStage.java
+++ b/src/main/java/build/buildfarm/worker/SuperscalarPipelineStage.java
@@ -28,7 +28,7 @@ import lombok.Getter;
 
 public abstract class SuperscalarPipelineStage extends PipelineStage {
   private final BlockingQueue<ExecutionContext> queue = new ArrayBlockingQueue<>(1);
-  protected Set<String> operationNames = new HashSet<>();
+  protected final Set<String> operationNames = new HashSet<>();
   @Getter protected int width;
 
   protected final BlockingQueue<Object> claims;
@@ -83,10 +83,17 @@ public abstract class SuperscalarPipelineStage extends PipelineStage {
     throw new UnsupportedOperationException("use getOperationNames on superscalar stages");
   }
 
+  @Override
+  public boolean isEmpty() {
+    return getSlotUsage() == 0;
+  }
+
+  @Override
   public int getSlotUsage() {
     return executor.getActiveCount();
   }
 
+  @Override
   public Iterable<String> getOperationNames() {
     synchronized (operationNames) {
       return new HashSet<>(operationNames);

--- a/src/main/java/build/buildfarm/worker/UserPrincipalLease.java
+++ b/src/main/java/build/buildfarm/worker/UserPrincipalLease.java
@@ -1,4 +1,4 @@
-// Copyright 2024 The Buildfarm Authors. All rights reserved.
+// Copyright 2026 The Buildfarm Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,20 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package build.buildfarm.common;
+package build.buildfarm.worker;
 
-import java.util.List;
-import java.util.Map.Entry;
+import build.buildfarm.common.Claim.Lease;
+import build.buildfarm.common.Claim.Stage;
+import java.nio.file.attribute.UserPrincipal;
 
-public interface Claim {
-  enum Stage {
-    EXECUTE_ACTION_STAGE,
-    REPORT_RESULT_STAGE,
-  }
-
-  void release(Stage stage);
-
-  void release();
-
-  Iterable<Entry<String, List<Object>>> getPools();
+public record UserPrincipalLease(String name, int amount, Stage stage, UserPrincipal owner)
+    implements Lease {
+  public static final String RESOURCE_NAME = "user-principal";
 }

--- a/src/main/java/build/buildfarm/worker/WorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/WorkerContext.java
@@ -19,6 +19,7 @@ import build.bazel.remote.execution.v2.Command;
 import build.bazel.remote.execution.v2.Digest;
 import build.bazel.remote.execution.v2.Directory;
 import build.bazel.remote.execution.v2.ExecutionStage;
+import build.bazel.remote.execution.v2.RequestMetadata;
 import build.buildfarm.common.DigestUtil.ActionKey;
 import build.buildfarm.common.Poller;
 import build.buildfarm.common.Write;
@@ -42,10 +43,18 @@ import org.jspecify.annotations.Nullable;
 
 public interface WorkerContext {
   interface IOResource extends AutoCloseable {
+    /**
+     * This close() must be implemented idempotently Several closes in sequence will be called in
+     * order to release resources early with finally-completion for safety.
+     */
     @Override
     void close() throws IOException;
 
     boolean isReferenced();
+
+    Map<String, Long> sample();
+
+    void setCpu(int cores_us) throws IOException;
   }
 
   String getName();
@@ -142,4 +151,13 @@ public interface WorkerContext {
   int commandExecutionClaims(Command command);
 
   ResourceLimits commandExecutionSettings(Command command);
+
+  @Nullable
+  default Market market() {
+    return null;
+  }
+
+  default boolean shouldMarketExecution(RequestMetadata requestMetadata) {
+    return false;
+  }
 }

--- a/src/main/java/build/buildfarm/worker/cgroup/Cpu.java
+++ b/src/main/java/build/buildfarm/worker/cgroup/Cpu.java
@@ -15,11 +15,21 @@
 package build.buildfarm.worker.cgroup;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.logging.Level.SEVERE;
 
+import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.StringTokenizer;
+import lombok.extern.java.Log;
 
+@Log
 public class Cpu extends Controller {
-  private static final int CPU_GRANULARITY = 100_000; // microseconds (μS)
+  private static final int CPU_GRANULARITY = 100_000; // 100 milliseconds (mS)
 
   Cpu(Group group) {
     super(group);
@@ -28,6 +38,83 @@ public class Cpu extends Controller {
   @Override
   public String getControllerName() {
     return "cpu";
+  }
+
+  @Override
+  public Map<String, Long> sample() {
+    ImmutableMap.Builder<String, Long> sample = ImmutableMap.builder();
+    Path statPath = getPath().resolve("cpu.stat");
+    Path pressurePath = getPath().resolve("cpu.pressure");
+
+    char[] data = new char[1024];
+    int len;
+    try (Reader in = new InputStreamReader(Files.newInputStream(statPath))) {
+      len = in.read(data);
+      if (len == data.length) {
+        throw new RuntimeException("cpu.stat data too long");
+      }
+      // codepoint?
+      String name = null;
+      for (StringTokenizer st = new StringTokenizer(new String(data)); st.hasMoreTokens(); ) {
+        String token = st.nextToken();
+        if (name == null) {
+          name = token;
+        } else {
+          sample.put(getControllerName() + "." + name, Long.parseLong(token));
+          name = null;
+        }
+      }
+    } catch (IOException e) {
+      log.log(SEVERE, "error reading " + statPath, e);
+    }
+
+    try (Reader in = new InputStreamReader(Files.newInputStream(pressurePath))) {
+      len = in.read(data);
+      if (len == data.length) {
+        throw new RuntimeException("cpu.pressure data too long");
+      }
+      // codepoint?
+      String name = null;
+      // some avg10=0.00 avg60=0.00 avg300=0.00 total=0
+      boolean hundredths = false;
+      long value_hths = 0;
+      boolean first = true;
+      for (StringTokenizer st =
+              new StringTokenizer(new String(data), " \t\n\r\f=.", /* returnDelims= */ true);
+          st.hasMoreTokens(); ) {
+        String token = st.nextToken();
+        if (first) {
+          first = false;
+        } else if (token.equals("\n") || token.equals(" ")) {
+          if (name != null) {
+            sample.put(getControllerName() + ".pressure." + name, value_hths);
+            name = null;
+          }
+          // only concern ourselves with some
+          if (token.equals("\n")) {
+            break;
+          }
+        } else if (!token.equals("=") && !token.equals("some")) {
+          if (name == null) {
+            name = token;
+          } else if (token.equals(".")) {
+            hundredths = true;
+          } else {
+            long value = Long.parseLong(token);
+            if (hundredths) {
+              value_hths += value;
+              hundredths = false;
+            } else {
+              value_hths = value * 100;
+            }
+          }
+        }
+      }
+    } catch (IOException e) {
+      log.log(SEVERE, "error reading " + pressurePath, e);
+    }
+
+    return sample.build();
   }
 
   /**
@@ -56,7 +143,12 @@ public class Cpu extends Controller {
    * @param cpuCores whole cores. 1 == 1 CPU core.
    */
   public void setMaxCpu(int cpuCores) throws IOException {
+    setCpu(cpuCores * CPU_GRANULARITY);
+  }
+
+  @Override
+  public void setCpu(int cpu_us) throws IOException {
     open();
-    writeIntPair("cpu.max", cpuCores * CPU_GRANULARITY, CPU_GRANULARITY);
+    writeIntPair("cpu.max", cpu_us, CPU_GRANULARITY);
   }
 }

--- a/src/main/java/build/buildfarm/worker/cgroup/Mem.java
+++ b/src/main/java/build/buildfarm/worker/cgroup/Mem.java
@@ -14,7 +14,9 @@
 
 package build.buildfarm.worker.cgroup;
 
+import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
+import java.util.Map;
 
 public class Mem extends Controller {
   Mem(Group group) {
@@ -24,6 +26,11 @@ public class Mem extends Controller {
   @Override
   public String getControllerName() {
     return "memory";
+  }
+
+  @Override
+  public Map<String, Long> sample() {
+    return ImmutableMap.of();
   }
 
   public long getMemoryLimit() throws IOException {
@@ -44,5 +51,10 @@ public class Mem extends Controller {
   public void setMemorySwapLimit(long limitBytes) throws IOException {
     open();
     writeLong("memory.memsw.limit_in_bytes", limitBytes);
+  }
+
+  @Override
+  public void setCpu(int cpu_us) {
+    throw new UnsupportedOperationException();
   }
 }

--- a/src/main/java/build/buildfarm/worker/resources/ExecutionPropertiesParser.java
+++ b/src/main/java/build/buildfarm/worker/resources/ExecutionPropertiesParser.java
@@ -70,6 +70,13 @@ public class ExecutionPropertiesParser {
     parser.put(
         ExecutionProperties.PERSISTENT_WORKER_KEY,
         ExecutionPropertiesParser::storePersistentWorkerKey);
+    // todo reconcile with min-cores/max-cores for broker
+    parser.put(ExecutionProperties.CPU_SHARE_FLOOR, ExecutionPropertiesParser::storeCpuShareFloor);
+    parser.put(ExecutionProperties.PCT_MIN_UNUSED, ExecutionPropertiesParser::storePctMinUnused);
+    parser.put(
+        ExecutionProperties.PCT_MIN_THROTTLED, ExecutionPropertiesParser::storePctMinThrottled);
+    parser.put(ExecutionProperties.MIN_SHARES_SOLD, ExecutionPropertiesParser::storeMinSharesSold);
+    parser.put(ExecutionProperties.MAX_SHARES_SOLD, ExecutionPropertiesParser::storeMaxSharesSold);
 
     ResourceLimits limits = new ResourceLimits();
     command
@@ -347,6 +354,41 @@ public class ExecutionPropertiesParser {
     ArrayList<String> xs = new ArrayList<>();
     xs.add("Hash of tool inputs for remote persistent workers");
     describeChange(xs, "persistentWorkerKey(hash of tool inputs)", property.getValue(), property);
+  }
+
+  private static void storeCpuShareFloor(ResourceLimits limits, Property property) {
+    limits.cpuShareFloor = Integer.parseInt(property.getValue());
+    ArrayList<String> xs = new ArrayList<>();
+    xs.add("Meaningless, lost");
+    describeChange(xs, "cpu share floor", property.getValue(), property);
+  }
+
+  private static void storePctMinUnused(ResourceLimits limits, Property property) {
+    limits.pctMinUnused = Integer.parseInt(property.getValue());
+    ArrayList<String> xs = new ArrayList<>();
+    xs.add("Meaningless, lost");
+    describeChange(xs, "cpu percent minimum unused", property.getValue(), property);
+  }
+
+  private static void storePctMinThrottled(ResourceLimits limits, Property property) {
+    limits.pctMinThrottled = Integer.parseInt(property.getValue());
+    ArrayList<String> xs = new ArrayList<>();
+    xs.add("Meaningless, lost");
+    describeChange(xs, "cpu percent minimum throttled", property.getValue(), property);
+  }
+
+  private static void storeMinSharesSold(ResourceLimits limits, Property property) {
+    limits.minSharesSold = Integer.parseInt(property.getValue());
+    ArrayList<String> xs = new ArrayList<>();
+    xs.add("Meaningless, lost");
+    describeChange(xs, "minimum cpu shares sold", property.getValue(), property);
+  }
+
+  private static void storeMaxSharesSold(ResourceLimits limits, Property property) {
+    limits.maxSharesSold = Integer.parseInt(property.getValue());
+    ArrayList<String> xs = new ArrayList<>();
+    xs.add("Meaningless, lost");
+    describeChange(xs, "maximum cpu shares sold", property.getValue(), property);
   }
 
   /**

--- a/src/main/java/build/buildfarm/worker/resources/LocalResourceSet.java
+++ b/src/main/java/build/buildfarm/worker/resources/LocalResourceSet.java
@@ -15,6 +15,7 @@
 package build.buildfarm.worker.resources;
 
 import build.buildfarm.common.Claim.Stage;
+import build.buildfarm.common.Resource;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Queue;
@@ -30,7 +31,22 @@ import java.util.concurrent.Semaphore;
  *     resources are specific to the individual worker.
  */
 public class LocalResourceSet {
-  public record SemaphoreResource(Semaphore semaphore, Stage stage) {}
+  public record SemaphoreResource(Semaphore semaphore, Stage stage) implements Resource {
+    @Override
+    public void release(int amount) {
+      semaphore().release(amount);
+    }
+
+    @Override
+    public int availablePermits() {
+      return semaphore().availablePermits();
+    }
+
+    @Override
+    public boolean tryAcquire(int amount) {
+      return semaphore().tryAcquire(amount);
+    }
+  }
 
   public record PoolResource(Queue<Object> pool, Stage stage) {}
 
@@ -39,7 +55,7 @@ public class LocalResourceSet {
    * @brief A set containing resource semaphores organized by name.
    * @details Key is name, and value contains current usage amount.
    */
-  public Map<String, SemaphoreResource> resources = new HashMap<>();
+  public Map<String, Resource> resources = new HashMap<>();
 
   public Map<String, PoolResource> poolResources = new HashMap<>();
 }

--- a/src/main/java/build/buildfarm/worker/resources/LocalResourceSetUtils.java
+++ b/src/main/java/build/buildfarm/worker/resources/LocalResourceSetUtils.java
@@ -21,7 +21,6 @@ import build.buildfarm.common.Claim;
 import build.buildfarm.common.config.LimitedResource;
 import build.buildfarm.worker.resources.LocalResourceSet.PoolResource;
 import build.buildfarm.worker.resources.LocalResourceSet.SemaphoreResource;
-import java.nio.file.attribute.UserPrincipal;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -105,11 +104,6 @@ public class LocalResourceSetUtils {
         PoolResource resource = resourceSet.poolResources.get(resourceName);
         poolRelease(resource.pool(), resourceName, pool.claims());
       }
-    }
-
-    @Override
-    public UserPrincipal owner() {
-      return null;
     }
 
     @Override

--- a/src/main/java/build/buildfarm/worker/resources/LocalResourceSetUtils.java
+++ b/src/main/java/build/buildfarm/worker/resources/LocalResourceSetUtils.java
@@ -18,6 +18,7 @@ import static com.google.common.collect.Iterables.transform;
 
 import build.bazel.remote.execution.v2.Platform;
 import build.buildfarm.common.Claim;
+import build.buildfarm.common.Resource;
 import build.buildfarm.common.config.LimitedResource;
 import build.buildfarm.worker.resources.LocalResourceSet.PoolResource;
 import build.buildfarm.worker.resources.LocalResourceSet.SemaphoreResource;
@@ -32,6 +33,7 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.Semaphore;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.commons.lang3.StringUtils;
 import org.jspecify.annotations.Nullable;
@@ -44,36 +46,55 @@ import org.jspecify.annotations.Nullable;
 public class LocalResourceSetUtils {
   private static final LocalResourceSetMetrics metrics = new LocalResourceSetMetrics();
 
-  private record SemaphoreLease(String name, int amount, Claim.Stage stage) {}
+  private record SemaphoreLease(String name, int amount, Claim.Stage stage)
+      implements Claim.Lease {}
 
   private record PoolLease(String name, List<Object> claims, Claim.Stage stage) {}
 
   public static final class LocalResourceSetClaim implements Claim {
-    private final List<SemaphoreLease> semaphores;
+    private final List<Lease> leases;
     private final List<PoolLease> pools;
     private final LocalResourceSet resourceSet;
 
-    LocalResourceSetClaim(
-        List<SemaphoreLease> semaphores, List<PoolLease> pools, LocalResourceSet resourceSet) {
-      this.semaphores = semaphores;
+    LocalResourceSetClaim(List<Lease> leases, List<PoolLease> pools, LocalResourceSet resourceSet) {
+      this.leases = leases;
       this.pools = pools;
       this.resourceSet = resourceSet;
+    }
+
+    public void add(Lease lease) {
+      leases.add(lease);
+    }
+
+    public Lease get(String name) {
+      // O(n), use sparingly
+      for (Lease lease : leases) {
+        if (lease.name().equals(name)) {
+          return lease;
+        }
+      }
+      return null;
+    }
+
+    @Override
+    public Iterable<build.buildfarm.v1test.Resource> resources() {
+      return leases.stream().map(Claim.Lease::toResource).collect(Collectors.toList());
     }
 
     @Override
     public synchronized void release(Stage stage) {
       // only remove resources that match the specified stage
       // O(n) search for staged resources
-      Iterator<SemaphoreLease> semaphoreIter = semaphores.iterator();
-      while (semaphoreIter.hasNext()) {
-        SemaphoreLease semaphore = semaphoreIter.next();
-        if (semaphore.stage() != stage) {
+      Iterator<Lease> leaseIter = leases.iterator();
+      while (leaseIter.hasNext()) {
+        Lease lease = leaseIter.next();
+        if (lease.stage() != stage) {
           continue;
         }
-        semaphoreIter.remove();
-        String resourceName = semaphore.name();
-        SemaphoreResource resource = resourceSet.resources.get(resourceName);
-        semaphoreRelease(resource.semaphore(), resourceName, semaphore.amount());
+        leaseIter.remove();
+        String resourceName = lease.name();
+        Resource resource = resourceSet.resources.get(resourceName);
+        expire(resource, resourceName, lease.amount());
       }
       Iterator<PoolLease> poolIter = pools.iterator();
       while (poolIter.hasNext()) {
@@ -91,11 +112,11 @@ public class LocalResourceSetUtils {
     // safe for multiple sequential calls with removal to release
     @Override
     public synchronized void release() {
-      while (!semaphores.isEmpty()) {
-        SemaphoreLease semaphore = semaphores.removeFirst();
-        String resourceName = semaphore.name();
-        SemaphoreResource resource = resourceSet.resources.get(resourceName);
-        semaphoreRelease(resource.semaphore(), resourceName, semaphore.amount());
+      while (!leases.isEmpty()) {
+        Lease lease = leases.removeFirst();
+        String resourceName = lease.name();
+        Resource resource = resourceSet.resources.get(resourceName);
+        expire(resource, resourceName, lease.amount());
       }
 
       while (!pools.isEmpty()) {
@@ -139,8 +160,8 @@ public class LocalResourceSetUtils {
 
   public static Set<String> exhausted(LocalResourceSet resourceSet) {
     Set<String> exhausted = new HashSet<>();
-    for (Entry<String, SemaphoreResource> resource : resourceSet.resources.entrySet()) {
-      if (resource.getValue().semaphore().availablePermits() == 0) {
+    for (Entry<String, Resource> resource : resourceSet.resources.entrySet()) {
+      if (resource.getValue().availablePermits() == 0) {
         exhausted.add(resource.getKey());
       }
     }
@@ -153,7 +174,7 @@ public class LocalResourceSetUtils {
   }
 
   public static @Nullable Claim claimResources(Platform platform, LocalResourceSet resourceSet) {
-    List<SemaphoreLease> semaphoreClaimed = new ArrayList<>();
+    List<Claim.Lease> semaphoreClaimed = new ArrayList<>();
     List<PoolLease> poolClaimed = new ArrayList<>();
 
     boolean allClaimed = true;
@@ -161,10 +182,10 @@ public class LocalResourceSetUtils {
       String resourceName = getResourceName(property.getName());
       int requestAmount = getResourceRequestAmount(property);
       if (resourceSet.resources.containsKey(resourceName)) {
-        SemaphoreResource resource = resourceSet.resources.get(resourceName);
+        Resource resource = resourceSet.resources.get(resourceName);
 
         // Attempt to claim.  If claiming fails, we must return all other claims.
-        boolean wasAcquired = semaphoreAquire(resource.semaphore(), resourceName, requestAmount);
+        boolean wasAcquired = acquire(resource, resourceName, requestAmount);
         if (wasAcquired) {
           semaphoreClaimed.add(new SemaphoreLease(resourceName, requestAmount, resource.stage()));
         } else {
@@ -186,11 +207,8 @@ public class LocalResourceSetUtils {
 
     // cleanup remaining resources if they were not all claimed.
     if (!allClaimed) {
-      for (SemaphoreLease semaphore : semaphoreClaimed) {
-        semaphoreRelease(
-            resourceSet.resources.get(semaphore.name()).semaphore(),
-            semaphore.name(),
-            semaphore.amount());
+      for (Claim.Lease semaphore : semaphoreClaimed) {
+        expire(resourceSet.resources.get(semaphore.name()), semaphore.name(), semaphore.amount());
       }
       for (PoolLease pool : poolClaimed) {
         poolRelease(resourceSet.poolResources.get(pool.name()).pool(), pool.name(), pool.claims());
@@ -202,7 +220,7 @@ public class LocalResourceSetUtils {
         : null;
   }
 
-  private static boolean semaphoreAquire(Semaphore resource, String resourceName, int amount) {
+  private static boolean acquire(Resource resource, String resourceName, int amount) {
     boolean wasAcquired = resource.tryAcquire(amount);
     if (wasAcquired) {
       metrics.resourceUsageMetric.labels(resourceName).inc(amount);
@@ -227,7 +245,7 @@ public class LocalResourceSetUtils {
     return true;
   }
 
-  private static void semaphoreRelease(Semaphore resource, String resourceName, int amount) {
+  private static void expire(Resource resource, String resourceName, int amount) {
     resource.release(amount);
     metrics.resourceUsageMetric.labels(resourceName).dec(amount);
     metrics.requestersMetric.labels(resourceName).dec();

--- a/src/main/java/build/buildfarm/worker/resources/ResourceLimits.java
+++ b/src/main/java/build/buildfarm/worker/resources/ResourceLimits.java
@@ -163,4 +163,43 @@ public class ResourceLimits {
    * @details See https://github.com/bazelbuild/bazel/issues/10091
    */
   public String persistentWorkerKey = "";
+
+  /**
+   * @field cpuShareFloor
+   * @brief minimum number of cpu shares an execution must own, there are 1000 shares per cpu
+   * @details Prevent available cpu from being reduced beyond this amount Must not be <= 0 for
+   *     market interactions
+   */
+  public int cpuShareFloor = 100;
+
+  /**
+   * @field pctMinUnused
+   * @brief Percentage of owned shares that must be unused before sale
+   * @details Headroom for per-sample volatility of use before its cpu may be sold Must not be <= 0
+   *     for market interactions
+   */
+  public int pctMinUnused = 10;
+
+  /**
+   * @field pctMinThrottled
+   * @brief Percentage of throttled that must be observed before buying cpu shares
+   * @details Headroom for per-sample volatility of throttle before cpu may be bought Must not be <=
+   *     0 for market interactions
+   */
+  public int pctMinThrottled = 10;
+
+  /**
+   * @field minSharesSold
+   * @brief Minimum Unused CPU Shares to sell
+   * @details Headroom for per-sample volatility of use before its cpu may be sold Must not be <= 0
+   *     for market interactions
+   */
+  public int minSharesSold = 10;
+
+  /**
+   * @field maxSharesSold
+   * @brief Maximum Unused CPU Shares to sell
+   * @details Control the sale rate of unused shares Must not be <= 0 for market interactions
+   */
+  public int maxSharesSold = -1;
 }

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -59,6 +59,7 @@ import build.buildfarm.worker.ExecFileSystem;
 import build.buildfarm.worker.ExecutionPolicies;
 import build.buildfarm.worker.MatchListener;
 import build.buildfarm.worker.RetryingMatchListener;
+import build.buildfarm.worker.UserPrincipalLease;
 import build.buildfarm.worker.WorkerContext;
 import build.buildfarm.worker.cgroup.Cpu;
 import build.buildfarm.worker.cgroup.Group;
@@ -345,7 +346,6 @@ class ShardWorkerContext implements WorkerContext {
     return ProtoUtils.parseQueuedOperation(queuedOperationBlob, queueEntry);
   }
 
-  // FIXME make OwnedClaim with owner
   // how will this play out with persistent workers, should we have one per user?
   private @Nullable Claim acquireClaim(Platform platform) {
     // expand platform requirements with exec owner
@@ -363,34 +363,13 @@ class ShardWorkerContext implements WorkerContext {
           continue;
         }
         String name = (String) Iterables.getOnlyElement(pool.getValue());
-
-        return new Claim() {
-          UserPrincipal owner = execFileSystem.getOwner(name);
-
-          @Override
-          public void release(Claim.Stage stage) {
-            claim.release(stage);
-          }
-
-          @Override
-          public void release() {
-            owner = null;
-            claim.release();
-          }
-
-          @Override
-          public UserPrincipal owner() {
-            if (owner != null) {
-              return owner;
-            }
-            return claim.owner();
-          }
-
-          @Override
-          public Iterable<Entry<String, List<Object>>> getPools() {
-            return claim.getPools();
-          }
-        };
+        UserPrincipalLease userPrincipalLease =
+            new UserPrincipalLease(
+                UserPrincipalLease.RESOURCE_NAME,
+                /* amount= */ 1,
+                Claim.Stage.REPORT_RESULT_STAGE,
+                execFileSystem.getOwner(name));
+        claim.add(userPrincipalLease);
       }
       // claim was not provided with owner name value
     }

--- a/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
+++ b/src/main/java/build/buildfarm/worker/shard/ShardWorkerContext.java
@@ -18,6 +18,8 @@ import static build.buildfarm.cas.ContentAddressableStorage.UNLIMITED_ENTRY_SIZE
 import static build.buildfarm.common.Actions.checkPreconditionFailure;
 import static build.buildfarm.common.Errors.VIOLATION_TYPE_INVALID;
 import static build.buildfarm.common.Errors.VIOLATION_TYPE_MISSING;
+import static build.buildfarm.worker.ExecuteActionStage.SHARES_PER_SLOT;
+import static com.google.common.base.Preconditions.checkState;
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.DAYS;
 
@@ -27,6 +29,7 @@ import build.bazel.remote.execution.v2.Compressor;
 import build.bazel.remote.execution.v2.Directory;
 import build.bazel.remote.execution.v2.ExecutionStage;
 import build.bazel.remote.execution.v2.Platform;
+import build.bazel.remote.execution.v2.RequestMetadata;
 import build.buildfarm.backplane.Backplane;
 import build.buildfarm.cas.ContentAddressableStorage;
 import build.buildfarm.common.Claim;
@@ -54,9 +57,11 @@ import build.buildfarm.v1test.Digest;
 import build.buildfarm.v1test.QueueEntry;
 import build.buildfarm.v1test.QueuedOperation;
 import build.buildfarm.v1test.WorkerExecutedMetadata;
+import build.buildfarm.worker.CPULease;
 import build.buildfarm.worker.DequeueMatchEvaluator;
 import build.buildfarm.worker.ExecFileSystem;
 import build.buildfarm.worker.ExecutionPolicies;
+import build.buildfarm.worker.Market;
 import build.buildfarm.worker.MatchListener;
 import build.buildfarm.worker.RetryingMatchListener;
 import build.buildfarm.worker.UserPrincipalLease;
@@ -70,6 +75,7 @@ import build.buildfarm.worker.resources.ResourceLimits;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.ListMultimap;
@@ -94,6 +100,7 @@ import java.nio.file.Path;
 import java.nio.file.attribute.UserPrincipal;
 import java.util.ArrayList;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -130,6 +137,7 @@ class ShardWorkerContext implements WorkerContext {
   private final int reportResultStageWidth;
   private final Backplane backplane;
   private final ExecFileSystem execFileSystem;
+  private final Market market = new Market();
   private final InputStreamFactory inputStreamFactory;
   private final ListMultimap<String, ExecutionPolicy> policies;
   private final Instance instance;
@@ -146,6 +154,8 @@ class ShardWorkerContext implements WorkerContext {
   private final boolean errorOperationRemainingResources;
   private final LocalResourceSet resourceSet;
   private final boolean errorOperationOutputSizeExceeded;
+  private final boolean marketExecution;
+  private final Set<String> ignoreMarketExecutionMnemonics;
   private final boolean provideOwnedClaim;
   private boolean inGracefulShutdown = false;
   private boolean pauseMatch = false;
@@ -182,6 +192,7 @@ class ShardWorkerContext implements WorkerContext {
    * @param inputFetchDeadline The duration input fetch must complete in before return to queue
    * @param backplane A source of truth and reporting for execution and content
    * @param execFileSystem Manager of execution filesystem presentation
+   * @param market CPU Marketplace for worker-scope trade of cpu shares
    * @param inputStreamFactory Supplier of CAS streams for reading
    * @param policies Policies which will/can be applied to executions
    * @param instance Instance used for ActionResult post and Operation lease reporting
@@ -222,6 +233,8 @@ class ShardWorkerContext implements WorkerContext {
       boolean allowBringYourOwnContainer,
       boolean errorOperationRemainingResources,
       boolean errorOperationOutputSizeExceeded,
+      boolean marketExecution,
+      Set<String> ignoreMarketExecutionMnemonics,
       LocalResourceSet resourceSet,
       CasWriter writer) {
     this.name = name;
@@ -245,8 +258,13 @@ class ShardWorkerContext implements WorkerContext {
     this.allowBringYourOwnContainer = allowBringYourOwnContainer;
     this.errorOperationRemainingResources = errorOperationRemainingResources;
     this.errorOperationOutputSizeExceeded = errorOperationOutputSizeExceeded;
+    this.marketExecution = marketExecution;
+    this.ignoreMarketExecutionMnemonics = ignoreMarketExecutionMnemonics;
     this.resourceSet = resourceSet;
     this.writer = writer;
+
+    checkState(resourceSet.resources.put(CPULease.RESOURCE_NAME, market) == null);
+    market.sell(executeStageWidth * SHARES_PER_SLOT);
 
     provideOwnedClaim = this.resourceSet.poolResources.containsKey(EXEC_OWNER_RESOURCE_NAME);
   }
@@ -260,6 +278,11 @@ class ShardWorkerContext implements WorkerContext {
             /*options.experimentalRemoteRetryJitter=*/ 0.1,
             /*options.experimentalRemoteRetryMaxAttempts=*/ 5),
         Retrier.REDIS_IS_RETRIABLE);
+  }
+
+  @Override
+  public Market market() {
+    return market;
   }
 
   @Override
@@ -280,6 +303,12 @@ class ShardWorkerContext implements WorkerContext {
   @Override
   public boolean shouldErrorOperationOnRemainingResources() {
     return errorOperationRemainingResources;
+  }
+
+  @Override
+  public boolean shouldMarketExecution(RequestMetadata requestMetadata) {
+    return marketExecution
+        && !ignoreMarketExecutionMnemonics.contains(requestMetadata.getActionMnemonic());
   }
 
   @Override
@@ -852,11 +881,12 @@ class ShardWorkerContext implements WorkerContext {
   }
 
   boolean shouldLimitCoreUsage() {
-    return limitGlobalExecution || onlyMulticoreTests || defaultMaxCores > 0;
+    return marketExecution || limitGlobalExecution || onlyMulticoreTests || defaultMaxCores > 0;
   }
 
   @Override
   public void createExecutionLimits() {
+    market.start();
     if (shouldLimitCoreUsage() && configs.getWorker().getSandboxSettings().isAlwaysUseCgroups()) {
       createOperationExecutionLimits();
     }
@@ -887,6 +917,12 @@ class ShardWorkerContext implements WorkerContext {
       try {
         operationsGroup.getCpu().close();
         executionsGroup.getCpu().close();
+        try {
+          market.stop();
+        } catch (InterruptedException e) {
+          log.log(Level.SEVERE, "market await shutdown interrupted", e);
+          Thread.currentThread().interrupt();
+        }
       } catch (IOException e) {
         throw new RuntimeException(e);
       }
@@ -912,7 +948,7 @@ class ShardWorkerContext implements WorkerContext {
         command,
         defaultMaxCores,
         onlyMulticoreTests,
-        limitGlobalExecution,
+        marketExecution || limitGlobalExecution,
         getExecuteStageWidth(),
         allowBringYourOwnContainer,
         configs.getWorker().getSandboxSettings());
@@ -942,6 +978,14 @@ class ShardWorkerContext implements WorkerContext {
             public boolean isReferenced() {
               return false;
             }
+
+            @Override
+            public Map<String, Long> sample() {
+              return ImmutableMap.of();
+            }
+
+            @Override
+            public void setCpu(int cpu_us) {}
           };
     }
 
@@ -1167,6 +1211,24 @@ class ShardWorkerContext implements WorkerContext {
           }
         }
         return false;
+      }
+
+      @Override
+      public Map<String, Long> sample() {
+        Map<String, Long> sample = new HashMap<>();
+        for (IOResource resource : resources) {
+          sample.putAll(resource.sample());
+        }
+        return sample;
+      }
+
+      @Override
+      public void setCpu(int cpu_us) throws IOException {
+        for (IOResource resource : resources) {
+          if (resource instanceof Cpu) {
+            resource.setCpu(cpu_us);
+          }
+        }
       }
     };
   }

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -141,6 +141,8 @@ public final class Worker extends LoggingMain {
           .register();
   private static final Counter workerPausedMetric =
       Counter.build().name("worker_paused").help("Worker paused.").register();
+  private static final Gauge executionSlotUsage = // now Market stock - balance
+      Gauge.build().name("execution_slot_usage").help("Execution slot Usage.").register();
   private static final Gauge executionSlotsTotal =
       Gauge.build()
           .name("execution_slots_total")
@@ -792,6 +794,10 @@ public final class Worker extends LoggingMain {
             resourceSet,
             writer);
 
+    // initial balance for market is available slots
+    final int marketStock = context.market().balance();
+    context.market().onChangeBalance(balance -> executionSlotUsage.set(marketStock - balance));
+
     pipeline = new Pipeline();
     SuperscalarPipelineStage inputFetchStage = null;
     ExecuteActionStage executeActionStage = null;
@@ -861,7 +867,7 @@ public final class Worker extends LoggingMain {
     pipeline.start();
     healthCheckMetric.labels("start").inc();
     inputFetchSlotsTotal.set(inputFetchStageWidth);
-    executionSlotsTotal.set(executeStageWidth);
+    executionSlotsTotal.set(marketStock);
     reportResultSlotsTotal.set(reportResultStageWidth);
   }
 

--- a/src/main/java/build/buildfarm/worker/shard/Worker.java
+++ b/src/main/java/build/buildfarm/worker/shard/Worker.java
@@ -787,12 +787,14 @@ public final class Worker extends LoggingMain {
             configs.getWorker().isAllowBringYourOwnContainer(),
             configs.getWorker().isErrorOperationRemainingResources(),
             configs.getWorker().isErrorOperationOutputSizeExceeded(),
+            configs.getWorker().isExecutionMarket(),
+            configs.getWorker().getIgnoreMarketExecutionMnemonics(),
             resourceSet,
             writer);
 
     pipeline = new Pipeline();
     SuperscalarPipelineStage inputFetchStage = null;
-    SuperscalarPipelineStage executeActionStage = null;
+    ExecuteActionStage executeActionStage = null;
     SuperscalarPipelineStage reportResultStage = null;
     PutOperationStage completeStage = null;
     if (configs.getWorker().getCapabilities().isExecution()) {

--- a/src/main/java/build/buildfarm/worker/shard/WorkerProfileService.java
+++ b/src/main/java/build/buildfarm/worker/shard/WorkerProfileService.java
@@ -16,9 +16,12 @@ package build.buildfarm.worker.shard;
 
 import build.buildfarm.cas.cfc.CASFileCache;
 import build.buildfarm.v1test.StageInformation;
+import build.buildfarm.v1test.WorkerExecution;
 import build.buildfarm.v1test.WorkerProfileGrpc;
 import build.buildfarm.v1test.WorkerProfileMessage;
 import build.buildfarm.v1test.WorkerProfileRequest;
+import build.buildfarm.worker.ExecuteActionStage;
+import build.buildfarm.worker.Executor;
 import build.buildfarm.worker.PipelineStage;
 import build.buildfarm.worker.PutOperationStage;
 import build.buildfarm.worker.PutOperationStage.OperationStageDurations;
@@ -33,7 +36,7 @@ public class WorkerProfileService extends WorkerProfileGrpc.WorkerProfileImplBas
   private final @Nullable CASFileCache storage;
   private final @Nullable PipelineStage matchStage;
   private final @Nullable SuperscalarPipelineStage inputFetchStage;
-  private final @Nullable SuperscalarPipelineStage executeActionStage;
+  private final @Nullable ExecuteActionStage executeActionStage;
   private final @Nullable SuperscalarPipelineStage reportResultStage;
   private final @Nullable PutOperationStage completeStage;
 
@@ -43,7 +46,7 @@ public class WorkerProfileService extends WorkerProfileGrpc.WorkerProfileImplBas
       @Nullable CASFileCache storage,
       @Nullable PipelineStage matchStage,
       @Nullable SuperscalarPipelineStage inputFetchStage,
-      @Nullable SuperscalarPipelineStage executeActionStage,
+      @Nullable ExecuteActionStage executeActionStage,
       @Nullable SuperscalarPipelineStage reportResultStage,
       @Nullable PutOperationStage completeStage) {
     this.name = name;
@@ -65,7 +68,22 @@ public class WorkerProfileService extends WorkerProfileGrpc.WorkerProfileImplBas
     return builder.build();
   }
 
-  private StageInformation superscalarStageInformation(SuperscalarPipelineStage stage) {
+  private StageInformation executeActionStageInformation(ExecuteActionStage stage) {
+    StageInformation.Builder builder =
+        StageInformation.newBuilder()
+            .setName(stage.getName())
+            .setSlotsConfigured(stage.getSharesConfigured())
+            .setSlotsUsed(stage.getSharesUsed());
+    for (Executor execution : stage.getExecutions()) {
+      builder.addExecutions(
+          WorkerExecution.newBuilder()
+              .setName(execution.name())
+              .addAllResources(execution.resources()));
+    }
+    return builder.build();
+  }
+
+  private StageInformation superscalarStageInformation(PipelineStage stage) {
     return StageInformation.newBuilder()
         .setName(stage.getName())
         .setSlotsConfigured(stage.getWidth())
@@ -108,7 +126,7 @@ public class WorkerProfileService extends WorkerProfileGrpc.WorkerProfileImplBas
       String matchOperation = matchStage.getOperationName();
       replyBuilder
           .addStages(superscalarStageInformation(reportResultStage))
-          .addStages(superscalarStageInformation(executeActionStage))
+          .addStages(executeActionStageInformation(executeActionStage))
           .addStages(superscalarStageInformation(inputFetchStage))
           .addStages(unaryStageInformation(matchStage.getName(), matchOperation));
     }

--- a/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
+++ b/src/main/protobuf/build/buildfarm/v1test/buildfarm.proto
@@ -595,6 +595,22 @@ message StageInformation {
   int32 slots_used = 3;
 
   repeated string operation_names = 4;
+
+  repeated WorkerExecution executions = 5;
+}
+
+message WorkerExecution {
+  // longrunning operation name
+  string name = 1;
+
+  repeated Resource resources = 2;
+}
+
+message Resource {
+  // retained resource name for execution
+  string name = 1;
+
+  int32 amount = 2;
 }
 
 message BatchWorkerProfilesResponse {
@@ -735,4 +751,9 @@ message WorkerExecutedMetadata {
   int64 fetched_bytes = 1;
 
   repeated string linked_input_directories = 2;
+
+  // variable resource-defined usage keys mapped to quantified usage consumed
+  // by an execution during worker processing. May include cpu, io, ram with
+  // descriptive prefixes.
+  map<string, int64> usage = 3;
 }

--- a/src/test/java/build/buildfarm/worker/DequeueMatchEvaluatorTest.java
+++ b/src/test/java/build/buildfarm/worker/DequeueMatchEvaluatorTest.java
@@ -229,7 +229,7 @@ public class DequeueMatchEvaluatorTest {
             .build();
 
     // PRE-ASSERT
-    assertThat(resourceSet.resources.get("FOO").semaphore().availablePermits()).isEqualTo(1);
+    assertThat(resourceSet.resources.get("FOO").availablePermits()).isEqualTo(1);
 
     // ACT
     Claim claim = acquireClaim(workerProvisions, resourceSet, platform);
@@ -237,7 +237,7 @@ public class DequeueMatchEvaluatorTest {
     // ASSERT
     // the worker accepts because the resource is available.
     assertThat(claim).isNotNull();
-    assertThat(resourceSet.resources.get("FOO").semaphore().availablePermits()).isEqualTo(0);
+    assertThat(resourceSet.resources.get("FOO").availablePermits()).isEqualTo(0);
 
     // ACT
     claim = acquireClaim(workerProvisions, resourceSet, platform);
@@ -245,7 +245,7 @@ public class DequeueMatchEvaluatorTest {
     // ASSERT
     // the worker rejects because there are no resources left.
     assertThat(claim).isNull();
-    assertThat(resourceSet.resources.get("FOO").semaphore().availablePermits()).isEqualTo(0);
+    assertThat(resourceSet.resources.get("FOO").availablePermits()).isEqualTo(0);
   }
 
   // Function under test: acquireClaim
@@ -266,7 +266,7 @@ public class DequeueMatchEvaluatorTest {
             .build();
 
     // PRE-ASSERT
-    assertThat(resourceSet.resources.get("FOO").semaphore().availablePermits()).isEqualTo(1);
+    assertThat(resourceSet.resources.get("FOO").availablePermits()).isEqualTo(1);
 
     // ACT
     Claim claim = acquireClaim(workerProvisions, resourceSet, platform);
@@ -274,7 +274,7 @@ public class DequeueMatchEvaluatorTest {
     // ASSERT
     // the worker rejects because the os is not satisfied
     assertThat(claim).isNull();
-    assertThat(resourceSet.resources.get("FOO").semaphore().availablePermits()).isEqualTo(1);
+    assertThat(resourceSet.resources.get("FOO").availablePermits()).isEqualTo(1);
   }
 
   // Function under test: acquireClaim
@@ -296,8 +296,8 @@ public class DequeueMatchEvaluatorTest {
             .build();
 
     // PRE-ASSERT
-    assertThat(resourceSet.resources.get("FOO").semaphore().availablePermits()).isEqualTo(2);
-    assertThat(resourceSet.resources.get("BAR").semaphore().availablePermits()).isEqualTo(4);
+    assertThat(resourceSet.resources.get("FOO").availablePermits()).isEqualTo(2);
+    assertThat(resourceSet.resources.get("BAR").availablePermits()).isEqualTo(4);
 
     // ACT
     Claim claim = acquireClaim(workerProvisions, resourceSet, platform);
@@ -305,8 +305,8 @@ public class DequeueMatchEvaluatorTest {
     // ASSERT
     // the worker accepts because the resource is available.
     assertThat(claim).isNotNull();
-    assertThat(resourceSet.resources.get("FOO").semaphore().availablePermits()).isEqualTo(1);
-    assertThat(resourceSet.resources.get("BAR").semaphore().availablePermits()).isEqualTo(2);
+    assertThat(resourceSet.resources.get("FOO").availablePermits()).isEqualTo(1);
+    assertThat(resourceSet.resources.get("BAR").availablePermits()).isEqualTo(2);
 
     // ACT
     claim = acquireClaim(workerProvisions, resourceSet, platform);
@@ -314,8 +314,8 @@ public class DequeueMatchEvaluatorTest {
     // ASSERT
     // the worker accepts because the resource is available.
     assertThat(claim).isNotNull();
-    assertThat(resourceSet.resources.get("FOO").semaphore().availablePermits()).isEqualTo(0);
-    assertThat(resourceSet.resources.get("BAR").semaphore().availablePermits()).isEqualTo(0);
+    assertThat(resourceSet.resources.get("FOO").availablePermits()).isEqualTo(0);
+    assertThat(resourceSet.resources.get("BAR").availablePermits()).isEqualTo(0);
 
     // ACT
     claim = acquireClaim(workerProvisions, resourceSet, platform);
@@ -323,8 +323,8 @@ public class DequeueMatchEvaluatorTest {
     // ASSERT
     // the worker rejects because there are no resources left.
     assertThat(claim).isNull();
-    assertThat(resourceSet.resources.get("FOO").semaphore().availablePermits()).isEqualTo(0);
-    assertThat(resourceSet.resources.get("BAR").semaphore().availablePermits()).isEqualTo(0);
+    assertThat(resourceSet.resources.get("FOO").availablePermits()).isEqualTo(0);
+    assertThat(resourceSet.resources.get("BAR").availablePermits()).isEqualTo(0);
   }
 
   // Function under test: acquireClaim
@@ -352,9 +352,9 @@ public class DequeueMatchEvaluatorTest {
             .build();
 
     // PRE-ASSERT
-    assertThat(resourceSet.resources.get("FOO").semaphore().availablePermits()).isEqualTo(50);
-    assertThat(resourceSet.resources.get("BAR").semaphore().availablePermits()).isEqualTo(100);
-    assertThat(resourceSet.resources.get("BAZ").semaphore().availablePermits()).isEqualTo(200);
+    assertThat(resourceSet.resources.get("FOO").availablePermits()).isEqualTo(50);
+    assertThat(resourceSet.resources.get("BAR").availablePermits()).isEqualTo(100);
+    assertThat(resourceSet.resources.get("BAZ").availablePermits()).isEqualTo(200);
 
     // ACT
     Claim claim = acquireClaim(workerProvisions, resourceSet, platform);
@@ -363,9 +363,9 @@ public class DequeueMatchEvaluatorTest {
     // the worker rejects because there are no resources left.
     // The same amount are returned.
     assertThat(claim).isNull();
-    assertThat(resourceSet.resources.get("FOO").semaphore().availablePermits()).isEqualTo(50);
-    assertThat(resourceSet.resources.get("BAR").semaphore().availablePermits()).isEqualTo(100);
-    assertThat(resourceSet.resources.get("BAZ").semaphore().availablePermits()).isEqualTo(200);
+    assertThat(resourceSet.resources.get("FOO").availablePermits()).isEqualTo(50);
+    assertThat(resourceSet.resources.get("BAR").availablePermits()).isEqualTo(100);
+    assertThat(resourceSet.resources.get("BAZ").availablePermits()).isEqualTo(200);
   }
 
   @Test

--- a/src/test/java/build/buildfarm/worker/shard/ShardWorkerContextTest.java
+++ b/src/test/java/build/buildfarm/worker/shard/ShardWorkerContextTest.java
@@ -48,6 +48,7 @@ import build.buildfarm.worker.WorkerContext;
 import build.buildfarm.worker.resources.LocalResourceSet;
 import build.buildfarm.worker.resources.LocalResourceSet.PoolResource;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.jimfs.Jimfs;
 import com.google.protobuf.Duration;
@@ -123,6 +124,8 @@ public class ShardWorkerContextTest {
         /* allowBringYourOwnContainer= */ false,
         /* errorOperationRemainingResources= */ false,
         /* errorOperationOutputSizeExceeded= */ false,
+        /* marketExecution= */ false,
+        /* ignoreMarketExecutionMnemonics= */ ImmutableSet.of(),
         resourceSet,
         writer);
   }


### PR DESCRIPTION
Instead of slots of single core CPU usage, provide a marketplace for executions to buy and sell the CPU they [think they] need or observably, don't.
Initialize actions with a single core of cpu request. Executions will not sell below 1/10th of a single core - this is mostly for stability reasons, but is also a limitation of cgroups.

Extend deadline for execution polls

Attempting to extend deadlines for market tolerance leaves the poll deadline based on original timeout ready to kill processes. This deadline seems unnecessary, and should live closer to the input fetcher.

Wallet is represented by a claimed resource for an execution, as safe as that system for preventing leaks. Resources are reworked to emphasize this capacity for mutation.