### PR TITLE
fix(actioncache): make ShardActionCache eviction deterministic in tests

### DIFF
--- a/src/main/java/build/buildfarm/actioncache/ShardActionCache.java
+++ b/src/main/java/build/buildfarm/actioncache/ShardActionCache.java
@@ -51,7 +51,8 @@ public class ShardActionCache implements ActionCache {
                     },
                     executor));
 
-    actionResultCache = Caffeine.newBuilder().maximumSize(maxLocalCacheSize).buildAsync(loader);
+    actionResultCache =
+        Caffeine.newBuilder().maximumSize(maxLocalCacheSize).executor(service).buildAsync(loader);
   }
 
   @Override


### PR DESCRIPTION
## Summary
- `ShardActionCacheTest.readThroughShouldEvictOldEntriesAndReloadFromBackplaneWhenCapExceeded` flaked ~24% of runs locally (12/50 fails).
- Root cause: Caffeine's `AsyncLoadingCache` runs size-based eviction maintenance on its configured executor (default `ForkJoinPool.commonPool()`), not on the executor passed to the loader. After the test filled the cache past its cap, `get(KEY_A)` could race ahead of eviction — the key was still cached, the backplane was never called, and Mockito reported "zero interactions."
- Fix: pass the injected `ListeningExecutorService` to `Caffeine.executor(...)`. In tests `newDirectExecutorService()` makes maintenance synchronous; in production it shares the configured pool instead of the common pool.

## Test plan
- [x] `bazel test //src/test/java/build/buildfarm/actioncache:ShardActionCacheTest --runs_per_test=100` — 100/100 pass (was 38/50 before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)