### PR TITLE
Classify wrapped BlobNotFoundException as MISSING violation

### DIFF
--- a/src/main/java/build/buildfarm/worker/ExecDirException.java
+++ b/src/main/java/build/buildfarm/worker/ExecDirException.java
@@ -60,13 +60,26 @@ public class ExecDirException extends IOException {
 
     static void toViolation(
         Violation.Builder violation, Throwable cause, Path path, boolean isExecutable) {
-      if (cause instanceof NoSuchFileException || cause instanceof BlobNotFoundException) {
+      // A BlobNotFoundException may be wrapped, possibly at multiple layers, by the stream class
+      // reporting exceptions (e.g. an IOException from a rejected retry). Seek it in the cause
+      // chain rather than relying on the immediate type, so the violation is reported as MISSING
+      // rather than as an INVALID precondition failure.
+      if (cause instanceof NoSuchFileException || hasBlobNotFoundCause(cause)) {
         violation
             .setType(VIOLATION_TYPE_MISSING)
             .setDescription(getDescription(path, isExecutable));
       } else {
         violation.setType(VIOLATION_TYPE_INVALID).setDescription(cause.getMessage());
       }
+    }
+
+    private static boolean hasBlobNotFoundCause(Throwable cause) {
+      for (Throwable t = cause; t != null; t = t.getCause()) {
+        if (t instanceof BlobNotFoundException) {
+          return true;
+        }
+      }
+      return false;
     }
 
     public Violation getViolation() {

--- a/src/test/java/build/buildfarm/worker/ExecDirExceptionTest.java
+++ b/src/test/java/build/buildfarm/worker/ExecDirExceptionTest.java
@@ -1,0 +1,87 @@
+// Copyright 2026 The Buildfarm Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buildfarm.worker;
+
+import static build.buildfarm.common.Errors.VIOLATION_TYPE_INVALID;
+import static build.buildfarm.common.Errors.VIOLATION_TYPE_MISSING;
+import static com.google.common.truth.Truth.assertThat;
+
+import build.buildfarm.common.BlobNotFoundException;
+import build.buildfarm.v1test.Digest;
+import build.buildfarm.worker.ExecDirException.ViolationException;
+import com.google.rpc.PreconditionFailure.Violation;
+import java.io.IOException;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.util.concurrent.RejectedExecutionException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class ExecDirExceptionTest {
+  private static final Digest DIGEST = Digest.newBuilder().setHash("hash").setSize(1).build();
+
+  @Test
+  public void directBlobNotFoundIsMissing() {
+    ViolationException e =
+        new ViolationException(
+            DIGEST,
+            Path.of("file"),
+            /* isExecutable= */ false,
+            new BlobNotFoundException("file", new IOException("not found")));
+    assertThat(e.getViolation().getType()).isEqualTo(VIOLATION_TYPE_MISSING);
+  }
+
+  @Test
+  public void noSuchFileIsMissing() {
+    ViolationException e =
+        new ViolationException(
+            DIGEST, Path.of("file"), /* isExecutable= */ false, new NoSuchFileException("file"));
+    assertThat(e.getViolation().getType()).isEqualTo(VIOLATION_TYPE_MISSING);
+  }
+
+  @Test
+  public void wrappedBlobNotFoundIsMissing() {
+    // Issue #1964: a BlobNotFoundException, wrapped (possibly at multiple layers) by the stream
+    // class reporting exceptions, must still be classified as a MISSING violation rather than an
+    // INVALID precondition failure.
+    Throwable wrapped =
+        new IOException(
+            "outer",
+            new IOException(
+                "inner",
+                new BlobNotFoundException(
+                    "file", new RejectedExecutionException("could not retry read"))));
+    ViolationException e =
+        new ViolationException(DIGEST, Path.of("file"), /* isExecutable= */ false, wrapped);
+    Violation violation = e.getViolation();
+    assertThat(violation.getType()).isEqualTo(VIOLATION_TYPE_MISSING);
+    assertThat(violation.getDescription()).contains("was not found in the CAS");
+  }
+
+  @Test
+  public void unrelatedCauseIsInvalid() {
+    ViolationException e =
+        new ViolationException(
+            DIGEST,
+            Path.of("file"),
+            /* isExecutable= */ false,
+            new IOException("some other failure"));
+    Violation violation = e.getViolation();
+    assertThat(violation.getType()).isEqualTo(VIOLATION_TYPE_INVALID);
+    assertThat(violation.getDescription()).isEqualTo("some other failure");
+  }
+}


### PR DESCRIPTION
## Problem

Fixes #1964.

When a worker fails to populate an execution directory, `ExecDirException` turns the captured causes into `PreconditionFailure` violations. A blob that cannot be fetched should produce a **MISSING** violation (so the client knows to re-upload the input); anything else becomes an **INVALID** precondition failure.

`ViolationException.toViolation` only inspected the *immediate* exception type with `instanceof BlobNotFoundException`. That check fails when the `BlobNotFoundException` is wrapped:

- `ByteStreamHelper` wraps a `RejectedExecutionException` (e.g. when the retry executor is shut down) in a `BlobNotFoundException`.
- That can itself be wrapped in further `IOException` layers by the stream class reporting exceptions before it reaches `toViolation`.

The wrapped case fell through to `VIOLATION_TYPE_INVALID`, misreporting a missing blob as an invalid precondition.

## Fix

Per the issue's guidance, the throw sites are left untouched to preserve stack information; the fix is on the interpretation side. `toViolation` now walks the cause chain via a new `hasBlobNotFoundCause` helper, so a `BlobNotFoundException` at any depth is classified as MISSING.

## Test

Adds `ExecDirExceptionTest` covering:
- a direct `BlobNotFoundException`,
- a `NoSuchFileException`,
- the regression case (a `BlobNotFoundException` nested two `IOException` layers deep around a `RejectedExecutionException`),
- an unrelated cause that must remain INVALID.

🤖 Generated with [Claude Code](https://claude.com/claude-code)