### PR TITLE
fix(CFCLinkExecFileSystem): advance directory iterator correctly

### DIFF
--- a/src/main/java/build/buildfarm/worker/CFCLinkExecFileSystem.java
+++ b/src/main/java/build/buildfarm/worker/CFCLinkExecFileSystem.java
@@ -50,6 +50,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.Stack;
 import java.util.concurrent.CancellationException;
@@ -162,12 +163,20 @@ public class CFCLinkExecFileSystem extends CFCExecFileSystem {
   }
 
   private static final class DirectoryIterator implements Iterator<String> {
+    private static final class Frame {
+      private final String prefix;
+      private final Iterator<DirectoryNode> directories;
+
+      private Frame(String prefix, Iterator<DirectoryNode> directories) {
+        this.prefix = prefix;
+        this.directories = directories;
+      }
+    }
+
     private final Map<build.bazel.remote.execution.v2.Digest, Directory> directoriesIndex;
     private final Set<String> ignorePaths;
-    private Iterator<DirectoryNode> current;
-    private Stack<Iterator<DirectoryNode>> route = new Stack<>();
-    private Stack<String> path = new Stack<>();
-    private DirectoryNode next;
+    private final Stack<Frame> route = new Stack<>();
+    private String next;
 
     DirectoryIterator(
         Directory root,
@@ -175,8 +184,8 @@ public class CFCLinkExecFileSystem extends CFCExecFileSystem {
         Set<String> ignorePaths) {
       this.directoriesIndex = directoriesIndex;
       this.ignorePaths = ignorePaths;
-      current = root.getDirectoriesList().iterator();
-      advance("");
+      route.push(new Frame("", root.getDirectoriesList().iterator()));
+      advance();
     }
 
     @Override
@@ -184,44 +193,49 @@ public class CFCLinkExecFileSystem extends CFCExecFileSystem {
       return next != null;
     }
 
-    private void advance(String prefix) {
+    private void advance() {
       next = null;
-      while (current.hasNext()) {
-        DirectoryNode next = current.next();
-        if (!ignorePaths.contains(prefix + next.getName())) {
-          this.next = next;
-          return;
+      while (!route.isEmpty()) {
+        Frame frame = route.peek();
+        if (!frame.directories.hasNext()) {
+          route.pop();
+          continue;
         }
+
+        DirectoryNode nextNode = frame.directories.next();
+        String nextPath =
+            frame.prefix.isEmpty() ? nextNode.getName() : frame.prefix + "/" + nextNode.getName();
+        if (ignorePaths.contains(nextPath)) {
+          continue;
+        }
+
+        build.bazel.remote.execution.v2.Digest digest = nextNode.getDigest();
+        if (digest.getSizeBytes() != 0) {
+          Directory directory = checkNotNull(directoriesIndex.get(digest));
+          route.push(new Frame(nextPath, directory.getDirectoriesList().iterator()));
+        }
+        next = nextPath;
+        return;
       }
     }
 
     @Override
     public String next() {
-      String nextPath;
-      String name = next.getName();
-      path.push(name);
-      nextPath = String.join("/", path);
-      build.bazel.remote.execution.v2.Digest digest = next.getDigest();
-      if (digest.getSizeBytes() != 0) {
-        route.push(current);
-        current = directoriesIndex.get(digest).getDirectoriesList().iterator();
-        // nextPath guaranteed to be non-empty
-        advance(nextPath + "/");
-        if (!current.hasNext()) {
-          current = route.pop();
-          path.pop();
-        }
-      } else {
-        path.pop();
+      if (next == null) {
+        throw new NoSuchElementException();
       }
-      while (!current.hasNext() && !route.isEmpty()) {
-        current = route.pop();
-        path.pop();
-        String prefix = path.isEmpty() ? "" : (String.join("/", path) + "/");
-        advance(prefix);
-      }
+      String nextPath = next;
+      advance();
       return nextPath;
     }
+  }
+
+  @VisibleForTesting
+  static Iterator<String> directoriesIterator(
+      Directory root,
+      Map<build.bazel.remote.execution.v2.Digest, Directory> directoriesIndex,
+      Set<String> ignorePaths) {
+    return new DirectoryIterator(root, directoriesIndex, ignorePaths);
   }
 
   private Set<String> linkedDirectories(
@@ -233,7 +247,7 @@ public class CFCLinkExecFileSystem extends CFCExecFileSystem {
       ImmutableSet.Builder<String> builder = ImmutableSet.builder();
 
       Directory root = directoriesIndex.get(rootDigest);
-      Iterator<String> dirs = new DirectoryIterator(root, directoriesIndex, ignorePaths);
+      Iterator<String> dirs = directoriesIterator(root, directoriesIndex, ignorePaths);
       while (dirs.hasNext()) {
         String dir = dirs.next();
         for (Pattern pattern : linkedInputDirectories) {

--- a/src/test/java/build/buildfarm/worker/CFCLinkExecFileSystemTest.java
+++ b/src/test/java/build/buildfarm/worker/CFCLinkExecFileSystemTest.java
@@ -35,11 +35,13 @@ import build.buildfarm.v1test.Digest;
 import build.buildfarm.v1test.WorkerExecutedMetadata;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import org.junit.Test;
@@ -291,5 +293,42 @@ public class CFCLinkExecFileSystemTest {
     // "a" matched the linked-directories pattern; it should have been linked via
     // putDirectory. If the constructor double-advance bug skipped "a", this fails.
     verify(cfc, times(1)).putDirectory(aDigest, directoriesIndex, fetchService);
+  }
+
+  @Test
+  public void directoryIteratorAdvancesPastEmptyDirectory() {
+    Digest emptyDigest = DIGEST_UTIL.compute(Directory.getDefaultInstance());
+    Directory nonEmptyDirectory =
+        Directory.newBuilder()
+            .addDirectories(
+                DirectoryNode.newBuilder()
+                    .setName("child")
+                    .setDigest(DigestUtil.toDigest(emptyDigest))
+                    .build())
+            .build();
+    Digest nonEmptyDigest = DIGEST_UTIL.compute(nonEmptyDirectory);
+    Directory inputRootDirectory =
+        Directory.newBuilder()
+            .addDirectories(
+                DirectoryNode.newBuilder()
+                    .setName("empty")
+                    .setDigest(DigestUtil.toDigest(emptyDigest))
+                    .build())
+            .addDirectories(
+                DirectoryNode.newBuilder()
+                    .setName("nonempty")
+                    .setDigest(DigestUtil.toDigest(nonEmptyDigest))
+                    .build())
+            .build();
+    Iterator<String> dirs =
+        CFCLinkExecFileSystem.directoriesIterator(
+            inputRootDirectory,
+            ImmutableMap.of(DigestUtil.toDigest(nonEmptyDigest), nonEmptyDirectory),
+            ImmutableSet.of());
+
+    assertThat(dirs.next()).isEqualTo("empty");
+    assertThat(dirs.next()).isEqualTo("nonempty");
+    assertThat(dirs.next()).isEqualTo("nonempty/child");
+    assertThat(dirs.hasNext()).isFalse();
   }
 }


### PR DESCRIPTION
## Summary

This fixes `CFCLinkExecFileSystem.DirectoryIterator` so linked input directory discovery advances correctly after every returned directory path.

The iterator added for `output_paths` filtering cached the next `DirectoryNode`, but the cached value was not always advanced after `next()`. In particular, when the returned directory had the empty-directory digest, the iterator could keep returning the same path while `hasNext()` remained true because the current sibling iterator still had entries. That can make `linkedDirectories()` spin during exec directory creation.

The fix replaces the cached-node state with explicit DFS frames containing the current path prefix and child iterator. This preserves ignored-output-path filtering while ensuring each directory path is returned once and exhausted iteration follows the `Iterator` contract.

Related to:
* https://github.com/buildfarm/buildfarm/issues/2562

## Testing

Ran:
```shell
bazel test //src/test/java/build/buildfarm/worker:tests
bazel build //container:buildfarm-worker
bazel run //tools/lint/hawkeye -- check --fail-if-unknown
./.bazelci/format.sh
```

Added a regression test for an empty directory followed by a non-empty sibling.

Also validated the change in a staging Buildfarm cluster with `linkInputDirectories: true`. Before this patch, some remote actions would get stuck while preparing the exec directory, with worker thread dumps showing CPU time in `CFCLinkExecFileSystem.linkedDirectories()` / `DirectoryIterator.next()`. Deploying a worker image with this fix allowed the same build workload to get past that original input-fetch hang.
