### PR TITLE
fix(tilt): build container images via oci_load targets

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -23,12 +23,12 @@ USE_BAZEL_QUERY_TO_REBUILD=False
 
 def worker_deps():
   if USE_BAZEL_QUERY_TO_REBUILD:
-    return bazel_sourcefile_deps('//:buildfarm-shard-worker.tar')
+    return bazel_sourcefile_deps('//container:buildfarm-worker.load')
   return ()
 
 def server_deps():
   if USE_BAZEL_QUERY_TO_REBUILD:
-    return bazel_sourcefile_deps('//:buildfarm-shard-worker.tar')
+    return bazel_sourcefile_deps('//container:buildfarm-server.load')
   return ()
 
 # Inform tilt about the custom images built within the repository.
@@ -36,20 +36,16 @@ def server_deps():
 custom_build(
   ref='bazelbuild/buildfarm-worker',
   command=(
-    'bazelisk build --javabase=@bazel_tools//tools/jdk:remote_jdk11 //:buildfarm-shard-worker.tar && ' +
-    'docker load < bazel-bin/buildfarm-shard-worker.tar && ' +
-    'docker tag bazel:buildfarm-shard-worker $EXPECTED_REF'
-
+    'bazelisk run //container:buildfarm-worker.load && ' +
+    'docker tag bazel:buildfarm-worker $EXPECTED_REF'
     ),
     deps = worker_deps()
 )
 custom_build(
   ref='bazelbuild/buildfarm-server',
   command=(
-    'bazelisk build --javabase=@bazel_tools//tools/jdk:remote_jdk11 //:buildfarm-server.tar && ' +
-    'docker load < bazel-bin/buildfarm-server.tar && ' +
+    'bazelisk run //container:buildfarm-server.load && ' +
     'docker tag bazel:buildfarm-server $EXPECTED_REF'
-
     ),
     deps = server_deps()
 )

--- a/container/BUILD
+++ b/container/BUILD
@@ -1,4 +1,4 @@
-load("@rules_oci//oci:defs.bzl", "oci_image")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files")
 load("//:jvm_flags.bzl", "server_jvm_flags", "worker_jvm_flags")
@@ -211,4 +211,18 @@ multiarch_oci_image(
 multiarch_oci_image(
     name = "buildfarm-worker",
     image = ":_buildfarm-worker.image",
+)
+
+# Local single-arch tarball loaders for development (e.g. Tilt).
+# Produce a .tar that `docker load` can consume.
+oci_load(
+    name = "buildfarm-server.load",
+    image = ":_buildfarm-server.image",
+    repo_tags = ["bazel:buildfarm-server"],
+)
+
+oci_load(
+    name = "buildfarm-worker.load",
+    image = ":_buildfarm-worker.image",
+    repo_tags = ["bazel:buildfarm-worker"],
 )


### PR DESCRIPTION
The Tiltfile referenced `//:buildfarm-server.tar` and `//:buildfarm-shard-worker.tar`, which no longer exist after the migration to rules_oci. Add `oci_load` targets in container/BUILD that produce loadable single-arch tarballs for the local platform, and point the Tiltfile at them via `bazelisk run`.