### PR TITLE
Prevent pipeline stalls in CasWorkerMap reporting

### DIFF
--- a/src/main/java/build/buildfarm/instance/shard/JedisCasWorkerMap.java
+++ b/src/main/java/build/buildfarm/instance/shard/JedisCasWorkerMap.java
@@ -31,6 +31,8 @@ import redis.clients.jedis.UnifiedJedis;
  *     set(worker1,worker2)}.
  */
 public class JedisCasWorkerMap implements CasWorkerMap {
+  private static final int PIPELINE_CHUNK_MAX = 10000;
+
   private final UnifiedJedis jedis;
 
   /**
@@ -109,10 +111,16 @@ public class JedisCasWorkerMap implements CasWorkerMap {
   @Override
   public void addAll(Iterable<Digest> blobDigests, String workerName) {
     try (AbstractPipeline p = jedis.pipelined()) {
+      int chunkCount = 0;
       for (Digest blobDigest : blobDigests) {
         String key = redisCasKey(blobDigest);
         p.sadd(key, workerName);
         p.expire(key, keyExpiration_s);
+        chunkCount++;
+        if (chunkCount >= PIPELINE_CHUNK_MAX) {
+          p.sync();
+          chunkCount = 0;
+        }
       }
     }
   }
@@ -141,9 +149,15 @@ public class JedisCasWorkerMap implements CasWorkerMap {
   @Override
   public void removeAll(Iterable<Digest> blobDigests, String workerName) {
     try (AbstractPipeline p = jedis.pipelined()) {
+      int chunkCount = 0;
       for (Digest blobDigest : blobDigests) {
         String key = redisCasKey(blobDigest);
         p.srem(key, workerName);
+        chunkCount++;
+        if (chunkCount >= PIPELINE_CHUNK_MAX) {
+          p.sync();
+          chunkCount = 0;
+        }
       }
     }
   }


### PR DESCRIPTION
A pipeline created with indefinite command appends has been observed to lock up in the case of addBlobsLocations content, after 25k commands. The pipeline is effective until that point, but fails to successfully flush. This is presumably a limitation of a specific redis protocol server, since it controls stream clearing, but setting a chunk size to much lower than this - 10k - grants substantial benefits to execution time while avoiding an undiscoverable block.

It is surprising that the jedis implementation does not decide on a flush to first read the inbound stream, though this may simply not resolve the block - the stream may be too far gone at this point on the redis side, waiting for something without being responsive to an output stream clear.