### PR TITLE
fix(helm): point redis subchart at bitnamilegacy mirror

### DIFF
--- a/kubernetes/helm-charts/buildfarm/values.yaml
+++ b/kubernetes/helm-charts/buildfarm/values.yaml
@@ -417,6 +417,14 @@ redis:
     enabled: false
   replica:
     replicaCount: 1
+  ## Bitnami relocated free public images from `bitnami/*` to `bitnamilegacy/*`
+  ## in late 2025; the original `bitnami/redis` tags referenced by this pinned
+  ## subchart (~18.14.2) no longer resolve. Point at the legacy mirror.
+  image:
+    repository: bitnamilegacy/redis
+  sentinel:
+    image:
+      repository: bitnamilegacy/redis-sentinel
 
 externalRedis:
   uri: "redis://localhost:6379"


### PR DESCRIPTION
Bitnami relocated free public images from `bitnami/*` to `bitnamilegacy/*` in late 2025, breaking the pinned `bitnami/redis:7.2.4-debian-11-r19` tag referenced by the redis subchart (~18.14.2). Override the image repository so the chart pulls from the legacy mirror until the subchart is bumped.